### PR TITLE
 fix: bigdecimal decoding ob1 for positive weight multiples of 4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ categories = [ "database", "asynchronous" ]
 authors = [
     "Ryan Leckey <leckey.ryan@gmail.com>", # ryan@launchbadge.com
     "Austin Bonander <austin.bonander@gmail.com>", # austin@launchbadge.com
-    "Zachery Gyurkovitz <zgyurkovitz@gmail.com>", # zach@launchbadge.com
+    "Chloe Ross <orangesnowfox@gmail.com>", # zach@launchbadge.com
     "Daniel Akhterov <akhterovd@gmail.com>", # daniel@launchbadge.com
 ]
 


### PR DESCRIPTION
Previously any number like 1000, 1000_0000, etc, would have the wrong scale by 1

Closes #423 