### PR TITLE
Format SQL queries when printing them to the logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,6 +991,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,6 +1730,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "sqlformat"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce64a4576e1720a2e511bf3ccdb8c0f6cfed0fc265bcbaa0bd369485e02c631"
+dependencies = [
+ "lazy_static",
+ "maplit",
+ "regex",
+]
+
+[[package]]
 name = "sqlx"
 version = "0.3.4"
 dependencies = [
@@ -1777,6 +1794,7 @@ dependencies = [
  "serde_json",
  "sha-1",
  "sha2",
+ "sqlformat",
  "time 0.2.9",
  "tokio 0.2.13",
  "url 2.1.1",

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -66,6 +66,7 @@ uuid = { version = "0.8.1", default-features = false, optional = true, features 
 serde = { version = "1.0", features = [ "derive" ], optional = true }
 time = { version = "0.2.7", optional = true }
 serde_json = { version = "1.0", features = [ "raw_value" ], optional = true }
+sqlformat = "0.1.0"
 
 # <https://github.com/jgallagher/rusqlite/tree/master/libsqlite3-sys>
 [dependencies.libsqlite3-sys]

--- a/sqlx-core/src/logging.rs
+++ b/sqlx-core/src/logging.rs
@@ -8,17 +8,25 @@ macro_rules! log_execution {
         let elapsed = timer.elapsed();
         if elapsed >= std::time::Duration::from_secs(1) {
             log::warn!(
-                "{} ..., elapsed: {:.3?}\n\n    {}\n",
+                "{} ..., elapsed: {:.3?}\n\n{}\n",
                 crate::logging::parse_query_summary(query_string),
                 elapsed,
-                query_string
+                sqlformat::format(
+                    query_string,
+                    &sqlformat::QueryParams::None,
+                    sqlformat::FormatOptions::default()
+                )
             );
         } else {
             log::debug!(
-                "{} ..., elapsed: {:.3?}\n\n    {}\n",
+                "{} ..., elapsed: {:.3?}\n\n{}\n",
                 crate::logging::parse_query_summary(query_string),
                 elapsed,
-                query_string
+                sqlformat::format(
+                    query_string,
+                    &sqlformat::QueryParams::None,
+                    sqlformat::FormatOptions::default()
+                )
             );
         }
         result


### PR DESCRIPTION
Before, the query would be formatted equivalent to the input string:

```
[2020-04-18T23:47:32Z DEBUG sqlx_core::postgres::executor] SELECT id, queue, ..., elapsed: 2.320µs

        SELECT id, queue, payload, status, priority, created_at, updated_at
    FROM jobs
    WHERE status = $1
    ORDER BY priority ASC, created_at ASC

```

After, the query is formatted cleanly and consistently:

```
[2020-04-19T00:30:18Z DEBUG sqlx_core::postgres::executor] SELECT id, queue, ..., elapsed: 2.280µs

    SELECT
      id,
      queue,
      payload,
      status,
      priority,
      created_at,
      updated_at
    FROM
      jobs
    WHERE
      status = $1
    ORDER BY
      priority ASC,
      created_at ASC

```

This uses the [`sqlformat`](https://github.com/shssoichiro/sqlformat-rs) crate, which was ported from the Javascript [`sql-formatter-plus`](https://github.com/kufii/sql-formatter-plus) library specifically for this purpose.