### PR TITLE
Refactor HasSqlType to provide an array of compatible types

### DIFF
--- a/sqlx-core/src/database.rs
+++ b/sqlx-core/src/database.rs
@@ -1,13 +1,15 @@
+use std::fmt::Display;
+
 use crate::arguments::Arguments;
 use crate::connection::Connection;
 use crate::row::Row;
-use crate::types::HasTypeMetadata;
+use crate::types::TypeInfo;
 
 /// A database driver.
 ///
 /// This trait encapsulates a complete driver implementation to a specific
 /// database (e.g., MySQL, Postgres).
-pub trait Database: HasTypeMetadata + 'static {
+pub trait Database: 'static {
     /// The concrete `Connection` implementation for this database.
     type Connection: Connection<Database = Self>;
 
@@ -16,4 +18,10 @@ pub trait Database: HasTypeMetadata + 'static {
 
     /// The concrete `Row` implementation for this database.
     type Row: Row<Database = Self>;
+
+    /// The concrete `TypeInfo` implementation for this database.
+    type TypeInfo: TypeInfo;
+
+    /// The Rust type of table identifiers for this database.
+    type TableId: Display + Clone;
 }

--- a/sqlx-core/src/describe.rs
+++ b/sqlx-core/src/describe.rs
@@ -1,6 +1,5 @@
 //! Types for returning SQL type information about queries.
 
-use crate::types::HasTypeMetadata;
 use crate::Database;
 use std::fmt::{self, Debug};
 
@@ -11,7 +10,7 @@ where
     DB: Database + ?Sized,
 {
     /// The expected types for the parameters of the query.
-    pub param_types: Box<[<DB as HasTypeMetadata>::TypeId]>,
+    pub param_types: Box<[DB::TypeInfo]>,
 
     /// The type and table information, if any for the results of the query.
     pub result_columns: Box<[Column<DB>]>,
@@ -20,7 +19,7 @@ where
 impl<DB> Debug for Describe<DB>
 where
     DB: Database,
-    <DB as HasTypeMetadata>::TypeId: Debug,
+    DB::TypeInfo: Debug,
     Column<DB>: Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -38,21 +37,21 @@ where
     DB: Database + ?Sized,
 {
     pub name: Option<Box<str>>,
-    pub table_id: Option<<DB as HasTypeMetadata>::TableId>,
-    pub type_id: <DB as HasTypeMetadata>::TypeId,
+    pub table_id: Option<DB::TableId>,
+    pub type_info: DB::TypeInfo,
 }
 
 impl<DB> Debug for Column<DB>
 where
     DB: Database + ?Sized,
-    <DB as HasTypeMetadata>::TableId: Debug,
-    <DB as HasTypeMetadata>::TypeId: Debug,
+    DB::TableId: Debug,
+    DB::TypeInfo: Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Column")
             .field("name", &self.name)
             .field("table_id", &self.table_id)
-            .field("type_id", &self.type_id)
+            .field("type_id", &self.type_info)
             .finish()
     }
 }

