### PR TITLE
derive Debug for Pool

### DIFF
--- a/sqlx-core/src/pool/inner.rs
+++ b/sqlx-core/src/pool/inner.rs
@@ -70,12 +70,20 @@ where
         &self.options
     }
 
+    pub(super) fn url(&self) -> &str {
+        &self.url
+    }
+
     pub(super) fn size(&self) -> u32 {
         self.size.load(Ordering::Acquire)
     }
 
     pub(super) fn num_idle(&self) -> usize {
         self.pool_rx.len()
+    }
+
+    pub(super) fn closed(&self) -> bool {
+        self.closed.load(Ordering::SeqCst)
     }
 
     pub(super) async fn close(&self) {

--- a/sqlx-core/src/pool/mod.rs
+++ b/sqlx-core/src/pool/mod.rs
@@ -1,6 +1,7 @@
 //! **Pool** for SQLx database connections.
 
 use std::{
+    fmt,
     ops::{Deref, DerefMut},
     sync::Arc,
     time::{Duration, Instant},
@@ -138,6 +139,18 @@ where
             inner: Arc::clone(&self.inner),
             pool_tx: self.pool_tx.clone(),
         }
+    }
+}
+
+impl<DB: Database> fmt::Debug for Pool<DB> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("Pool")
+            .field("url", &self.inner.url())
+            .field("size", &self.inner.size())
+            .field("num_idle", &self.inner.num_idle())
+            .field("closed", &self.inner.closed())
+            .field("options", self.inner.options())
+            .finish()
     }
 }
 

--- a/sqlx-core/src/pool/options.rs
+++ b/sqlx-core/src/pool/options.rs
@@ -110,6 +110,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct Options {
     pub max_size: u32,
     pub connect_timeout: Duration,


### PR DESCRIPTION
In some frameworks `Debug` is required to put `Pool` in app state's context structs which define Debug by default.