### PR TITLE
handle ExprGroup in get_type_override

### DIFF
--- a/sqlx-macros/src/query/args.rs
+++ b/sqlx-macros/src/query/args.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use syn::spanned::Spanned;
-use syn::Expr;
+use syn::{Expr, ExprGroup};
 
 use quote::{quote, quote_spanned, ToTokens};
 use sqlx_core::describe::Describe;
@@ -101,6 +101,7 @@ fn get_type_override(expr: &Expr) -> Option<TokenStream> {
     match expr {
         Expr::Cast(cast) => Some(cast.ty.to_token_stream()),
         Expr::Type(ascription) => Some(ascription.ty.to_token_stream()),
+        Expr::Group(ExprGroup { expr, .. }) => get_type_override(expr.as_ref()),
         _ => None,
     }
 }


### PR DESCRIPTION
this is needed in (some?) cases to properly detect the casts