### PR TITLE
mysql: always use column alias when available

### DIFF
--- a/sqlx-core/src/mysql/connection/executor.rs
+++ b/sqlx-core/src/mysql/connection/executor.rs
@@ -275,10 +275,10 @@ impl<'c> Executor<'c> for &'c mut MySqlConnection {
                 for _ in 0..(ok.columns as usize) {
                     let def: ColumnDefinition = self.stream.recv().await?;
                     let ty = MySqlTypeInfo::from_column(&def);
-                    let name = def.name()?;
+                    let alias = def.alias()?;
 
                     columns.push(Column {
-                        name: if name.is_empty() { def.alias()? } else { name }.to_owned(),
+                        name: if alias.is_empty() { def.name()? } else { alias }.to_owned(),
                         type_info: ty,
                         not_null: Some(def.flags.contains(ColumnFlags::NOT_NULL)),
                     })

--- a/tests/mysql/describe.rs
+++ b/tests/mysql/describe.rs
@@ -36,3 +36,18 @@ async fn it_describes_simple() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[sqlx_macros::test]
+async fn uses_alias_name() -> anyhow::Result<()> {
+    let mut conn = new::<MySql>().await?;
+
+    let d = conn
+        .describe("SELECT text AS tweet_text FROM tweet")
+        .await?;
+
+    let columns = d.columns;
+
+    assert_eq!(columns[0].name, "tweet_text");
+
+    Ok(())
+}


### PR DESCRIPTION
If a query has a column alias available we should use that name instead
of the column name.

Fixes #385