### PR TITLE
add bit_vec crate to support mysql bit(n), support decode bit(1) to bool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-vec"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2259,6 +2265,7 @@ dependencies = [
  "atoi",
  "base64 0.12.2",
  "bigdecimal",
+ "bit-vec",
  "bitflags",
  "byteorder",
  "bytes 0.5.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ offline = [ "sqlx-macros/offline", "sqlx-core/offline" ]
 # intended mainly for CI and docs
 all = [ "tls", "all-databases", "all-types" ]
 all-databases = [ "mysql", "sqlite", "postgres", "mssql" ]
-all-types = [ "bigdecimal", "json", "time", "chrono", "ipnetwork", "uuid" ]
+all-types = [ "bigdecimal", "json", "time", "chrono", "ipnetwork", "uuid", "bit-vec" ]
 
 # runtime
 runtime-async-std = [ "sqlx-core/runtime-async-std", "sqlx-macros/runtime-async-std" ]
@@ -65,6 +65,7 @@ mssql = [ "sqlx-core/mssql", "sqlx-macros/mssql" ]
 # types
 bigdecimal = ["sqlx-core/bigdecimal", "sqlx-macros/bigdecimal"]
 chrono = [ "sqlx-core/chrono", "sqlx-macros/chrono" ]
+bit-vec = [ "sqlx-core/bit-vec", "sqlx-macros/bit-vec" ]
 ipnetwork = [ "sqlx-core/ipnetwork", "sqlx-macros/ipnetwork" ]
 uuid = [ "sqlx-core/uuid", "sqlx-macros/uuid" ]
 json = [ "sqlx-core/json", "sqlx-macros/json" ]

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -23,7 +23,7 @@ sqlite = [ "libsqlite3-sys" ]
 mssql = [ "uuid", "encoding_rs", "regex" ]
 
 # types
-all-types = [ "chrono", "time", "bigdecimal", "ipnetwork", "json", "uuid" ]
+all-types = [ "chrono", "time", "bigdecimal", "ipnetwork", "json", "uuid", "bit-vec" ]
 bigdecimal = [ "bigdecimal_", "num-bigint" ]
 json = [ "serde", "serde_json" ]
 
@@ -41,6 +41,7 @@ sqlx-rt = { path = "../sqlx-rt", version = "0.1.0-pre" }
 base64 = { version = "0.12.1", default-features = false, optional = true, features = [ "std" ] }
 bigdecimal_ = { version = "0.1.0", optional = true, package = "bigdecimal" }
 bitflags = { version = "1.2.1", default-features = false }
+bit-vec = { version = "0.6.2", optional=true, package="bit-vec"}
 bytes = "0.5.4"
 byteorder = { version = "1.3.4", default-features = false, features = [ "std" ] }
 chrono = { version = "0.4.11", default-features = false, features = [ "clock" ], optional = true }

