### PR TITLE
Fix a misspelling in MySQL types document

### DIFF
--- a/sqlx-core/src/mysql/types/mod.rs
+++ b/sqlx-core/src/mysql/types/mod.rs
@@ -25,7 +25,7 @@
 //! | Rust type                             | MySQL type(s)                                        |
 //! |---------------------------------------|------------------------------------------------------|
 //! | `chrono::DateTime<Utc>`               | TIMESTAMP                                            |
-//! | `chrono::DateTime<Local>`             | TIMETAMP                                             |
+//! | `chrono::DateTime<Local>`             | TIMESTAMP                                             |
 //! | `chrono::NaiveDateTime`               | DATETIME                                             |
 //! | `chrono::NaiveDate`                   | DATE                                                 |
 //! | `chrono::NaiveTime`                   | TIME                                                 |


### PR DESCRIPTION
Spell mistake: "TIMETAMP" -> "TIMESTAMP"