### PR TITLE
allow `Option<&str>` to be accepted in place of `String`

### DIFF
--- a/sqlx-core/src/encode.rs
+++ b/sqlx-core/src/encode.rs
@@ -73,10 +73,6 @@ where
     }
 
     fn size_hint(&self) -> usize {
-        if self.is_some() {
-            (*self).size_hint()
-        } else {
-            0
-        }
+        self.as_ref().map_or(0, Encode::size_hint)
     }
 }

--- a/sqlx-macros/src/database/postgres.rs
+++ b/sqlx-macros/src/database/postgres.rs
@@ -1,7 +1,7 @@
 impl_database_ext! {
     sqlx::Postgres {
         bool,
-        String,
+        String | &str,
         i16,
         i32,
         i64,
@@ -9,7 +9,7 @@ impl_database_ext! {
         f64,
 
         // BYTEA
-        Vec<u8>,
+        Vec<u8> | &[u8],
 
         #[cfg(feature = "uuid")]
         sqlx::types::Uuid,

--- a/sqlx-macros/src/query_macros/args.rs
+++ b/sqlx-macros/src/query_macros/args.rs
@@ -49,11 +49,11 @@ pub fn quote_args<DB: DatabaseExt>(
                         let _expr = sqlx::ty_match::dupe_value(&$#name);
 
                         // if `_expr` is `Option<T>`, get `Option<$ty>`, otherwise `$ty`
-                        let wrapped_same = sqlx::ty_match::WrapSame::<#param_ty, _>::new(&_expr).wrap_same();
+                        let ty_check = sqlx::ty_match::WrapSame::<#param_ty, _>::new(&_expr).wrap_same();
                         // if `_expr` is `&str`, convert `String` to `&str`
-                        let mut ty_check = sqlx::ty_match::MatchBorrow::new(wrapped_same, &_expr).match_borrow();
+                        let (mut ty_check, match_borrow) = sqlx::ty_match::MatchBorrow::new(ty_check, &_expr);
 
-                        ty_check = _expr;
+                        ty_check = match_borrow.match_borrow();
 
                         // this causes move-analysis to effectively ignore this block
                         panic!();

--- a/sqlx-macros/src/query_macros/input.rs
+++ b/sqlx-macros/src/query_macros/input.rs
@@ -57,10 +57,8 @@ impl QueryMacroInput {
         };
 
         let arg_exprs: Vec<_> = args.collect();
-        let arg_names = arg_exprs
-            .iter()
-            .enumerate()
-            .map(|(i, arg)| format_ident!("arg{}", i, span = expr_span(arg)))
+        let arg_names = (0..arg_exprs.len())
+            .map(|i| format_ident!("arg{}", i))
             .collect();
 
         Ok(Self {
@@ -212,12 +210,4 @@ async fn read_file_src(source: &str, source_span: Span) -> syn::Result<String> {
             ),
         )
     })
-}
-
-fn expr_span(expr: &Expr) -> Span {
-    if let Expr::Group(ExprGroup { expr, .. }) = expr {
-        expr.span()
-    } else {
-        expr.span()
-    }
 }

--- a/sqlx-macros/src/query_macros/mod.rs
+++ b/sqlx-macros/src/query_macros/mod.rs
@@ -45,8 +45,7 @@ where
         .into());
     }
 
-    let args_tokens = args::quote_args(&input.query_input, &describe)?;
-    let arg_names = &input.query_input.arg_names;
+    let args = args::quote_args(&input.query_input, &describe)?;
 
     let columns = output::columns_to_rust(&describe)?;
     let output = output::quote_query_as::<C::Database>(
@@ -55,24 +54,14 @@ where
         &columns,
     );
 
-    let db_path = <C::Database as DatabaseExt>::quotable_path();
-    let args_count = arg_names.len();
-    let arg_indices = (0..args_count).map(|i| syn::Index::from(i));
-    let arg_indices_2 = arg_indices.clone();
+    let arg_names = &input.query_input.arg_names;
 
     Ok(quote! {
         macro_rules! macro_result {
             (#($#arg_names:expr),*) => {{
                 use sqlx::arguments::Arguments as _;
 
-                #args_tokens
-
-                let mut query_args = <#db_path as sqlx::Database>::Arguments::default();
-                query_args.reserve(
-                    #args_count,
-                    0 #(+ sqlx::encode::Encode::<#db_path>::size_hint(args.#arg_indices))*
-                );
-                #(query_args.add(args.#arg_indices_2);)*
+                #args
 
                 #output.bind_all(query_args)
             }}

--- a/sqlx-macros/src/query_macros/query.rs
+++ b/sqlx-macros/src/query_macros/query.rs
@@ -26,10 +26,6 @@ where
     let args = args::quote_args(&input, &describe)?;
 
     let arg_names = &input.arg_names;
-    let args_count = arg_names.len();
-    let arg_indices = (0..args_count).map(|i| syn::Index::from(i));
-    let arg_indices_2 = arg_indices.clone();
-    let db_path = <C::Database as DatabaseExt>::quotable_path();
 
     if describe.result_columns.is_empty() {
         return Ok(quote! {
@@ -38,14 +34,6 @@ where
                     use sqlx::arguments::Arguments as _;
 
                     #args
-
-                    let mut query_args = <#db_path as sqlx::Database>::Arguments::default();
-                    query_args.reserve(
-                        #args_count,
-                        0 #(+ sqlx::encode::Encode::<#db_path>::size_hint(args.#arg_indices))*
-                    );
-
-                    #(query_args.add(args.#arg_indices_2);)*
 
                     sqlx::query_as_mapped(#sql, |_| Ok(())).bind_all(query_args)
                 }
@@ -83,14 +71,6 @@ where
                 }
 
                 #args
-
-                let mut query_args = <#db_path as sqlx::Database>::Arguments::default();
-                query_args.reserve(
-                    #args_count,
-                    0 #(+ sqlx::encode::Encode::<#db_path>::size_hint(args.#arg_indices))*
-                );
-
-                #(query_args.add(args.#arg_indices_2);)*
 
                 #output.bind_all(query_args)
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ mod macros;
 // macro support
 #[cfg(feature = "macros")]
 #[doc(hidden)]
-pub mod ty_cons;
+pub mod ty_match;
 
 #[cfg(feature = "macros")]
 #[doc(hidden)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -94,12 +94,12 @@ macro_rules! query (
         }
         macro_result!()
     });
-    ($query:literal, $($args:expr),*) => ({
+    ($query:literal, $($args:tt)*) => ({
         #[macro_use]
         mod _macro_result {
-            $crate::sqlx_macros::query!($query, $($args),*);
+            $crate::sqlx_macros::query!($query, $($args)*);
         }
-        macro_result!($($args),*)
+        macro_result!($($args)*)
     })
 );
 
@@ -155,12 +155,12 @@ macro_rules! query_file (
         }
         macro_result!()
     });
-    ($query:literal, $($args:expr),*) => (#[allow(dead_code)]{
+    ($query:literal, $($args:tt)*) => (#[allow(dead_code)]{
         #[macro_use]
         mod _macro_result {
-            $crate::sqlx_macros::query_file!($query, $($args),*);
+            $crate::sqlx_macros::query_file!($query, $($args)*);
         }
-        macro_result!($($args),*)
+        macro_result!($($args)*)
     })
 );
 
