### PR TITLE
mysql(chrono): support decoding ZERO_DATES without panicing 

### DIFF
--- a/sqlx-core/src/mysql/types/mod.rs
+++ b/sqlx-core/src/mysql/types/mod.rs
@@ -66,8 +66,11 @@ mod bool;
 mod bytes;
 mod float;
 mod int;
+mod mysql_zero_date;
 mod str;
 mod uint;
+
+pub use mysql_zero_date::MysqlZeroDate;
 
 #[cfg(feature = "bigdecimal")]
 mod bigdecimal;

--- a/sqlx-core/src/mysql/types/mod.rs
+++ b/sqlx-core/src/mysql/types/mod.rs
@@ -30,6 +30,11 @@
 //! | `chrono::NaiveDate`                   | DATE                                                 |
 //! | `chrono::NaiveTime`                   | TIME                                                 |
 //!
+//! If you know you have data that contains zero dates (0000-00-00 00:00:00) you probably want to
+//! use the wrapper type `MysqlZeroDate<T>`, where T can be `NaiveDate` or `NaiveDateTime`.
+//! This enum has a variant for zero dates `MysqlZeroDate::Zero`, and a variant for normal dates
+//! `MysqlZeroDate::NotZero(date)`.
+//!
 //! ### [`time`](https://crates.io/crates/time)
 //!
 //! Requires the `time` Cargo feature flag.

--- a/sqlx-core/src/mysql/types/mysql_zero_date.rs
+++ b/sqlx-core/src/mysql/types/mysql_zero_date.rs
@@ -1,0 +1,16 @@
+#[derive(Debug, PartialEq)]
+pub enum MysqlZeroDate<T> {
+    Zero,
+    NotZero(T),
+}
+
+#[derive(Debug, Clone)]
+struct ZeroDateError;
+
+impl std::fmt::Display for ZeroDateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Unexpected ZERO_DATE encountered!")
+    }
+}
+
+impl std::error::Error for ZeroDateError {}


### PR DESCRIPTION
I forgot to pull from upstream until the very last moment, so I hope I didn't mess anything up while fixing merge conflicts. But it's all still building and the tests still pass so I should be good.

I'm not entirely sure if this is what you had in mind when we discussed this on discord, let me know if I should change anything. I'll try to add something similar for the time feature too.