### PR TITLE
(0.5) implement `query_scalar!()`

### DIFF
--- a/sqlx-core/src/arguments.rs
+++ b/sqlx-core/src/arguments.rs
@@ -39,5 +39,14 @@ macro_rules! impl_into_arguments_for_arguments {
     };
 }
 
+/// used by the query macros to prevent supernumerary `.bind()` calls
+pub struct ImmutableArguments<'q, DB: HasArguments<'q>>(pub <DB as HasArguments<'q>>::Arguments);
+
+impl<'q, DB: HasArguments<'q>> IntoArguments<'q, DB> for ImmutableArguments<'q, DB> {
+    fn into_arguments(self) -> <DB as HasArguments<'q>>::Arguments {
+        self.0
+    }
+}
+
 // TODO: Impl `IntoArguments` for &[&dyn Encode]
 // TODO: Impl `IntoArguments` for (impl Encode, ...) x16

--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -178,8 +178,6 @@ pub(super) async fn explain(
                 // r[p2] = <value of constant>
                 r.insert(p2, opcode_to_type(&opcode));
                 n.insert(p2, n.get(&p2).copied().unwrap_or(false));
-
-                println!("[x] <?> set column {} as INTEGER", p2);
             }
 
             OP_NOT => {

--- a/sqlx-macros/src/query/mod.rs
+++ b/sqlx-macros/src/query/mod.rs
@@ -1,7 +1,6 @@
-use std::borrow::Cow;
 use std::env;
 
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::TokenStream;
 use syn::Type;
 use url::Url;
 
@@ -196,11 +195,9 @@ where
 
     if let Some(num) = num_parameters {
         if num != input.arg_exprs.len() {
-            return Err(syn::Error::new(
-                Span::call_site(),
-                format!("expected {} parameters, got {}", num, input.arg_exprs.len()),
-            )
-            .into());
+            return Err(
+                format!("expected {} parameters, got {}", num, input.arg_exprs.len()).into(),
+            );
         }
     }
 
@@ -216,10 +213,10 @@ where
             sqlx::query_with::<#db_path, _>(#sql, #query_args)
         }
     } else {
-        let columns = output::columns_to_rust::<DB>(&data.describe)?;
-
-        let (out_ty, mut record_tokens) = match input.record_type {
+        match input.record_type {
             RecordType::Generated => {
+                let columns = output::columns_to_rust::<DB>(&data.describe)?;
+
                 let record_name: Type = syn::parse_str("Record").unwrap();
 
                 for rust_col in &columns {
@@ -238,26 +235,31 @@ where
                      }| quote!(#ident: #type_,),
                 );
 
-                let record_tokens = quote! {
+                let mut record_tokens = quote! {
                     #[derive(Debug)]
                     struct #record_name {
                         #(#record_fields)*
                     }
                 };
 
-                (Cow::Owned(record_name), record_tokens)
+                record_tokens.extend(output::quote_query_as::<DB>(
+                    &input,
+                    &record_name,
+                    &query_args,
+                    &columns,
+                ));
+
+                record_tokens
             }
-            RecordType::Given(ref out_ty) => (Cow::Borrowed(out_ty), quote!()),
-        };
+            RecordType::Given(ref out_ty) => {
+                let columns = output::columns_to_rust::<DB>(&data.describe)?;
 
-        record_tokens.extend(output::quote_query_as::<DB>(
-            &input,
-            &out_ty,
-            &query_args,
-            &columns,
-        ));
-
-        record_tokens
+                output::quote_query_as::<DB>(&input, out_ty, &query_args, &columns)
+            }
+            RecordType::Scalar => {
+                output::quote_query_scalar::<DB>(&input, &query_args, &data.describe)?
+            }
+        }
     };
 
     let ret_tokens = quote! {{

--- a/sqlx-macros/src/query/output.rs
+++ b/sqlx-macros/src/query/output.rs
@@ -305,9 +305,9 @@ fn parse_ident(name: &str) -> crate::Result<Ident> {
     // workaround for the following issue (it's semi-fixed but still spits out extra diagnostics)
     // https://github.com/dtolnay/syn/issues/749#issuecomment-575451318
 
-    let is_valid_ident = !name.is_empty() &&
-        name.starts_with(|c: char| c.is_alphabetic() || c == '_') &&
-        name.chars().all(|c| c.is_alphanumeric() || c == '_');
+    let is_valid_ident = !name.is_empty()
+        && name.starts_with(|c: char| c.is_alphabetic() || c == '_')
+        && name.chars().all(|c| c.is_alphanumeric() || c == '_');
 
     if is_valid_ident {
         let ident = String::from("r#") + name;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -593,6 +593,77 @@ macro_rules! query_file_as_unchecked (
     })
 );
 
+/// A variant of [query!] which expects a single column from the query and evaluates to an
+/// instance of [QueryScalar][crate::query::QueryScalar].
+///
+/// The name of the column is not required to be a valid Rust identifier, however you can still
+/// use the column type override syntax in which case the column name _does_ have to be a valid
+/// Rust identifier for the override to parse properly. If the override parse fails the error
+/// is silently ignored (we just don't have a reliable way to tell the difference). **If you're
+/// getting a different type than expected, please check to see if your override syntax is correct
+/// before opening an issue.**
+///
+/// Wildcard overrides like in [query_as!] are also allowed, in which case the output type
+/// is left up to inference.
+///
+/// See [query!] for more information.
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+macro_rules! query_scalar (
+    ($query:expr) => (
+        $crate::sqlx_macros::expand_query!(scalar = _, source = $query)
+    );
+    ($query:expr, $($args:tt)*) => (
+        $crate::sqlx_macros::expand_query!(scalar = _, source = $query, args = [$($args)*])
+    )
+);
+
+/// A variant of [query_scalar!] which takes a file path like [query_file!].
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+macro_rules! query_file_scalar (
+    ($path:literal) => (
+        $crate::sqlx_macros::expand_query!(scalar = _, source_file = $path)
+    );
+    ($path:literal, $($args:tt)*) => (
+        $crate::sqlx_macros::expand_query!(scalar = _, source_file = $path, args = [$($args)*])
+    )
+);
+
+/// A variant of [query_scalar!] which does not typecheck bind parameters and leaves the output type
+/// to inference. The query itself is still checked that it is syntactically and semantically
+/// valid for the database, that it only produces one column and that the number of bind parameters
+/// is correct.
+///
+/// For this macro variant the name of the column is irrelevant.
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+macro_rules! query_scalar_unchecked (
+    ($query:expr) => (
+        $crate::sqlx_macros::expand_query!(scalar = _, source = $query, checked = false)
+    );
+    ($query:expr, $($args:tt)*) => (
+        $crate::sqlx_macros::expand_query!(scalar = _, source = $query, args = [$($args)*], checked = false)
+    )
+);
+
+/// A variant of [query_file_scalar!] which does not typecheck bind parameters and leaves the output
+/// type to inference. The query itself is still checked that it is syntactically and
+/// semantically valid for the database, that it only produces one column and that the number of
+/// bind parameters is correct.
+///
+/// For this macro variant the name of the column is irrelevant.
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+macro_rules! query_file_scalar_unchecked (
+    ($path:literal) => (
+        $crate::sqlx_macros::expand_query!(scalar = _, source_file = $path, checked = false)
+    );
+    ($path:literal, $($args:tt)*) => (
+        $crate::sqlx_macros::expand_query!(scalar = _, source_file = $path, args = [$($args)*], checked = false)
+    )
+);
+
 /// Embeds migrations into the binary by expanding to a static instance of [Migrator][crate::migrate::Migrator].
 ///
 /// ```rust,ignore

--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -196,12 +196,18 @@ async fn it_describes_left_join() -> anyhow::Result<()> {
     assert_eq!(d.column(0).type_info().name(), "INTEGER");
     assert_eq!(d.nullable(0), Some(false));
 
-    let d = conn.describe("select tweet.id from accounts left join tweet on owner_id = accounts.id").await?;
+    let d = conn
+        .describe("select tweet.id from accounts left join tweet on owner_id = accounts.id")
+        .await?;
 
     assert_eq!(d.column(0).type_info().name(), "INTEGER");
     assert_eq!(d.nullable(0), Some(true));
 
-    let d = conn.describe("select tweet.id, accounts.id from accounts left join tweet on owner_id = accounts.id").await?;
+    let d = conn
+        .describe(
+            "select tweet.id, accounts.id from accounts left join tweet on owner_id = accounts.id",
+        )
+        .await?;
 
     assert_eq!(d.column(0).type_info().name(), "INTEGER");
     assert_eq!(d.nullable(0), Some(true));
@@ -209,7 +215,11 @@ async fn it_describes_left_join() -> anyhow::Result<()> {
     assert_eq!(d.column(1).type_info().name(), "INTEGER");
     assert_eq!(d.nullable(1), Some(false));
 
-    let d = conn.describe("select tweet.id, accounts.id from accounts inner join tweet on owner_id = accounts.id").await?;
+    let d = conn
+        .describe(
+            "select tweet.id, accounts.id from accounts inner join tweet on owner_id = accounts.id",
+        )
+        .await?;
 
     assert_eq!(d.column(0).type_info().name(), "INTEGER");
     assert_eq!(d.nullable(0), Some(false));


### PR DESCRIPTION
closes #428 

TODO:

- [x] test column type overrides
- [x] add `query_scalar_unchecked!()` and `query_file_scalar_unchecked!()`
- [x] test on MySQL
- [x] test on SQLite