### PR TITLE
WIP: First attempt at roundtripping chrono types through SQLite

### DIFF
--- a/sqlx-core/src/sqlite/type_info.rs
+++ b/sqlx-core/src/sqlite/type_info.rs
@@ -12,6 +12,7 @@ pub(crate) enum SqliteType {
 
     // Non-standard extensions
     Boolean,
+    Timestamp,
 }
 
 // https://www.sqlite.org/datatype3.html#type_affinity
@@ -47,6 +48,7 @@ impl Display for SqliteTypeInfo {
             SqliteType::Integer => "INTEGER",
             SqliteType::Float => "DOUBLE",
             SqliteType::Blob => "BLOB",
+            SqliteType::Timestamp => "TIMESTAMP",
         })
     }
 }

--- a/sqlx-core/src/sqlite/types/chrono.rs
+++ b/sqlx-core/src/sqlite/types/chrono.rs
@@ -1,0 +1,71 @@
+use crate::{
+    decode::Decode,
+    encode::Encode,
+    sqlite::{
+        type_info::{SqliteType, SqliteTypeAffinity},
+        Sqlite, SqliteArgumentValue, SqliteTypeInfo, SqliteValue,
+    },
+    types::Type,
+    Result,
+};
+use chrono::NaiveDateTime;
+
+impl Type<Sqlite> for NaiveDateTime {
+    fn type_info() -> SqliteTypeInfo {
+        SqliteTypeInfo::new(SqliteType::Timestamp, SqliteTypeAffinity::Text)
+    }
+}
+
+impl Encode<Sqlite> for NaiveDateTime {
+    fn encode(&self, buf: &mut Vec<SqliteArgumentValue>) {
+        buf.push(SqliteArgumentValue::Text(
+            self.format("%F %T%.f").to_string(),
+        ))
+    }
+}
+
+impl<'a> Decode<'a, Sqlite> for NaiveDateTime {
+    fn decode(value: SqliteValue) -> Result<Self> {
+        let the_type = value.r#type();
+
+        match the_type {
+            Some(SqliteType::Text) => return decode_from_text(value.text()),
+            _ => {}
+        }
+
+        Err(protocol_err!("Unexpected affinity for data: {:?} in value", the_type).into())
+    }
+}
+
+fn decode_from_text(text: Option<&str>) -> Result<NaiveDateTime> {
+    if let Some(raw) = text {
+        // Loop over common date time partterns, inspired by Diesel
+        // https://docs.diesel.rs/src/diesel/sqlite/types/date_and_time/chrono.rs.html#56-97
+        let sqlite_datetime_formats = &[
+            // Most likely format
+            "%F %T%.f",
+            // Other formats in order of appearance in docs
+            "%F %R",
+            "%F %RZ",
+            "%F %R%:z",
+            "%F %T%.fZ",
+            "%F %T%.f%:z",
+            "%FT%R",
+            "%FT%RZ",
+            "%FT%R%:z",
+            "%FT%T%.f",
+            "%FT%T%.fZ",
+            "%FT%T%.f%:z",
+        ];
+
+        for format in sqlite_datetime_formats {
+            if let Ok(dt) = NaiveDateTime::parse_from_str(raw, format) {
+                return Ok(dt);
+            }
+        }
+
+        return Err(protocol_err!("Did not find a matching pattern").into());
+    }
+
+    Err(protocol_err!("There was not text value to decode").into())
+}

--- a/sqlx-core/src/sqlite/types/mod.rs
+++ b/sqlx-core/src/sqlite/types/mod.rs
@@ -17,14 +17,9 @@
 //!
 //! Requires the `chrono` Cargo feature flag.
 //!
-//! | Rust type                             | MySQL type(s)                                        |
+//! | Rust type                             | Sqlite type(s)                                        |
 //! |---------------------------------------|------------------------------------------------------|
-//! | `chrono::DateTime<Utc>`               | TIMESTAMP                                            |
-//! | `chrono::DateTime<Local>`             | TIMETAMP                                             |
-//! | `chrono::NaiveDateTime`               | DATETIME                                             |
-//! | `chrono::NaiveDate`                   | DATE                                                 |
-//! | `chrono::NaiveTime`                   | TIME                                                 |
-
+//! | `chrono::NaiveDateTime`               | TIMESTAMP                                             |
 //!
 //! # Nullable
 //!

--- a/sqlx-core/src/sqlite/types/mod.rs
+++ b/sqlx-core/src/sqlite/types/mod.rs
@@ -13,6 +13,19 @@
 //! | `&str`, `String`                      | TEXT                                                 |
 //! | `&[u8]`, `Vec<u8>`                    | BLOB                                                 |
 //!
+//! ### [`chrono`](https://crates.io/crates/chrono)
+//!
+//! Requires the `chrono` Cargo feature flag.
+//!
+//! | Rust type                             | MySQL type(s)                                        |
+//! |---------------------------------------|------------------------------------------------------|
+//! | `chrono::DateTime<Utc>`               | TIMESTAMP                                            |
+//! | `chrono::DateTime<Local>`             | TIMETAMP                                             |
+//! | `chrono::NaiveDateTime`               | DATETIME                                             |
+//! | `chrono::NaiveDate`                   | DATE                                                 |
+//! | `chrono::NaiveTime`                   | TIME                                                 |
+
+//!
 //! # Nullable
 //!
 //! In addition, `Option<T>` is supported where `T` implements `Type`. An `Option<T>` represents
@@ -25,6 +38,8 @@ use crate::sqlite::Sqlite;
 
 mod bool;
 mod bytes;
+#[cfg(feature = "chrono")]
+mod chrono;
 mod float;
 mod int;
 mod str;

--- a/sqlx-core/src/sqlite/value.rs
+++ b/sqlx-core/src/sqlite/value.rs
@@ -30,7 +30,7 @@ impl<'c> SqliteValue<'c> {
         self.r#type().is_none()
     }
 
-    fn r#type(&self) -> Option<SqliteType> {
+    pub(super) fn r#type(&self) -> Option<SqliteType> {
         let type_code = unsafe { sqlite3_column_type(self.statement.handle(), self.index) };
 
         // SQLITE_INTEGER, SQLITE_FLOAT, SQLITE_TEXT, SQLITE_BLOB, or SQLITE_NULL


### PR DESCRIPTION
This is a first draft of what I believe needs to be done to store `chono` types into `TIMESTAMP` columns in SQLite.

My intent is to get a sense of direction with where I'm heading.
I am not 100% how to test this other than creating a bunch of databases and roundtripping a bunch of  values.

Also, I am not sure if my decode is right? 
I was expecting to work with affinity not with `r#type()`?

Any feedback is welcome ❤️  

Addresses #164