### PR TITLE
fix bug in init_min_connections

### DIFF
--- a/sqlx-core/src/pool/inner.rs
+++ b/sqlx-core/src/pool/inner.rs
@@ -183,7 +183,7 @@ impl<DB: Database> SharedPool<DB> {
             let deadline = Instant::now() + self.options.connect_timeout;
 
             // this guard will prevent us from exceeding `max_size`
-            while let Some(guard) = self.try_increment_size() {
+            if let Some(guard) = self.try_increment_size() {
                 // [connect] will raise an error when past deadline
                 // [connect] returns None if its okay to retry
                 if let Some(conn) = self.connect(deadline, guard).await? {


### PR DESCRIPTION
I tried to create a database connection pool, the code is as follows, and then I found a bug

```rust
//......
let conn_string = format!(
    "mysql://{user}:{password}@{host}:{port}/{database}",
    user = server_config.db_user(),
    password = server_config.db_password(),
    host = server_config.db_host(),
    port = server_config.db_port(),
    database = server_config.db_name()
);
MySqlPool::builder()
    .connect_timeout(Duration::from_secs(10))
    .min_size(10)
    .max_size(100)
    .idle_timeout(Duration::from_secs(5 * 60))
    .max_lifetime(Duration::from_secs(30 * 60))
    .build(&conn_string)
    .await;
```

I want it to create 10 connections when it is initialized, and it can hold up to 100 connections.

But in fact it did not do this, it directly created 100 connections during initialization.

I finally found the location of the bug。

```rust
 async fn init_min_connections(&mut self) -> Result<(), Error> {
        for _ in 0..self.options.min_size {
            let deadline = Instant::now() + self.options.connect_timeout;

            // Please note the following while loop,It will continue to create connections during the first round of loops until it reaches max_size
            //But in fact, in each round of [0..min_size], we only need to create a single connection
            while let Some(guard) = self.try_increment_size() {
                // [connect] will raise an error when past deadline
                // [connect] returns None if its okay to retry
                if let Some(conn) = self.connect(deadline, guard).await? {
                    self.idle_conns
                        .push(conn.into_idle().into_leakable())
                        .expect("BUG: connection queue overflow in init_min_connections");
                }
            }
        }

        Ok(())
    }
```

