### PR TITLE
Prepare migrator for more databases

### DIFF
--- a/cargo-sqlx/Cargo.toml
+++ b/cargo-sqlx/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 dotenv = "0.15"
 tokio = { version = "0.2", features = ["macros"] }
-sqlx = { version = "0.3", path = "..", default-features = false, features = [ "runtime-tokio", "postgres" ] }
+sqlx = { version = "0.3", path = "..", default-features = false, features = [ "runtime-tokio" ] }
 futures = "0.3"
 structopt = "0.3"
 chrono = "0.4"

--- a/cargo-sqlx/Cargo.toml
+++ b/cargo-sqlx/Cargo.toml
@@ -24,3 +24,12 @@ chrono = "0.4"
 anyhow = "1.0"
 url = { version = "2.1.1", default-features = false }
 async-trait = "0.1.30"
+
+[features]
+default = [ "postgres", "sqlite" ]
+
+
+# database
+mysql = [ "sqlx/mysql" ]
+postgres = [ "sqlx/postgres" ]
+sqlite = [ "sqlx/sqlite" ]

--- a/cargo-sqlx/Cargo.toml
+++ b/cargo-sqlx/Cargo.toml
@@ -23,3 +23,4 @@ structopt = "0.3"
 chrono = "0.4"
 anyhow = "1.0"
 url = { version = "2.1.1", default-features = false }
+async-trait = "0.1.30"

--- a/cargo-sqlx/src/database_migrator.rs
+++ b/cargo-sqlx/src/database_migrator.rs
@@ -1,0 +1,17 @@
+use async_trait::async_trait;
+use anyhow::{Result};
+
+#[async_trait]
+pub trait DatabaseMigrator {
+    fn database_type(&self) -> String;
+
+    fn get_database_name(&self) -> Result<String>;
+
+    fn can_migrate_database(&self) -> bool;
+    fn can_create_database(&self) -> bool;
+    fn can_drop_database(&self) -> bool;
+
+    async fn check_if_database_exists(&self, db_name: &str) -> Result<bool>;
+    async fn create_database(&self, db_name: &str) -> Result<()>;
+    async fn drop_database(&self, db_name: &str) -> Result<()>;
+}

--- a/cargo-sqlx/src/database_migrator.rs
+++ b/cargo-sqlx/src/database_migrator.rs
@@ -1,17 +1,32 @@
+use anyhow::Result;
 use async_trait::async_trait;
-use anyhow::{Result};
+
+#[async_trait]
+pub trait MigTrans {
+    async fn commit(self: Box<Self>) -> Result<()>;
+    async fn rollback(self: Box<Self>) -> Result<()>;
+    async fn check_if_applied(&mut self, migration: &str) -> Result<bool>;
+    async fn execute_migration(&mut self, migration_sql: &str) -> Result<()>;
+    async fn save_applied_migration(&mut self, migration_name: &str) -> Result<()>;
+}
 
 #[async_trait]
 pub trait DatabaseMigrator {
+    // Misc info
     fn database_type(&self) -> String;
-
     fn get_database_name(&self) -> Result<String>;
 
+    // Features
     fn can_migrate_database(&self) -> bool;
     fn can_create_database(&self) -> bool;
     fn can_drop_database(&self) -> bool;
 
+    // Database creation
     async fn check_if_database_exists(&self, db_name: &str) -> Result<bool>;
     async fn create_database(&self, db_name: &str) -> Result<()>;
     async fn drop_database(&self, db_name: &str) -> Result<()>;
+
+    // Migration
+    async fn create_migration_table(&self) -> Result<()>;
+    async fn begin_migration(&self) -> Result<Box<dyn MigTrans>>;
 }

