### PR TITLE
Implement support for 1-dim arrays for PostgreSQL

### DIFF
--- a/sqlx-core/src/error.rs
+++ b/sqlx-core/src/error.rs
@@ -244,3 +244,10 @@ macro_rules! impl_fmt_error {
         }
     };
 }
+
+#[allow(unused_macros)]
+macro_rules! decode_err (
+    ($($args:tt)*) => {
+        $crate::decode::DecodeError::Message(Box::new(format!($($args)*)))
+    }
+);

--- a/sqlx-core/src/postgres/types/array.rs
+++ b/sqlx-core/src/postgres/types/array.rs
@@ -182,15 +182,6 @@ where
 
         self.count += 1;
     }
-    fn extend<'a, I>(&mut self, items: I)
-    where
-        I: Iterator<Item = &'a T>,
-        T: 'a,
-    {
-        for item in items {
-            self.push(item);
-        }
-    }
     fn update_len(&mut self) {
         const I32_SIZE: usize = std::mem::size_of::<i32>();
 

--- a/sqlx-core/src/postgres/types/array.rs
+++ b/sqlx-core/src/postgres/types/array.rs
@@ -1,0 +1,211 @@
+/// Encoding and decoding of Postgres arrays. Documentation of the byte format can be found [here](https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/include/utils/array.h;h=7f7e744cb12bc872f628f90dad99dfdf074eb314;hb=master#l6)
+use crate::decode::Decode;
+use crate::decode::DecodeError;
+use crate::encode::Encode;
+use crate::io::{Buf, BufMut};
+use crate::postgres::database::Postgres;
+use crate::types::HasSqlType;
+use PhantomData;
+
+impl<T> Encode<Postgres> for [T]
+where
+    T: Encode<Postgres>,
+    Postgres: HasSqlType<T>,
+{
+    fn encode(&self, buf: &mut Vec<u8>) {
+        let mut encoder = ArrayEncoder::new(buf);
+        for item in self {
+            encoder.push(item);
+        }
+    }
+}
+impl<T> Encode<Postgres> for Vec<T>
+where
+    [T]: Encode<Postgres>,
+    Postgres: HasSqlType<T>,
+{
+    fn encode(&self, buf: &mut Vec<u8>) {
+        self.as_slice().encode(buf)
+    }
+}
+
+impl<T> Decode<Postgres> for Vec<T>
+where
+    T: Decode<Postgres>,
+    Postgres: HasSqlType<T>,
+{
+    fn decode(buf: &[u8]) -> Result<Self, DecodeError> {
+        let decoder = ArrayDecoder::<T>::new(buf)?;
+        decoder.collect()
+    }
+}
+
+type Order = byteorder::BigEndian;
+
+struct ArrayDecoder<'a, T>
+where
+    T: Decode<Postgres>,
+    Postgres: HasSqlType<T>,
+{
+    left: usize,
+    did_error: bool,
+
+    buf: &'a [u8],
+
+    phantom: PhantomData<T>,
+}
+
+impl<T> ArrayDecoder<'_, T>
+where
+    T: Decode<Postgres>,
+    Postgres: HasSqlType<T>,
+{
+    fn new(mut buf: &[u8]) -> Result<ArrayDecoder<T>, DecodeError> {
+        let ndim = buf.get_i32::<Order>()?;
+        let dataoffset = buf.get_i32::<Order>()?;
+        let elemtype = buf.get_i32::<Order>()?;
+
+        if ndim == 0 {
+            return Ok(ArrayDecoder {
+                left: 0,
+                did_error: false,
+                buf,
+                phantom: PhantomData,
+            });
+        }
+
+        assert_eq!(ndim, 1, "only arrays of dimension 1 is supported");
+
+        let dimensions = buf.get_i32::<Order>()?;
+        let lower_bnds = buf.get_i32::<Order>()?;
+
+        assert_eq!(dataoffset, 0, "arrays with [null bitmap] is not supported");
+        assert_eq!(
+            elemtype,
+            <Postgres as HasSqlType<T>>::type_info().id.0 as i32,
+            "mismatched array element type"
+        );
+        assert_eq!(lower_bnds, 1);
+
+        Ok(ArrayDecoder {
+            left: dimensions as usize,
+            did_error: false,
+            buf,
+
+            phantom: PhantomData,
+        })
+    }
+
+    /// Decodes the next element without worring how many are left, or if it previously errored
+    fn decode_next_element(&mut self) -> Result<T, DecodeError> {
+        let len = self.buf.get_i32::<Order>()?;
+        let bytes = self.buf.get_bytes(len as usize)?;
+        Decode::decode(bytes)
+    }
+}
+
+impl<T> Iterator for ArrayDecoder<'_, T>
+where
+    T: Decode<Postgres>,
+    Postgres: HasSqlType<T>,
+{
+    type Item = Result<T, DecodeError>;
+
+    fn next(&mut self) -> Option<Result<T, DecodeError>> {
+        if self.did_error || self.left == 0 {
+            return None;
+        }
+
+        self.left -= 1;
+
+        let decoded = self.decode_next_element();
+        self.did_error = decoded.is_err();
+        Some(decoded)
+    }
+}
+
+struct ArrayEncoder<'a, T>
+where
+    T: Encode<Postgres>,
+    Postgres: HasSqlType<T>,
+{
+    count: usize,
+    len_start_index: usize,
+    buf: &'a mut Vec<u8>,
+
+    phantom: PhantomData<T>,
+}
+
+impl<T> ArrayEncoder<'_, T>
+where
+    T: Encode<Postgres>,
+    Postgres: HasSqlType<T>,
+{
+    fn new(buf: &mut Vec<u8>) -> ArrayEncoder<T> {
+        let ty = <Postgres as HasSqlType<T>>::type_info();
+
+        // ndim
+        buf.put_i32::<Order>(1);
+        // dataoffset
+        buf.put_i32::<Order>(0);
+        // elemtype
+        buf.put_i32::<Order>(ty.id.0 as i32);
+        let len_start_index = buf.len();
+        // dimensions
+        buf.put_i32::<Order>(0);
+        // lower_bnds
+        buf.put_i32::<Order>(1);
+
+        ArrayEncoder {
+            count: 0,
+            len_start_index,
+            buf,
+
+            phantom: PhantomData,
+        }
+    }
+    fn push(&mut self, item: &T) {
+        // Allocate space for the length of the encoded elemement up front
+        let el_len_index = self.buf.len();
+        self.buf.put_i32::<Order>(0);
+
+        // Allocate the element it self
+        let el_start = self.buf.len();
+        Encode::encode(item, self.buf);
+        let el_end = self.buf.len();
+
+        // Now we know the actual length of the encoded element
+        let el_len = el_end - el_start;
+
+        // And we can now go back and update the length
+        self.buf[el_len_index..el_start].copy_from_slice(&(el_len as i32).to_be_bytes());
+
+        self.count += 1;
+    }
+    fn extend<'a, I>(&mut self, items: I)
+    where
+        I: Iterator<Item = &'a T>,
+        T: 'a,
+    {
+        for item in items {
+            self.push(item);
+        }
+    }
+    fn update_len(&mut self) {
+        const I32_SIZE: usize = std::mem::size_of::<i32>();
+
+        let size_bytes = (self.count as i32).to_be_bytes();
+
+        self.buf[self.len_start_index..self.len_start_index + I32_SIZE]
+            .copy_from_slice(&size_bytes);
+    }
+}
+impl<T> Drop for ArrayEncoder<'_, T>
+where
+    T: Encode<Postgres>,
+    Postgres: HasSqlType<T>,
+{
+    fn drop(&mut self) {
+        self.update_len();
+    }
+}

--- a/sqlx-core/src/postgres/types/array.rs
+++ b/sqlx-core/src/postgres/types/array.rs
@@ -5,7 +5,7 @@ use crate::encode::Encode;
 use crate::io::{Buf, BufMut};
 use crate::postgres::database::Postgres;
 use crate::types::HasSqlType;
-use PhantomData;
+use std::marker::PhantomData;
 
 impl<T> Encode<Postgres> for [T]
 where

--- a/sqlx-core/src/postgres/types/bool.rs
+++ b/sqlx-core/src/postgres/types/bool.rs
@@ -16,6 +16,11 @@ impl HasSqlType<[bool]> for Postgres {
         PgTypeInfo::new(TypeId::ARRAY_BOOL)
     }
 }
