### PR TITLE
Fix null bitmap bytes being cleared

### DIFF
--- a/sqlx-core/src/mysql/arguments.rs
+++ b/sqlx-core/src/mysql/arguments.rs
@@ -45,7 +45,7 @@ impl Arguments for MySqlArguments {
         self.null_bitmap.resize((index / 8) + 1, 0);
 
         if let IsNull::Yes = value.encode_nullable(&mut self.params) {
-            self.null_bitmap[index / 8] &= (1 << index % 8) as u8;
+            self.null_bitmap[index / 8] |= (1 << index % 8) as u8;
         }
     }
 }


### PR DESCRIPTION
Fixes #125.

The cause was the bitmap bytes being cleared by the `&=`, only if the very last bit of that byte would ever be set (if it was null), all others would be `AND`'d away to zero