### PR TITLE
Fix the example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ The `fetch` query finalizer returns a stream-like type that iterates through the
 ```rust
 let mut cursor = sqlx::query("SELECT * FROM users WHERE email = ?")
     .bind(email)
-    .fetch(&mut conn).await?;
+    .fetch(&mut conn);
 
 while let Some(row) = cursor.next().await? {
     // map the row into a user-defined domain type 


### PR DESCRIPTION
This  `.await?` in the example code looks unnecessary.

## Example

```
$ rustc -V
rustc 1.43.0 (4fb7144ed 2020-04-20)
```

```toml
# Cargo.toml
[dependencies]
tokio = { version = "0.2", features = ["full"] }
sqlx = { version = "0.3", default-features = false, features = [ "runtime-tokio", "macros", "mysql" ] }
```

```rust
// main.rs
use sqlx::mysql::MySqlPool;
use sqlx::Cursor;

#[tokio::main]
async fn main() -> Result<(), sqlx::Error> {
    // Create a connection pool
    let pool = MySqlPool::new("mysql://root:secret@localhost:3306/foo").await.unwrap();

    let email = "test@example.com";
    // Make a simple query to return the given parameter
    let mut cursor = sqlx::query("SELECT * FROM users WHERE email = ?")
        .bind(email)
        .fetch(&pool).await.unwrap();

    while let Some(row) = cursor.next().await? {
        // map the row into a user-defined domain type
    }

    Ok(())
}
```

### Compilation Error

```
error[E0277]: the trait bound `sqlx_core::mysql::cursor::MySqlCursor<'_, '_>: std::future::Future` is not satisfied
  --> src/main.rs:11:22
   |
11 |       let mut cursor = sqlx::query("SELECT * FROM users WHERE email = ?")
   |  ______________________^
12 | |         .bind(email)
13 | |         .fetch(&pool).await.unwrap();
   | |___________________________^ the trait `std::future::Future` is not implemented for `sqlx_core::mysql::cursor::MySqlCursor<'_, '_>`
```