### PR TITLE
postgres: remove IntervalStyle to fix #130

### DIFF
--- a/sqlx-core/src/postgres/connection.rs
+++ b/sqlx-core/src/postgres/connection.rs
@@ -111,8 +111,6 @@ async fn startup(stream: &mut PgStream, url: &Url) -> crate::Result<BackendKeyDa
         // Sets the display format for date and time values,
         // as well as the rules for interpreting ambiguous date input values.
         ("DateStyle", "ISO, MDY"),
-        // Sets the display format for interval values.
-        ("IntervalStyle", "iso_8601"),
         // Sets the time zone for displaying and interpreting time stamps.
         ("TimeZone", "UTC"),
         // Adjust postgres to return percise values for floats


### PR DESCRIPTION
This way SQLx can support more server versions, including CockroachDB, which only supports the `postgres` style.

Of note: If we wanted to support conversion of PostgresSQL's `INTERVAL`s to a special type, we'd have to support all IntervalStyles anyway, in case somebody used `SET SESSION IntervalStyle` to change it after connection is established.

Fixes #130.
I believe the current `master` struggles with Postgres tests a little so CI might fail.

Thanks for the immediate response y'all!