### PR TITLE
Ensure all statements are dropped before closing sqlite connection

### DIFF
--- a/sqlx-core/src/sqlite/connection.rs
+++ b/sqlx-core/src/sqlite/connection.rs
@@ -150,6 +150,7 @@ impl Drop for SqliteConnection {
     fn drop(&mut self) {
         // Drop all statements first
         self.statements.clear();
+        drop(self.statement.take());
 
         // Next close the statement
         // https://sqlite.org/c3ref/close.html


### PR DESCRIPTION
Fixes #272 