### PR TITLE
Enable create database

### DIFF
--- a/cargo-sqlx/Cargo.toml
+++ b/cargo-sqlx/Cargo.toml
@@ -22,3 +22,4 @@ futures = "0.3"
 structopt = "0.3"
 chrono = "0.4"
 anyhow = "1.0"
+url = { version = "2.1.1", default-features = false }

--- a/cargo-sqlx/Cargo.toml
+++ b/cargo-sqlx/Cargo.toml
@@ -21,3 +21,4 @@ sqlx = { version = "0.3", path = "..", default-features = false, features = [ "r
 futures = "0.3"
 structopt = "0.3"
 chrono = "0.4"
+anyhow = "1.0"

--- a/cargo-sqlx/src/main.rs
+++ b/cargo-sqlx/src/main.rs
@@ -22,28 +22,34 @@ const MIGRATION_FOLDER: &'static str = "migrations";
 #[derive(StructOpt, Debug)]
 #[structopt(name = "Sqlx")]
 enum Opt {
-    // #[structopt(subcommand)]
     Migrate(MigrationCommand),
+
+    #[structopt(alias = "db")]
+    Database(DatabaseCommand),
 }
 
-/// Simple postgres migrator
+/// Adds and runs migrations
 #[derive(StructOpt, Debug)]
 #[structopt(name = "Sqlx migrator")]
 enum MigrationCommand {
-    /// Initalizes new migration directory with db create script
-    // Init {
-    //     // #[structopt(long)]
-    //     database_name: String,
-    // },
-
-    /// Add new migration with name <timestamp>_<migration_name>.sql
+     /// Add new migration with name <timestamp>_<migration_name>.sql
     Add {
-        // #[structopt(long)]
         name: String,
     },
 
     /// Run all migrations
     Run,
+}
+
+/// Create or drops database depending on your connection string. Alias: db
+#[derive(StructOpt, Debug)]
+#[structopt(name = "Sqlx migrator")]
+enum DatabaseCommand {
+    /// Create database in url
+    Create,
+
+    /// Drop database in url
+    Drop,
 }
 
 #[tokio::main]
@@ -52,10 +58,16 @@ async fn main() -> Result<()> {
 
     match opt {
         Opt::Migrate(command) => match command {
-            // Opt::Init { database_name } => init_migrations(&database_name),
             MigrationCommand::Add { name } => add_migration_file(&name)?,
             MigrationCommand::Run => run_migrations().await?,
         },
+        Opt::Database(command) => {
+            match command {
+                DatabaseCommand::Create => println!("Creating your database"),
+                DatabaseCommand::Drop => println!("Killing your database"),
+            }
+            
+        }
     };
 
     println!("All done!");

--- a/cargo-sqlx/src/main.rs
+++ b/cargo-sqlx/src/main.rs
@@ -216,10 +216,7 @@ fn get_base_url<'a>(db_url: &'a str) -> Result<DbUrl> {
     let db_name = split[0];
     let base_url = split[1];
 
-    Ok(DbUrl {
-        base_url,
-        db_name,
-    })
+    Ok(DbUrl { base_url, db_name })
 }
 
 async fn check_if_db_exists(db_url: &DbUrl<'_>) -> Result<bool> {


### PR DESCRIPTION
So I did some clean up and integrated anyhow for cleaner error messages.
I also included a function that uses the connection string to create a database if there is none with the correct name in the database. Would like some feedback on wether that is a good idea or not. 

As is you can't actually create the database in a normal migration because the connection will fail because there is no database... 
This could be worked around in a number of ways.

1. We could assume there is always a database created 
2. There could be specialized migration script that creates the database (like `create_db.sql`)
3. Assume the first migration always is a create database script
4. Use the connection string to create a database
5. A mix of the above

I can see pros and cons with all of these methods. This PR implements nr 4.

ps. Also fixed so you can create two tables in the same migration.