### PR TITLE
Add a Transaction type to simplify dealing with Transactions

### DIFF
--- a/examples/realworld-postgres/src/main.rs
+++ b/examples/realworld-postgres/src/main.rs
@@ -50,7 +50,9 @@ async fn register(mut req: Request<PgPool>) -> Response {
     let body: RegisterRequestBody = req.body_json().await.unwrap();
     let hash = hash_password(&body.password).unwrap();
 
-    let mut pool = req.state();
+    // Make a new transaction
+    let pool = req.state();
+    let mut tx = pool.begin().await.unwrap();
 
     let rec = sqlx::query!(
         r#"
@@ -62,11 +64,14 @@ RETURNING id, username, email
         body.email,
         hash,
     )
-    .fetch_one(&mut pool)
+    .fetch_one(&mut tx)
     .await
     .unwrap();
 
     let token = generate_token(rec.id).unwrap();
+
+    // Explicitly commit
+    tx.commit().await.unwrap();
 
     #[derive(serde::Serialize)]
     struct RegisterResponseBody {

--- a/examples/realworld-postgres/src/main.rs
+++ b/examples/realworld-postgres/src/main.rs
@@ -50,7 +50,7 @@ async fn register(mut req: Request<PgPool>) -> Response {
     let body: RegisterRequestBody = req.body_json().await.unwrap();
     let hash = hash_password(&body.password).unwrap();
 
-    // Make a new transaction
+    // Make a new transaction (for giggles)
     let pool = req.state();
     let mut tx = pool.begin().await.unwrap();
 
@@ -70,7 +70,7 @@ RETURNING id, username, email
 
     let token = generate_token(rec.id).unwrap();
 
-    // Explicitly commit
+    // Explicitly commit (otherwise this would rollback on drop)
     tx.commit().await.unwrap();
 
     #[derive(serde::Serialize)]

--- a/sqlx-core/src/lib.rs
+++ b/sqlx-core/src/lib.rs
@@ -16,6 +16,7 @@ mod database;
 mod executor;
 mod query;
 mod query_as;
+mod transaction;
 mod url;
 
 #[macro_use]
@@ -47,6 +48,7 @@ pub use connection::{Connect, Connection};
 pub use executor::Executor;
 pub use query::{query, Query};
 pub use query_as::{query_as, QueryAs};
+pub use transaction::Transaction;
 
 #[doc(hidden)]
 pub use query_as::query_as_mapped;

--- a/sqlx-core/src/mysql/connection.rs
+++ b/sqlx-core/src/mysql/connection.rs
@@ -7,7 +7,7 @@ use futures_core::future::BoxFuture;
 use sha1::Sha1;
 
 use crate::cache::StatementCache;
-use crate::connection::Connection;
+use crate::connection::{Connect, Connection};
 use crate::io::{Buf, BufMut, BufStream, MaybeTlsStream};
 use crate::mysql::error::MySqlError;
 use crate::mysql::protocol::{
@@ -475,7 +475,7 @@ impl MySqlConnection {
 }
 
 impl MySqlConnection {
-    pub(super) async fn open(url: crate::Result<Url>) -> crate::Result<Self> {
+    pub(super) async fn establish(url: crate::Result<Url>) -> crate::Result<Self> {
         let url = url?;
         let mut self_ = Self::new(&url).await?;
 
@@ -598,19 +598,19 @@ impl MySqlConnection {
         T: TryInto<Url, Error = crate::Error>,
         Self: Sized,
     {
-        Box::pin(MySqlConnection::open(url.try_into()))
+        Box::pin(MySqlConnection::establish(url.try_into()))
     }
 }
 
 impl Connect for MySqlConnection {
     type Connection = MySqlConnection;
 
-    fn connect<T>(url: T) -> BoxFuture<'static, Result<MySqlConnection>>
+    fn connect<T>(url: T) -> BoxFuture<'static, crate::Result<MySqlConnection>>
     where
         T: TryInto<Url, Error = crate::Error>,
         Self: Sized,
     {
-        Box::pin(PgConnection::open(url.try_into()))
+        Box::pin(MySqlConnection::establish(url.try_into()))
     }
 }
 

--- a/sqlx-core/src/mysql/mod.rs
+++ b/sqlx-core/src/mysql/mod.rs
@@ -26,16 +26,3 @@ pub use row::MySqlRow;
 
 /// An alias for [`Pool`], specialized for **MySQL**.
 pub type MySqlPool = super::Pool<MySql>;
-
-use std::convert::TryInto;
-
-use crate::url::Url;
-
-// used in tests and hidden code in examples
-#[doc(hidden)]
-pub async fn connect<T>(url: T) -> crate::Result<MySqlConnection>
-where
-    T: TryInto<Url, Error = crate::Error>,
-{
-    MySqlConnection::open(url.try_into()).await
-}

--- a/sqlx-core/src/mysql/mod.rs
+++ b/sqlx-core/src/mysql/mod.rs
@@ -25,4 +25,4 @@ pub use types::MySqlTypeInfo;
 pub use row::MySqlRow;
 
 /// An alias for [`Pool`], specialized for **MySQL**.
-pub type MySqlPool = super::Pool<MySql>;
+pub type MySqlPool = super::Pool<MySqlConnection>;

--- a/sqlx-core/src/pool/mod.rs
+++ b/sqlx-core/src/pool/mod.rs
@@ -1,8 +1,7 @@
 //! **Pool** for SQLx database connections.
 
 use std::{
-    fmt,
-    mem,
+    fmt, mem,
     ops::{Deref, DerefMut},
     sync::Arc,
     time::{Duration, Instant},

--- a/sqlx-core/src/postgres/connection.rs
+++ b/sqlx-core/src/postgres/connection.rs
@@ -8,7 +8,7 @@ use rand::Rng;
 use sha2::{Digest, Sha256};
 
 use crate::cache::StatementCache;
-use crate::connection::Connection;
+use crate::connection::{Connect, Connection};
 use crate::io::{Buf, BufStream, MaybeTlsStream};
 use crate::postgres::protocol::{
     self, hi, Authentication, Decode, Encode, Message, SaslInitialResponse, SaslResponse,
@@ -334,7 +334,7 @@ impl PgConnection {
 }
 
 impl PgConnection {
-    pub(super) async fn open(url: Result<Url>) -> Result<Self> {
+    pub(super) async fn establish(url: Result<Url>) -> Result<Self> {
         let url = url?;
 
         let stream = MaybeTlsStream::connect(&url, 5432).await?;
@@ -402,7 +402,7 @@ impl PgConnection {
         T: TryInto<Url, Error = crate::Error>,
         Self: Sized,
     {
-        Box::pin(PgConnection::open(url.try_into()))
+        Box::pin(PgConnection::establish(url.try_into()))
     }
 }
 
@@ -414,7 +414,7 @@ impl Connect for PgConnection {
         T: TryInto<Url, Error = crate::Error>,
         Self: Sized,
     {
-        Box::pin(PgConnection::open(url.try_into()))
+        Box::pin(PgConnection::establish(url.try_into()))
     }
 }
 

--- a/sqlx-core/src/postgres/mod.rs
+++ b/sqlx-core/src/postgres/mod.rs
@@ -18,16 +18,3 @@ mod types;
 
 /// An alias for [`Pool`], specialized for **Postgres**.
 pub type PgPool = super::Pool<Postgres>;
-
-use std::convert::TryInto;
-
-use crate::url::Url;
-
-// used in tests and hidden code in examples
-#[doc(hidden)]
-pub async fn connect<T>(url: T) -> crate::Result<PgConnection>
-where
-    T: TryInto<Url, Error = crate::Error>,
-{
-    PgConnection::open(url.try_into()).await
-}

--- a/sqlx-core/src/postgres/mod.rs
+++ b/sqlx-core/src/postgres/mod.rs
@@ -17,4 +17,4 @@ mod row;
 mod types;
 
 /// An alias for [`Pool`], specialized for **Postgres**.
-pub type PgPool = super::Pool<Postgres>;
+pub type PgPool = super::Pool<PgConnection>;

--- a/sqlx-core/src/transaction.rs
+++ b/sqlx-core/src/transaction.rs
@@ -4,10 +4,10 @@ use async_std::task;
 use futures_core::future::BoxFuture;
 use futures_core::stream::BoxStream;
 
+use crate::connection::Connection;
 use crate::database::Database;
 use crate::describe::Describe;
 use crate::executor::Executor;
-use crate::connection::Connection;
 
 pub struct Transaction<T>
 where
@@ -96,15 +96,13 @@ where
     }
 }
 
-impl<T> Connection for Transaction<T> 
-where 
-    T: Connection
+impl<T> Connection for Transaction<T>
+where
+    T: Connection,
 {
     // Close is equivalent to ROLLBACK followed by CLOSE
     fn close(self) -> BoxFuture<'static, crate::Result<()>> {
-        Box::pin(async move {
-            self.rollback().await?.close().await
-        })
+        Box::pin(async move { self.rollback().await?.close().await })
     }
 }
 

--- a/sqlx-core/src/transaction.rs
+++ b/sqlx-core/src/transaction.rs
@@ -1,0 +1,173 @@
+use std::ops::{Deref, DerefMut};
+
+use async_std::task;
+use futures_core::future::BoxFuture;
+use futures_core::stream::BoxStream;
+
+use crate::database::Database;
+use crate::describe::Describe;
+use crate::executor::Executor;
+use crate::connection::Connection;
+
+pub struct Transaction<T>
+where
+    T: Connection + Send + 'static,
+{
+    inner: Option<T>,
+    depth: u32,
+}
+
+impl<T> Transaction<T>
+where
+    T: Connection + Send + 'static,
+{
+    pub(crate) async fn new(depth: u32, mut inner: T) -> crate::Result<Self> {
+        if depth == 0 {
+            inner.send("BEGIN").await?;
+        } else {
+            inner
+                .send(&format!("SAVEPOINT _sqlx_savepoint_{}", depth))
+                .await?;
+        }
+
+        Ok(Self {
+            inner: Some(inner),
+            depth: depth + 1,
+        })
+    }
+
+    pub async fn begin(mut self) -> crate::Result<Transaction<T>> {
+        Transaction::new(self.depth, self.inner.take().expect(ERR_FINALIZED)).await
+    }
+
+    pub async fn commit(mut self) -> crate::Result<T> {
+        let mut inner = self.inner.take().expect(ERR_FINALIZED);
+        let depth = self.depth;
+
+        if depth == 1 {
+            inner.send("COMMIT").await?;
+        } else {
+            inner
+                .send(&format!("RELEASE SAVEPOINT _sqlx_savepoint_{}", depth - 1))
+                .await?;
+        }
+
+        Ok(inner)
+    }
+
+    pub async fn rollback(mut self) -> crate::Result<T> {
+        let mut inner = self.inner.take().expect(ERR_FINALIZED);
+        let depth = self.depth;
+
+        if depth == 1 {
+            inner.send("ROLLBACK").await?;
+        } else {
+            inner
+                .send(&format!(
+                    "ROLLBACK TO SAVEPOINT _sqlx_savepoint_{}",
+                    depth - 1
+                ))
+                .await?;
+        }
+
+        Ok(inner)
+    }
+}
+
+const ERR_FINALIZED: &str = "(bug) transaction already finalized";
+
+impl<Conn> Deref for Transaction<Conn>
+where
+    Conn: Connection,
+{
+    type Target = Conn;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner.as_ref().expect(ERR_FINALIZED)
+    }
+}
+
+impl<Conn> DerefMut for Transaction<Conn>
+where
+    Conn: Connection,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.inner.as_mut().expect(ERR_FINALIZED)
+    }
+}
+
+impl<T> Connection for Transaction<T> 
+where 
+    T: Connection
+{
+    // Close is equivalent to ROLLBACK followed by CLOSE
+    fn close(self) -> BoxFuture<'static, crate::Result<()>> {
+        Box::pin(async move {
+            self.rollback().await?.close().await
+        })
+    }
+}
+
+impl<T> Executor for Transaction<T>
+where
+    T: Connection,
+{
+    type Database = T::Database;
+
+    fn send<'e, 'q: 'e>(&'e mut self, commands: &'q str) -> BoxFuture<'e, crate::Result<()>> {
+        self.deref_mut().send(commands)
+    }
+
+    fn execute<'e, 'q: 'e>(
+        &'e mut self,
+        query: &'q str,
+        args: <Self::Database as Database>::Arguments,
+    ) -> BoxFuture<'e, crate::Result<u64>> {
+        self.deref_mut().execute(query, args)
+    }
+
+    fn fetch<'e, 'q: 'e>(
+        &'e mut self,
+        query: &'q str,
+        args: <Self::Database as Database>::Arguments,
+    ) -> BoxStream<'e, crate::Result<<Self::Database as Database>::Row>> {
+        self.deref_mut().fetch(query, args)
+    }
+
+    fn fetch_optional<'e, 'q: 'e>(
+        &'e mut self,
+        query: &'q str,
+        args: <Self::Database as Database>::Arguments,
+    ) -> BoxFuture<'e, crate::Result<Option<<Self::Database as Database>::Row>>> {
+        self.deref_mut().fetch_optional(query, args)
+    }
+
+    fn describe<'e, 'q: 'e>(
+        &'e mut self,
+        query: &'q str,
+    ) -> BoxFuture<'e, crate::Result<Describe<Self::Database>>> {
+        self.deref_mut().describe(query)
+    }
+}
+
+impl<Conn> Drop for Transaction<Conn>
+where
+    Conn: Connection,
+{
+    fn drop(&mut self) {
+        if self.depth > 0 {
+            if let Some(mut inner) = self.inner.take() {
+                task::spawn(async move {
+                    let res = inner.send("ROLLBACK").await;
+
+                    // If the rollback failed we need to close the inner connection
+                    if res.is_err() {
+                        // This will explicitly forget the connection so it will not
+                        // return to the pool
+                        let _ = inner.close().await;
+                    }
+                });
+            }
+        }
+    }
+}