--- a/sqlx-core/src/mysql/protocol/text/column.rs
+++ b/sqlx-core/src/mysql/protocol/text/column.rs
@@ -108,7 +108,7 @@ pub(crate) struct ColumnDefinition {
     alias: Bytes,
     name: Bytes,
     pub(crate) char_set: u16,
-    max_size: u32,
+    pub(crate) max_size: u32,
     pub(crate) r#type: ColumnType,
     pub(crate) flags: ColumnFlags,
     decimals: u8,

--- a/sqlx-core/src/mysql/type_info.rs
+++ b/sqlx-core/src/mysql/type_info.rs
@@ -8,6 +8,7 @@ use crate::type_info::TypeInfo;
 #[cfg_attr(feature = "offline", derive(serde::Serialize, serde::Deserialize))]
 pub struct MySqlTypeInfo {
     pub(crate) r#type: ColumnType,
+    pub(crate) max_size: Option<u32>,
     pub(crate) flags: ColumnFlags,
     pub(crate) char_set: u16,
 }
@@ -16,6 +17,7 @@ impl MySqlTypeInfo {
     pub(crate) const fn binary(ty: ColumnType) -> Self {
         Self {
             r#type: ty,
+            max_size: None,
             flags: ColumnFlags::BINARY,
             char_set: 63,
         }
@@ -25,6 +27,7 @@ impl MySqlTypeInfo {
     pub const fn __enum() -> Self {
         Self {
             r#type: ColumnType::Enum,
+            max_size: None,
             flags: ColumnFlags::BINARY,
             char_set: 63,
         }
@@ -51,6 +54,7 @@ impl MySqlTypeInfo {
             Some(Self {
                 r#type: column.r#type,
                 flags: column.flags,
+                max_size: Some(column.max_size),
                 char_set: column.char_set,
             })
         }

--- a/sqlx-core/src/mysql/types/bit_vec.rs
+++ b/sqlx-core/src/mysql/types/bit_vec.rs
@@ -1,0 +1,29 @@
+use bit_vec::BitVec;
+
+use crate::decode::Decode;
+use crate::encode::{Encode, IsNull};
+use crate::error::BoxDynError;
+use crate::mysql::io::MySqlBufMutExt;
+use crate::mysql::protocol::text::ColumnType;
+use crate::mysql::{MySql, MySqlTypeInfo, MySqlValueRef};
+use crate::types::Type;
+
+impl Type<MySql> for BitVec {
+    fn type_info() -> MySqlTypeInfo {
+        MySqlTypeInfo::binary(ColumnType::Bit)
+    }
+}
+
+impl Encode<'_, MySql> for BitVec {
+    fn encode_by_ref(&self, buf: &mut Vec<u8>) -> IsNull {
+        buf.put_bytes_lenenc(&self.to_bytes());
+
+        IsNull::No
+    }
+}
+
+impl Decode<'_, MySql> for BitVec {
+    fn decode(value: MySqlValueRef<'_>) -> Result<Self, BoxDynError> {
+        Ok(BitVec::from_bytes(value.as_bytes()?))
+    }
+}

--- a/sqlx-core/src/mysql/types/bool.rs
+++ b/sqlx-core/src/mysql/types/bool.rs
@@ -2,6 +2,7 @@ use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
 use crate::error::BoxDynError;
 use crate::mysql::{MySql, MySqlTypeInfo, MySqlValueRef};
+use crate::mysql::protocol::text::ColumnType;
 use crate::types::Type;
 
 impl Type<MySql> for bool {
@@ -11,7 +12,8 @@ impl Type<MySql> for bool {
     }
 
     fn compatible(ty: &MySqlTypeInfo) -> bool {
-        <i8 as Type<MySql>>::compatible(ty)
+        let is_one_bit = ty.r#type == ColumnType::Bit && ty.max_size == Some(1);
+        <i8 as Type<MySql>>::compatible(ty) || is_one_bit
     }
 }
 

--- a/sqlx-core/src/mysql/types/mod.rs
+++ b/sqlx-core/src/mysql/types/mod.rs
@@ -72,6 +72,9 @@ mod uint;
 #[cfg(feature = "bigdecimal")]
 mod bigdecimal;
 
+#[cfg(feature = "bit-vec")]
+mod bit_vec;
+
 #[cfg(feature = "chrono")]
 mod chrono;
 

--- a/sqlx-core/src/mysql/types/str.rs
+++ b/sqlx-core/src/mysql/types/str.rs
@@ -10,6 +10,7 @@ impl Type<MySql> for str {
     fn type_info() -> MySqlTypeInfo {
         MySqlTypeInfo {
             r#type: ColumnType::VarString, // VARCHAR
+            max_size: None,
             char_set: 224,                 // utf8mb4_unicode_ci
             flags: ColumnFlags::empty(),
         }

--- a/sqlx-core/src/mysql/types/uint.rs
+++ b/sqlx-core/src/mysql/types/uint.rs
@@ -12,6 +12,7 @@ use crate::types::Type;
 fn uint_type_info(ty: ColumnType) -> MySqlTypeInfo {
     MySqlTypeInfo {
         r#type: ty,
+        max_size: None,
         flags: ColumnFlags::BINARY | ColumnFlags::UNSIGNED,
         char_set: 63,
     }

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -34,6 +34,7 @@ mssql = [ "sqlx-core/mssql" ]
 
 # type
 bigdecimal = [ "sqlx-core/bigdecimal" ]
+bit-vec = [ "sqlx-core/bit-vec" ]
 chrono = [ "sqlx-core/chrono" ]
 time = [ "sqlx-core/time" ]
 ipnetwork = [ "sqlx-core/ipnetwork" ]


### PR DESCRIPTION
there are some legacy database use bit(1) to mean bool value.
but seems we can't decode mysql bit column value to any datatype in this project.

according @mehcode suggestion
add bit_vec crate to support mysql bit(n) and support BIT(1) to be decode to boolean