+impl HasSqlType<Vec<bool>> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        <Self as HasSqlType<[bool]>>::type_info()
+    }
+}
 
 impl Encode<Postgres> for bool {
     fn encode(&self, buf: &mut Vec<u8>) {

--- a/sqlx-core/src/postgres/types/bytes.rs
+++ b/sqlx-core/src/postgres/types/bytes.rs
@@ -17,6 +17,12 @@ impl HasSqlType<[&'_ [u8]]> for Postgres {
     }
 }
 
+impl HasSqlType<Vec<&'_ [u8]>> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        <Postgres as HasSqlType<[&'_ [u8]]>>::type_info()
+    }
+}
+
 // TODO: Do we need the [HasSqlType] here on the Vec?
 impl HasSqlType<Vec<u8>> for Postgres {
     fn type_info() -> PgTypeInfo {

--- a/sqlx-core/src/postgres/types/chrono.rs
+++ b/sqlx-core/src/postgres/types/chrono.rs
@@ -55,6 +55,24 @@ impl HasSqlType<[NaiveDateTime]> for Postgres {
     }
 }
 
+impl HasSqlType<Vec<NaiveTime>> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        <Postgres as HasSqlType<[NaiveTime]>>::type_info()
+    }
+}
+
+impl HasSqlType<Vec<NaiveDate>> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        <Postgres as HasSqlType<[NaiveDate]>>::type_info()
+    }
+}
+
+impl HasSqlType<Vec<NaiveDateTime>> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        <Postgres as HasSqlType<[NaiveDateTime]>>::type_info()
+    }
+}
+
 impl<Tz> HasSqlType<[DateTime<Tz>]> for Postgres
 where
     Tz: TimeZone,

