### PR TITLE
Add uppercase support for Type macro

### DIFF
--- a/sqlx-macros/src/derives/attributes.rs
+++ b/sqlx-macros/src/derives/attributes.rs
@@ -30,6 +30,7 @@ macro_rules! try_set {
 pub enum RenameAll {
     LowerCase,
     SnakeCase,
+    UpperCase,
 }
 
 pub struct SqlxContainerAttributes {
@@ -70,6 +71,7 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
                                 let val = match &*val.value() {
                                     "lowercase" => RenameAll::LowerCase,
                                     "snake_case" => RenameAll::SnakeCase,
+                                    "uppercase" => RenameAll::UpperCase,
 
                                     _ => fail!(meta, "unexpected value for rename_all"),
                                 };

--- a/sqlx-macros/src/derives/mod.rs
+++ b/sqlx-macros/src/derives/mod.rs
@@ -32,5 +32,6 @@ pub(crate) fn rename_all(s: &str, pattern: RenameAll) -> String {
     match pattern {
         RenameAll::LowerCase => s.to_lowercase(),
         RenameAll::SnakeCase => s.to_snake_case(),
+        RenameAll::UpperCase => s.to_uppercase(),
     }
 }

--- a/tests/mysql-derives.rs
+++ b/tests/mysql-derives.rs
@@ -65,6 +65,6 @@ test_type!(strong_color_snake_enum(
 ));
 test_type!(strong_color_upper_enum(
     MySql,
-    ColorLower,
+    ColorUpper,
     "'GREEN'" == ColorUpper::Green
 ));

--- a/tests/mysql-derives.rs
+++ b/tests/mysql-derives.rs
@@ -53,17 +53,17 @@ test_type!(weak_enum(
     "4" == Weak::Three
 ));
 
-test_type!(strong_color_enum(
+test_type!(strong_color_lower_enum(
     MySql,
     ColorLower,
     "'green'" == ColorLower::Green
 ));
-test_type!(strong_color_enum(
+test_type!(strong_color_snake_enum(
     MySql,
     ColorSnake,
     "'red_green'" == ColorSnake::RedGreen
 ));
-test_type!(strong_color_enum(
+test_type!(strong_color_upper_enum(
     MySql,
     ColorLower,
     "'GREEN'" == ColorUpper::Green

--- a/tests/mysql-derives.rs
+++ b/tests/mysql-derives.rs
@@ -19,7 +19,20 @@ enum Weak {
 // "Strong" enums can map to TEXT or a custom enum
 #[derive(PartialEq, Debug, sqlx::Type)]
 #[sqlx(rename_all = "lowercase")]
-enum Color {
+enum ColorLower {
+    Red,
+    Green,
+    Blue,
+}
+#[derive(PartialEq, Debug, sqlx::Type)]
+#[sqlx(rename_all = "snake_case")]
+enum ColorSnake {
+    RedGreen,
+    BlueBlack,
+}
+#[derive(PartialEq, Debug, sqlx::Type)]
+#[sqlx(rename_all = "uppercase")]
+enum ColorUpper {
     Red,
     Green,
     Blue,
@@ -40,4 +53,6 @@ test_type!(weak_enum(
     "4" == Weak::Three
 ));
 
-test_type!(strong_color_enum(MySql, Color, "'green'" == Color::Green));
+test_type!(strong_color_enum(MySql, ColorLower, "'green'" == ColorLower::Green));
+test_type!(strong_color_enum(MySql, ColorSnake, "'red_green'" == ColorSnake::RedGreen));
+test_type!(strong_color_enum(MySql, ColorLower, "'GREEN'" == ColorUpper::Green));

--- a/tests/mysql-derives.rs
+++ b/tests/mysql-derives.rs
@@ -53,6 +53,18 @@ test_type!(weak_enum(
     "4" == Weak::Three
 ));
 
-test_type!(strong_color_enum(MySql, ColorLower, "'green'" == ColorLower::Green));
-test_type!(strong_color_enum(MySql, ColorSnake, "'red_green'" == ColorSnake::RedGreen));
-test_type!(strong_color_enum(MySql, ColorLower, "'GREEN'" == ColorUpper::Green));
+test_type!(strong_color_enum(
+    MySql,
+    ColorLower,
+    "'green'" == ColorLower::Green
+));
+test_type!(strong_color_enum(
+    MySql,
+    ColorSnake,
+    "'red_green'" == ColorSnake::RedGreen
+));
+test_type!(strong_color_enum(
+    MySql,
+    ColorLower,
+    "'GREEN'" == ColorUpper::Green
+));

--- a/tests/postgres-derives.rs
+++ b/tests/postgres-derives.rs
@@ -105,7 +105,7 @@ test_type!(strong_color_snake_enum(
 ));
 test_type!(strong_color_upper_enum(
     Postgres,
-    ColorLower,
+    ColorUpper,
     "'GREEN'" == ColorUpper::Green
 ));
 

--- a/tests/postgres-derives.rs
+++ b/tests/postgres-derives.rs
@@ -93,17 +93,17 @@ test_type!(strong_enum(
     "'four'::text" == Strong::Three
 ));
 
-test_type!(strong_color_enum(
+test_type!(strong_color_lower_enum(
     MySql,
     ColorLower,
     "'green'" == ColorLower::Green
 ));
-test_type!(strong_color_enum(
+test_type!(strong_color_snake_enum(
     MySql,
     ColorSnake,
     "'red_green'" == ColorSnake::RedGreen
 ));
-test_type!(strong_color_enum(
+test_type!(strong_color_upper_enum(
     MySql,
     ColorLower,
     "'GREEN'" == ColorUpper::Green

--- a/tests/postgres-derives.rs
+++ b/tests/postgres-derives.rs
@@ -96,22 +96,6 @@ test_type!(strong_enum(
     "'four'::text" == Strong::Three
 ));
 
-test_type!(strong_color_lower_enum(
-    Postgres,
-    ColorLower,
-    "'green'" == ColorLower::Green
-));
-test_type!(strong_color_snake_enum(
-    Postgres,
-    ColorSnake,
-    "'red_green'" == ColorSnake::RedGreen
-));
-test_type!(strong_color_upper_enum(
-    Postgres,
-    ColorUpper,
-    "'GREEN'" == ColorUpper::Green
-));
-
 #[cfg_attr(feature = "runtime-async-std", async_std::test)]
 #[cfg_attr(feature = "runtime-tokio", tokio::test)]
 async fn test_enum_type() -> anyhow::Result<()> {
@@ -207,6 +191,42 @@ SELECT $1 = 'happy'::mood, $1
 
     assert!(rec.0);
     assert_eq!(rec.1, Mood::Happy);
+
+    let rec: (bool, ColorLower) = sqlx::query_as(
+        "
+SELECT $1 = 'green'::color_lower, $1
+        ",
+    )
+    .bind(&ColorLower::Green)
+    .fetch_one(&mut conn)
+    .await?;
+
+    assert!(rec.0);
+    assert_eq!(rec.1, ColorLower::Green);
+
+    let rec: (bool, ColorSnake) = sqlx::query_as(
+        "
+SELECT $1 = 'red_green'::color_snake, $1
+        ",
+    )
+    .bind(&ColorSnake::RedGreen)
+    .fetch_one(&mut conn)
+    .await?;
+
+    assert!(rec.0);
+    assert_eq!(rec.1, ColorSnake::RedGreen);
+
+    let rec: (bool, ColorUpper) = sqlx::query_as(
+        "
+SELECT $1 = 'RED'::color_upper, $1
+        ",
+    )
+    .bind(&ColorUpper::Red)
+    .fetch_one(&mut conn)
+    .await?;
+
+    assert!(rec.0);
+    assert_eq!(rec.1, ColorUpper::Red);
 
     Ok(())
 }

--- a/tests/postgres-derives.rs
+++ b/tests/postgres-derives.rs
@@ -93,10 +93,21 @@ test_type!(strong_enum(
     "'four'::text" == Strong::Three
 ));
 
-test_type!(strong_color_enum(MySql, ColorLower, "'green'" == ColorLower::Green));
-test_type!(strong_color_enum(MySql, ColorSnake, "'red_green'" == ColorSnake::RedGreen));
-test_type!(strong_color_enum(MySql, ColorLower, "'GREEN'" == ColorUpper::Green));
-
+test_type!(strong_color_enum(
+    MySql,
+    ColorLower,
+    "'green'" == ColorLower::Green
+));
+test_type!(strong_color_enum(
+    MySql,
+    ColorSnake,
+    "'red_green'" == ColorSnake::RedGreen
+));
+test_type!(strong_color_enum(
+    MySql,
+    ColorLower,
+    "'GREEN'" == ColorUpper::Green
+));
 
 #[cfg_attr(feature = "runtime-async-std", async_std::test)]
 #[cfg_attr(feature = "runtime-tokio", tokio::test)]

--- a/tests/postgres-derives.rs
+++ b/tests/postgres-derives.rs
@@ -30,6 +30,7 @@ enum Strong {
 
 // rename_all variants
 #[derive(PartialEq, Debug, sqlx::Type)]
+#[sqlx(rename = "color_lower")]
 #[sqlx(rename_all = "lowercase")]
 enum ColorLower {
     Red,
@@ -37,12 +38,14 @@ enum ColorLower {
     Blue,
 }
 #[derive(PartialEq, Debug, sqlx::Type)]
+#[sqlx(rename = "color_snake")]
 #[sqlx(rename_all = "snake_case")]
 enum ColorSnake {
     RedGreen,
     BlueBlack,
 }
 #[derive(PartialEq, Debug, sqlx::Type)]
+#[sqlx(rename = "color_upper")]
 #[sqlx(rename_all = "uppercase")]
 enum ColorUpper {
     Red,
@@ -122,6 +125,14 @@ DROP TABLE IF EXISTS people;
 DROP TYPE IF EXISTS mood CASCADE;
 
 CREATE TYPE mood AS ENUM ( 'ok', 'happy', 'sad' );
+
+DROP TYPE IF EXISTS color_lower CASCADE;
+DROP TYPE IF EXISTS color_snake CASCADE;
+DROP TYPE IF EXISTS color_upper CASCADE;
+
+CREATE TYPE color_lower AS ENUM ( 'red', 'green', 'blue' );
+CREATE TYPE color_snake AS ENUM ( 'red_green', 'blue_black' );
+CREATE TYPE color_upper AS ENUM ( 'RED', 'GREEN', 'BLUE' );
 
 CREATE TABLE people (
     id      serial PRIMARY KEY,

--- a/tests/postgres-derives.rs
+++ b/tests/postgres-derives.rs
@@ -28,6 +28,28 @@ enum Strong {
     Three,
 }
 
+// rename_all variants
+#[derive(PartialEq, Debug, sqlx::Type)]
+#[sqlx(rename_all = "lowercase")]
+enum ColorLower {
+    Red,
+    Green,
+    Blue,
+}
+#[derive(PartialEq, Debug, sqlx::Type)]
+#[sqlx(rename_all = "snake_case")]
+enum ColorSnake {
+    RedGreen,
+    BlueBlack,
+}
+#[derive(PartialEq, Debug, sqlx::Type)]
+#[sqlx(rename_all = "uppercase")]
+enum ColorUpper {
+    Red,
+    Green,
+    Blue,
+}
+
 // "Strong" enum can map to a custom type
 #[derive(PartialEq, Debug, sqlx::Type)]
 #[sqlx(rename = "mood")]
@@ -70,6 +92,11 @@ test_type!(strong_enum(
     "'two'::text" == Strong::Two,
     "'four'::text" == Strong::Three
 ));
+
+test_type!(strong_color_enum(MySql, ColorLower, "'green'" == ColorLower::Green));
+test_type!(strong_color_enum(MySql, ColorSnake, "'red_green'" == ColorSnake::RedGreen));
+test_type!(strong_color_enum(MySql, ColorLower, "'GREEN'" == ColorUpper::Green));
+
 
 #[cfg_attr(feature = "runtime-async-std", async_std::test)]
 #[cfg_attr(feature = "runtime-tokio", tokio::test)]

--- a/tests/postgres-derives.rs
+++ b/tests/postgres-derives.rs
@@ -94,17 +94,17 @@ test_type!(strong_enum(
 ));
 
 test_type!(strong_color_lower_enum(
-    MySql,
+    Postgres,
     ColorLower,
     "'green'" == ColorLower::Green
 ));
 test_type!(strong_color_snake_enum(
-    MySql,
+    Postgres,
     ColorSnake,
     "'red_green'" == ColorSnake::RedGreen
 ));
 test_type!(strong_color_upper_enum(
-    MySql,
+    Postgres,
     ColorLower,
     "'GREEN'" == ColorUpper::Green
 ));

--- a/tests/sqlite-derives.rs
+++ b/tests/sqlite-derives.rs
@@ -65,6 +65,6 @@ test_type!(strong_color_snake_enum(
 ));
 test_type!(strong_color_upper_enum(
     Sqlite,
-    ColorLower,
+    ColorUpper,
     "'GREEN'" == ColorUpper::Green
 ));

--- a/tests/sqlite-derives.rs
+++ b/tests/sqlite-derives.rs
@@ -53,17 +53,17 @@ test_type!(weak_enum(
     "4" == Weak::Three
 ));
 
-test_type!(strong_color_enum(
+test_type!(strong_color_lower_enum(
     MySql,
     ColorLower,
     "'green'" == ColorLower::Green
 ));
-test_type!(strong_color_enum(
+test_type!(strong_color_snake_enum(
     MySql,
     ColorSnake,
     "'red_green'" == ColorSnake::RedGreen
 ));
-test_type!(strong_color_enum(
+test_type!(strong_color_upper_enum(
     MySql,
     ColorLower,
     "'GREEN'" == ColorUpper::Green

--- a/tests/sqlite-derives.rs
+++ b/tests/sqlite-derives.rs
@@ -19,7 +19,20 @@ enum Weak {
 // "Strong" enums can map to TEXT or a custom enum
 #[derive(PartialEq, Debug, sqlx::Type)]
 #[sqlx(rename_all = "lowercase")]
-enum Color {
+enum ColorLower {
+    Red,
+    Green,
+    Blue,
+}
+#[derive(PartialEq, Debug, sqlx::Type)]
+#[sqlx(rename_all = "snake_case")]
+enum ColorSnake {
+    RedGreen,
+    BlueBlack,
+}
+#[derive(PartialEq, Debug, sqlx::Type)]
+#[sqlx(rename_all = "uppercase")]
+enum ColorUpper {
     Red,
     Green,
     Blue,
@@ -40,4 +53,6 @@ test_type!(weak_enum(
     "4" == Weak::Three
 ));
 
-test_type!(strong_color_enum(Sqlite, Color, "'green'" == Color::Green));
+test_type!(strong_color_enum(MySql, ColorLower, "'green'" == ColorLower::Green));
+test_type!(strong_color_enum(MySql, ColorSnake, "'red_green'" == ColorSnake::RedGreen));
+test_type!(strong_color_enum(MySql, ColorLower, "'GREEN'" == ColorUpper::Green));

--- a/tests/sqlite-derives.rs
+++ b/tests/sqlite-derives.rs
@@ -54,17 +54,17 @@ test_type!(weak_enum(
 ));
 
 test_type!(strong_color_lower_enum(
-    MySql,
+    Sqlite,
     ColorLower,
     "'green'" == ColorLower::Green
 ));
 test_type!(strong_color_snake_enum(
-    MySql,
+    Sqlite,
     ColorSnake,
     "'red_green'" == ColorSnake::RedGreen
 ));
 test_type!(strong_color_upper_enum(
-    MySql,
+    Sqlite,
     ColorLower,
     "'GREEN'" == ColorUpper::Green
 ));

--- a/tests/sqlite-derives.rs
+++ b/tests/sqlite-derives.rs
@@ -53,6 +53,18 @@ test_type!(weak_enum(
     "4" == Weak::Three
 ));
 
-test_type!(strong_color_enum(MySql, ColorLower, "'green'" == ColorLower::Green));
-test_type!(strong_color_enum(MySql, ColorSnake, "'red_green'" == ColorSnake::RedGreen));
-test_type!(strong_color_enum(MySql, ColorLower, "'GREEN'" == ColorUpper::Green));
+test_type!(strong_color_enum(
+    MySql,
+    ColorLower,
+    "'green'" == ColorLower::Green
+));
+test_type!(strong_color_enum(
+    MySql,
+    ColorSnake,
+    "'red_green'" == ColorSnake::RedGreen
+));
+test_type!(strong_color_enum(
+    MySql,
+    ColorLower,
+    "'GREEN'" == ColorUpper::Green
+));


### PR DESCRIPTION
Thank you for this project!

I've begun switching my project to sqlx and I ran into an issue with my custom enum types. I've created all my enum types as uppercase and rename_all for uppercase didn't exist.