### PR TITLE
[wip] postgres: ipnetwork support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,6 +830,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnetwork"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8eca9f51da27bc908ef3dd85c21e1bbba794edaf94d7841e37356275b82d31e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,6 +1715,8 @@ dependencies = [
  "generic-array",
  "hex",
  "hmac",
+ "ipnetwork",
+ "libc",
  "libsqlite3-sys",
  "log",
  "matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,9 +834,6 @@ name = "ipnetwork"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8eca9f51da27bc908ef3dd85c21e1bbba794edaf94d7841e37356275b82d31e"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "itoa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ sqlite = [ "sqlx-core/sqlite", "sqlx-macros/sqlite" ]
 # types
 bigdecimal = ["sqlx-core/bigdecimal_bigint", "sqlx-macros/bigdecimal"]
 chrono = [ "sqlx-core/chrono", "sqlx-macros/chrono" ]
+ipnetwork = [ "sqlx-core/ipnetwork", "sqlx-macros/ipnetwork" ]
 uuid = [ "sqlx-core/uuid", "sqlx-macros/uuid" ]
 
 [dependencies]

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -18,7 +18,6 @@ unstable = []
 # we need a feature which activates `num-bigint` as well because
 # `bigdecimal` uses types from it but does not reexport (tsk tsk)
 bigdecimal_bigint = ["bigdecimal", "num-bigint"]
-network-address = [ "ipnetwork", "libc" ]
 postgres = [ "md-5", "sha2", "base64", "sha-1", "rand", "hmac", "futures-channel/sink", "futures-util/sink" ]
 mysql = [ "sha-1", "sha2", "generic-array", "num-bigint", "base64", "digest", "rand" ]
 sqlite = [ "libsqlite3-sys" ]