--- a/sqlx-core/src/postgres/types/float.rs
+++ b/sqlx-core/src/postgres/types/float.rs
@@ -16,6 +16,11 @@ impl HasSqlType<[f32]> for Postgres {
         PgTypeInfo::new(TypeId::ARRAY_FLOAT4)
     }
 }
+impl HasSqlType<Vec<f32>> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        <Self as HasSqlType<[f32]>>::type_info()
+    }
+}
 
 impl Encode<Postgres> for f32 {
     fn encode(&self, buf: &mut Vec<u8>) {
@@ -40,6 +45,11 @@ impl HasSqlType<f64> for Postgres {
 impl HasSqlType<[f64]> for Postgres {
     fn type_info() -> PgTypeInfo {
         PgTypeInfo::new(TypeId::ARRAY_FLOAT8)
+    }
+}
+impl HasSqlType<Vec<f64>> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        <Self as HasSqlType<[f64]>>::type_info()
     }
 }
 

--- a/sqlx-core/src/postgres/types/int.rs
+++ b/sqlx-core/src/postgres/types/int.rs
@@ -18,6 +18,11 @@ impl HasSqlType<[i16]> for Postgres {
         PgTypeInfo::new(TypeId::ARRAY_INT2)
     }
 }
+impl HasSqlType<Vec<i16>> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        <Self as HasSqlType<[i16]>>::type_info()
+    }
+}
 
 impl Encode<Postgres> for i16 {
     fn encode(&self, buf: &mut Vec<u8>) {
@@ -42,6 +47,11 @@ impl HasSqlType<[i32]> for Postgres {
         PgTypeInfo::new(TypeId::ARRAY_INT4)
     }
 }
+impl HasSqlType<Vec<i32>> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        <Self as HasSqlType<[i32]>>::type_info()
+    }
+}
 
 impl Encode<Postgres> for i32 {
     fn encode(&self, buf: &mut Vec<u8>) {
@@ -64,6 +74,11 @@ impl HasSqlType<i64> for Postgres {
 impl HasSqlType<[i64]> for Postgres {
     fn type_info() -> PgTypeInfo {
         PgTypeInfo::new(TypeId::ARRAY_INT8)
+    }
+}
+impl HasSqlType<Vec<i64>> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        <Self as HasSqlType<[i64]>>::type_info()
     }
 }
 

--- a/sqlx-core/src/postgres/types/mod.rs
+++ b/sqlx-core/src/postgres/types/mod.rs
@@ -1,3 +1,4 @@
+mod array;
 mod bool;
 mod bytes;
 mod float;

--- a/sqlx-core/src/postgres/types/str.rs
+++ b/sqlx-core/src/postgres/types/str.rs
@@ -18,11 +18,21 @@ impl HasSqlType<[&'_ str]> for Postgres {
         PgTypeInfo::new(TypeId::ARRAY_TEXT)
     }
 }