@@ -221,12 +221,12 @@ macro_rules! query_as (
         }
         macro_result!()
     });
-    ($out_struct:path, $query:literal, $($args:expr),*) => (#[allow(dead_code)] {
+    ($out_struct:path, $query:literal, $($args:tt)*) => (#[allow(dead_code)] {
         #[macro_use]
         mod _macro_result {
-            $crate::sqlx_macros::query_as!($out_struct, $query, $($args),*);
+            $crate::sqlx_macros::query_as!($out_struct, $query, $($args)*);
         }
-        macro_result!($($args),*)
+        macro_result!($($args)*)
     })
 );
 
@@ -272,11 +272,11 @@ macro_rules! query_file_as (
         }
         macro_result!()
     });
-    ($out_struct:path, $query:literal, $($args:expr),*) => (#[allow(dead_code)] {
+    ($out_struct:path, $query:literal, $($args:tt)*) => (#[allow(dead_code)] {
         #[macro_use]
         mod _macro_result {
-            $crate::sqlx_macros::query_file_as!($out_struct, $query, $($args),*);
+            $crate::sqlx_macros::query_file_as!($out_struct, $query, $($args)*);
         }
-        macro_result!($($args),*)
+        macro_result!($($args)*)
     })
 );

--- a/src/ty_cons.rs
+++ b/src/ty_cons.rs
@@ -5,95 +5,107 @@ use std::marker::PhantomData;
 
 // For query parameters, database gives us a single type ID which we convert to an "expected" or
 // preferred Rust type, but there can actually be several types that are compatible for a given type
-// in input position.
+// in input position. E.g. for an expected parameter of `String`, we want to accept `String`,
+// `Option<String>`, `&str` and `Option<&str>`. And for the best compiler errors we don't just
+// want an `IsCompatible` trait (at least not without `#[on_unimplemented]` which is unstable
+// for the foreseeable future).
 
 // We can do this by using autoref (for method calls, the compiler adds reference ops until
 // it finds a matching impl) with impls that technically don't overlap as a hacky form of
 // specialization (but this works only if all types are statically known, i.e. we're not in a
 // generic context; this should suit 99% of use cases for the macros).
 
-#[doc(hidden)]
-pub struct TyCons<T: ?Sized>(PhantomData<T>);
+pub struct InnerType<T>(PhantomData<T>);
 