@@ -45,7 +44,7 @@ generic-array = { version = "0.12.3", default-features = false, optional = true 
 hex = "0.4.2"
 hmac = { version = "0.7.1", default-features = false, optional = true }
 ipnetwork = { version = "0.16.0", default-feature = false, optional = true }
-libc = { version = "0.2.68", default-feature = false, optional = true }
+libc = "0.2.68"
 log = { version = "0.4.8", default-features = false }
 md-5 = { version = "0.8.0", default-features = false, optional = true }
 memchr = { version = "2.3.3", default-features = false }

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -18,6 +18,7 @@ unstable = []
 # we need a feature which activates `num-bigint` as well because
 # `bigdecimal` uses types from it but does not reexport (tsk tsk)
 bigdecimal_bigint = ["bigdecimal", "num-bigint"]
+network-address = [ "ipnetwork", "libc" ]
 postgres = [ "md-5", "sha2", "base64", "sha-1", "rand", "hmac", "futures-channel/sink", "futures-util/sink" ]
 mysql = [ "sha-1", "sha2", "generic-array", "num-bigint", "base64", "digest", "rand" ]
 sqlite = [ "libsqlite3-sys" ]
@@ -43,6 +44,8 @@ futures-util = { version = "0.3.4", default-features = false }
 generic-array = { version = "0.12.3", default-features = false, optional = true }
 hex = "0.4.2"
 hmac = { version = "0.7.1", default-features = false, optional = true }
+ipnetwork = { version = "0.16.0", default-feature = false, optional = true }
+libc = { version = "0.2.68", default-feature = false, optional = true }
 log = { version = "0.4.8", default-features = false }
 md-5 = { version = "0.8.0", default-features = false, optional = true }
 memchr = { version = "2.3.3", default-features = false }

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -43,7 +43,7 @@ futures-util = { version = "0.3.4", default-features = false }
 generic-array = { version = "0.12.3", default-features = false, optional = true }
 hex = "0.4.2"
 hmac = { version = "0.7.1", default-features = false, optional = true }
-ipnetwork = { version = "0.16.0", default-feature = false, optional = true }
+ipnetwork = { version = "0.16.0", default-features = false, optional = true }
 libc = "0.2.68"
 log = { version = "0.4.8", default-features = false }
 md-5 = { version = "0.8.0", default-features = false, optional = true }

--- a/sqlx-core/src/postgres/protocol/type_id.rs
+++ b/sqlx-core/src/postgres/protocol/type_id.rs
@@ -33,6 +33,9 @@ impl TypeId {
 
     pub(crate) const UUID: TypeId = TypeId(2950);
 
+    pub(crate) const CIDR: TypeId = TypeId(650);
+    pub(crate) const INET: TypeId = TypeId(869);
+
     // Arrays
 
     pub(crate) const ARRAY_BOOL: TypeId = TypeId(1000);
@@ -56,4 +59,7 @@ impl TypeId {
     pub(crate) const ARRAY_BYTEA: TypeId = TypeId(1001);
 
     pub(crate) const ARRAY_UUID: TypeId = TypeId(2951);
+
+    pub(crate) const ARRAY_CIDR: TypeId = TypeId(651);
+    pub(crate) const ARRAY_INET: TypeId = TypeId(1041);
 }

--- a/sqlx-core/src/postgres/types/ipnetwork.rs
+++ b/sqlx-core/src/postgres/types/ipnetwork.rs
@@ -55,7 +55,7 @@ impl<'de> Decode<'de, Postgres> for IpNetwork {
     fn decode(value: Option<PgValue<'de>>) -> crate::Result<Self> {
         match value.try_into()? {
             PgValue::Binary(buf) => decode(buf, INET_TYPE),
-            PgValue::Text(s) => decode(s.as_bytes(), INET_TYPE),
+            PgValue::Text(s) => s.parse().map_err(|err| crate::Error::decode(err)),
         }
     }
 }

--- a/sqlx-core/src/postgres/types/mod.rs
+++ b/sqlx-core/src/postgres/types/mod.rs
@@ -35,7 +35,7 @@
 //!
 //! ### [`ipnetwork`](https://crates.io/crates/ipnetwork)
 //!
-//! Requires the `network-address` Cargo feature flag.
+//! Requires the `ipnetwork` Cargo feature flag.
 //!
 //! | Rust type                             | Postgres type(s)                                     |
 //! |---------------------------------------|------------------------------------------------------|
@@ -78,7 +78,8 @@ mod chrono;
 #[cfg(feature = "uuid")]
 mod uuid;
 
-mod network;
+#[cfg(feature = "ipnetwork")]
+mod ipnetwork;
 
 /// Type information for a Postgres SQL type.
 #[derive(Debug, Clone)]
@@ -118,6 +119,7 @@ impl PgTypeInfo {
             TypeId::UUID => Some("uuid"),
             // we can support decoding `PgNumeric` but it's decidedly less useful to the layman
             TypeId::NUMERIC => Some("bigdecimal"),
+            TypeId::CIDR | TypeId::INET => Some("ipnetwork"),
             _ => None,
         }
     }

--- a/sqlx-core/src/postgres/types/mod.rs
+++ b/sqlx-core/src/postgres/types/mod.rs
@@ -142,8 +142,16 @@ impl Display for PgTypeInfo {
 
 impl TypeInfo for PgTypeInfo {
     fn compatible(&self, other: &Self) -> bool {
-        // TODO: 99% of postgres types are direct equality for [compatible]; when we add something that isn't (e.g, JSON/JSONB), fix this here
-        self.id.0 == other.id.0
+        match (self.id, other.id) {
+            (TypeId::CIDR, TypeId::INET)
+            | (TypeId::INET, TypeId::CIDR)
+            | (TypeId::ARRAY_CIDR, TypeId::ARRAY_INET)
+            | (TypeId::ARRAY_INET, TypeId::ARRAY_CIDR) => true,
+            _ => {
+                // TODO: 99% of postgres types are direct equality for [compatible]; when we add something that isn't (e.g, JSON/JSONB), fix this here
+                self.id.0 == other.id.0
+            }
+        }
     }
 }
 

--- a/sqlx-core/src/postgres/types/mod.rs
+++ b/sqlx-core/src/postgres/types/mod.rs
@@ -33,6 +33,14 @@
 //! |---------------------------------------|------------------------------------------------------|
 //! | `uuid::Uuid`                          | UUID                                                 |
 //!
+//! ### [`ipnetwork`](https://crates.io/crates/ipnetwork)
+//!
+//! Requires the `network-address` Cargo feature flag.
+//!
+//! | Rust type                             | Postgres type(s)                                     |
+//! |---------------------------------------|------------------------------------------------------|
+//! | `ipnetwork::IpNetwork`                | INET, CIDR                                           |
+//!
 //! # Composite types
 //!
 //! Anonymous composite types are represented as tuples.
@@ -69,6 +77,8 @@ mod chrono;
 
 #[cfg(feature = "uuid")]
 mod uuid;
+
+mod network;
 
 /// Type information for a Postgres SQL type.
 #[derive(Debug, Clone)]

--- a/sqlx-core/src/postgres/types/network.rs
+++ b/sqlx-core/src/postgres/types/network.rs
@@ -1,0 +1,119 @@
+use std::convert::TryInto;
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
+
+use crate::decode::Decode;
+use crate::encode::Encode;
+use crate::postgres::protocol::TypeId;
+use crate::postgres::row::PgValue;
+use crate::postgres::types::PgTypeInfo;
+use crate::postgres::Postgres;
+use crate::types::Type;
+use crate::Error;
+
+#[cfg(windows)]
+const AF_INET: u8 = 2;
+// Maybe not used, but defining to follow Rust's libstd/net/sys
+#[cfg(redox)]
+const AF_INET: u8 = 1;
+#[cfg(not(any(windows, redox)))]
+const AF_INET: u8 = libc::AF_INET as u8;
+
+const PGSQL_AF_INET: u8 = AF_INET;
+const PGSQL_AF_INET6: u8 = AF_INET + 1;
+
+const INET_TYPE: u8 = 0;
+const CIDR_TYPE: u8 = 1;
+
+impl Type<Postgres> for IpNetwork {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::INET, "INET")
+    }
+}
+
+impl Type<Postgres> for [IpNetwork] {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::ARRAY_INET, "INET[]")
+    }
+}
+
+impl Encode<Postgres> for IpNetwork {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        encode(self, INET_TYPE, buf)
+    }
+
+    fn size_hint(&self) -> usize {
+        match self {
+            IpNetwork::V4(_) => 8,
+            IpNetwork::V6(_) => 20,
+        }
+    }
+}
+
+impl<'de> Decode<'de, Postgres> for IpNetwork {
+    fn decode(value: Option<PgValue<'de>>) -> crate::Result<Self> {
+        match value.try_into()? {
+            PgValue::Binary(buf) => decode(buf, INET_TYPE),
+            PgValue::Text(s) => decode(s.as_bytes(), INET_TYPE),
+        }
+    }
+}
+
+fn encode(net: &IpNetwork, net_type: u8, buf: &mut Vec<u8>) {
+    match net {
+        IpNetwork::V4(net) => {
+            buf.push(PGSQL_AF_INET);
+            buf.push(net.prefix());
+            buf.push(net_type);
+            buf.push(4);
+            buf.extend_from_slice(&net.ip().octets());
+        }
+        IpNetwork::V6(net) => {
+            buf.push(PGSQL_AF_INET6);
+            buf.push(net.prefix());
+            buf.push(net_type);
+            buf.push(16);
+            buf.extend_from_slice(&net.ip().octets());
+        }
+    }
+}
+
+fn decode(bytes: &[u8], net_type: u8) -> crate::Result<IpNetwork> {
+    if bytes.len() <= 8 {
+        return Err(Error::Decode("Input too short".into()));
+    }
+
+    let af = bytes[0];
+    let prefix = bytes[1];
+    let type_ = bytes[2];
+    let len = bytes[3];
+
+    if type_ == net_type {
+        if af == PGSQL_AF_INET && bytes.len() == 8 && len == 4 {
+            let inet = Ipv4Network::new(
+                Ipv4Addr::new(bytes[4], bytes[5], bytes[6], bytes[7]),
+                prefix,
+            )
+            .map_err(Error::decode)?;
+
+            return Ok(IpNetwork::V4(inet));
+        }
+
+        if af == PGSQL_AF_INET6 && bytes.len() == 20 && len == 16 {
+            let inet = Ipv6Network::new(
+                Ipv6Addr::from([
+                    bytes[4], bytes[5], bytes[6], bytes[7], bytes[8], bytes[9], bytes[10],
+                    bytes[11], bytes[12], bytes[13], bytes[14], bytes[15], bytes[16], bytes[17],
+                    bytes[18], bytes[19],
+                ]),
+                prefix,
+            )
+            .map_err(Error::decode)?;
+
+            return Ok(IpNetwork::V6(inet));
+        }
+    }
+
+    return Err(Error::Decode("Invalid inet_struct".into()));
+}

