### PR TITLE
Log queries from sqlx::query

### DIFF
--- a/sqlx-core/src/logging.rs
+++ b/sqlx-core/src/logging.rs
@@ -8,6 +8,7 @@ macro_rules! log_execution {
         let elapsed = timer.elapsed();
         if elapsed >= std::time::Duration::from_secs(1) {
             log::warn!(
+                target: "sqlx::query",
                 "{} ..., elapsed: {:.3?}\n\n{}\n",
                 crate::logging::parse_query_summary(query_string),
                 elapsed,
@@ -19,6 +20,7 @@ macro_rules! log_execution {
             );
         } else {
             log::debug!(
+                target: "sqlx::query",
                 "{} ..., elapsed: {:.3?}\n\n{}\n",
                 crate::logging::parse_query_summary(query_string),
                 elapsed,

--- a/sqlx-core/src/logging.rs
+++ b/sqlx-core/src/logging.rs
@@ -1,3 +1,7 @@
+use std::time::Duration;
+
+pub(crate) const SLOW_QUERY_THRESHOLD: Duration = Duration::from_secs(1);
+
 /// Logs the query and execution time of a statement as it runs.
 macro_rules! log_execution {
     ( $query:expr, $block:expr ) => {{
@@ -6,7 +10,7 @@ macro_rules! log_execution {
         let timer = std::time::Instant::now();
         let result = $block;
         let elapsed = timer.elapsed();
-        if elapsed >= std::time::Duration::from_secs(1) {
+        if elapsed >= crate::logging::SLOW_QUERY_THRESHOLD {
             log::warn!(
                 target: "sqlx::query",
                 "{} ..., elapsed: {:.3?}\n\n{}\n",


### PR DESCRIPTION
This will make logged queries show
as from `sqlx::query` instead of `sqlx::db_name::executor`.

Followup to #268 [comment](https://github.com/launchbadge/sqlx/pull/268#issuecomment-616241075)