-impl<T: ?Sized> TyCons<T> {
-    pub fn new(_t: &T) -> TyCons<T> {
-        TyCons(PhantomData)
+impl<T: Sized> InnerType<T> {
+    fn new(_t: T) -> Self { InnerType(PhantomData) }
+}
+
+pub trait InnerTypeExt: Sized {
+    type Inner: Sized;
+    fn inner_type(self) -> Self::Inner {
+        panic!("only for type resolution")
     }
 }
 
-#[doc(hidden)]
-pub trait TyConsExt: Sized {
-    type Cons;
-    fn ty_cons(self) -> Self::Cons {
-        panic!("should not be run, only for type resolution")
+impl<T> InnerTypeExt for InnerType<Option<T>> {
+    type Inner = T;
+}
+
+impl<T> InnerTypeExt for &'_ InnerType<T> {
+    type Inner = T;
+}
+
+pub struct MatchBorrow<T, U>(PhantomData<T>, PhantomData<U>);
+
+impl<T, U> MatchBorrow<T, U> {
+    fn new(_u: U) -> Self { MatchBorrow(PhantomData, PhantomData) }
+}
+
+pub trait MatchBorrowExt: Sized {
+    type Matched;
+
+    fn match_borrow(self) -> Self::Matched {
+        panic!("only for type resolution")
     }
-
-    // if we're two resolutions deep, e.g. trying to match `Option<&str>` with `String`,
-    // lift through one of them.
-    // https://github.com/launchbadge/sqlx/issues/93
-    fn lift(self) -> TyCons<Self::Cons> {
-        TyCons::new(&self.ty_cons())
-    }
 }
 
-impl<T> TyCons<Option<&'_ T>> {
-    pub fn ty_cons(self) -> T {
-        panic!("should not be run, only for type resolution")
-    }
+impl<'a> MatchBorrowExt for MatchBorrow<String, &'a str> {
+    type Matched = &'a str;
 }
 
-// no overlap with the following impls because of the `: Sized` bound
-impl<T: Sized> TyConsExt for TyCons<&'_ T> {
-    type Cons = T;
+impl<'a> MatchBorrowExt for MatchBorrow<Vec<u8>, &'a [u8]> {
+    type Matched = &'a [u8];
 }
 
-impl TyConsExt for TyCons<str> {
-    type Cons = String;
+impl<'a, T: 'a, U: 'a> MatchBorrowExt for MatchBorrow<T, &'a U> {
+    type Matched = &'a U;
 }
 
-impl<T> TyConsExt for TyCons<[T]> {
-    type Cons = Vec<T>;
+impl<T, U> MatchBorrowExt for &'_ MatchBorrow<T, U> {
+    type Matched = T;
 }
 
-impl TyConsExt for TyCons<&'_ str> {
-    type Cons = String;
-}
-
-impl<T> TyConsExt for TyCons<&'_ [T]> {
-    type Cons = Vec<T>;
-}
-
-impl<T> TyConsExt for TyCons<Option<T>> {
-    type Cons = T;
-}
-
-impl<T> TyConsExt for &'_ TyCons<T> {
-    type Cons = T;
+fn conjure_value<T>() -> T {
+    panic!()
 }
 
 #[test]
 fn test_tycons_ext() {
     if false {
-        let _: u64 = TyCons::new(&Some(5u64)).lift().ty_cons();
-        let _: u64 = TyCons::new(&Some(&5u64)).lift().ty_cons();
-        let _: u64 = TyCons::new(&&5u64).lift().ty_cons();
-        let _: u64 = TyCons::new(&5u64).lift().ty_cons();
+        let mut arg: u64 = InnerType::new(Some(5u64)).inner_type();
+        arg = MatchBorrow::<u64, _>::new(arg).match_borrow();
 
-        // Option<&str>
-        let _: String = TyCons::new(&Some("Hello, world!")).lift().ty_cons();
-        // Option<String>
-        let _: String = TyCons::new(&Some("Hello, world!".to_string()))
-            .lift()
-            .ty_cons();
-        // Option<&String>
-        let _: String = TyCons::new(&Some(&"Hello, world!".to_string()))
-            .lift()
-            .ty_cons();
-        // &str
-        let _: String = TyCons::new(&"Hello, world!").lift().ty_cons();
-        // String
-        let _: String = TyCons::new(&"Hello, world!".to_string()).lift().ty_cons();
-        // str
-        let _: String = TyCons::new("Hello, world!").lift().ty_cons();
+        let mut arg: &u64 = InnerType::new(Some(&5u64)).inner_type();
+        arg = MatchBorrow::<u64, _>::new(arg).match_borrow();
+
+        let mut arg: &u64 = InnerType::new(&5u64).inner_type();
+        arg = MatchBorrow::<u64, _>::new(arg).match_borrow();
+
+        let mut arg: &u64 = InnerType::new(&&5u64).inner_type();
+        arg = MatchBorrow::<u64, _>::new(arg).match_borrow();
+
+        let mut arg: &str = InnerType::new("Hello, world").inner_type();
+        arg = MatchBorrow::<String, _>::new(arg).match_borrow();
+
+        let mut arg: &&str = InnerType::new(&"Hello, world").inner_type();
+        arg = MatchBorrow::<String, _>::new(arg).match_borrow();
+
+        let mut arg: &str = InnerType::new(Some("Hello, world")).inner_type();
+        arg = MatchBorrow::<String, _>::new(arg).match_borrow();
+
+        let s = "Hello, world".to_string();
+        let mut arg: &String = InnerType::new(Some(&s)).inner_type();
+        arg = MatchBorrow::<String, _>::new(arg).match_borrow();
+
+        let mut arg: String = InnerType::new(Some(s)).inner_type();
+        arg = MatchBorrow::<String, _>::new(arg).match_borrow();
+
+        let s = "Hello, world".to_string();
+        let mut arg: &String = InnerType::new(&s).inner_type();
+        arg = MatchBorrow::<String, _>::new(arg).match_borrow();
+
+        let mut arg: String = InnerType::new(s).inner_type();
+        arg = MatchBorrow::<String, _>::new(arg).match_borrow();
     }
 }

--- a/src/ty_cons.rs
+++ b/src/ty_cons.rs
@@ -1,13 +1,21 @@
 use std::marker::PhantomData;
 
-// These types allow the `sqlx_macros::query_[as]!()` macros to polymorphically compare a
-// given parameter's type to an expected parameter type even if the former
-// is behind a reference or in `Option`
+// These types allow the `query!()` and friends to compare a given parameter's type to
+// an expected parameter type even if the former is behind a reference or in `Option`.
+
+// For query parameters, database gives us a single type ID which we convert to an "expected" or
+// preferred Rust type, but there can actually be several types that are compatible for a given type
+// in input position.
+
+// We can do this by using autoref (for method calls, the compiler adds reference ops until
+// it finds a matching impl) with impls that technically don't overlap as a hacky form of
+// specialization (but this works only if all types are statically known, i.e. we're not in a
+// generic context; this should suit 99% of use cases for the macros).
 
 #[doc(hidden)]
-pub struct TyCons<T>(PhantomData<T>);
+pub struct TyCons<T: ?Sized>(PhantomData<T>);
 
-impl<T> TyCons<T> {
+impl<T: ?Sized> TyCons<T> {
     pub fn new(_t: &T) -> TyCons<T> {
         TyCons(PhantomData)
     }
@@ -18,6 +26,13 @@ pub trait TyConsExt: Sized {
     type Cons;
     fn ty_cons(self) -> Self::Cons {
         panic!("should not be run, only for type resolution")
+    }
+
+    // if we're two resolutions deep, e.g. trying to match `Option<&str>` with `String`,
+    // lift through one of them.
+    // https://github.com/launchbadge/sqlx/issues/93
+    fn lift(self) -> TyCons<Self::Cons> {
+        TyCons::new(&self.ty_cons())
     }
 }
 
@@ -30,6 +45,14 @@ impl<T> TyCons<Option<&'_ T>> {
 // no overlap with the following impls because of the `: Sized` bound
 impl<T: Sized> TyConsExt for TyCons<&'_ T> {
     type Cons = T;
+}
+
+impl TyConsExt for TyCons<str> {
+    type Cons = String;
+}
+
+impl<T> TyConsExt for TyCons<[T]> {
+    type Cons = Vec<T>;
 }
 
 impl TyConsExt for TyCons<&'_ str> {
@@ -51,9 +74,26 @@ impl<T> TyConsExt for &'_ TyCons<T> {
 #[test]
 fn test_tycons_ext() {
     if false {
-        let _: u64 = TyCons::new(&Some(5u64)).ty_cons();
-        let _: u64 = TyCons::new(&Some(&5u64)).ty_cons();
-        let _: u64 = TyCons::new(&&5u64).ty_cons();
-        let _: u64 = TyCons::new(&5u64).ty_cons();
+        let _: u64 = TyCons::new(&Some(5u64)).lift().ty_cons();
+        let _: u64 = TyCons::new(&Some(&5u64)).lift().ty_cons();
+        let _: u64 = TyCons::new(&&5u64).lift().ty_cons();
+        let _: u64 = TyCons::new(&5u64).lift().ty_cons();
+
+        // Option<&str>
+        let _: String = TyCons::new(&Some("Hello, world!")).lift().ty_cons();
+        // Option<String>
+        let _: String = TyCons::new(&Some("Hello, world!".to_string()))
+            .lift()
+            .ty_cons();
+        // Option<&String>
+        let _: String = TyCons::new(&Some(&"Hello, world!".to_string()))
+            .lift()
+            .ty_cons();
+        // &str
+        let _: String = TyCons::new(&"Hello, world!").lift().ty_cons();
+        // String
+        let _: String = TyCons::new(&"Hello, world!".to_string()).lift().ty_cons();
+        // str
+        let _: String = TyCons::new("Hello, world!").lift().ty_cons();
     }
 }

--- a/src/ty_match.rs
+++ b/src/ty_match.rs
@@ -18,7 +18,9 @@ use std::marker::PhantomData;
 pub struct InnerType<T>(PhantomData<T>);
 
 impl<T: Sized> InnerType<T> {
-    pub fn new(_t: T) -> Self { InnerType(PhantomData) }
+    pub fn new(_t: T) -> Self {
+        InnerType(PhantomData)
+    }
 }
 
 pub trait InnerTypeExt: Sized {
@@ -39,7 +41,9 @@ impl<T> InnerTypeExt for &'_ InnerType<T> {
 pub struct MatchBorrow<T, U>(PhantomData<T>, PhantomData<U>);
 
 impl<T, U> MatchBorrow<T, U> {
-    pub fn new(_u: U) -> Self { MatchBorrow(PhantomData, PhantomData) }
+    pub fn new(_u: U) -> Self {
+        MatchBorrow(PhantomData, PhantomData)
+    }
 }
 
 pub trait MatchBorrowExt: Sized {
@@ -64,10 +68,6 @@ impl<'a, T: 'a, U: 'a> MatchBorrowExt for MatchBorrow<T, &'a U> {
 
 impl<T, U> MatchBorrowExt for &'_ MatchBorrow<T, U> {
     type Matched = T;
-}
-
-fn conjure_value<T>() -> T {
-    panic!()
 }
 
 #[test]

--- a/src/ty_match.rs
+++ b/src/ty_match.rs
@@ -44,8 +44,8 @@ impl<T, U> WrapSameExt for &'_ WrapSame<T, U> {
 pub struct MatchBorrow<T, U>(PhantomData<T>, PhantomData<U>);
 
 impl<T, U> MatchBorrow<T, U> {
-    pub fn new(_t: T, _u: &U) -> Self {
-        MatchBorrow(PhantomData, PhantomData)
+    pub fn new(t: T, _u: &U) -> (T, Self) {
+        (t, MatchBorrow(PhantomData, PhantomData))
     }
 }
 
@@ -57,32 +57,24 @@ pub trait MatchBorrowExt: Sized {
     }
 }
 
-impl<'a> MatchBorrowExt for MatchBorrow<Option<String>, Option<&'a str>> {
+impl<'a> MatchBorrowExt for MatchBorrow<Option<&'a str>, Option<String>> {
     type Matched = Option<&'a str>;
 }
 
-impl<'a> MatchBorrowExt for MatchBorrow<Option<Vec<u8>>, Option<&'a [u8]>> {
+impl<'a> MatchBorrowExt for MatchBorrow<Option<&'a str>, Option<Vec<u8>>> {
     type Matched = Option<&'a [u8]>;
 }
 
-impl<'a> MatchBorrowExt for MatchBorrow<String, &'a str> {
+impl<'a> MatchBorrowExt for MatchBorrow<&'a str, String> {
     type Matched = &'a str;
 }
 
-impl<'a> MatchBorrowExt for MatchBorrow<Vec<u8>, &'a [u8]> {
+impl<'a> MatchBorrowExt for MatchBorrow<&'a [u8], Vec<u8>> {
     type Matched = &'a [u8];
 }
 
-impl<'a, T: 'a, U: 'a> MatchBorrowExt for MatchBorrow<Option<T>, Option<&'a U>> {
-    type Matched = Option<&'a T>;
-}
-
-impl<'a, T: 'a, U: 'a> MatchBorrowExt for MatchBorrow<T, &'a U> {
-    type Matched = &'a T;
-}
-
 impl<T, U> MatchBorrowExt for &'_ MatchBorrow<T, U> {
-    type Matched = T;
+    type Matched = U;
 }
 
 pub fn conjure_value<T>() -> T {

--- a/src/ty_match.rs
+++ b/src/ty_match.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 // These types allow the `query!()` and friends to compare a given parameter's type to
 // an expected parameter type even if the former is behind a reference or in `Option`.
 
-// For query parameters, database gives us a single type ID which we convert to an "expected" or
+// For query parameters, Postgres gives us a single type ID which we convert to an "expected" or
 // preferred Rust type, but there can actually be several types that are compatible for a given type
 // in input position. E.g. for an expected parameter of `String`, we want to accept `String`,
 // `Option<String>`, `&str` and `Option<&str>`. And for the best compiler errors we don't just
@@ -15,35 +15,7 @@ use std::marker::PhantomData;
 // specialization (but this works only if all types are statically known, i.e. we're not in a
 // generic context; this should suit 99% of use cases for the macros).
 
-#[macro_export]
-#[doc(hidden)]
-macro_rules! match_type(
-    ($($ty:ty : $expr:expr),*,) => ({
-        // this shouldn't actually run
-        $(if false {
-            use $crate::ty_match::{WrapSameExt as _, MatchBorrowExt as _};
-
-            let mut _expr = $crate::ty_match::conjure_value();
-
-            if false {
-                // make sure `_expr` has the right type but in a way that the compiler
-                // doesn't consider `$expr` to be moved
-                _expr = $expr;
-                panic!();
-            }
-
-            // if `_expr` is `Option<T>`, get `Option<$ty>`, otherwise `$ty`
-            let wrapped_same = $crate::ty_match::WrapSame::<$ty, _>::new(&_expr).wrap_same();
-            // if `_expr` is `&str`, convert `String` to `&str`
-            let mut _ty_check = $crate::ty_match::MatchBorrow::new(&wrapped_same, &_expr).match_borrow();
-
-            // test that `typeof ty_check == typeof $expr`
-            _ty_check = $expr;
-            // prevents `$expr` from being considered moved
-            panic!();
-        })*
-    })
-);
+pub fn same_type<T>(_1: &T, _2: &T) {}
 
 pub struct WrapSame<T, U>(PhantomData<T>, PhantomData<U>);
 
@@ -72,7 +44,7 @@ impl<T, U> WrapSameExt for &'_ WrapSame<T, U> {
 pub struct MatchBorrow<T, U>(PhantomData<T>, PhantomData<U>);
 
 impl<T, U> MatchBorrow<T, U> {
-    pub fn new(_t: &T, _u: &U) -> Self {
+    pub fn new(_t: T, _u: &U) -> Self {
         MatchBorrow(PhantomData, PhantomData)
     }
 }
@@ -117,31 +89,34 @@ pub fn conjure_value<T>() -> T {
     panic!()
 }
 
+pub fn dupe_value<T>(_t: &T) -> T {
+    panic!()
+}
+
 #[test]
-fn test_match_type() {
-    match_type!(
-        u64: 5u64,
-        u64: &5u64,
-        u64: &&5u64,
-        u64: Some(5u64),
-        u64: Some(&5u64),
-        u64: Option::<u64>::None,
-    );
+fn test_dupe_value() {
+    let ref val = (String::new(),);
 
-    match_type!(
-        String: "Hello, world",
-        String: "Hello, world",
-        String: Some("Hello, world"),
-    );
+    if false {
+        let _: i32 = dupe_value(&0i32);
+        let _: String = dupe_value(&String::new());
+        let _: String = dupe_value(&val.0);
+    }
+}
 
-    let s = "Hello, world".to_string();
+#[test]
+fn test_wrap_same() {
+    if false {
+        let _: i32 = WrapSame::<i32, _>::new(&0i32).wrap_same();
+        let _: i32 = WrapSame::<i32, _>::new(&"hello, world!").wrap_same();
+        let _: Option<i32> = WrapSame::<i32, _>::new(&Some(String::new())).wrap_same();
+    }
+}
 
-    match_type!(
-        String: &s,
-        String: &s[..],
-        String: Some(&s),
-        String: Some(&s[..]),
-        String: Some(s.clone()),
-        String: s,
-    );
+#[test]
+fn test_match_borrow() {
+    if false {
+        let _: String = MatchBorrow::new(String::new(), &0i32).match_borrow();
+        let _: &str = MatchBorrow::new(String::new(), &&0i32).match_borrow();
+    }
 }

--- a/src/ty_match.rs
+++ b/src/ty_match.rs
@@ -18,7 +18,7 @@ use std::marker::PhantomData;
 pub struct InnerType<T>(PhantomData<T>);
 
 impl<T: Sized> InnerType<T> {
-    fn new(_t: T) -> Self { InnerType(PhantomData) }
+    pub fn new(_t: T) -> Self { InnerType(PhantomData) }
 }
 
 pub trait InnerTypeExt: Sized {
@@ -39,7 +39,7 @@ impl<T> InnerTypeExt for &'_ InnerType<T> {
 pub struct MatchBorrow<T, U>(PhantomData<T>, PhantomData<U>);
 
 impl<T, U> MatchBorrow<T, U> {
-    fn new(_u: U) -> Self { MatchBorrow(PhantomData, PhantomData) }
+    pub fn new(_u: U) -> Self { MatchBorrow(PhantomData, PhantomData) }
 }
 
 pub trait MatchBorrowExt: Sized {

--- a/tests/postgres-macros.rs
+++ b/tests/postgres-macros.rs
@@ -54,9 +54,11 @@ struct Account {
 async fn test_query_as() -> anyhow::Result<()> {
     let mut conn = connect().await?;
 
+    let name: Option<&str> = None;
     let account = sqlx::query_as!(
         Account,
-        "SELECT * from (VALUES (1, null)) accounts(id, name)"
+        "SELECT * from (VALUES (1, $1)) accounts(id, name)",
+        name
     )
     .fetch_one(&mut conn)
     .await?;

--- a/tests/postgres-macros.rs
+++ b/tests/postgres-macros.rs
@@ -119,9 +119,12 @@ async fn query_by_string() -> anyhow::Result<()> {
 
     let result = sqlx::query!(
         "SELECT * from (VALUES('Hello, world!')) strings(string)\
-         where string = $1 or string = $2",
+         where string in ($1, $2, $3, $4, $5)",
         string,
-        string[..]
+        string[..],
+        Some(&string),
+        Some(&string[..]),
+        Option::<String>::None
     )
     .fetch_one(&mut conn)
     .await?;

--- a/tests/postgres-macros.rs
+++ b/tests/postgres-macros.rs
@@ -119,12 +119,13 @@ async fn query_by_string() -> anyhow::Result<()> {
 
     let result = sqlx::query!(
         "SELECT * from (VALUES('Hello, world!')) strings(string)\
-         where string in ($1, $2, $3, $4, $5)",
-        string,
-        string[..],
+         where string in ($1, $2, $3, $4, $5, $6)",
+        string, // make sure we don't actually take ownership here
+        &string[..],
         Some(&string),
         Some(&string[..]),
-        Option::<String>::None
+        Option::<String>::None,
+        string.clone()
     )
     .fetch_one(&mut conn)
     .await?;

--- a/tests/postgres-macros.rs
+++ b/tests/postgres-macros.rs
@@ -116,16 +116,18 @@ async fn query_by_string() -> anyhow::Result<()> {
     let mut conn = connect().await?;
 
     let string = "Hello, world!".to_string();
+    let ref tuple = ("Hello, world!".to_string(),);
 
     let result = sqlx::query!(
         "SELECT * from (VALUES('Hello, world!')) strings(string)\
-         where string in ($1, $2, $3, $4, $5, $6)",
+         where string in ($1, $2, $3, $4, $5, $6, $7)",
         string, // make sure we don't actually take ownership here
         &string[..],
         Some(&string),
         Some(&string[..]),
         Option::<String>::None,
-        string.clone()
+        string.clone(),
+        tuple.0 // make sure we're not trying to move out of a field expression
     )
     .fetch_one(&mut conn)
     .await?;

--- a/tests/ui/postgres/wrong_param_type.rs
+++ b/tests/ui/postgres/wrong_param_type.rs
@@ -1,6 +1,8 @@
 fn main() {
     let _query = sqlx::query!("select $1::text", 0i32);
 
+    let _query = sqlx::query!("select $1::text", &0i32);
+
     let _query = sqlx::query!("select $1::text", Some(0i32));
 
     let arg = 0i32;

--- a/tests/ui/postgres/wrong_param_type.rs
+++ b/tests/ui/postgres/wrong_param_type.rs
@@ -1,0 +1,11 @@
+fn main() {
+    let _query = sqlx::query!("select $1::text", 0i32);
+
+    let _query = sqlx::query!("select $1::text", Some(0i32));
+
+    let arg = Some(0i32);
+    let _query = sqlx::query!("select $1::text", arg);
+
+    let arg = 0i32;
+    let _query = sqlx::query!("select $1::text", arg);
+}

--- a/tests/ui/postgres/wrong_param_type.rs
+++ b/tests/ui/postgres/wrong_param_type.rs
@@ -3,9 +3,10 @@ fn main() {
 
     let _query = sqlx::query!("select $1::text", Some(0i32));
 
-    let arg = Some(0i32);
-    let _query = sqlx::query!("select $1::text", arg);
-
     let arg = 0i32;
     let _query = sqlx::query!("select $1::text", arg);
+
+    let arg = Some(0i32);
+    let _query = sqlx::query!("select $1::text", arg);
+    let _query = sqlx::query!("select $1::text", arg.as_ref());
 }

--- a/tests/ui/postgres/wrong_param_type.stderr
+++ b/tests/ui/postgres/wrong_param_type.stderr
@@ -2,43 +2,46 @@ error[E0308]: mismatched types
  --> $DIR/wrong_param_type.rs:2:50
   |
 2 |     let _query = sqlx::query!("select $1::text", 0i32);
-  |                                                  ^^^^
-  |                                                  |
-  |                                                  expected struct `std::string::String`, found `i32`
-  |                                                  help: try using a conversion method: `0i32.to_string()`
+  |                                                  ^^^^ expected `&str`, found `i32`
 
 error[E0308]: mismatched types
  --> $DIR/wrong_param_type.rs:4:50
   |
-4 |     let _query = sqlx::query!("select $1::text", Some(0i32));
-  |                                                  ^^^^^^^^^^ expected struct `std::string::String`, found `i32`
+4 |     let _query = sqlx::query!("select $1::text", &0i32);
+  |                                                  ^^^^^ expected `str`, found `i32`
   |
-  = note: expected enum `std::option::Option<std::string::String>`
+  = note: expected reference `&str`
+             found reference `&i32`
+
+error[E0308]: mismatched types
+ --> $DIR/wrong_param_type.rs:6:50
+  |
+6 |     let _query = sqlx::query!("select $1::text", Some(0i32));
+  |                                                  ^^^^^^^^^^ expected `&str`, found `i32`
+  |
+  = note: expected enum `std::option::Option<&str>`
              found enum `std::option::Option<i32>`
 
 error[E0308]: mismatched types
- --> $DIR/wrong_param_type.rs:7:50
+ --> $DIR/wrong_param_type.rs:9:50
   |
-7 |     let _query = sqlx::query!("select $1::text", arg);
-  |                                                  ^^^
-  |                                                  |
-  |                                                  expected struct `std::string::String`, found `i32`
-  |                                                  help: try using a conversion method: `arg.to_string()`
+9 |     let _query = sqlx::query!("select $1::text", arg);
+  |                                                  ^^^ expected `&str`, found `i32`
 
 error[E0308]: mismatched types
-  --> $DIR/wrong_param_type.rs:10:50
+  --> $DIR/wrong_param_type.rs:12:50
    |
-10 |     let _query = sqlx::query!("select $1::text", arg);
-   |                                                  ^^^ expected struct `std::string::String`, found `i32`
+12 |     let _query = sqlx::query!("select $1::text", arg);
+   |                                                  ^^^ expected `&str`, found `i32`
    |
-   = note: expected enum `std::option::Option<std::string::String>`
+   = note: expected enum `std::option::Option<&str>`
               found enum `std::option::Option<i32>`
 
 error[E0308]: mismatched types
-  --> $DIR/wrong_param_type.rs:11:50
+  --> $DIR/wrong_param_type.rs:13:50
    |
-11 |     let _query = sqlx::query!("select $1::text", arg.as_ref());
-   |                                                  ^^^^^^^^^^^^ expected struct `std::string::String`, found `i32`
+13 |     let _query = sqlx::query!("select $1::text", arg.as_ref());
+   |                                                  ^^^^^^^^^^^^ expected `str`, found `i32`
    |
-   = note: expected enum `std::option::Option<&std::string::String>`
+   = note: expected enum `std::option::Option<&str>`
               found enum `std::option::Option<&i32>`

--- a/tests/ui/postgres/wrong_param_type.stderr
+++ b/tests/ui/postgres/wrong_param_type.stderr
@@ -8,28 +8,37 @@ error[E0308]: mismatched types
   |                                                  help: try using a conversion method: `0i32.to_string()`
 
 error[E0308]: mismatched types
- --> $DIR/wrong_param_type.rs:4:55
+ --> $DIR/wrong_param_type.rs:4:50
   |
 4 |     let _query = sqlx::query!("select $1::text", Some(0i32));
-  |                                                       ^^^^
-  |                                                       |
-  |                                                       expected struct `std::string::String`, found `i32`
-  |                                                       help: try using a conversion method: `0i32.to_string()`
-
-error[E0308]: mismatched types
- --> $DIR/wrong_param_type.rs:7:50
-  |
-7 |     let _query = sqlx::query!("select $1::text", arg);
-  |                                                  ^^^ expected struct `std::string::String`, found `i32`
+  |                                                  ^^^^^^^^^^ expected struct `std::string::String`, found `i32`
   |
   = note: expected enum `std::option::Option<std::string::String>`
              found enum `std::option::Option<i32>`
 
 error[E0308]: mismatched types
+ --> $DIR/wrong_param_type.rs:7:50
+  |
+7 |     let _query = sqlx::query!("select $1::text", arg);
+  |                                                  ^^^
+  |                                                  |
+  |                                                  expected struct `std::string::String`, found `i32`
+  |                                                  help: try using a conversion method: `arg.to_string()`
+
+error[E0308]: mismatched types
   --> $DIR/wrong_param_type.rs:10:50
    |
 10 |     let _query = sqlx::query!("select $1::text", arg);
-   |                                                  ^^^
-   |                                                  |
-   |                                                  expected struct `std::string::String`, found `i32`
-   |                                                  help: try using a conversion method: `arg.to_string()`
+   |                                                  ^^^ expected struct `std::string::String`, found `i32`
+   |
+   = note: expected enum `std::option::Option<std::string::String>`
+              found enum `std::option::Option<i32>`
+
+error[E0308]: mismatched types
+  --> $DIR/wrong_param_type.rs:11:50
+   |
+11 |     let _query = sqlx::query!("select $1::text", arg.as_ref());
+   |                                                  ^^^^^^^^^^^^ expected struct `std::string::String`, found `i32`
+   |
+   = note: expected enum `std::option::Option<&std::string::String>`
+              found enum `std::option::Option<&i32>`

--- a/tests/ui/postgres/wrong_param_type.stderr
+++ b/tests/ui/postgres/wrong_param_type.stderr
@@ -1,0 +1,35 @@
+error[E0308]: mismatched types
+ --> $DIR/wrong_param_type.rs:2:50
+  |
+2 |     let _query = sqlx::query!("select $1::text", 0i32);
+  |                                                  ^^^^
+  |                                                  |
+  |                                                  expected struct `std::string::String`, found `i32`
+  |                                                  help: try using a conversion method: `0i32.to_string()`
+
+error[E0308]: mismatched types
+ --> $DIR/wrong_param_type.rs:4:55
+  |
+4 |     let _query = sqlx::query!("select $1::text", Some(0i32));
+  |                                                       ^^^^
+  |                                                       |
+  |                                                       expected struct `std::string::String`, found `i32`
+  |                                                       help: try using a conversion method: `0i32.to_string()`
+
+error[E0308]: mismatched types
+ --> $DIR/wrong_param_type.rs:7:50
+  |
+7 |     let _query = sqlx::query!("select $1::text", arg);
+  |                                                  ^^^ expected struct `std::string::String`, found `i32`
+  |
+  = note: expected enum `std::option::Option<std::string::String>`
+             found enum `std::option::Option<i32>`
+
+error[E0308]: mismatched types
+  --> $DIR/wrong_param_type.rs:10:50
+   |
+10 |     let _query = sqlx::query!("select $1::text", arg);
+   |                                                  ^^^
+   |                                                  |
+   |                                                  expected struct `std::string::String`, found `i32`
+   |                                                  help: try using a conversion method: `arg.to_string()`


### PR DESCRIPTION
The way I implemented it, we cannot accept unsized expressions like `string[..]` which is a breaking change from the current behavior. However, `println!()` doesn't accept unsized expressions, either, so while this is a regression (and has to wait until 0.3) it actually makes the behavior closer to what's expected.

Closes #93