--- a/cargo-sqlx/src/database_migrator.rs
+++ b/cargo-sqlx/src/database_migrator.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 #[async_trait]
-pub trait MigTrans {
+pub trait MigrationTransaction {
     async fn commit(self: Box<Self>) -> Result<()>;
     async fn rollback(self: Box<Self>) -> Result<()>;
     async fn check_if_applied(&mut self, migration: &str) -> Result<bool>;
@@ -28,5 +28,5 @@ pub trait DatabaseMigrator {
 
     // Migration
     async fn create_migration_table(&self) -> Result<()>;
-    async fn begin_migration(&self) -> Result<Box<dyn MigTrans>>;
+    async fn begin_migration(&self) -> Result<Box<dyn MigrationTransaction>>;
 }

--- a/cargo-sqlx/src/main.rs
+++ b/cargo-sqlx/src/main.rs
@@ -24,13 +24,14 @@ const MIGRATION_FOLDER: &'static str = "migrations";
 #[derive(StructOpt, Debug)]
 #[structopt(name = "Sqlx")]
 enum Opt {
+    #[structopt(alias = "mig")]
     Migrate(MigrationCommand),
 
     #[structopt(alias = "db")]
     Database(DatabaseCommand),
 }
 
-/// Adds and runs migrations
+/// Adds and runs migrations. Alias: mig
 #[derive(StructOpt, Debug)]
 #[structopt(name = "Sqlx migrator")]
 enum MigrationCommand {

--- a/cargo-sqlx/src/main.rs
+++ b/cargo-sqlx/src/main.rs
@@ -127,6 +127,8 @@ async fn run_create_database(db_creator: &dyn DatabaseMigrator) -> Result<()> {
 }
 
 async fn run_drop_database(db_creator: &dyn DatabaseMigrator) -> Result<()> {
+    use std::io;
+
     if !db_creator.can_drop_database() {
         return Err(anyhow!(
             "Database drop is not implemented for {}",
@@ -138,6 +140,24 @@ async fn run_drop_database(db_creator: &dyn DatabaseMigrator) -> Result<()> {
     let db_exists = db_creator.check_if_database_exists(&db_name).await?;
 
     if db_exists {
+
+        loop {
+            println!("\nAre you sure you want to drop the database: {}? Y/n", db_name);
+    
+            let mut input = String::new();
+        
+            io::stdin()
+                .read_line(&mut input)
+                .context("Failed to read line")?;
+        
+            match input.trim() {
+                "Y" => break,
+                "N" => return Ok(()),
+                "n" => return Ok(()),
+                _ => continue,
+            };
+        };
+
         println!("Dropping database: {}", db_name);
         Ok(db_creator.drop_database(&db_name).await?)
     } else {

--- a/cargo-sqlx/src/main.rs
+++ b/cargo-sqlx/src/main.rs
@@ -141,23 +141,25 @@ async fn run_drop_database(migrator: &dyn DatabaseMigrator) -> Result<()> {
     let db_exists = migrator.check_if_database_exists(&db_name).await?;
 
     if db_exists {
-
         loop {
-            println!("\nAre you sure you want to drop the database: {}? Y/n", db_name);
-    
+            println!(
+                "\nAre you sure you want to drop the database: {}? Y/n",
+                db_name
+            );
+
             let mut input = String::new();
-        
+
             io::stdin()
                 .read_line(&mut input)
                 .context("Failed to read line")?;
-        
+
             match input.trim() {
                 "Y" => break,
                 "N" => return Ok(()),
                 "n" => return Ok(()),
                 _ => continue,
             };
-        };
+        }
 
         println!("Dropping database: {}", db_name);
         Ok(migrator.drop_database(&db_name).await?)

--- a/cargo-sqlx/src/main.rs
+++ b/cargo-sqlx/src/main.rs
@@ -76,8 +76,15 @@ async fn main() -> Result<()> {
 }
 
 async fn run_create_database(db_creator: &dyn DatabaseCreator) -> Result<()> {
-    let db_name = db_creator.get_db_name()?;
-    let db_exists = db_creator.check_if_db_exists(&db_name).await?;
+    if !db_creator.can_create_database() {
+        return Err(anyhow!(
+            "Database drop is not implemented for {}",
+            db_creator.database_type()
+        ));
+    }
+
+    let db_name = db_creator.get_database_name()?;
+    let db_exists = db_creator.check_if_database_exists(&db_name).await?;
 
     if !db_exists {
         println!("Creating database: {}", db_name);
@@ -89,8 +96,15 @@ async fn run_create_database(db_creator: &dyn DatabaseCreator) -> Result<()> {
 }
 
 async fn run_drop_database(db_creator: &dyn DatabaseCreator) -> Result<()> {
-    let db_name = db_creator.get_db_name()?;
-    let db_exists = db_creator.check_if_db_exists(&db_name).await?;
+    if !db_creator.can_drop_database() {
+        return Err(anyhow!(
+            "Database drop is not implemented for {}",
+            db_creator.database_type()
+        ));
+    }
+
+    let db_name = db_creator.get_database_name()?;
+    let db_exists = db_creator.check_if_database_exists(&db_name).await?;
 
     if db_exists {
         println!("Dropping database: {}", db_name);

--- a/cargo-sqlx/src/main.rs
+++ b/cargo-sqlx/src/main.rs
@@ -12,11 +12,11 @@ use anyhow::{anyhow, Context, Result};
 
 mod database_migrator;
 mod postgres;
-// mod sqlite;
+mod sqlite;
 
 use database_migrator::DatabaseMigrator;
 use postgres::Postgres;
-// use sqlite::Sqlite;
+use sqlite::Sqlite;
 
 const MIGRATION_FOLDER: &'static str = "migrations";
 
@@ -63,8 +63,7 @@ async fn main() -> Result<()> {
     // This code is taken from: https://github.com/launchbadge/sqlx/blob/master/sqlx-macros/src/lib.rs#L63
     match db_url.scheme() {
         #[cfg(feature = "sqlite")]
-        // "sqlite" => run_command(&Sqlite { db_url: &db_url_raw }).await?,
-         "sqlite" => return Err(anyhow!("error")),
+        "sqlite" => run_command(&Sqlite::new(db_url_raw )).await?,
         #[cfg(not(feature = "sqlite"))]
         "sqlite" => return Err(anyhow!("Not implemented. DATABASE_URL {} has the scheme of a SQLite database but the `sqlite` feature of sqlx was not enabled",
                             db_url)),
@@ -110,7 +109,7 @@ async fn run_command(db_creator: &dyn DatabaseMigrator) -> Result<()> {
 async fn run_create_database(db_creator: &dyn DatabaseMigrator) -> Result<()> {
     if !db_creator.can_create_database() {
         return Err(anyhow!(
-            "Database drop is not implemented for {}",
+            "Database creation is not implemented for {}",
             db_creator.database_type()
         ));
     }

--- a/cargo-sqlx/src/postgres.rs
+++ b/cargo-sqlx/src/postgres.rs
@@ -1,0 +1,104 @@
+use sqlx::postgres::PgRow;
+use sqlx::Connect;
+use sqlx::PgConnection;
+use sqlx::Row;
+
+use async_trait::async_trait;
+use anyhow::{anyhow, Context, Result};
+
+use crate::database_migrator::DatabaseMigrator;
+
+pub struct Postgres<'a> {
+    pub db_url: &'a str,
+}
+
+struct DbUrl<'a> {
+    base_url: &'a str,
+    db_name: &'a str,
+}
+
+fn get_base_url<'a>(db_url: &'a str) -> Result<DbUrl> {
+    let split: Vec<&str> = db_url.rsplitn(2, '/').collect();
+
+    if split.len() != 2 {
+        return Err(anyhow!("Failed to find database name in connection string"));
+    }
+
+    let db_name = split[0];
+    let base_url = split[1];
+
+    Ok(DbUrl { base_url, db_name })
+}
+
+
+#[async_trait]
+impl DatabaseMigrator for Postgres<'_> {
+    fn database_type(&self) -> String {
+        "Postgres".to_string()
+    }
+
+    fn can_migrate_database(&self) -> bool {
+        true
+    }
+
+    fn can_create_database(&self) -> bool {
+        true
+    }
+
+    fn can_drop_database(&self) -> bool {
+        true
+    }
+
+    fn get_database_name(&self) -> Result<String> {
+        let db_url = get_base_url(self.db_url)?;
+        Ok(db_url.db_name.to_string())
+    }
+
+    async fn check_if_database_exists(&self, db_name: &str) -> Result<bool> {
+        let db_url = get_base_url(self.db_url)?;
+
+        let base_url = db_url.base_url;
+
+        let mut conn = PgConnection::connect(base_url).await?;
+
+        let result: bool =
+            sqlx::query("select exists(SELECT 1 from pg_database WHERE datname = $1) as exists")
+                .bind(db_name)
+                .try_map(|row: PgRow| row.try_get("exists"))
+                .fetch_one(&mut conn)
+                .await
+                .context("Failed to check if database exists")?;
+
+        Ok(result)
+    }
+
+    async fn create_database(&self, db_name: &str) -> Result<()> {
+        let db_url = get_base_url(self.db_url)?;
+
+        let base_url = db_url.base_url;
+
+        let mut conn = PgConnection::connect(base_url).await?;
+
+        sqlx::query(&format!("CREATE DATABASE {}", db_name))
+            .execute(&mut conn)
+            .await
+            .with_context(|| format!("Failed to create database: {}", db_name))?;
+
+        Ok(())
+    }
+
+    async fn drop_database(&self, db_name: &str) -> Result<()> {
+        let db_url = get_base_url(self.db_url)?;
+
+        let base_url = db_url.base_url;
+
+        let mut conn = PgConnection::connect(base_url).await?;
+
+        sqlx::query(&format!("DROP DATABASE {}", db_name))
+            .execute(&mut conn)
+            .await
+            .with_context(|| format!("Failed to create database: {}", db_name))?;
+
+        Ok(())
+    }
+}

--- a/cargo-sqlx/src/postgres.rs
+++ b/cargo-sqlx/src/postgres.rs
@@ -1,9 +1,9 @@
 use sqlx::pool::PoolConnection;
 use sqlx::postgres::PgRow;
 use sqlx::Connect;
+use sqlx::Executor;
 use sqlx::PgConnection;
 use sqlx::PgPool;
-use sqlx::Executor;
 use sqlx::Row;
 
 use anyhow::{anyhow, Context, Result};

--- a/cargo-sqlx/src/sqlite.rs
+++ b/cargo-sqlx/src/sqlite.rs
@@ -1,0 +1,104 @@
+use sqlx::postgres::PgRow;
+use sqlx::Connect;
+use sqlx::PgConnection;
+use sqlx::Row;
+
+use async_trait::async_trait;
+use anyhow::{anyhow, Context, Result};
+
+use crate::database_migrator::DatabaseMigrator;
+
+pub struct Sqlite<'a> {
+    pub db_url: &'a str,
+}
+
+struct DbUrl<'a> {
+    base_url: &'a str,
+    db_name: &'a str,
+}
+
+fn get_base_url<'a>(db_url: &'a str) -> Result<DbUrl> {
+    let split: Vec<&str> = db_url.rsplitn(2, '/').collect();
+
+    if split.len() != 2 {
+        return Err(anyhow!("Failed to find database name in connection string"));
+    }
+
+    let db_name = split[0];
+    let base_url = split[1];
+
+    Ok(DbUrl { base_url, db_name })
+}
+
+
+#[async_trait]
+impl DatabaseMigrator for Sqlite<'_> {
+    fn database_type(&self) -> String {
+        "Sqlite".to_string()
+    }
+
+    fn can_migrate_database(&self) -> bool {
+        false
+    }
+
+    fn can_create_database(&self) -> bool {
+        false
+    }
+
+    fn can_drop_database(&self) -> bool {
+        false
+    }
+
+    fn get_database_name(&self) -> Result<String> {
+        let db_url = get_base_url(self.db_url)?;
+        Ok(db_url.db_name.to_string())
+    }
+
+    async fn check_if_database_exists(&self, db_name: &str) -> Result<bool> {
+        let db_url = get_base_url(self.db_url)?;
+
+        let base_url = db_url.base_url;
+
+        let mut conn = PgConnection::connect(base_url).await?;
+
+        let result: bool =
+            sqlx::query("select exists(SELECT 1 from pg_database WHERE datname = $1) as exists")
+                .bind(db_name)
+                .try_map(|row: PgRow| row.try_get("exists"))
+                .fetch_one(&mut conn)
+                .await
+                .context("Failed to check if database exists")?;
+
+        Ok(result)
+    }
+
+    async fn create_database(&self, db_name: &str) -> Result<()> {
+        let db_url = get_base_url(self.db_url)?;
+
+        let base_url = db_url.base_url;
+
+        let mut conn = PgConnection::connect(base_url).await?;
+
+        sqlx::query(&format!("CREATE DATABASE {}", db_name))
+            .execute(&mut conn)
+            .await
+            .with_context(|| format!("Failed to create database: {}", db_name))?;
+
+        Ok(())
+    }
+
+    async fn drop_database(&self, db_name: &str) -> Result<()> {
+        let db_url = get_base_url(self.db_url)?;
+
+        let base_url = db_url.base_url;
+
+        let mut conn = PgConnection::connect(base_url).await?;
+
+        sqlx::query(&format!("DROP DATABASE {}", db_name))
+            .execute(&mut conn)
+            .await
+            .with_context(|| format!("Failed to create database: {}", db_name))?;
+
+        Ok(())
+    }
+}

--- a/cargo-sqlx/src/sqlite.rs
+++ b/cargo-sqlx/src/sqlite.rs
@@ -31,74 +31,78 @@ fn get_base_url<'a>(db_url: &'a str) -> Result<DbUrl> {
 }
 
 
-#[async_trait]
-impl DatabaseMigrator for Sqlite<'_> {
-    fn database_type(&self) -> String {
-        "Sqlite".to_string()
-    }
+// #[async_trait]
+// impl DatabaseMigrator for Sqlite<'_> {
+//     fn database_type(&self) -> String {
+//         "Sqlite".to_string()
+//     }
 
-    fn can_migrate_database(&self) -> bool {
-        false
-    }
+//     fn can_migrate_database(&self) -> bool {
+//         false
+//     }
 
-    fn can_create_database(&self) -> bool {
-        false
-    }
+//     fn can_create_database(&self) -> bool {
+//         false
+//     }
 
-    fn can_drop_database(&self) -> bool {
-        false
-    }
+//     fn can_drop_database(&self) -> bool {
+//         false
+//     }
 
-    fn get_database_name(&self) -> Result<String> {
-        let db_url = get_base_url(self.db_url)?;
-        Ok(db_url.db_name.to_string())
-    }
+//     fn get_database_name(&self) -> Result<String> {
+//         let db_url = get_base_url(self.db_url)?;
+//         Ok(db_url.db_name.to_string())
+//     }
 
-    async fn check_if_database_exists(&self, db_name: &str) -> Result<bool> {
-        let db_url = get_base_url(self.db_url)?;
+//     async fn check_if_database_exists(&self, db_name: &str) -> Result<bool> {
+//         let db_url = get_base_url(self.db_url)?;
 
-        let base_url = db_url.base_url;
+//         let base_url = db_url.base_url;
 
-        let mut conn = PgConnection::connect(base_url).await?;
+//         let mut conn = PgConnection::connect(base_url).await?;
 
-        let result: bool =
-            sqlx::query("select exists(SELECT 1 from pg_database WHERE datname = $1) as exists")
-                .bind(db_name)
-                .try_map(|row: PgRow| row.try_get("exists"))
-                .fetch_one(&mut conn)
-                .await
-                .context("Failed to check if database exists")?;
+//         let result: bool =
+//             sqlx::query("select exists(SELECT 1 from pg_database WHERE datname = $1) as exists")
+//                 .bind(db_name)
+//                 .try_map(|row: PgRow| row.try_get("exists"))
+//                 .fetch_one(&mut conn)
+//                 .await
+//                 .context("Failed to check if database exists")?;
 
-        Ok(result)
-    }
+//         Ok(result)
+//     }
 
-    async fn create_database(&self, db_name: &str) -> Result<()> {
-        let db_url = get_base_url(self.db_url)?;
+//     async fn create_database(&self, db_name: &str) -> Result<()> {
+//         let db_url = get_base_url(self.db_url)?;
 
-        let base_url = db_url.base_url;
+//         let base_url = db_url.base_url;
 
-        let mut conn = PgConnection::connect(base_url).await?;
+//         let mut conn = PgConnection::connect(base_url).await?;
 
-        sqlx::query(&format!("CREATE DATABASE {}", db_name))
-            .execute(&mut conn)
-            .await
-            .with_context(|| format!("Failed to create database: {}", db_name))?;
+//         sqlx::query(&format!("CREATE DATABASE {}", db_name))
+//             .execute(&mut conn)
+//             .await
+//             .with_context(|| format!("Failed to create database: {}", db_name))?;
 
-        Ok(())
-    }
+//         Ok(())
+//     }
 
-    async fn drop_database(&self, db_name: &str) -> Result<()> {
-        let db_url = get_base_url(self.db_url)?;
+//     async fn drop_database(&self, db_name: &str) -> Result<()> {
+//         let db_url = get_base_url(self.db_url)?;
 
-        let base_url = db_url.base_url;
+//         let base_url = db_url.base_url;
 
-        let mut conn = PgConnection::connect(base_url).await?;
+//         let mut conn = PgConnection::connect(base_url).await?;
 
-        sqlx::query(&format!("DROP DATABASE {}", db_name))
-            .execute(&mut conn)
-            .await
-            .with_context(|| format!("Failed to create database: {}", db_name))?;
+//         sqlx::query(&format!("DROP DATABASE {}", db_name))
+//             .execute(&mut conn)
+//             .await
+//             .with_context(|| format!("Failed to create database: {}", db_name))?;
 
-        Ok(())
-    }
-}
+//         Ok(())
+//     }
+
+//     async fn create_migration_table(&self) -> Result<()> {
+//         Err(anyhow!("Not supported"))
+//     }
+// }

--- a/cargo-sqlx/src/sqlite.rs
+++ b/cargo-sqlx/src/sqlite.rs
@@ -104,7 +104,7 @@ impl DatabaseMigrator for Sqlite {
         Ok(())
     }
 
-    // 
+    //
     async fn begin_migration(&self) -> Result<Box<dyn MigrationTransaction>> {
         // let pool = SqlitePool::new(&self.db_url)
         //     .await

--- a/cargo-sqlx/src/sqlite.rs
+++ b/cargo-sqlx/src/sqlite.rs
@@ -1,108 +1,167 @@
-use sqlx::postgres::PgRow;
+// use sqlx::pool::PoolConnection;
+use sqlx::sqlite::SqliteRow;
 use sqlx::Connect;
-use sqlx::PgConnection;
+use sqlx::Executor;
 use sqlx::Row;
+use sqlx::SqliteConnection;
+// use sqlx::SqlitePool;
 
-use async_trait::async_trait;
 use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
 
-use crate::database_migrator::DatabaseMigrator;
+use crate::database_migrator::{DatabaseMigrator, MigrationTransaction};
 
-pub struct Sqlite<'a> {
-    pub db_url: &'a str,
+pub struct Sqlite {
+    db_url: String,
+    path: String,
 }
 
-struct DbUrl<'a> {
-    base_url: &'a str,
-    db_name: &'a str,
+impl Sqlite {
+    pub fn new(db_url: String) -> Self {
+        let path = crop_letters(&db_url, "sqlite://".len());
+        Sqlite {
+            db_url: db_url.clone(),
+            path: path.to_string(),
+        }
+    }
 }
 
-fn get_base_url<'a>(db_url: &'a str) -> Result<DbUrl> {
-    let split: Vec<&str> = db_url.rsplitn(2, '/').collect();
+fn crop_letters(s: &str, pos: usize) -> &str {
+    match s.char_indices().skip(pos).next() {
+        Some((pos, _)) => &s[pos..],
+        None => "",
+    }
+}
 
-    if split.len() != 2 {
-        return Err(anyhow!("Failed to find database name in connection string"));
+#[async_trait]
+impl DatabaseMigrator for Sqlite {
+    fn database_type(&self) -> String {
+        "Sqlite".to_string()
     }
 
-    let db_name = split[0];
-    let base_url = split[1];
+    fn can_migrate_database(&self) -> bool {
+        true
+    }
 
-    Ok(DbUrl { base_url, db_name })
+    fn can_create_database(&self) -> bool {
+        true
+    }
+
+    fn can_drop_database(&self) -> bool {
+        true
+    }
+
+    fn get_database_name(&self) -> Result<String> {
+        let split: Vec<&str> = self.db_url.rsplitn(2, '/').collect();
+
+        if split.len() != 2 {
+            return Err(anyhow!("Failed to find database name in connection string"));
+        }
+
+        let db_name = split[0];
+
+        Ok(db_name.to_string())
+    }
+
+    async fn check_if_database_exists(&self, _db_name: &str) -> Result<bool> {
+        use std::path::Path;
+        Ok(Path::new(&self.path).exists())
+    }
+
+    async fn create_database(&self, _db_name: &str) -> Result<()> {
+        use std::fs::OpenOptions;
+
+        println!("DB {}", self.path);
+
+        OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&self.path)?;
+
+        Ok(())
+    }
+
+    async fn drop_database(&self, _db_name: &str) -> Result<()> {
+        std::fs::remove_file(&self.path)?;
+        Ok(())
+    }
+
+    async fn create_migration_table(&self) -> Result<()> {
+        let mut conn = SqliteConnection::connect(&self.db_url).await?;
+
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS __migrations (
+                migration VARCHAR (255) PRIMARY KEY,
+                created TIMESTAMP NOT NULL DEFAULT current_timestamp
+            );
+        "#,
+        )
+        .execute(&mut conn)
+        .await
+        .context("Failed to create migration table")?;
+
+        Ok(())
+    }
+
+    // 
+    async fn begin_migration(&self) -> Result<Box<dyn MigrationTransaction>> {
+        // let pool = SqlitePool::new(&self.db_url)
+        //     .await
+        //     .context("Failed to connect to pool")?;
+
+        // let tx = pool.begin().await?;
+
+        // Ok(Box::new(MigrationTransaction { transaction: tx }))
+        Ok(Box::new(SqliteMigration {
+            db_url: self.db_url.clone(),
+        }))
+    }
 }
 
+pub struct SqliteMigration {
+    db_url: String,
+    // pub transaction: sqlx::Transaction<PoolConnection<SqliteConnection>>,
+}
 
-// #[async_trait]
-// impl DatabaseMigrator for Sqlite<'_> {
-//     fn database_type(&self) -> String {
-//         "Sqlite".to_string()
-//     }
+#[async_trait]
+impl MigrationTransaction for SqliteMigration {
+    async fn commit(self: Box<Self>) -> Result<()> {
+        // self.transaction.commit().await?;
+        Ok(())
+    }
 
-//     fn can_migrate_database(&self) -> bool {
-//         false
-//     }
+    async fn rollback(self: Box<Self>) -> Result<()> {
+        // self.transaction.rollback().await?;
+        Ok(())
+    }
 
-//     fn can_create_database(&self) -> bool {
-//         false
-//     }
+    async fn check_if_applied(&mut self, migration_name: &str) -> Result<bool> {
+        let mut conn = SqliteConnection::connect(&self.db_url).await?;
 
-//     fn can_drop_database(&self) -> bool {
-//         false
-//     }
+        let result =
+            sqlx::query("select exists(select migration from __migrations where migration = $1)")
+                .bind(migration_name.to_string())
+                .try_map(|row: SqliteRow| row.try_get(0))
+                .fetch_one(&mut conn)
+                .await?;
 
-//     fn get_database_name(&self) -> Result<String> {
-//         let db_url = get_base_url(self.db_url)?;
-//         Ok(db_url.db_name.to_string())
-//     }
+        Ok(result)
+    }
 
-//     async fn check_if_database_exists(&self, db_name: &str) -> Result<bool> {
-//         let db_url = get_base_url(self.db_url)?;
+    async fn execute_migration(&mut self, migration_sql: &str) -> Result<()> {
+        let mut conn = SqliteConnection::connect(&self.db_url).await?;
+        conn.execute(migration_sql).await?;
+        // self.transaction.execute(migration_sql).await?;
+        Ok(())
+    }
 
-//         let base_url = db_url.base_url;
-
-//         let mut conn = PgConnection::connect(base_url).await?;
-
-//         let result: bool =
-//             sqlx::query("select exists(SELECT 1 from pg_database WHERE datname = $1) as exists")
-//                 .bind(db_name)
-//                 .try_map(|row: PgRow| row.try_get("exists"))
-//                 .fetch_one(&mut conn)
-//                 .await
-//                 .context("Failed to check if database exists")?;
-
-//         Ok(result)
-//     }
-
-//     async fn create_database(&self, db_name: &str) -> Result<()> {
-//         let db_url = get_base_url(self.db_url)?;
-
-//         let base_url = db_url.base_url;
-
-//         let mut conn = PgConnection::connect(base_url).await?;
-
-//         sqlx::query(&format!("CREATE DATABASE {}", db_name))
-//             .execute(&mut conn)
-//             .await
-//             .with_context(|| format!("Failed to create database: {}", db_name))?;
-
-//         Ok(())
-//     }
-
-//     async fn drop_database(&self, db_name: &str) -> Result<()> {
-//         let db_url = get_base_url(self.db_url)?;
-
-//         let base_url = db_url.base_url;
-
-//         let mut conn = PgConnection::connect(base_url).await?;
-
-//         sqlx::query(&format!("DROP DATABASE {}", db_name))
-//             .execute(&mut conn)
-//             .await
-//             .with_context(|| format!("Failed to create database: {}", db_name))?;
-
-//         Ok(())
-//     }
-
-//     async fn create_migration_table(&self) -> Result<()> {
-//         Err(anyhow!("Not supported"))
-//     }
-// }
+    async fn save_applied_migration(&mut self, migration_name: &str) -> Result<()> {
+        let mut conn = SqliteConnection::connect(&self.db_url).await?;
+        sqlx::query("insert into __migrations (migration) values ($1)")
+            .bind(migration_name.to_string())
+            .execute(&mut conn)
+            .await?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Start refactoring a bit so it's not all in main.

* Added support for sqlite and prepared for mysql
* Ask if user want to drop database 
* Add alias `mig` for migrate

Had some issues with performing migrations in a transaction with sqlite, so would appreciate some help there.
