### PR TITLE
Added quotes to listen/unlisten channel names to honor case sensitivi…

### DIFF
--- a/examples/postgres/listen/src/main.rs
+++ b/examples/postgres/listen/src/main.rs
@@ -51,6 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 async fn notify(mut pool: &PgPool) {
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
 
+    // Note that channel names are lower-cased by Postgres unless they are quoted
     let res = pool
         .execute(&*format!(
             r#"

--- a/sqlx-core/src/postgres/listener.rs
+++ b/sqlx-core/src/postgres/listener.rs
@@ -64,9 +64,10 @@ impl PgListener {
     }
 
     /// Starts listening for notifications on a channel.
+    /// The channel name is quoted here to ensure case sensitivity.
     pub async fn listen(&mut self, channel: &str) -> Result<(), Error> {
         self.connection()
-            .execute(&*format!("LISTEN {}", ident(channel)))
+            .execute(&*format!(r#"LISTEN "{}""#, ident(channel)))
             .await?;
 
         self.channels.push(channel.to_owned());
@@ -92,9 +93,10 @@ impl PgListener {
     }
 
     /// Stops listening for notifications on a channel.
+    /// The channel name is quoted here to ensure case sensitivity.
     pub async fn unlisten(&mut self, channel: &str) -> Result<(), Error> {
         self.connection()
-            .execute(&*format!("UNLISTEN {}", ident(channel)))
+            .execute(&*format!(r#"UNLISTEN "{}""#, ident(channel)))
             .await?;
 
         if let Some(pos) = self.channels.iter().position(|s| s == channel) {


### PR DESCRIPTION
…ty and be consistent with 'listen_all()'

Fixes #369 