### PR TITLE
Add method to get the underlying sqlite3 pointer

### DIFF
--- a/sqlx-core/src/sqlite/connection/handle.rs
+++ b/sqlx-core/src/sqlite/connection/handle.rs
@@ -7,7 +7,7 @@ use crate::sqlite::SqliteError;
 /// Managed handle to the raw SQLite3 database handle.
 /// The database handle will be closed when this is dropped.
 #[derive(Debug)]
-pub(crate) struct ConnectionHandle(pub(super) NonNull<sqlite3>);
+pub struct ConnectionHandle(pub NonNull<sqlite3>);
 
 // A SQLite3 handle is safe to send between threads, provided not more than
 // one is accessing it at the same time. This is upheld as long as [SQLITE_CONFIG_MULTITHREAD] is

--- a/sqlx-core/src/sqlite/connection/handle.rs
+++ b/sqlx-core/src/sqlite/connection/handle.rs
@@ -7,7 +7,7 @@ use crate::sqlite::SqliteError;
 /// Managed handle to the raw SQLite3 database handle.
 /// The database handle will be closed when this is dropped.
 #[derive(Debug)]
-pub struct ConnectionHandle(pub NonNull<sqlite3>);
+pub(crate) struct ConnectionHandle(pub(super) NonNull<sqlite3>);
 
 // A SQLite3 handle is safe to send between threads, provided not more than
 // one is accessing it at the same time. This is upheld as long as [SQLITE_CONFIG_MULTITHREAD] is

--- a/sqlx-core/src/sqlite/connection/mod.rs
+++ b/sqlx-core/src/sqlite/connection/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use futures_core::future::BoxFuture;
 use futures_util::future;
 use hashbrown::HashMap;
+use libsqlite3_sys::sqlite3;
 
 use crate::connection::{Connect, Connection};
 use crate::error::Error;
@@ -35,8 +36,8 @@ pub struct SqliteConnection {
 
 impl SqliteConnection {
     /// Returns the underlying sqlite3* connection handle
-    pub fn as_raw_handle(&self) -> handle::ConnectionHandle {
-        self.handle
+    pub fn as_raw_handle(&self) -> *mut sqlite3 {
+        self.handle.as_ptr()
     }
 }
 

--- a/sqlx-core/src/sqlite/connection/mod.rs
+++ b/sqlx-core/src/sqlite/connection/mod.rs
@@ -33,6 +33,13 @@ pub struct SqliteConnection {
     scratch_row_column_names: Arc<HashMap<UStr, usize>>,
 }
 
+impl SqliteConnection {
+    /// Returns the underlying sqlite3* connection handle
+    pub fn as_raw_handle(&self) -> handle::ConnectionHandle {
+        self.handle
+    }
+}
+
 impl Debug for SqliteConnection {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("SqliteConnection").finish()


### PR DESCRIPTION
Per #430 adds a simple method to retrieve the underlying `sqlite3*` connection handle.