### PR TITLE
Adds a method get the underlying sqlite3 pointer

### DIFF
--- a/sqlx-core/src/sqlite/connection/mod.rs
+++ b/sqlx-core/src/sqlite/connection/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use futures_core::future::BoxFuture;
 use futures_util::future;
 use hashbrown::HashMap;
+use libsqlite3_sys::sqlite3;
 
 use crate::connection::{Connect, Connection};
 use crate::error::Error;
@@ -31,6 +32,13 @@ pub struct SqliteConnection {
 
     // working memory for the active row's column information
     scratch_row_column_names: Arc<HashMap<UStr, usize>>,
+}
+
+impl SqliteConnection {
+    /// Returns the underlying sqlite3* connection handle
+    pub fn as_raw_handle(&self) -> *mut sqlite3 {
+        self.handle.as_ptr()
+    }
 }
 
 impl Debug for SqliteConnection {

--- a/sqlx-core/src/sqlite/connection/mod.rs
+++ b/sqlx-core/src/sqlite/connection/mod.rs
@@ -36,7 +36,7 @@ pub struct SqliteConnection {
 
 impl SqliteConnection {
     /// Returns the underlying sqlite3* connection handle
-    pub fn as_raw_handle(&self) -> *mut sqlite3 {
+    pub fn as_raw_handle(&mut self) -> *mut sqlite3 {
         self.handle.as_ptr()
     }
 }


### PR DESCRIPTION
Per #430, adds a method `as_raw_handle()` to get the underlying `sqlite3*` from a `SqliteConnection`.

This PR is cleaner (a single commit). The previous PR also failed CI due to a (hopefully) random fault in docker.