### PR TITLE
fix(mysql): improve compatibility with ProxySQL

### DIFF
--- a/sqlx-core/src/mysql/connection/mod.rs
+++ b/sqlx-core/src/mysql/connection/mod.rs
@@ -119,11 +119,11 @@ impl Connect for MySqlConnection {
 
             // https://mathiasbynens.be/notes/mysql-utf8mb4
 
-            conn.execute(r#"
-            SET sql_mode=(SELECT CONCAT(@@sql_mode, ',PIPES_AS_CONCAT,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE'));
-            SET time_zone = '+00:00';
-            SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci;
-                    "#).await?;
+            conn.execute(concat!(
+                r#"SET sql_mode=(SELECT CONCAT(@@sql_mode, ',PIPES_AS_CONCAT,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE')),"#,
+                r#"time_zone='+00:00',"#,
+                r#"NAMES utf8mb4 COLLATE utf8mb4_unicode_ci;"#,
+            )).await?;
 
             Ok(conn)
         })


### PR DESCRIPTION
Joins the MySQL connection setup statements into a single statement to prevent issues with ProxySQL, which requires special handling of connections that might be shared between multiple backends.

Original:

> Splits the MySQL connection setup statements into discrete executions to
> prevent issues with proxies, such as ProxySQL, which may need to balance
> and share connections between different backends.
> 
> Fixes #422
> 
> Signed-off-by: Marcus Griep <marcus@griep.us>