### PR TITLE
Only create tokio runtime once for block_on

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,6 +1420,7 @@ dependencies = [
  "async-std 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -34,9 +34,10 @@ async-std = { version = "1.4.0", default-features = false, optional = true }
 tokio = { version = "0.2", optional = true }
 once_cell = { version = "1.3", optional = true }
 dotenv = { version = "0.15.0", default-features = false }
-futures = { version = "0.3.1", default-features = false }
+futures = { version = "0.3.1", default-features = false, features = ["executor"] }
 proc-macro2 = { version = "1.0.6", default-features = false }
 sqlx = { version = "0.2.0", default-features = false, path = "../sqlx-core", package = "sqlx-core" }
 syn = { version = "1.0.11", default-features = false, features = [ "full" ] }
 quote = { version = "1.0.2", default-features = false }
 url = { version = "2.1.0", default-features = false }
+lazy_static = "1.4.0"

--- a/sqlx-macros/src/lib.rs
+++ b/sqlx-macros/src/lib.rs
@@ -28,7 +28,12 @@ use query_macros::*;
 #[cfg(feature = "runtime-tokio")]
 lazy_static::lazy_static! {
     static ref BASIC_RUNTIME: tokio::runtime::Runtime = {
-        tokio::runtime::Builder::new().threaded_scheduler().enable_all().build().expect("failed to build tokio runtime")
+        tokio::runtime::Builder::new()
+            .threaded_scheduler()
+            .enable_io()
+            .enable_time()
+            .build()
+            .expect("failed to build tokio runtime")
     };
 }
 

--- a/sqlx-macros/src/lib.rs
+++ b/sqlx-macros/src/lib.rs
@@ -28,7 +28,7 @@ use query_macros::*;
 #[cfg(feature = "runtime-tokio")]
 lazy_static::lazy_static! {
     static ref BASIC_RUNTIME: tokio::runtime::Runtime = {
-        tokio::runtime::Builder::new().basic_scheduler().enable_all().build().expect("failed to build tokio runtime")
+        tokio::runtime::Builder::new().threaded_scheduler().enable_all().build().expect("failed to build tokio runtime")
     };
 }
 

--- a/sqlx-macros/src/lib.rs
+++ b/sqlx-macros/src/lib.rs
@@ -26,9 +26,15 @@ mod query_macros;
 use query_macros::*;
 
 #[cfg(feature = "runtime-tokio")]
+lazy_static::lazy_static! {
+    static ref BASIC_RUNTIME: tokio::runtime::Runtime = {
+        tokio::runtime::Builder::new().basic_scheduler().enable_all().build().expect("failed to build tokio runtime")
+    };
+}
+
+#[cfg(feature = "runtime-tokio")]
 fn block_on<F: std::future::Future>(future: F) -> F::Output {
-    // TODO: Someone think of something better for async proc macros + tokio
-    tokio::runtime::Runtime::new().unwrap().block_on(future)
+    BASIC_RUNTIME.enter(|| futures::executor::block_on(future))
 }
 
 fn macro_result(tokens: proc_macro2::TokenStream) -> TokenStream {


### PR DESCRIPTION
Sets up a runtime in a lazy_static for blocking on current thread, and makes use of [`Builder::basic_scheduler`](https://docs.rs/tokio/0.2.9/tokio/runtime/struct.Builder.html#method.basic_scheduler) to _definitely_ avoid spinning up a thread pool for blocking the current thread.

Even if you don't want this particular PR, we should probably still make use of `basic_scheduler`.