--- a/sqlx-core/src/encode.rs
+++ b/sqlx-core/src/encode.rs
@@ -74,7 +74,7 @@ where
 
     fn size_hint(&self) -> usize {
         if self.is_some() {
-            mem::size_of::<T>()
+            (*self).size_hint()
         } else {
             0
         }

--- a/sqlx-core/src/executor.rs
+++ b/sqlx-core/src/executor.rs
@@ -64,7 +64,7 @@ pub trait Executor {
         Box::pin(async move { s.try_next().await?.ok_or(crate::Error::NotFound) })
     }
 
-    /// Analyze the SQL query and report the inferred bind parameter types and returned columns.
+    #[doc(hidden)]
     fn describe<'e, 'q: 'e>(
         &'e mut self,
         query: &'q str,

--- a/sqlx-core/src/lib.rs
+++ b/sqlx-core/src/lib.rs
@@ -20,7 +20,10 @@ mod url;
 
 #[macro_use]
 pub mod arguments;
+
+#[doc(hidden)]
 pub mod decode;
+
 pub mod describe;
 pub mod encode;
 pub mod pool;

--- a/sqlx-core/src/mysql/arguments.rs
+++ b/sqlx-core/src/mysql/arguments.rs
@@ -1,12 +1,12 @@
 use crate::arguments::Arguments;
 use crate::encode::{Encode, IsNull};
-use crate::mysql::types::MySqlTypeMetadata;
+use crate::mysql::types::MySqlTypeInfo;
 use crate::mysql::MySql;
 use crate::types::HasSqlType;
 
 #[derive(Default)]
 pub struct MySqlArguments {
-    pub(crate) param_types: Vec<MySqlTypeMetadata>,
+    pub(crate) param_types: Vec<MySqlTypeInfo>,
     pub(crate) params: Vec<u8>,
     pub(crate) null_bitmap: Vec<u8>,
 }
@@ -38,10 +38,10 @@ impl Arguments for MySqlArguments {
         Self::Database: HasSqlType<T>,
         T: Encode<Self::Database>,
     {
-        let metadata = <MySql as HasSqlType<T>>::metadata();
+        let type_id = <MySql as HasSqlType<T>>::type_info();
         let index = self.param_types.len();
 
-        self.param_types.push(metadata);
+        self.param_types.push(type_id);
         self.null_bitmap.resize((index / 8) + 1, 0);
 
         if let IsNull::Yes = value.encode_nullable(&mut self.params) {

--- a/sqlx-core/src/mysql/database.rs
+++ b/sqlx-core/src/mysql/database.rs
@@ -9,6 +9,10 @@ impl Database for MySql {
     type Arguments = super::MySqlArguments;
 
     type Row = super::MySqlRow;
+
+    type TypeInfo = super::MySqlTypeInfo;
+
+    type TableId = Box<str>;
 }
 
 impl_into_arguments_for_database!(MySql);

--- a/sqlx-core/src/mysql/mod.rs
+++ b/sqlx-core/src/mysql/mod.rs
@@ -20,6 +20,8 @@ pub use connection::MySqlConnection;
 
 pub use error::MySqlError;
 
+pub use types::MySqlTypeInfo;
+
 pub use row::MySqlRow;
 
 /// An alias for [`Pool`], specialized for **MySQL**.

--- a/sqlx-core/src/mysql/protocol/column_def.rs
+++ b/sqlx-core/src/mysql/protocol/column_def.rs
@@ -2,7 +2,7 @@ use byteorder::LittleEndian;
 
 use crate::io::Buf;
 use crate::mysql::io::BufExt;
-use crate::mysql::protocol::{Decode, FieldFlags, Type};
+use crate::mysql::protocol::{Decode, FieldFlags, TypeId};
 
 // https://dev.mysql.com/doc/dev/mysql-server/8.0.12/page_protocol_com_query_response_text_resultset_column_definition.html
 // https://mariadb.com/kb/en/resultset/#column-definition-packet
@@ -20,7 +20,7 @@ pub struct ColumnDefinition {
 
     pub max_size: u32,
 
-    pub r#type: Type,
+    pub type_id: TypeId,
 
     pub flags: FieldFlags,
 
@@ -57,7 +57,7 @@ impl Decode for ColumnDefinition {
         let char_set = buf.get_u16::<LittleEndian>()?;
         let max_size = buf.get_u32::<LittleEndian>()?;
 
-        let r#type = buf.get_u8()?;
+        let type_id = buf.get_u8()?;
         let flags = buf.get_u16::<LittleEndian>()?;
         let decimals = buf.get_u8()?;
 
@@ -69,7 +69,7 @@ impl Decode for ColumnDefinition {
             column_alias,
             char_set,
             max_size,
-            r#type: Type(r#type),
+            type_id: TypeId(type_id),
             flags: FieldFlags::from_bits_truncate(flags),
             decimals,
         })

--- a/sqlx-core/src/mysql/protocol/com_stmt_execute.rs
+++ b/sqlx-core/src/mysql/protocol/com_stmt_execute.rs
@@ -3,7 +3,7 @@ use byteorder::LittleEndian;
 use crate::io::BufMut;
 use crate::mysql::io::BufMutExt;
 use crate::mysql::protocol::{Capabilities, Encode};
-use crate::mysql::types::MySqlTypeMetadata;
+use crate::mysql::types::MySqlTypeInfo;
 
 bitflags::bitflags! {
     // https://dev.mysql.com/doc/dev/mysql-server/8.0.12/mysql__com_8h.html#a3e5e9e744ff6f7b989a604fd669977da
@@ -23,7 +23,7 @@ pub struct ComStmtExecute<'a> {
     pub cursor: Cursor,
     pub params: &'a [u8],
     pub null_bitmap: &'a [u8],
-    pub param_types: &'a [MySqlTypeMetadata],
+    pub param_types: &'a [MySqlTypeInfo],
 }
 
 impl Encode for ComStmtExecute<'_> {
@@ -49,7 +49,7 @@ impl Encode for ComStmtExecute<'_> {
 
             for ty in self.param_types {
                 // field type : byte<1>
-                buf.put_u8(ty.r#type.0);
+                buf.put_u8(ty.id.0);
 
                 // parameter flag : byte<1>
                 buf.put_u8(if ty.is_unsigned { 0x80 } else { 0 });

--- a/sqlx-core/src/mysql/protocol/field.rs
+++ b/sqlx-core/src/mysql/protocol/field.rs
@@ -18,7 +18,7 @@ bitflags::bitflags! {
         const BLOB = 16;
 
         /// Field is unsigned
-        const UNISIGNED = 32;
+        const UNSIGNED = 32;
 
         /// Field is zero filled.
         const ZEROFILL = 64;

--- a/sqlx-core/src/mysql/protocol/mod.rs
+++ b/sqlx-core/src/mysql/protocol/mod.rs
@@ -17,7 +17,7 @@ mod r#type;
 pub use auth_plugin::AuthPlugin;
 pub use capabilities::Capabilities;
 pub use field::FieldFlags;
-pub use r#type::Type;
+pub use r#type::TypeId;
 pub use status::Status;
 
 mod com_query;

--- a/sqlx-core/src/mysql/protocol/type.rs
+++ b/sqlx-core/src/mysql/protocol/type.rs
@@ -1,39 +1,42 @@
 // https://dev.mysql.com/doc/dev/mysql-server/8.0.12/binary__log__types_8h.html
 // https://mariadb.com/kb/en/library/resultset/#field-types
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct Type(pub u8);
+pub struct TypeId(pub u8);
 
-impl Type {
-    pub const BIT: Type = Type(16);
-    pub const BLOB: Type = Type(252);
-    pub const DATE: Type = Type(10);
-    pub const DATETIME: Type = Type(12);
-    pub const DECIMAL: Type = Type(0);
-    pub const DOUBLE: Type = Type(5);
-    pub const ENUM: Type = Type(247);
-    pub const FLOAT: Type = Type(4);
-    pub const GEOMETRY: Type = Type(255);
-    pub const INT24: Type = Type(9);
-    pub const JSON: Type = Type(245); // MySQL Only
-    pub const LONG: Type = Type(3);
-    pub const LONGLONG: Type = Type(8);
-    pub const LONG_BLOB: Type = Type(251);
-    pub const MEDIUM_BLOB: Type = Type(250);
-    pub const NULL: Type = Type(6);
-    pub const SET: Type = Type(248);
-    pub const SHORT: Type = Type(2);
-    pub const STRING: Type = Type(254);
-    pub const TIME: Type = Type(11);
-    pub const TIMESTAMP: Type = Type(7);
-    pub const TINY: Type = Type(1);
-    pub const TINY_BLOB: Type = Type(249);
-    pub const VARCHAR: Type = Type(15);
-    pub const VAR_STRING: Type = Type(253);
-    pub const YEAR: Type = Type(13);
+// https://github.com/google/mysql/blob/c01fc2134d439282a21a2ddf687566e198ddee28/include/mysql_com.h#L429
+impl TypeId {
+    pub const NULL: TypeId = TypeId(6);
+
+    // String: CHAR, VARCHAR, TEXT
+    // Bytes: BINARY, VARBINARY, BLOB
+    pub const CHAR: TypeId = TypeId(254); // or BINARY
+    pub const VAR_CHAR: TypeId = TypeId(253); // or VAR_BINARY
+    pub const TEXT: TypeId = TypeId(252); // or BLOB
+
+    // More Bytes
+    pub const TINY_BLOB: TypeId = TypeId(249);
+    pub const MEDIUM_BLOB: TypeId = TypeId(250);
+    pub const LONG_BLOB: TypeId = TypeId(251);
+
+    // Numeric: TINYINT, SMALLINT, INT, BIGINT
+    pub const TINY_INT: TypeId = TypeId(1);
+    pub const SMALL_INT: TypeId = TypeId(2);
+    pub const INT: TypeId = TypeId(3);
+    pub const BIG_INT: TypeId = TypeId(8);
+
+    // Numeric: FLOAT, DOUBLE
+    pub const FLOAT: TypeId = TypeId(4);
+    pub const DOUBLE: TypeId = TypeId(5);
+
+    // Date/Time: DATE, TIME, DATETIME, TIMESTAMP
+    pub const DATE: TypeId = TypeId(10);
+    pub const TIME: TypeId = TypeId(11);
+    pub const DATETIME: TypeId = TypeId(12);
+    pub const TIMESTAMP: TypeId = TypeId(7);
 }
 
-impl Default for Type {
-    fn default() -> Type {
-        Type::NULL
+impl Default for TypeId {
+    fn default() -> TypeId {
+        TypeId::NULL
     }
 }

--- a/sqlx-core/src/mysql/rsa.rs
+++ b/sqlx-core/src/mysql/rsa.rs
@@ -178,7 +178,6 @@ mod tests {
     use super::{BigUint, PublicKey};
     use rand::rngs::adapter::ReadRng;
     use sha1::Sha1;
-    use sha2::Sha256;
 
     const INPUT: &str = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAv9E+l0oFIoGnZmu6bdil\nI3WK79iug/hukj5QrWRrJVVCHL8rRxNsQGYPvQfXgqEnJW0Rqy2BBebNrnSMduny\nCazz1KM1h57hSI1xHGhg/o82Us1j9fUucKo0Pt3vg7xjVVcN0j1bwr96gEbt6B4Q\nt4eKZBhtle1bgoBcqFBhGfU17cnedSzMUCutM+kXTzzOTplKoqXeJpEZDTX8AP9F\nQ9JkoA22yTn8H2GROIAffm1UQS7DXXjI5OnzBJNs72oNSeK8i72xLkoSdfVw3vCu\ni+mpt4LJgAZLvzc2O4nLzu4Bljb+Mrch34HSWyxOfWzt1v9vpJfEVQ2/VZaIng6U\nUQIDAQAB\n-----END PUBLIC KEY-----\n";
 
@@ -239,7 +238,7 @@ mod tests {
             0x2c, 0x49,
         ];
 
-        let mut seed = &[
+        let seed = &[
             0xaa, 0xfd, 0x12, 0xf6, 0x59, 0xca, 0xe6, 0x34, 0x89, 0xb4, 0x79, 0xe5, 0x07, 0x6d,
             0xde, 0xc2, 0xf0, 0x6c, 0xb5, 0x8f,
         ][..];

--- a/sqlx-core/src/mysql/types/bool.rs
+++ b/sqlx-core/src/mysql/types/bool.rs
@@ -1,13 +1,13 @@
 use crate::decode::{Decode, DecodeError};
 use crate::encode::Encode;
-use crate::mysql::protocol::Type;
-use crate::mysql::types::MySqlTypeMetadata;
+use crate::mysql::protocol::TypeId;
+use crate::mysql::types::MySqlTypeInfo;
 use crate::mysql::MySql;
 use crate::types::HasSqlType;
 
 impl HasSqlType<bool> for MySql {
-    fn metadata() -> MySqlTypeMetadata {
-        MySqlTypeMetadata::new(Type::TINY)
+    fn type_info() -> MySqlTypeInfo {
+        MySqlTypeInfo::new(TypeId::TINY_INT)
     }
 }
 

--- a/sqlx-core/src/mysql/types/bytes.rs
+++ b/sqlx-core/src/mysql/types/bytes.rs
@@ -3,22 +3,25 @@ use byteorder::LittleEndian;
 use crate::decode::{Decode, DecodeError};
 use crate::encode::Encode;
 use crate::mysql::io::{BufExt, BufMutExt};
-use crate::mysql::protocol::Type;
-use crate::mysql::types::MySqlTypeMetadata;
+use crate::mysql::protocol::TypeId;
+use crate::mysql::types::MySqlTypeInfo;
 use crate::mysql::MySql;
 use crate::types::HasSqlType;
 
-// TODO: We only have support for BLOB below; we map [u8] to BLOB, as we do not have the size information yet
-
 impl HasSqlType<[u8]> for MySql {
-    fn metadata() -> MySqlTypeMetadata {
-        MySqlTypeMetadata::new(Type::BLOB)
+    fn type_info() -> MySqlTypeInfo {
+        MySqlTypeInfo {
+            id: TypeId::TEXT,
+            is_binary: true,
+            is_unsigned: false,
+            char_set: 63, // binary
+        }
     }
 }
 
 impl HasSqlType<Vec<u8>> for MySql {
-    fn metadata() -> MySqlTypeMetadata {
-        <Self as HasSqlType<[u8]>>::metadata()
+    fn type_info() -> MySqlTypeInfo {
+        <Self as HasSqlType<[u8]>>::type_info()
     }
 }
 

--- a/sqlx-core/src/mysql/types/chrono.rs
+++ b/sqlx-core/src/mysql/types/chrono.rs
@@ -6,14 +6,14 @@ use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike, 
 use crate::decode::{Decode, DecodeError};
 use crate::encode::Encode;
 use crate::io::{Buf, BufMut};
-use crate::mysql::protocol::Type;
-use crate::mysql::types::MySqlTypeMetadata;
+use crate::mysql::protocol::TypeId;
+use crate::mysql::types::MySqlTypeInfo;
 use crate::mysql::MySql;
 use crate::types::HasSqlType;
 
 impl HasSqlType<DateTime<Utc>> for MySql {
-    fn metadata() -> Self::TypeMetadata {
-        MySqlTypeMetadata::new(Type::TIMESTAMP)
+    fn type_info() -> MySqlTypeInfo {
+        MySqlTypeInfo::new(TypeId::TIMESTAMP)
     }
 }
 
@@ -32,8 +32,8 @@ impl Decode<MySql> for DateTime<Utc> {
 }
 
 impl HasSqlType<NaiveTime> for MySql {
-    fn metadata() -> Self::TypeMetadata {
-        MySqlTypeMetadata::new(Type::TIME)
+    fn type_info() -> MySqlTypeInfo {
+        MySqlTypeInfo::new(TypeId::TIME)
     }
 }
 
@@ -81,8 +81,8 @@ impl Decode<MySql> for NaiveTime {
 }
 
 impl HasSqlType<NaiveDate> for MySql {
-    fn metadata() -> Self::TypeMetadata {
-        MySqlTypeMetadata::new(Type::DATE)
+    fn type_info() -> MySqlTypeInfo {
+        MySqlTypeInfo::new(TypeId::DATE)
     }
 }
 
@@ -105,8 +105,8 @@ impl Decode<MySql> for NaiveDate {
 }
 
 impl HasSqlType<NaiveDateTime> for MySql {
-    fn metadata() -> Self::TypeMetadata {
-        MySqlTypeMetadata::new(Type::DATETIME)
+    fn type_info() -> MySqlTypeInfo {
+        MySqlTypeInfo::new(TypeId::DATETIME)
     }
 }
 

--- a/sqlx-core/src/mysql/types/float.rs
+++ b/sqlx-core/src/mysql/types/float.rs
@@ -1,14 +1,13 @@
 use crate::decode::{Decode, DecodeError};
 use crate::encode::Encode;
-use crate::mysql::protocol::Type;
-use crate::mysql::types::MySqlTypeMetadata;
+use crate::mysql::protocol::TypeId;
+use crate::mysql::types::MySqlTypeInfo;
 use crate::mysql::MySql;
 use crate::types::HasSqlType;
 
 impl HasSqlType<f32> for MySql {
-    #[inline]
-    fn metadata() -> MySqlTypeMetadata {
-        MySqlTypeMetadata::new(Type::FLOAT)
+    fn type_info() -> MySqlTypeInfo {
+        MySqlTypeInfo::new(TypeId::FLOAT)
     }
 }
 
@@ -25,9 +24,8 @@ impl Decode<MySql> for f32 {
 }
 
 impl HasSqlType<f64> for MySql {
-    #[inline]
-    fn metadata() -> MySqlTypeMetadata {
-        MySqlTypeMetadata::new(Type::DOUBLE)
+    fn type_info() -> MySqlTypeInfo {
+        MySqlTypeInfo::new(TypeId::DOUBLE)
     }
 }
 

--- a/sqlx-core/src/mysql/types/int.rs
+++ b/sqlx-core/src/mysql/types/int.rs
@@ -3,15 +3,14 @@ use byteorder::LittleEndian;
 use crate::decode::{Decode, DecodeError};
 use crate::encode::Encode;
 use crate::io::{Buf, BufMut};
-use crate::mysql::protocol::Type;
-use crate::mysql::types::MySqlTypeMetadata;
+use crate::mysql::protocol::TypeId;
+use crate::mysql::types::MySqlTypeInfo;
 use crate::mysql::MySql;
 use crate::types::HasSqlType;
 
 impl HasSqlType<i8> for MySql {
-    #[inline]
-    fn metadata() -> MySqlTypeMetadata {
-        MySqlTypeMetadata::new(Type::TINY)
+    fn type_info() -> MySqlTypeInfo {
+        MySqlTypeInfo::new(TypeId::TINY_INT)
     }
 }
 
@@ -28,9 +27,8 @@ impl Decode<MySql> for i8 {
 }
 
 impl HasSqlType<i16> for MySql {
-    #[inline]
-    fn metadata() -> MySqlTypeMetadata {
-        MySqlTypeMetadata::new(Type::SHORT)
+    fn type_info() -> MySqlTypeInfo {
+        MySqlTypeInfo::new(TypeId::SMALL_INT)
     }
 }
 
@@ -47,9 +45,8 @@ impl Decode<MySql> for i16 {
 }
 
 impl HasSqlType<i32> for MySql {
-    #[inline]
-    fn metadata() -> MySqlTypeMetadata {
-        MySqlTypeMetadata::new(Type::LONG)
+    fn type_info() -> MySqlTypeInfo {
+        MySqlTypeInfo::new(TypeId::INT)
     }
 }
 
@@ -66,9 +63,8 @@ impl Decode<MySql> for i32 {
 }
 
 impl HasSqlType<i64> for MySql {
-    #[inline]
-    fn metadata() -> MySqlTypeMetadata {
-        MySqlTypeMetadata::new(Type::LONGLONG)
+    fn type_info() -> MySqlTypeInfo {
+        MySqlTypeInfo::new(TypeId::BIG_INT)
     }
 }
 

--- a/sqlx-core/src/mysql/types/str.rs
+++ b/sqlx-core/src/mysql/types/str.rs
@@ -5,14 +5,19 @@ use byteorder::LittleEndian;
 use crate::decode::{Decode, DecodeError};
 use crate::encode::Encode;
 use crate::mysql::io::{BufExt, BufMutExt};
-use crate::mysql::protocol::Type;
-use crate::mysql::types::MySqlTypeMetadata;
+use crate::mysql::protocol::TypeId;
+use crate::mysql::types::MySqlTypeInfo;
 use crate::mysql::MySql;
 use crate::types::HasSqlType;
 
 impl HasSqlType<str> for MySql {
-    fn metadata() -> MySqlTypeMetadata {
-        MySqlTypeMetadata::new(Type::VAR_STRING)
+    fn type_info() -> MySqlTypeInfo {
+        MySqlTypeInfo {
+            id: TypeId::TEXT,
+            is_binary: false,
+            is_unsigned: false,
+            char_set: 224, // utf8mb4_unicode_ci
+        }
     }
 }
 
@@ -22,9 +27,10 @@ impl Encode<MySql> for str {
     }
 }
 
+// TODO: Do we need the [HasSqlType] for String
 impl HasSqlType<String> for MySql {
-    fn metadata() -> MySqlTypeMetadata {
-        <MySql as HasSqlType<&str>>::metadata()
+    fn type_info() -> MySqlTypeInfo {
+        <Self as HasSqlType<&str>>::type_info()
     }
 }
 

--- a/sqlx-core/src/mysql/types/uint.rs
+++ b/sqlx-core/src/mysql/types/uint.rs
@@ -3,15 +3,14 @@ use byteorder::LittleEndian;
 use crate::decode::{Decode, DecodeError};
 use crate::encode::Encode;
 use crate::io::{Buf, BufMut};
-use crate::mysql::protocol::Type;
-use crate::mysql::types::MySqlTypeMetadata;
+use crate::mysql::protocol::TypeId;
+use crate::mysql::types::MySqlTypeInfo;
 use crate::mysql::MySql;
 use crate::types::HasSqlType;
 
 impl HasSqlType<u8> for MySql {
-    #[inline]
-    fn metadata() -> MySqlTypeMetadata {
-        MySqlTypeMetadata::unsigned(Type::TINY)
+    fn type_info() -> MySqlTypeInfo {
+        MySqlTypeInfo::unsigned(TypeId::TINY_INT)
     }
 }
 
@@ -28,9 +27,8 @@ impl Decode<MySql> for u8 {
 }
 
 impl HasSqlType<u16> for MySql {
-    #[inline]
-    fn metadata() -> MySqlTypeMetadata {
-        MySqlTypeMetadata::unsigned(Type::SHORT)
+    fn type_info() -> MySqlTypeInfo {
+        MySqlTypeInfo::unsigned(TypeId::SMALL_INT)
     }
 }
 
@@ -47,9 +45,8 @@ impl Decode<MySql> for u16 {
 }
 
 impl HasSqlType<u32> for MySql {
-    #[inline]
-    fn metadata() -> MySqlTypeMetadata {
-        MySqlTypeMetadata::unsigned(Type::LONG)
+    fn type_info() -> MySqlTypeInfo {
+        MySqlTypeInfo::unsigned(TypeId::INT)
     }
 }
 
@@ -66,9 +63,8 @@ impl Decode<MySql> for u32 {
 }
 
 impl HasSqlType<u64> for MySql {
-    #[inline]
-    fn metadata() -> MySqlTypeMetadata {
-        MySqlTypeMetadata::unsigned(Type::LONGLONG)
+    fn type_info() -> MySqlTypeInfo {
+        MySqlTypeInfo::unsigned(TypeId::BIG_INT)
     }
 }
 

--- a/sqlx-core/src/postgres/arguments.rs
+++ b/sqlx-core/src/postgres/arguments.rs
@@ -39,7 +39,8 @@ impl Arguments for PgArguments {
         // TODO: When/if we receive types that do _not_ support BINARY, we need to check here
         // TODO: There is no need to be explicit unless we are expecting mixed BINARY / TEXT
 
-        self.types.push(<Postgres as HasSqlType<T>>::metadata().oid);
+        self.types
+            .push(<Postgres as HasSqlType<T>>::type_info().id.0);
 
         let pos = self.values.len();
 

--- a/sqlx-core/src/postgres/database.rs
+++ b/sqlx-core/src/postgres/database.rs
@@ -9,6 +9,10 @@ impl Database for Postgres {
     type Arguments = super::PgArguments;
 
     type Row = super::PgRow;
+
+    type TypeInfo = super::PgTypeInfo;
+
+    type TableId = u32;
 }
 
 impl_into_arguments_for_database!(Postgres);

--- a/sqlx-core/src/postgres/mod.rs
+++ b/sqlx-core/src/postgres/mod.rs
@@ -1,14 +1,11 @@
 //! **Postgres** database and connection types.
 
-use std::convert::TryInto;
-
 pub use arguments::PgArguments;
 pub use connection::PgConnection;
 pub use database::Postgres;
 pub use error::PgError;
 pub use row::PgRow;
-
-use crate::url::Url;
+pub use types::PgTypeInfo;
 
 mod arguments;
 mod connection;
@@ -21,6 +18,10 @@ mod types;
 
 /// An alias for [`Pool`], specialized for **Postgres**.
 pub type PgPool = super::Pool<Postgres>;
+
+use std::convert::TryInto;
+
+use crate::url::Url;
 
 // used in tests and hidden code in examples
 #[doc(hidden)]

--- a/sqlx-core/src/postgres/protocol/authentication.rs
+++ b/sqlx-core/src/postgres/protocol/authentication.rs
@@ -1,8 +1,6 @@
 use crate::io::Buf;
 use crate::postgres::protocol::Decode;
 use byteorder::NetworkEndian;
-use std::borrow::Cow;
-use std::io;
 use std::str;
 
 #[derive(Debug)]

--- a/sqlx-core/src/postgres/protocol/backend_key_data.rs
+++ b/sqlx-core/src/postgres/protocol/backend_key_data.rs
@@ -1,7 +1,6 @@
 use super::Decode;
 use crate::io::Buf;
 use byteorder::NetworkEndian;
-use std::io;
 
 #[derive(Debug)]
 pub struct BackendKeyData {

--- a/sqlx-core/src/postgres/protocol/bind.rs
+++ b/sqlx-core/src/postgres/protocol/bind.rs
@@ -1,9 +1,7 @@
 use super::Encode;
 use crate::io::BufMut;
-use crate::postgres::protocol::StatementId;
-use crate::postgres::types::TypeFormat;
+use crate::postgres::protocol::{StatementId, TypeFormat};
 use byteorder::{ByteOrder, NetworkEndian};
-use std::num::NonZeroU32;
 
 pub struct Bind<'a> {
     /// The name of the destination portal (an empty string selects the unnamed portal).

--- a/sqlx-core/src/postgres/protocol/command_complete.rs
+++ b/sqlx-core/src/postgres/protocol/command_complete.rs
@@ -1,6 +1,5 @@
 use crate::io::Buf;
 use crate::postgres::protocol::Decode;
-use std::io;
 
 #[derive(Debug)]
 pub struct CommandComplete {

--- a/sqlx-core/src/postgres/protocol/data_row.rs
+++ b/sqlx-core/src/postgres/protocol/data_row.rs
@@ -1,13 +1,8 @@
 use crate::io::{Buf, ByteStr};
 use crate::postgres::protocol::Decode;
 use byteorder::NetworkEndian;
+use std::fmt::{self, Debug};
 use std::ops::Range;
-use std::{
-    fmt::{self, Debug},
-    io,
-    pin::Pin,
-    ptr::NonNull,
-};
 
 pub struct DataRow {
     buffer: Box<[u8]>,
@@ -58,8 +53,6 @@ impl Decode for DataRow {
 
 impl Debug for DataRow {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use crate::row::Row;
-
         write!(f, "DataRow(")?;
 
         let len = self.values.len();
@@ -77,7 +70,6 @@ impl Debug for DataRow {
 #[cfg(test)]
 mod tests {
     use super::{DataRow, Decode};
-    use crate::Row;
 
     const DATA_ROW: &[u8] = b"\0\x03\0\0\0\x011\0\0\0\x012\0\0\0\x013";
 

--- a/sqlx-core/src/postgres/protocol/decode.rs
+++ b/sqlx-core/src/postgres/protocol/decode.rs
@@ -1,5 +1,3 @@
-use std::io;
-
 pub trait Decode {
     fn decode(buf: &[u8]) -> crate::Result<Self>
     where

--- a/sqlx-core/src/postgres/protocol/describe.rs
+++ b/sqlx-core/src/postgres/protocol/describe.rs
@@ -35,7 +35,6 @@ impl Encode for Describe<'_> {
 #[cfg(test)]
 mod test {
     use super::{Describe, Encode};
-    use crate::io::ByteStr;
     use crate::postgres::protocol::StatementId;
 
     #[test]

--- a/sqlx-core/src/postgres/protocol/mod.rs
+++ b/sqlx-core/src/postgres/protocol/mod.rs
@@ -1,9 +1,11 @@
 //! Low level Postgres protocol. Defines the encoding and decoding of the messages communicated
 //! to and from the database server.
 
-// There is much to the Postgres protocol that is not yet used. As we mature we'll be trimming
-// the size of this module to exactly what is necessary.
-#![allow(unused)]
+mod type_format;
+mod type_id;
+
+pub use type_format::TypeFormat;
+pub use type_id::TypeId;
 
 mod bind;
 mod cancel_request;

--- a/sqlx-core/src/postgres/protocol/notification_response.rs
+++ b/sqlx-core/src/postgres/protocol/notification_response.rs
@@ -1,7 +1,6 @@
 use crate::io::Buf;
 use crate::postgres::protocol::Decode;
 use byteorder::NetworkEndian;
-use std::{fmt, io, pin::Pin, ptr::NonNull};
 
 #[derive(Debug)]
 pub struct NotificationResponse {

--- a/sqlx-core/src/postgres/protocol/parameter_description.rs
+++ b/sqlx-core/src/postgres/protocol/parameter_description.rs
@@ -1,11 +1,10 @@
 use crate::io::Buf;
-use crate::postgres::protocol::Decode;
+use crate::postgres::protocol::{Decode, TypeId};
 use byteorder::NetworkEndian;
-use std::io;
 
 #[derive(Debug)]
 pub struct ParameterDescription {
-    pub ids: Box<[u32]>,
+    pub ids: Box<[TypeId]>,
 }
 
 impl Decode for ParameterDescription {
@@ -14,7 +13,7 @@ impl Decode for ParameterDescription {
         let mut ids = Vec::with_capacity(cnt);
 
         for _ in 0..cnt {
-            ids.push(buf.get_u32::<NetworkEndian>()?);
+            ids.push(TypeId(buf.get_u32::<NetworkEndian>()?));
         }
 
         Ok(Self {
@@ -33,8 +32,8 @@ mod test {
         let desc = ParameterDescription::decode(buf).unwrap();
 
         assert_eq!(desc.ids.len(), 2);
-        assert_eq!(desc.ids[0], 0x0000_0000);
-        assert_eq!(desc.ids[1], 0x0000_0500);
+        assert_eq!(desc.ids[0].0, 0x0000_0000);
+        assert_eq!(desc.ids[1].0, 0x0000_0500);
     }
 
     #[test]

--- a/sqlx-core/src/postgres/protocol/ready_for_query.rs
+++ b/sqlx-core/src/postgres/protocol/ready_for_query.rs
@@ -1,5 +1,4 @@
 use crate::postgres::protocol::Decode;
-use std::io;
 
 #[derive(Debug)]
 #[repr(u8)]

--- a/sqlx-core/src/postgres/protocol/response.rs
+++ b/sqlx-core/src/postgres/protocol/response.rs
@@ -1,11 +1,6 @@
 use crate::io::Buf;
 use crate::postgres::protocol::Decode;
-use std::{
-    fmt, io,
-    pin::Pin,
-    ptr::NonNull,
-    str::{self, FromStr},
-};
+use std::str::{self, FromStr};
 
 #[derive(Debug, Copy, Clone)]
 pub enum Severity {
@@ -24,31 +19,6 @@ impl Severity {
         match self {
             Severity::Panic | Severity::Fatal | Severity::Error => true,
             _ => false,
-        }
-    }
-
-    pub fn is_notice(self) -> bool {
-        match self {
-            Severity::Warning
-            | Severity::Notice
-            | Severity::Debug
-            | Severity::Info
-            | Severity::Log => true,
-
-            _ => false,
-        }
-    }
-
-    pub fn to_str(self) -> &'static str {
-        match self {
-            Severity::Panic => "PANIC",
-            Severity::Fatal => "FATAL",
-            Severity::Error => "ERROR",
-            Severity::Warning => "WARNING",
-            Severity::Notice => "NOTICE",
-            Severity::Debug => "DEBUG",
-            Severity::Info => "INFO",
-            Severity::Log => "LOG",
         }
     }
 }

--- a/sqlx-core/src/postgres/protocol/sasl.rs
+++ b/sqlx-core/src/postgres/protocol/sasl.rs
@@ -1,12 +1,9 @@
 use crate::io::BufMut;
-use crate::postgres::connection::PgConnection;
-use crate::postgres::protocol::authentication::Authentication::SaslContinue;
 use crate::postgres::protocol::Encode;
-use crate::postgres::protocol::Message;
 use crate::Result;
 use byteorder::NetworkEndian;
 use hmac::{Hmac, Mac};
-use sha2::{Digest, Sha256};
+use sha2::Sha256;
 
 pub struct SaslInitialResponse<'a>(pub &'a str);
 

--- a/sqlx-core/src/postgres/protocol/type_format.rs
+++ b/sqlx-core/src/postgres/protocol/type_format.rs
@@ -1,0 +1,17 @@
+#[derive(Debug, Copy, Clone)]
+#[repr(i16)]
+pub enum TypeFormat {
+    Text = 0,
+    Binary = 1,
+}
+
+impl From<i16> for TypeFormat {
+    fn from(code: i16) -> TypeFormat {
+        match code {
+            0 => TypeFormat::Text,
+            1 => TypeFormat::Binary,
+
+            _ => unreachable!(),
+        }
+    }
+}

--- a/sqlx-core/src/postgres/protocol/type_id.rs
+++ b/sqlx-core/src/postgres/protocol/type_id.rs
@@ -1,0 +1,49 @@
+#[derive(Debug, Clone, Copy)]
+pub struct TypeId(pub(crate) u32);
+
+#[allow(dead_code)]
+impl TypeId {
+    // Scalar
+
+    pub(crate) const BOOL: TypeId = TypeId(16);
+
+    pub(crate) const INT2: TypeId = TypeId(21);
+    pub(crate) const INT4: TypeId = TypeId(23);
+    pub(crate) const INT8: TypeId = TypeId(20);
+
+    pub(crate) const FLOAT4: TypeId = TypeId(700);
+    pub(crate) const FLOAT8: TypeId = TypeId(701);
+
+    pub(crate) const TEXT: TypeId = TypeId(25);
+
+    pub(crate) const DATE: TypeId = TypeId(1082);
+    pub(crate) const TIME: TypeId = TypeId(1083);
+    pub(crate) const TIMESTAMP: TypeId = TypeId(1114);
+    pub(crate) const TIMESTAMPTZ: TypeId = TypeId(1184);
+
+    pub(crate) const BYTEA: TypeId = TypeId(17);
+
+    pub(crate) const UUID: TypeId = TypeId(2950);
+
+    // Arrays
+
+    pub(crate) const ARRAY_BOOL: TypeId = TypeId(1000);
+
+    pub(crate) const ARRAY_INT2: TypeId = TypeId(1005);
+    pub(crate) const ARRAY_INT4: TypeId = TypeId(1007);
+    pub(crate) const ARRAY_INT8: TypeId = TypeId(1016);
+
+    pub(crate) const ARRAY_FLOAT4: TypeId = TypeId(1021);
+    pub(crate) const ARRAY_FLOAT8: TypeId = TypeId(1022);
+
+    pub(crate) const ARRAY_TEXT: TypeId = TypeId(1009);
+
+    pub(crate) const ARRAY_DATE: TypeId = TypeId(1182);
+    pub(crate) const ARRAY_TIME: TypeId = TypeId(1183);
+    pub(crate) const ARRAY_TIMESTAMP: TypeId = TypeId(1115);
+    pub(crate) const ARRAY_TIMESTAMPTZ: TypeId = TypeId(1185);
+
+    pub(crate) const ARRAY_BYTEA: TypeId = TypeId(1001);
+
+    pub(crate) const ARRAY_UUID: TypeId = TypeId(2951);
+}

--- a/sqlx-core/src/postgres/types/chrono.rs
+++ b/sqlx-core/src/postgres/types/chrono.rs
@@ -1,27 +1,30 @@
-use crate::decode::{Decode, DecodeError};
-use crate::encode::Encode;
-use crate::postgres::types::PgTypeMetadata;
-use crate::postgres::Postgres;
-use crate::types::HasSqlType;
-use chrono::{DateTime, Duration, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 use std::convert::TryInto;
 use std::mem;
 
+use chrono::{DateTime, Duration, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
+
+use crate::decode::{Decode, DecodeError};
+use crate::encode::Encode;
+use crate::postgres::protocol::TypeId;
+use crate::postgres::types::PgTypeInfo;
+use crate::postgres::Postgres;
+use crate::types::HasSqlType;
+
 impl HasSqlType<NaiveTime> for Postgres {
-    fn metadata() -> PgTypeMetadata {
-        PgTypeMetadata::binary(1083, 1183)
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::TIME)
     }
 }
 
 impl HasSqlType<NaiveDate> for Postgres {
-    fn metadata() -> PgTypeMetadata {
-        PgTypeMetadata::binary(1082, 1182)
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::DATE)
     }
 }
 
 impl HasSqlType<NaiveDateTime> for Postgres {
-    fn metadata() -> PgTypeMetadata {
-        PgTypeMetadata::binary(1114, 1115)
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::TIMESTAMP)
     }
 }
 
@@ -29,8 +32,35 @@ impl<Tz> HasSqlType<DateTime<Tz>> for Postgres
 where
     Tz: TimeZone,
 {
-    fn metadata() -> PgTypeMetadata {
-        PgTypeMetadata::binary(1184, 1185)
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::TIMESTAMPTZ)
+    }
+}
+
+impl HasSqlType<[NaiveTime]> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::ARRAY_TIME)
+    }
+}
+
+impl HasSqlType<[NaiveDate]> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::ARRAY_DATE)
+    }
+}
+
+impl HasSqlType<[NaiveDateTime]> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::ARRAY_TIMESTAMP)
+    }
+}
+
+impl<Tz> HasSqlType<[DateTime<Tz>]> for Postgres
+where
+    Tz: TimeZone,
+{
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::ARRAY_TIMESTAMPTZ)
     }
 }
 

--- a/sqlx-core/src/postgres/types/float.rs
+++ b/sqlx-core/src/postgres/types/float.rs
@@ -1,12 +1,19 @@
 use crate::decode::{Decode, DecodeError};
 use crate::encode::Encode;
-use crate::postgres::types::PgTypeMetadata;
+use crate::postgres::protocol::TypeId;
+use crate::postgres::types::PgTypeInfo;
 use crate::postgres::Postgres;
 use crate::types::HasSqlType;
 
 impl HasSqlType<f32> for Postgres {
-    fn metadata() -> PgTypeMetadata {
-        PgTypeMetadata::binary(700, 1021)
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::FLOAT4)
+    }
+}
+
+impl HasSqlType<[f32]> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::ARRAY_FLOAT4)
     }
 }
 
@@ -25,8 +32,14 @@ impl Decode<Postgres> for f32 {
 }
 
 impl HasSqlType<f64> for Postgres {
-    fn metadata() -> PgTypeMetadata {
-        PgTypeMetadata::binary(701, 1022)
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::FLOAT8)
+    }
+}
+
+impl HasSqlType<[f64]> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::ARRAY_FLOAT8)
     }
 }
 

--- a/sqlx-core/src/postgres/types/int.rs
+++ b/sqlx-core/src/postgres/types/int.rs
@@ -1,13 +1,21 @@
-use crate::decode::{Decode, DecodeError};
-use crate::encode::Encode;
-use crate::postgres::types::PgTypeMetadata;
-use crate::postgres::Postgres;
-use crate::types::HasSqlType;
 use byteorder::{ByteOrder, NetworkEndian};
 
+use crate::decode::{Decode, DecodeError};
+use crate::encode::Encode;
+use crate::postgres::protocol::TypeId;
+use crate::postgres::types::PgTypeInfo;
+use crate::postgres::Postgres;
+use crate::types::HasSqlType;
+
 impl HasSqlType<i16> for Postgres {
-    fn metadata() -> PgTypeMetadata {
-        PgTypeMetadata::binary(21, 1005)
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::INT2)
+    }
+}
+
+impl HasSqlType<[i16]> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::ARRAY_INT2)
     }
 }
 
@@ -24,8 +32,14 @@ impl Decode<Postgres> for i16 {
 }
 
 impl HasSqlType<i32> for Postgres {
-    fn metadata() -> PgTypeMetadata {
-        PgTypeMetadata::binary(23, 1007)
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::INT4)
+    }
+}
+
+impl HasSqlType<[i32]> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::ARRAY_INT4)
     }
 }
 
@@ -42,8 +56,14 @@ impl Decode<Postgres> for i32 {
 }
 
 impl HasSqlType<i64> for Postgres {
-    fn metadata() -> PgTypeMetadata {
-        PgTypeMetadata::binary(20, 1016)
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::INT8)
+    }
+}
+
+impl HasSqlType<[i64]> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::ARRAY_INT8)
     }
 }
 

--- a/sqlx-core/src/postgres/types/mod.rs
+++ b/sqlx-core/src/postgres/types/mod.rs
@@ -10,56 +10,32 @@ mod chrono;
 #[cfg(feature = "uuid")]
 mod uuid;
 
-#[derive(Debug, Copy, Clone)]
-#[repr(i16)]
-pub enum TypeFormat {
-    Text = 0,
-    Binary = 1,
+use std::fmt::{self, Debug, Display};
+
+use crate::postgres::protocol::TypeId;
+use crate::types::TypeInfo;
+
+#[derive(Debug, Clone)]
+pub struct PgTypeInfo {
+    pub(crate) id: TypeId,
 }
 
-impl From<i16> for TypeFormat {
-    fn from(code: i16) -> TypeFormat {
-        match code {
-            0 => TypeFormat::Text,
-            1 => TypeFormat::Binary,
-
-            _ => unreachable!(),
-        }
+impl PgTypeInfo {
+    pub(crate) fn new(id: TypeId) -> Self {
+        Self { id }
     }
 }
 
-impl crate::types::HasTypeMetadata for super::Postgres {
-    type TypeMetadata = PgTypeMetadata;
-
-    type TableId = u32;
-
-    type TypeId = u32;
-}
-
-/// Provides the OIDs for a SQL type and the expected format to be used for
-/// transmission between Rust and Postgres.
-///
-/// While the BINARY format is preferred in most cases, there are scenarios
-/// where only the TEXT format may be available for a type.
-pub struct PgTypeMetadata {
-    #[allow(unused)]
-    pub(crate) format: TypeFormat,
-    pub(crate) oid: u32,
-    pub(crate) array_oid: u32,
-}
-
-impl PgTypeMetadata {
-    const fn binary(oid: u32, array_oid: u32) -> Self {
-        Self {
-            format: TypeFormat::Binary,
-            oid,
-            array_oid,
-        }
+impl Display for PgTypeInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO: Should we attempt to render the type *name* here?
+        write!(f, "{}", self.id.0)
     }
 }
 
-impl PartialEq<u32> for PgTypeMetadata {
-    fn eq(&self, other: &u32) -> bool {
-        self.oid == *other || self.array_oid == *other
+impl TypeInfo for PgTypeInfo {
+    fn compatible(&self, other: &Self) -> bool {
+        // TODO: 99% of postgres types are direct equality for [compatible]; when we add something that isn't (e.g, JSON/JSONB), fix this here
+        self.id.0 == other.id.0
     }
 }

--- a/sqlx-core/src/postgres/types/str.rs
+++ b/sqlx-core/src/postgres/types/str.rs
@@ -1,19 +1,28 @@
-use crate::decode::{Decode, DecodeError};
-use crate::encode::Encode;
-use crate::postgres::types::PgTypeMetadata;
-use crate::types::HasSqlType;
-use crate::Postgres;
 use std::str;
 
+use crate::decode::{Decode, DecodeError};
+use crate::encode::Encode;
+use crate::postgres::protocol::TypeId;
+use crate::postgres::types::PgTypeInfo;
+use crate::types::HasSqlType;
+use crate::Postgres;
+
 impl HasSqlType<str> for Postgres {
-    fn metadata() -> PgTypeMetadata {
-        PgTypeMetadata::binary(25, 1009)
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::TEXT)
     }
 }
 
+impl HasSqlType<[&'_ str]> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::ARRAY_TEXT)
+    }
+}
+
+// TODO: Do we need [HasSqlType] on String here?
 impl HasSqlType<String> for Postgres {
-    fn metadata() -> PgTypeMetadata {
-        <Postgres as HasSqlType<str>>::metadata()
+    fn type_info() -> PgTypeInfo {
+        <Self as HasSqlType<str>>::type_info()
     }
 }
 

--- a/sqlx-core/src/postgres/types/uuid.rs
+++ b/sqlx-core/src/postgres/types/uuid.rs
@@ -1,13 +1,21 @@
-use crate::decode::{Decode, DecodeError};
-use crate::encode::Encode;
-use crate::postgres::types::PgTypeMetadata;
-use crate::postgres::Postgres;
-use crate::types::HasSqlType;
 use uuid::Uuid;
 
+use crate::decode::{Decode, DecodeError};
+use crate::encode::Encode;
+use crate::postgres::protocol::TypeId;
+use crate::postgres::types::PgTypeInfo;
+use crate::postgres::Postgres;
+use crate::types::HasSqlType;
+
 impl HasSqlType<Uuid> for Postgres {
-    fn metadata() -> PgTypeMetadata {
-        PgTypeMetadata::binary(2950, 2951)
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::UUID)
+    }
+}
+
+impl HasSqlType<[Uuid]> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::ARRAY_UUID)
     }
 }
 

--- a/sqlx-macros/src/database/mod.rs
+++ b/sqlx-macros/src/database/mod.rs
@@ -16,9 +16,9 @@ pub trait DatabaseExt: Database {
         syn::parse_str(Self::DATABASE_PATH).unwrap()
     }
 
-    fn param_type_for_id(id: &Self::TypeId) -> Option<&'static str>;
+    fn param_type_for_id(id: &Self::TypeInfo) -> Option<&'static str>;
 
-    fn return_type_for_id(id: &Self::TypeId) -> Option<&'static str>;
+    fn return_type_for_id(id: &Self::TypeInfo) -> Option<&'static str>;
 }
 
 macro_rules! impl_database_ext {
@@ -27,22 +27,22 @@ macro_rules! impl_database_ext {
             const DATABASE_PATH: &'static str = stringify!($database);
             const PARAM_CHECKING: $crate::database::ParamChecking = $crate::database::ParamChecking::$param_checking;
 
-            fn param_type_for_id(id: &Self::TypeId) -> Option<&'static str> {
+            fn param_type_for_id(info: &Self::TypeInfo) -> Option<&'static str> {
                 match () {
                     $(
                         // `if` statements cannot have attributes but these can
                         $(#[$meta])?
-                        _ if <$database as sqlx::types::HasSqlType<$ty>>::metadata().eq(id) => Some(input_ty!($ty $(, $input)?)),
+                        _ if sqlx::types::TypeInfo::compatible(&<$database as sqlx::types::HasSqlType<$ty>>::type_info(), &info) => Some(input_ty!($ty $(, $input)?)),
                     )*
                     _ => None
                 }
             }
 
-            fn return_type_for_id(id: &Self::TypeId) -> Option<&'static str> {
+            fn return_type_for_id(info: &Self::TypeInfo) -> Option<&'static str> {
                 match () {
                     $(
                         $(#[$meta])?
-                        _ if <$database as sqlx::types::HasSqlType<$ty>>::metadata().eq(id) => return Some(stringify!($ty)),
+                        _ if sqlx::types::TypeInfo::compatible(&<$database as sqlx::types::HasSqlType<$ty>>::type_info(), &info) => return Some(stringify!($ty)),
                     )*
                     _ => None
                 }

--- a/sqlx-macros/src/query_macros/mod.rs
+++ b/sqlx-macros/src/query_macros/mod.rs
@@ -8,8 +8,8 @@ pub use query::expand_query;
 
 use crate::database::DatabaseExt;
 
-use sqlx::types::HasTypeMetadata;
 use sqlx::Connection;
+use sqlx::Database;
 
 mod args;
 mod input;
@@ -22,7 +22,7 @@ pub async fn expand_query_file<C: Connection>(
 ) -> crate::Result<TokenStream>
 where
     C::Database: DatabaseExt + Sized,
-    <C::Database as HasTypeMetadata>::TypeId: Display,
+    <C::Database as Database>::TypeInfo: Display,
 {
     expand_query(input.expand_file_src().await?, conn).await
 }
@@ -33,7 +33,7 @@ pub async fn expand_query_as<C: Connection>(
 ) -> crate::Result<TokenStream>
 where
     C::Database: DatabaseExt + Sized,
-    <C::Database as HasTypeMetadata>::TypeId: Display,
+    <C::Database as Database>::TypeInfo: Display,
 {
     let describe = input.query_input.describe_validate(&mut conn).await?;
 
@@ -66,7 +66,7 @@ pub async fn expand_query_file_as<C: Connection>(
 ) -> crate::Result<TokenStream>
 where
     C::Database: DatabaseExt + Sized,
-    <C::Database as HasTypeMetadata>::TypeId: Display,
+    <C::Database as Database>::TypeInfo: Display,
 {
     expand_query_as(input.expand_file_src().await?, conn).await
 }

--- a/sqlx-macros/src/query_macros/output.rs
+++ b/sqlx-macros/src/query_macros/output.rs
@@ -25,8 +25,8 @@ pub fn columns_to_rust<DB: DatabaseExt>(describe: &Describe<DB>) -> crate::Resul
             let ident = syn::parse_str::<Ident>(name)
                 .map_err(|_| format!("{:?} is not a valid Rust identifier", name))?;
 
-            let type_ = <DB as DatabaseExt>::return_type_for_id(&column.type_id)
-                .ok_or_else(|| format!("unknown field type ID: {}", &column.type_id))?
+            let type_ = <DB as DatabaseExt>::return_type_for_id(&column.type_info)
+                .ok_or_else(|| format!("unknown type: {}", &column.type_info))?
                 .parse::<TokenStream>()
                 .unwrap();
 

--- a/sqlx-macros/src/query_macros/query.rs
+++ b/sqlx-macros/src/query_macros/query.rs
@@ -5,7 +5,7 @@ use proc_macro2::TokenStream;
 use syn::{Ident, Path};
 
 use quote::quote;
-use sqlx::{types::HasTypeMetadata, Connection};
+use sqlx::{Connection, Database};
 
 use super::{args, output, QueryMacroInput};
 use crate::database::DatabaseExt;
@@ -18,7 +18,7 @@ pub async fn expand_query<C: Connection>(
 ) -> crate::Result<TokenStream>
 where
     C::Database: DatabaseExt + Sized,
-    <C::Database as HasTypeMetadata>::TypeId: Display,
+    <C::Database as Database>::TypeInfo: Display,
 {
     let describe = input.describe_validate(&mut conn).await?;
     let sql = &input.source;


### PR DESCRIPTION
 * Intending to use in a new Row type to check types at runtime for
   dynamic queries and to guard against schema changes

 * Hoping the query! macro can utilize this to allow accepting N
   rust types for 1 sql type and returning N rust types for 1 sql
   type.