--- a/sqlx-macros/src/lib.rs
+++ b/sqlx-macros/src/lib.rs
@@ -29,14 +29,14 @@ use query_macros::*;
 macro_rules! async_macro (
     ($db:ident => $expr:expr) => {{
         let res: Result<proc_macro2::TokenStream> = task::block_on(async {
-            use sqlx::Connection;
+            use sqlx::Connect;
 
             let db_url = Url::parse(&dotenv::var("DATABASE_URL").map_err(|_| "DATABASE_URL not set")?)?;
 
             match db_url.scheme() {
                 #[cfg(feature = "postgres")]
                 "postgresql" | "postgres" => {
-                    let $db = sqlx::postgres::PgConnection::open(db_url.as_str())
+                    let $db = sqlx::postgres::PgConnection::connect(db_url.as_str())
                         .await
                         .map_err(|e| format!("failed to connect to database: {}", e))?;
 
@@ -50,7 +50,7 @@ macro_rules! async_macro (
                 ).into()),
                 #[cfg(feature = "mysql")]
                 "mysql" | "mariadb" => {
-                    let $db = sqlx::mysql::MySqlConnection::open(db_url.as_str())
+                    let $db = sqlx::mysql::MySqlConnection::connect(db_url.as_str())
                             .await
                             .map_err(|e| format!("failed to connect to database: {}", e))?;
 

--- a/sqlx-macros/src/lib.rs
+++ b/sqlx-macros/src/lib.rs
@@ -70,7 +70,7 @@ macro_rules! async_macro (
             Ok(ts) => ts.into(),
             Err(e) => {
                 if let Some(parse_err) = e.downcast_ref::<syn::Error>() {
-                    return dbg!(parse_err).to_compile_error().into();
+                    return parse_err.to_compile_error().into();
                 }
 
                 let msg = format!("{:?}", e);


### PR DESCRIPTION

 - [x] What happens if the _final_ `rollback` fails? For a transaction around an un-pooled connection, the error should make it unusable. For a transaction around a _pooled_ connection, we need to not let the connection go back to the pool. Perhaps an explicit close and `mem::forget` ?

 - [x] After the _final_ `rollback` or `commit`, the `Transaction` type currently maintains its ownership of the inner `Connection` type. There should probably be a way to get that `Connection` back out.

 - [x] The `Transaction` type needs to wrap _sticky_ `Executor`s. We probably need a marker trait here. `Pool` is not sticky but `MySqlConnection`, `PgConnection`, and `pool::Connection` are.

