### PR TITLE
Add snake_case rename support for Type macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,12 +291,14 @@ checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 name = "cargo-sqlx"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "dotenv",
  "futures 0.3.4",
  "sqlx",
  "structopt",
  "tokio 0.2.13",
+ "url",
 ]
 
 [[package]]
@@ -1808,6 +1810,7 @@ dependencies = [
  "async-std",
  "dotenv",
  "futures 0.3.4",
+ "heck",
  "lazy_static",
  "proc-macro2",
  "quote",

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -39,6 +39,7 @@ async-std = { version = "1.5.0", default-features = false, optional = true }
 tokio = { version = "0.2.13", default-features = false, features = [ "rt-threaded" ], optional = true }
 dotenv = { version = "0.15.0", default-features = false }
 futures = { version = "0.3.4", default-features = false, features = [ "executor" ] }
+heck = "0.3"
 proc-macro2 = { version = "1.0.9", default-features = false }
 sqlx = { version = "0.3.4", default-features = false, path = "../sqlx-core", package = "sqlx-core" }
 serde_json = { version = "1.0", features = [ "raw_value" ], optional = true }

--- a/sqlx-macros/src/derives/attributes.rs
+++ b/sqlx-macros/src/derives/attributes.rs
@@ -29,6 +29,7 @@ macro_rules! try_set {
 #[derive(Copy, Clone)]
 pub enum RenameAll {
     LowerCase,
+    SnakeCase,
 }
 
 pub struct SqlxContainerAttributes {
@@ -68,6 +69,7 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
                             }) if path.is_ident("rename_all") => {
                                 let val = match &*val.value() {
                                     "lowercase" => RenameAll::LowerCase,
+                                    "snake_case" => RenameAll::SnakeCase,
 
                                     _ => fail!(meta, "unexpected value for rename_all"),
                                 };

--- a/sqlx-macros/src/derives/mod.rs
+++ b/sqlx-macros/src/derives/mod.rs
@@ -10,6 +10,7 @@ pub(crate) use r#type::expand_derive_type;
 pub(crate) use row::expand_derive_from_row;
 
 use self::attributes::RenameAll;
+use heck::SnakeCase;
 use std::iter::FromIterator;
 use syn::DeriveInput;
 
@@ -30,5 +31,6 @@ pub(crate) fn expand_derive_type_encode_decode(
 pub(crate) fn rename_all(s: &str, pattern: RenameAll) -> String {
     match pattern {
         RenameAll::LowerCase => s.to_lowercase(),
+        RenameAll::SnakeCase => s.to_snake_case(),
     }
 }


### PR DESCRIPTION
I encountered a use case while converting a project
from Diesel to sqlx, where I had a custom Postgres enum
which included a snake case field name:

```rust
pub enum JobStatus {
    NotRun,
    Finished,
    Failed,
}
```

Which translates to:

```sql
CREATE TYPE job_status AS ENUM ('not_run', 'finished', 'failed');
```

This is likely to be a semi-common use case,
so this commit adds snake case support for enums
via the `#[sqlx(rename_all = "snake_case")]` attribute.