### PR TITLE
Add unix domain socket support for Postgres

### DIFF
--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -22,7 +22,7 @@ all-type = ["bigdecimal", "json", "time", "chrono", "ipnetwork", "uuid"]
 # we need a feature which activates `num-bigint` as well because
 # `bigdecimal` uses types from it but does not reexport (tsk tsk)
 bigdecimal = ["bigdecimal_", "num-bigint"]
-postgres = [ "md-5", "sha2", "base64", "sha-1", "rand", "hmac", "futures-channel/sink", "futures-util/sink" ]
+postgres = [ "md-5", "sha2", "base64", "sha-1", "rand", "hmac", "futures-channel/sink", "futures-util/sink", "tokio/uds" ]
 json = ["serde", "serde_json"]
 mysql = [ "sha-1", "sha2", "generic-array", "num-bigint", "base64", "digest", "rand" ]
 sqlite = [ "libsqlite3-sys" ]

--- a/sqlx-core/src/mysql/stream.rs
+++ b/sqlx-core/src/mysql/stream.rs
@@ -34,7 +34,9 @@ pub(crate) struct MySqlStream {
 
 impl MySqlStream {
     pub(super) async fn new(url: &Url) -> crate::Result<Self> {
-        let stream = MaybeTlsStream::connect(&url, 3306).await?;
+        let host = url.host().unwrap_or("localhost");
+        let port = url.port(3306);
+        let stream = MaybeTlsStream::connect(host, port).await?;
 
         let mut capabilities = Capabilities::PROTOCOL_41
             | Capabilities::IGNORE_SPACE

--- a/sqlx-core/src/mysql/tls.rs
+++ b/sqlx-core/src/mysql/tls.rs
@@ -116,5 +116,8 @@ async fn try_upgrade(
         )
         .await?;
 
-    stream.stream.upgrade(url, connector).await
+    stream
+        .stream
+        .upgrade(url.host().unwrap_or("localhost"), connector)
+        .await
 }

--- a/sqlx-core/src/postgres/connection.rs
+++ b/sqlx-core/src/postgres/connection.rs
@@ -112,7 +112,7 @@ pub struct PgConnection {
 async fn startup(stream: &mut PgStream, url: &Url) -> crate::Result<BackendKeyData> {
     // Defaults to postgres@.../postgres
     let username = url.username().unwrap_or(Cow::Borrowed("postgres"));
-    let database = url.database().unwrap_or("postgres");
+    let database = url.database().unwrap_or(&username);
 
     // See this doc for more runtime parameters
     // https://www.postgresql.org/docs/12/runtime-config-client.html

--- a/sqlx-core/src/postgres/connection.rs
+++ b/sqlx-core/src/postgres/connection.rs
@@ -110,8 +110,12 @@ pub struct PgConnection {
 
 // https://www.postgresql.org/docs/12/protocol-flow.html#id-1.10.5.7.3
 async fn startup(stream: &mut PgStream, url: &Url) -> crate::Result<BackendKeyData> {
-    // Defaults to postgres@.../postgres
-    let username = url.username().unwrap_or(Cow::Borrowed("postgres"));
+    // Defaults to $USER@.../$USER
+    // and falls back to postgres@.../postgres
+    let username = url
+        .username()
+        .or_else(|| std::env::var("USER").map(Cow::Owned).ok())
+        .unwrap_or(Cow::Borrowed("postgres"));
     let database = url.database().unwrap_or(&username);
 
     // See this doc for more runtime parameters

--- a/sqlx-core/src/postgres/stream.rs
+++ b/sqlx-core/src/postgres/stream.rs
@@ -33,6 +33,7 @@ impl PgStream {
                         .decode_utf8()
                         .expect("percent-encoded hostname contained non-UTF-8 bytes")
                 })
+                .or_else(|| url.param("host"))
                 .unwrap_or("/var/run/postgresql".into());
             if host.starts_with("/") {
                 let path = format!("{}/.s.PGSQL.{}", host, port);

--- a/sqlx-core/src/postgres/stream.rs
+++ b/sqlx-core/src/postgres/stream.rs
@@ -23,7 +23,9 @@ pub struct PgStream {
 
 impl PgStream {
     pub(super) async fn new(url: &Url) -> crate::Result<Self> {
-        let stream = MaybeTlsStream::connect(&url, 5432).await?;
+        let host = url.host().unwrap_or("localhost");
+        let port = url.port(5432);
+        let stream = MaybeTlsStream::connect(host, port).await?;
 
         Ok(Self {
             notifications: None,

--- a/sqlx-core/src/postgres/tls.rs
+++ b/sqlx-core/src/postgres/tls.rs
@@ -105,7 +105,8 @@ async fn try_upgrade(
         }
     }
 
-    stream.stream.upgrade(url, connector).await?;
+    let host = url.host().unwrap_or("localhost");
+    stream.stream.upgrade(host, connector).await?;
 
     Ok(true)
 }

--- a/sqlx-core/src/runtime.rs
+++ b/sqlx-core/src/runtime.rs
@@ -17,6 +17,9 @@ pub(crate) use async_std::{
     task::spawn,
 };
 
+#[cfg(all(feature = "runtime-async-std", feature = "postgres", unix))]
+pub(crate) use async_std::os::unix::net::UnixStream;
+
 #[cfg(feature = "runtime-tokio")]
 pub(crate) use tokio::{
     fs,
@@ -26,3 +29,6 @@ pub(crate) use tokio::{
     time::delay_for as sleep,
     time::timeout,
 };
+
+#[cfg(all(feature = "runtime-tokio", feature = "postgres", unix))]
+pub(crate) use tokio::net::UnixStream;

--- a/sqlx-core/src/url.rs
+++ b/sqlx-core/src/url.rs
@@ -34,13 +34,10 @@ impl Url {
         self.0.as_str()
     }
 
-    pub fn host(&self) -> &str {
-        let host = self.0.host_str();
-
-        match host {
-            Some(host) if !host.is_empty() => host,
-
-            _ => "localhost",
+    pub fn host(&self) -> Option<&str> {
+        match self.0.host_str()? {
+            "" => None,
+            host => Some(host),
         }
     }
 


### PR DESCRIPTION
This PR adds unix domain socket support for Postgres.  It also changes the default values of multiple connection parameters to match libpq behaviour, e.g. `postgres:///` was equivalent to `postgres:///postgres@localhost/postgres` for sqlx, but now sqlx would connect to the DB via UDS with the current user as username and database name (assuming we're running a Unix).

Current state: Works on my Linux :laughing:  What kind of tests would you like to see?

Open questions:
- This PR uses `$USER` to get the name of the current user.  Does this work on all (supported) Unixes? What about Windows? Do we want to be smarter? (e.g. call `geteuid` and `getpwuid`)
- What about TLS over UDS? This is currently not supported.

Fixes #144 