### PR TITLE
Enable raw ident support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,10 @@ name = "postgres-macros"
 required-features = [ "postgres", "macros" ]
 
 [[test]]
+name = "mysql-macros"
+required-features = [ "mysql", "macros" ]
+
+[[test]]
 name = "mysql"
 required-features = [ "mysql" ]
 

--- a/sqlx-macros/src/query_macros/output.rs
+++ b/sqlx-macros/src/query_macros/output.rs
@@ -68,7 +68,8 @@ fn parse_ident(name: &str) -> crate::Result<Ident> {
     let is_valid_ident = name.chars().all(|c| c.is_alphanumeric() || c == '_');
 
     if is_valid_ident {
-        if let Ok(ident) = syn::parse_str(name) {
+        let ident = String::from("r#") + name;
+        if let Ok(ident) = syn::parse_str(&ident) {
             return Ok(ident);
         }
     }

--- a/tests/mysql-macros.rs
+++ b/tests/mysql-macros.rs
@@ -1,0 +1,57 @@
+#[cfg_attr(feature = "runtime-async-std", async_std::test)]
+#[cfg_attr(feature = "runtime-tokio", tokio::test)]
+async fn macro_select_from_cte() -> anyhow::Result<()> {
+    let mut conn = connect().await?;
+    let account =
+        sqlx::query!("select * from (select (1) as id, 'Herp Derpinson' as name) accounts")
+            .fetch_one(&mut conn)
+            .await?;
+
+    println!("{:?}", account);
+    println!("{}: {}", account.id, account.name);
+
+    Ok(())
+}
+
+#[cfg_attr(feature = "runtime-async-std", async_std::test)]
+#[cfg_attr(feature = "runtime-tokio", tokio::test)]
+async fn macro_select_from_cte_bind() -> anyhow::Result<()> {
+    let mut conn = connect().await?;
+    let account = sqlx::query!(
+        "select * from (select (1) as id, 'Herp Derpinson' as name) accounts where id = ?",
+        1i32
+    )
+    .fetch_one(&mut conn)
+    .await?;
+
+    println!("{:?}", account);
+    println!("{}: {}", account.id, account.name);
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct RawAccount {
+    r#type: i32,
+    name: Option<String>,
+}
+
+#[cfg_attr(feature = "runtime-async-std", async_std::test)]
+#[cfg_attr(feature = "runtime-tokio", tokio::test)]
+async fn test_query_as_raw() -> anyhow::Result<()> {
+    let mut conn = connect().await?;
+
+    let account = sqlx::query_as!(
+        RawAccount,
+        "SELECT * from (VALUES (1, null)) accounts(type, name)"
+    )
+    .fetch_one(&mut conn)
+    .await?;
+
+    assert_eq!(None, account.name);
+    assert_eq!(1, account.r#type);
+
+    println!("{:?}", account);
+
+    Ok(())
+}

--- a/tests/mysql.rs
+++ b/tests/mysql.rs
@@ -87,40 +87,6 @@ async fn pool_immediately_fails_with_db_error() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "macros")]
-#[cfg_attr(feature = "runtime-async-std", async_std::test)]
-#[cfg_attr(feature = "runtime-tokio", tokio::test)]
-async fn macro_select_from_cte() -> anyhow::Result<()> {
-    let mut conn = connect().await?;
-    let account =
-        sqlx::query!("select * from (select (1) as id, 'Herp Derpinson' as name) accounts")
-            .fetch_one(&mut conn)
-            .await?;
-
-    println!("{:?}", account);
-    println!("{}: {}", account.id, account.name);
-
-    Ok(())
-}
-
-#[cfg(feature = "macros")]
-#[cfg_attr(feature = "runtime-async-std", async_std::test)]
-#[cfg_attr(feature = "runtime-tokio", tokio::test)]
-async fn macro_select_from_cte_bind() -> anyhow::Result<()> {
-    let mut conn = connect().await?;
-    let account = sqlx::query!(
-        "select * from (select (1) as id, 'Herp Derpinson' as name) accounts where id = ?",
-        1i32
-    )
-    .fetch_one(&mut conn)
-    .await?;
-
-    println!("{:?}", account);
-    println!("{}: {}", account.id, account.name);
-
-    Ok(())
-}
-
 fn url() -> anyhow::Result<String> {
     Ok(dotenv::var("DATABASE_URL")?)
 }

--- a/tests/postgres-macros.rs
+++ b/tests/postgres-macros.rs
@@ -68,6 +68,32 @@ async fn test_query_as() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[derive(Debug)]
+struct RawAccount {
+    r#type: i32,
+    name: Option<String>,
+}
+
+#[cfg_attr(feature = "runtime-async-std", async_std::test)]
+#[cfg_attr(feature = "runtime-tokio", tokio::test)]
+async fn test_query_as_raw() -> anyhow::Result<()> {
+    let mut conn = connect().await?;
+
+    let account = sqlx::query_as!(
+        RawAccount,
+        "SELECT * from (VALUES (1, null)) accounts(type, name)"
+    )
+    .fetch_one(&mut conn)
+    .await?;
+
+    assert_eq!(None, account.name);
+    assert_eq!(1, account.r#type);
+
+    println!("{:?}", account);
+
+    Ok(())
+}
+
 #[cfg_attr(feature = "runtime-async-std", async_std::test)]
 #[cfg_attr(feature = "runtime-tokio", tokio::test)]
 async fn test_query_file_as() -> anyhow::Result<()> {


### PR DESCRIPTION
This change makes it so the sqlx macros generate every ident as raw identifiers so that it will support the field if its name happens to coincide with a rust identifier.

closes #95 