### PR TITLE
Add array of uuid, chrono, time, bigdecimal, and ipnetwork as well as JsonValue to query macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,6 +1817,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
+ "serde_json",
  "sqlx-core 0.3.0-alpha.2",
  "syn",
  "tokio 0.2.13",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-std",
@@ -1688,8 +1688,8 @@ dependencies = [
  "paste",
  "serde",
  "serde_json",
- "sqlx-core 0.3.0-alpha.1",
- "sqlx-macros 0.3.0-alpha.1",
+ "sqlx-core 0.3.0-alpha.2",
+ "sqlx-macros 0.3.0-alpha.2",
  "sqlx-test",
  "time 0.2.9",
  "tokio 0.2.13",
@@ -1726,7 +1726,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.2"
 dependencies = [
  "async-native-tls",
  "async-std",
@@ -1771,7 +1771,7 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "futures 0.3.4",
- "sqlx 0.3.0-alpha.1",
+ "sqlx 0.3.0-alpha.2",
 ]
 
 [[package]]
@@ -1787,7 +1787,7 @@ dependencies = [
  "rand",
  "rust-argon2",
  "serde",
- "sqlx 0.3.0-alpha.1",
+ "sqlx 0.3.0-alpha.2",
  "tide",
 ]
 
@@ -1809,7 +1809,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.2"
 dependencies = [
  "async-std",
  "dotenv",
@@ -1817,7 +1817,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "sqlx-core 0.3.0-alpha.1",
+ "sqlx-core 0.3.0-alpha.2",
  "syn",
  "tokio 0.2.13",
  "url",
@@ -1831,7 +1831,7 @@ dependencies = [
  "async-std",
  "dotenv",
  "env_logger",
- "sqlx 0.3.0-alpha.1",
+ "sqlx 0.3.0-alpha.2",
  "tokio 0.2.13",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ bigdecimal = ["sqlx-core/bigdecimal", "sqlx-macros/bigdecimal"]
 chrono = [ "sqlx-core/chrono", "sqlx-macros/chrono" ]
 ipnetwork = [ "sqlx-core/ipnetwork", "sqlx-macros/ipnetwork" ]
 uuid = [ "sqlx-core/uuid", "sqlx-macros/uuid" ]
-json = [ "sqlx-core/json" ]
+json = [ "sqlx-core/json", "sqlx-macros/json" ]
 time = [ "sqlx-core/time", "sqlx-macros/time" ]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 
 [package]
 name = "sqlx"
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.2"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/launchbadge/sqlx"
@@ -59,8 +59,8 @@ json = [ "sqlx-core/json" ]
 time = [ "sqlx-core/time", "sqlx-macros/time" ]
 
 [dependencies]
-sqlx-core = { version = "0.3.0-alpha.1", path = "sqlx-core", default-features = false }
-sqlx-macros = { version = "0.3.0-alpha.1", path = "sqlx-macros", default-features = false, optional = true }
+sqlx-core = { version = "0.3.0-alpha.2", path = "sqlx-core", default-features = false }
+sqlx-macros = { version = "0.3.0-alpha.2", path = "sqlx-macros", default-features = false, optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.26"

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlx-core"
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.2"
 repository = "https://github.com/launchbadge/sqlx"
 description = "Core of SQLx, the rust SQL toolkit. Not intended to be used directly."
 license = "MIT OR Apache-2.0"

--- a/sqlx-core/src/postgres/types/bigdecimal.rs
+++ b/sqlx-core/src/postgres/types/bigdecimal.rs
@@ -6,6 +6,7 @@ use num_bigint::{BigInt, Sign};
 
 use crate::decode::Decode;
 use crate::encode::Encode;
+use crate::postgres::protocol::TypeId;
 use crate::postgres::{PgData, PgTypeInfo, PgValue, Postgres};
 use crate::types::Type;
 
@@ -14,6 +15,19 @@ use super::raw::{PgNumeric, PgNumericSign};
 impl Type<Postgres> for BigDecimal {
     fn type_info() -> PgTypeInfo {
         <PgNumeric as Type<Postgres>>::type_info()
+    }
+}
+
+impl Type<Postgres> for [BigDecimal] {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::new(TypeId::ARRAY_NUMERIC, "NUMERIC[]")
+        // <[PgNumeric] as Type<Postgres>>::type_info()
+    }
+}
+
+impl Type<Postgres> for Vec<BigDecimal> {
+    fn type_info() -> PgTypeInfo {
+        <[BigDecimal] as Type<Postgres>>::type_info()
     }
 }
 

--- a/sqlx-core/src/postgres/types/ipnetwork.rs
+++ b/sqlx-core/src/postgres/types/ipnetwork.rs
@@ -37,6 +37,12 @@ impl Type<Postgres> for [IpNetwork] {
     }
 }
 
+impl Type<Postgres> for Vec<IpNetwork> {
+    fn type_info() -> PgTypeInfo {
+        <[IpNetwork] as Type<Postgres>>::type_info()
+    }
+}
+
 impl Encode<Postgres> for IpNetwork {
     fn encode(&self, buf: &mut Vec<u8>) {
         match self {

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -32,6 +32,7 @@ chrono = [ "sqlx/chrono" ]
 time = [ "sqlx/time" ]
 ipnetwork = [ "sqlx/ipnetwork" ]
 uuid = [ "sqlx/uuid" ]
+json = [ "sqlx/json", "serde_json" ]
 
 [dependencies]
 async-std = { version = "1.5.0", default-features = false, optional = true }
@@ -40,6 +41,7 @@ dotenv = { version = "0.15.0", default-features = false }
 futures = { version = "0.3.4", default-features = false, features = [ "executor" ] }
 proc-macro2 = { version = "1.0.9", default-features = false }
 sqlx = { version = "0.3.0-alpha.2", default-features = false, path = "../sqlx-core", package = "sqlx-core" }
+serde_json = { version = "1.0", features = [ "raw_value" ], optional = true }
 syn = { version = "1.0.16", default-features = false, features = [ "full" ] }
 quote = { version = "1.0.2", default-features = false }
 url = { version = "2.1.1", default-features = false }

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlx-macros"
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.2"
 repository = "https://github.com/launchbadge/sqlx"
 description = "Macros for SQLx, the rust SQL toolkit. Not intended to be used directly."
 license = "MIT OR Apache-2.0"
@@ -39,7 +39,7 @@ tokio = { version = "0.2.13", default-features = false, features = [ "rt-threade
 dotenv = { version = "0.15.0", default-features = false }
 futures = { version = "0.3.4", default-features = false, features = [ "executor" ] }
 proc-macro2 = { version = "1.0.9", default-features = false }
-sqlx = { version = "0.3.0-alpha.1", default-features = false, path = "../sqlx-core", package = "sqlx-core" }
+sqlx = { version = "0.3.0-alpha.2", default-features = false, path = "../sqlx-core", package = "sqlx-core" }
 syn = { version = "1.0.16", default-features = false, features = [ "full" ] }
 quote = { version = "1.0.2", default-features = false }
 url = { version = "2.1.1", default-features = false }

--- a/sqlx-macros/src/database/postgres.rs
+++ b/sqlx-macros/src/database/postgres.rs
@@ -45,6 +45,9 @@ impl_database_ext! {
         #[cfg(feature = "ipnetwork")]
         sqlx::types::ipnetwork::IpNetwork,
 
+        #[cfg(feature = "json")]
+        serde_json::Value,
+
         // Arrays
         Vec<bool> | &[bool],
         Vec<String> | &[String],

--- a/sqlx-macros/src/database/postgres.rs
+++ b/sqlx-macros/src/database/postgres.rs
@@ -55,6 +55,42 @@ impl_database_ext! {
         Vec<i64> | &[i64],
         Vec<f32> | &[f32],
         Vec<f64> | &[f64],
+
+
+        #[cfg(feature = "uuid")]
+        Vec<sqlx::types::Uuid> | &[sqlx::types::Uuid],
+
+        #[cfg(feature = "chrono")]
+        Vec<sqlx::types::chrono::NaiveTime> | &[sqlx::types::sqlx::types::chrono::NaiveTime],
+
+        #[cfg(feature = "chrono")]
+        Vec<sqlx::types::chrono::NaiveDate> | &[sqlx::types::chrono::NaiveDate],
+
+        #[cfg(feature = "chrono")]
+        Vec<sqlx::types::chrono::NaiveDateTime> | &[sqlx::types::chrono::NaiveDateTime],
+
+        // TODO
+        // #[cfg(feature = "chrono")]
+        // Vec<sqlx::types::chrono::DateTime<sqlx::types::chrono::Utc>> | &[sqlx::types::chrono::DateTime<_>],
+
+        #[cfg(feature = "time")]
+        Vec<sqlx::types::time::Time> | &[sqlx::types::time::Time],
+
+        #[cfg(feature = "time")]
+        Vec<sqlx::types::time::Date> | &[sqlx::types::time::Date],
+
+        #[cfg(feature = "time")]
+        Vec<sqlx::types::time::PrimitiveDateTime> | &[sqlx::types::time::PrimitiveDateTime],
+
+        #[cfg(feature = "time")]
+        Vec<sqlx::types::time::OffsetDateTime> | &[sqlx::types::time::OffsetDateTime],
+
+        #[cfg(feature = "bigdecimal")]
+        Vec<sqlx::types::BigDecimal> | &[sqlx::types::BigDecimal],
+
+        #[cfg(feature = "ipnetwork")]
+        Vec<sqlx::types::ipnetwork::IpNetwork> | &[sqlx::types::ipnetwork::IpNetwork],
+
     },
     ParamChecking::Strong,
     feature-types: info => info.type_feature_gate(),


### PR DESCRIPTION
This adds most of the remaining types to `query!` macro arrays.

There was one type I wasn't able to get working, `DateTime<Utc>`. Currently, I left its non-working implementation and test just commented out.

As for testing, I added a macro for using the `query!` macros. Right now it is very verbose and needs a good rewrite when/if the concatenation of SQL literals gets implemented.