### PR TITLE
Process keyword fields correctly in FromRow macro

### DIFF
--- a/sqlx-macros/src/derives/row.rs
+++ b/sqlx-macros/src/derives/row.rs
@@ -74,7 +74,7 @@ fn expand_derive_from_row_struct(
 
     let reads = fields.iter().filter_map(|field| -> Option<Stmt> {
         let id = &field.ident.as_ref()?;
-        let id_s = id.to_string();
+        let id_s = id.to_string().trim_start_matches("r#").to_owned();
         let ty = &field.ty;
 
         Some(parse_quote!(


### PR DESCRIPTION
This PR fixes the the incorrect handling of keywords fields of a struct in the FromRow macro.

Currently a struct with a field like 'r#type' will try to read values from a column with the exact same name with r# prefix. With this change this field will now map to a database column with the correct name 'type' without the r# prefix.