--- a/sqlx-core/src/types.rs
+++ b/sqlx-core/src/types.rs
@@ -18,6 +18,12 @@ pub mod chrono {
 #[cfg_attr(docsrs, doc(cfg(feature = "bigdecimal")))]
 pub use bigdecimal::BigDecimal;
 
+#[cfg(feature = "ipnetwork")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ipnetwork")))]
+pub mod ipnetwork {
+    pub use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
+}
+
 pub trait TypeInfo: Debug + Display + Clone {
     /// Compares type information to determine if `other` is compatible at the Rust level
     /// with `self`.

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -29,6 +29,7 @@ sqlite = [ "sqlx/sqlite" ]
 # type
 bigdecimal = [ "sqlx/bigdecimal_bigint" ]
 chrono = [ "sqlx/chrono" ]
+ipnetwork = [ "sqlx/ipnetwork" ]
 uuid = [ "sqlx/uuid" ]
 
 [dependencies]

--- a/sqlx-macros/src/database/postgres.rs
+++ b/sqlx-macros/src/database/postgres.rs
@@ -27,7 +27,10 @@ impl_database_ext! {
         sqlx::types::chrono::DateTime<sqlx::types::chrono::Utc> | sqlx::types::chrono::DateTime<_>,
 
         #[cfg(feature = "bigdecimal")]
-        sqlx::types::BigDecimal
+        sqlx::types::BigDecimal,
+
+        #[cfg(feature = "ipnetwork")]
+        sqlx::types::ipnetwork::IpNetwork
     },
     ParamChecking::Strong,
     feature-types: info => info.type_feature_gate(),

--- a/tests/postgres-types.rs
+++ b/tests/postgres-types.rs
@@ -134,6 +134,36 @@ test_type!(uuid(
         == sqlx::types::Uuid::parse_str("00000000-0000-0000-0000-000000000000").unwrap()
 ));
 
+#[cfg(feature = "ipnetwork")]
+test_type!(ipnetwork(
+    Postgres,
+    sqlx::types::ipnetwork::IpNetwork,
+    "'127.0.0.1'::inet"
+        == "127.0.0.1"
+            .parse::<sqlx::types::ipnetwork::IpNetwork>()
+            .unwrap(),
+    "'8.8.8.8/24'::inet"
+        == "8.8.8.8/24"
+            .parse::<sqlx::types::ipnetwork::IpNetwork>()
+            .unwrap(),
+    "'::ffff:1.2.3.0'::inet"
+        == "::ffff:1.2.3.0"
+            .parse::<sqlx::types::ipnetwork::IpNetwork>()
+            .unwrap(),
+    "'2001:4f8:3:ba::/64'::inet"
+        == "2001:4f8:3:ba::/64"
+            .parse::<sqlx::types::ipnetwork::IpNetwork>()
+            .unwrap(),
+    "'192.168'::cidr"
+        == "192.168.0.0/24"
+            .parse::<sqlx::types::ipnetwork::IpNetwork>()
+            .unwrap(),
+    "'::ffff:1.2.3.0/120'::cidr"
+        == "::ffff:1.2.3.0/120"
+            .parse::<sqlx::types::ipnetwork::IpNetwork>()
+            .unwrap(),
+));
+
 #[cfg(feature = "chrono")]
 mod chrono {
     use sqlx::types::chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};

--- a/tests/ui-tests.rs
+++ b/tests/ui-tests.rs
@@ -13,6 +13,10 @@ fn ui_tests() {
         if cfg!(not(feature = "uuid")) {
             t.compile_fail("tests/ui/postgres/gated/uuid.rs");
         }
+
+        if cfg!(not(feature = "ipnetwork")) {
+            t.compile_fail("tests/ui/postgres/gated/ipnetwork.rs");
+        }
     }
 
     if cfg!(feature = "mysql") {

--- a/tests/ui/postgres/gated/ipnetwork.rs
+++ b/tests/ui/postgres/gated/ipnetwork.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let _ = sqlx::query!("select '127.0.0.1'::inet");
+
+    let _ = sqlx::query!("select '2001:4f8:3:ba::/64'::cidr");
+
+    let _ = sqlx::query!("select $1::inet", ());
+
+    let _ = sqlx::query!("select $1::cidr", ());
+}

--- a/tests/ui/postgres/gated/ipnetwork.stderr
+++ b/tests/ui/postgres/gated/ipnetwork.stderr
@@ -1,0 +1,31 @@
+error: optional feature `ipnetwork` required for type INET of column #1 ("inet")
+ --> $DIR/ipnetwork.rs:2:13
+  |
+2 |     let _ = sqlx::query!("select '127.0.0.1'::inet");
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: optional feature `ipnetwork` required for type CIDR of column #1 ("cidr")
+ --> $DIR/ipnetwork.rs:4:13
+  |
+4 |     let _ = sqlx::query!("select '2001:4f8:3:ba::/64'::cidr");
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: optional feature `ipnetwork` required for type INET of param #1
+ --> $DIR/ipnetwork.rs:6:13
+  |
+6 |     let _ = sqlx::query!("select $1::inet", ());
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: optional feature `ipnetwork` required for type CIDR of param #1
+ --> $DIR/ipnetwork.rs:8:13
+  |
+8 |     let _ = sqlx::query!("select $1::cidr", ());
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)


### PR DESCRIPTION
This pull request is trying to implement `ipnetwork` support for PostgreSQL.

Currently, it only implements the `Decode` and `Encode` trait for `IpNetwork`, because I have encountered a problem: there are no way to encoding one struct into two different types. In this case, `IpNetwork` can not be decoded into both `INET` and `CIDR`.

A workaround is to create two wrapper structs: 

```rust
pub struct Inet(IpNetwork);

pub struct Cidr(IpNetwork);
```

... but I'm not sure if it's acceptable. =)


 