### PR TITLE
Sqlite: fixed types of variables that interact with libsqlite3

### DIFF
--- a/sqlx-core/src/sqlite/arguments.rs
+++ b/sqlx-core/src/sqlite/arguments.rs
@@ -1,7 +1,7 @@
 use core::ffi::c_void;
 use core::mem;
 
-use std::os::raw::c_int;
+use std::os::raw::{c_char, c_int};
 
 use libsqlite3_sys::{
     sqlite3_bind_blob, sqlite3_bind_double, sqlite3_bind_int, sqlite3_bind_int64,
@@ -96,7 +96,7 @@ impl SqliteArgumentValue {
             SqliteArgumentValue::Text(value) => {
                 // TODO: Handle text that is too large
                 let bytes = value.as_bytes();
-                let bytes_ptr = bytes.as_ptr() as *const i8;
+                let bytes_ptr = bytes.as_ptr() as *const c_char;
                 let bytes_len = bytes.len() as i32;
 
                 unsafe {

--- a/sqlx-core/src/sqlite/statement.rs
+++ b/sqlx-core/src/sqlite/statement.rs
@@ -3,7 +3,7 @@
 use core::ptr::{null, null_mut, NonNull};
 use std::collections::HashMap;
 use std::ffi::CStr;
-use std::os::raw::c_int;
+use std::os::raw::{c_char, c_int};
 use std::ptr;
 
 use libsqlite3_sys::{
@@ -56,11 +56,11 @@ impl Statement {
         persistent: bool,
     ) -> crate::Result<Self> {
         // TODO: Error on queries that are too large
-        let query_ptr = query.as_bytes().as_ptr() as *const i8;
+        let query_ptr = query.as_bytes().as_ptr() as *const c_char;
         let query_len = query.len() as i32;
         let mut statement_handle: *mut sqlite3_stmt = null_mut();
         let mut flags = SQLITE_PREPARE_NO_VTAB;
-        let mut tail: *const i8 = null();
+        let mut tail: *const c_char = null();
 
         if persistent {
             // SQLITE_PREPARE_PERSISTENT

--- a/sqlx-core/src/sqlite/value.rs
+++ b/sqlx-core/src/sqlite/value.rs
@@ -63,12 +63,12 @@ impl<'c> SqliteValue<'c> {
     /// Returns the UTF-8 TEXT result.
     pub(super) fn text(&self) -> Option<&'c str> {
         unsafe {
-            let ptr = sqlite3_column_text(self.statement.handle(), self.index) as *const i8;
+            let ptr = sqlite3_column_text(self.statement.handle(), self.index);
 
             if ptr.is_null() {
                 None
             } else {
-                Some(from_utf8_unchecked(CStr::from_ptr(ptr).to_bytes()))
+                Some(from_utf8_unchecked(CStr::from_ptr(ptr as _).to_bytes()))
             }
         }
     }


### PR DESCRIPTION
Without these changes, sqlx couldn't be built with `sqlite` feature for such architectures as armv7: there are errors such as
```
   --> sqlx-core/src/sqlite/arguments.rs:106:25
    |
106 |                         bytes_ptr,
    |                         ^^^^^^^^^ expected `u8`, found `i8`
    |
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8`

```

These changes can verified by installing and running `cross` for cross-compiling (requires Docker)
```
cargo install cross --version 1.0.16
cross build --target armv7-unknown-linux-gnueabihf --features sqlite
```
or by building on real device (e.g. Raspberry Pi).