+impl HasSqlType<Vec<&'_ str>> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        <Self as HasSqlType<[&'_ str]>>::type_info()
+    }
+}
 
 // TODO: Do we need [HasSqlType] on String here?
 impl HasSqlType<String> for Postgres {
     fn type_info() -> PgTypeInfo {
         <Self as HasSqlType<str>>::type_info()
+    }
+}
+impl HasSqlType<Vec<String>> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        <Self as HasSqlType<Vec<&'_ str>>>::type_info()
     }
 }
 

--- a/sqlx-core/src/postgres/types/str.rs
+++ b/sqlx-core/src/postgres/types/str.rs
@@ -30,6 +30,11 @@ impl HasSqlType<String> for Postgres {
         <Self as HasSqlType<str>>::type_info()
     }
 }
+impl HasSqlType<[String]> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        <Self as HasSqlType<[&'_ str]>>::type_info()
+    }
+}
 impl HasSqlType<Vec<String>> for Postgres {
     fn type_info() -> PgTypeInfo {
         <Self as HasSqlType<Vec<&'_ str>>>::type_info()

--- a/sqlx-core/src/postgres/types/uuid.rs
+++ b/sqlx-core/src/postgres/types/uuid.rs
@@ -19,6 +19,12 @@ impl HasSqlType<[Uuid]> for Postgres {
     }
 }
 
+impl HasSqlType<Vec<Uuid>> for Postgres {
+    fn type_info() -> PgTypeInfo {
+        <Postgres as HasSqlType<[Uuid]>>::type_info()
+    }
+}
+
 impl Encode<Postgres> for Uuid {
     fn encode(&self, buf: &mut Vec<u8>) {
         buf.extend_from_slice(self.as_bytes());

--- a/sqlx-macros/src/database/postgres.rs
+++ b/sqlx-macros/src/database/postgres.rs
@@ -25,6 +25,16 @@ impl_database_ext! {
 
         #[cfg(feature = "chrono")]
         sqlx::types::chrono::DateTime<sqlx::types::chrono::Utc> | sqlx::types::chrono::DateTime<_>,
+
+        // Arrays
+
+        Vec<bool>, [bool],
+        Vec<String>, [String],
+        Vec<i16>, [i16],
+        Vec<i32>, [i32],
+        Vec<i64>, [i64],
+        Vec<f32>, [f32],
+        Vec<f64>, [f64],
     },
     ParamChecking::Strong
 }

--- a/sqlx-macros/src/database/postgres.rs
+++ b/sqlx-macros/src/database/postgres.rs
@@ -28,13 +28,12 @@ impl_database_ext! {
 
         // Arrays
 
-        Vec<bool>, [bool],
-        Vec<String>, [String],
-        Vec<i16>, [i16],
-        Vec<i32>, [i32],
-        Vec<i64>, [i64],
-        Vec<f32>, [f32],
-        Vec<f64>, [f64],
+        Vec<String> | &[String],
+        Vec<i16> | &[i16],
+        Vec<i32> | &[i32],
+        Vec<i64> | &[i64],
+        Vec<f32> | &[f32],
+        Vec<f64> | &[f64],
     },
     ParamChecking::Strong
 }

--- a/tests/postgres-macros.rs
+++ b/tests/postgres-macros.rs
@@ -176,6 +176,32 @@ async fn test_many_args() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg_attr(feature = "runtime-async-std", async_std::test)]
+#[cfg_attr(feature = "runtime-tokio", tokio::test)]
+async fn test_array_from_slice() -> anyhow::Result<()> {
+    let mut conn = connect().await?;
+
+    let list: &[i32] = &[1, 2, 3, 4i32];
+
+    let result = sqlx::query!("SELECT $1::int[] as my_array", *list)
+        .fetch_one(&mut conn)
+        .await?;
+
+    assert_eq!(result.my_array, vec![1, 2, 3, 4]);
+
+    println!("result ID: {:?}", result.my_array);
+
+    let account = sqlx::query!("SELECT ARRAY[4,3,2,1] as my_array")
+        .fetch_one(&mut conn)
+        .await?;
+
+    assert_eq!(account.my_array, vec![4, 3, 2, 1]);
+
+    println!("account ID: {:?}", account.my_array);
+
+    Ok(())
+}
+
 async fn connect() -> anyhow::Result<PgConnection> {
     let _ = dotenv::dotenv();
     let _ = env_logger::try_init();

--- a/tests/postgres-macros.rs
+++ b/tests/postgres-macros.rs
@@ -183,7 +183,7 @@ async fn test_array_from_slice() -> anyhow::Result<()> {
 
     let list: &[i32] = &[1, 2, 3, 4i32];
 
-    let result = sqlx::query!("SELECT $1::int[] as my_array", *list)
+    let result = sqlx::query!("SELECT $1::int[] as my_array", list)
         .fetch_one(&mut conn)
         .await?;
 

--- a/tests/postgres-types.rs
+++ b/tests/postgres-types.rs
@@ -37,6 +37,12 @@ test!(postgres_double: f64: "939399419.1225182::double precision" == 939399419.1
 
 test!(postgres_text: String: "'this is foo'" == "this is foo", "''" == "");
 
+test!(postgres_int_vec: Vec<i32>: "ARRAY[1, 2, 3]::int[]" == vec![1, 2, 3i32], "ARRAY[3, 292, 15, 2, 3]::int[]" == vec![3, 292, 15, 2, 3], "ARRAY[7, 6, 5, 4, 3, 2, 1]::int[]" == vec![7, 6, 5, 4, 3, 2, 1], "ARRAY[]::int[]" == vec![] as Vec<i32>);
+test!(postgres_string_vec: Vec<String>: "ARRAY['Hello', 'world', 'friend']::text[]" == vec!["Hello", "world", "friend"]);
+test!(postgres_bool_vec: Vec<bool>: "ARRAY[true, true, false, true]::bool[]" == vec![true, true, false, true]);
+test!(postgres_real_vec: Vec<f32>: "ARRAY[0.0, 1.0, 3.14, 1.234, -0.002, 100000.0]::real[]" == vec![0.0, 1.0, 3.14, 1.234, -0.002, 100000.0_f32]);
+test!(postgres_double_vec: Vec<f64>: "ARRAY[0.0, 1.0, 3.14, 1.234, -0.002, 100000.0]::double precision[]" == vec![0.0, 1.0, 3.14, 1.234, -0.002, 100000.0_f64]);
+
 #[cfg_attr(feature = "runtime-async-std", async_std::test)]
 #[cfg_attr(feature = "runtime-tokio", tokio::test)]
 async fn postgres_bytes() -> anyhow::Result<()> {


### PR DESCRIPTION
# Add support for 1-dimensional arrays for PostgreSQL

This pull request attempts to implement the foundation for encoding and decoding arrays for PostgreSQL, resolving #48 and #82.

One solution I came up with, after a bit of experimentation was having an `ArrayEncoder<T>` and `ArrayDecoder<T>`, allowing the encoding and decoding of elements one at a time.

Included in this pull request is encoding of the standard 1-dimensional postgres array types (`int[], text[], uuid[], ...`) from slices, as well as decoding into `Vec`'s.

The rest of this will contain the details of implementing this, and the problems and considerations that unfolded.

## Encoding

By supporting incremental encoding of the array it makes it easier to encode anything that implements `Iterator<Item = T>`. Creating the implementation for slices and vec's becomes trivial with this approach, as can be seen by the actual implementation:

```rust
impl<T> Encode<Postgres> for [T]
where
    T: Encode<Postgres>,
    Postgres: HasSqlType<T>,
{
    fn encode(&self, buf: &mut Vec<u8>) {
        let mut encoder = ArrayEncoder::new(buf);
        for item in self {
            encoder.push(item);
        }
    }
}
```

`ArrayEncoder` works by counting the number of elements that will be pushed/encoded, and updates the `dimensions` field of the array header on `Drop`.

This results in a potentially invalid buffer as long as elements are still being pushed, but as soon as the buffer is extracted from the encoder, which it must for it to be read, the encoder is dropped and the length is written. Alternatively, we could update the length field on each push, but only updating in the end could be marginally faster. I do not know which method is preferred.

### Implementing `Encode` for iterator of encodeable

Allowing `Encode` for `Iterator<Item = T>` could reduce allocations and make mapping of internal structures to postgres transferable types possible, without allocating new `Vec`'s or the like. An example of this:

```rust
struct Friend {
  name: &'static str,
  age: usize,
}

let friends = vec![
  Friend { name: "Joe", age: 34 },
  Friend { name: "Carl", age: 38 },
];

sqlx::query!(
  "update users set friend_names = $1",
  friends.iter().map(|friend| friend.name)
);
```

Unfortunately trying the write this implementation seems conflicts with the implementation for `impl<T> Encode for &T where T: Encode { ... }`.

Any thoughts on how this could be solved? (Maybe creating a wrapper type `EncodeIter(impl Iterator<Item = T>)`?)

## Decoding

Decoding is implemented similarly as encoding. A decoder is constructed at the start of the buffer containing the bytes for the array, it then parses the header, checks its validity, and now presents an `Iterator<Item = T>`, allowing for lazy decoding of the array. This makes the implementation of decoding to a `Vec` trivial:

```rust
impl<T> Decode<Postgres> for Vec<T>
where
    T: Decode<Postgres>,
    Postgres: HasSqlType<T>,
{
    fn decode(buf: &[u8]) -> Result<Self, DecodeError> {
        let decoder = ArrayDecoder::new(buf)?;
        decoder.collect()
    }
}
```

Note the `Vec`. This required the implementation of `HasSqlType<Vec<T>> for Postgres` for all of the array types, similar to the already existing `HasSqlType<[T]> for Postgres`. Also, the size of most arrays coming from the database cannot be known at compile-time, hence the dynamic allocation. I played a handful of different approaches for implementing decode for `[T; N]`, and some of the persistent considerations were:

- How do we represent the array when it's partially decoded? Do we require `T: Default`? Do we use some sort of `MaybeUninit`?
- How do we use const generics? Not knowing too much about const generics, it seems it is currently still unstable. Also when trying to create an array with `[T::default(); N]` we get `error: array lengths can't depend on generic parameters`.
- What if the array from postgres contains more elements then `N`? Do we just discard those?

### Errors

With regards to errors when decoding, how we handle those must also be considered. _Currently_ if the bytes we get from postgres contains an unexpected `elemtype`, is of dimensions of other then one, or it includes a `null bitmap` (currently not implemented), the decoder just panics. An appropriate error for each case such be returned, but I do not know in what shape or form.

Similarly, when decoding of an element fails, should no elements be returned, or should the ones that succeded be returned? Currently, it just stops at the first error and doesn't return any elements at all.
