### PR TITLE
MySQL UDS Support

### DIFF
--- a/sqlx-core/src/common/mod.rs
+++ b/sqlx-core/src/common/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
 mod statement_cache;
 
+#[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
 pub(crate) use statement_cache::StatementCache;

--- a/sqlx-core/src/common/statement_cache.rs
+++ b/sqlx-core/src/common/statement_cache.rs
@@ -27,7 +27,7 @@ impl<T> StatementCache<T> {
     pub fn insert(&mut self, k: &str, v: T) -> Option<T> {
         let mut lru_item = None;
 
-        if self.inner.capacity() == self.len() && !self.inner.contains_key(k) {
+        if self.capacity() == self.len() && !self.contains_key(k) {
             lru_item = self.remove_lru();
         } else if self.contains_key(k) {
             lru_item = self.inner.remove(k);
@@ -49,7 +49,7 @@ impl<T> StatementCache<T> {
     }
 
     /// Clear all cached statements from the cache.
-    #[cfg(any(feature = "sqlite"))]
+    #[cfg(feature = "sqlite")]
     pub fn clear(&mut self) {
         self.inner.clear();
     }

--- a/sqlx-core/src/mysql/connection/mod.rs
+++ b/sqlx-core/src/mysql/connection/mod.rs
@@ -1,5 +1,4 @@
 use std::fmt::{self, Debug, Formatter};
-use std::net::Shutdown;
 use std::sync::Arc;
 
 use futures_core::future::BoxFuture;
@@ -57,7 +56,7 @@ impl Connection for MySqlConnection {
     fn close(mut self) -> BoxFuture<'static, Result<(), Error>> {
         Box::pin(async move {
             self.stream.send_packet(Quit).await?;
-            self.stream.shutdown(Shutdown::Both)?;
+            self.stream.shutdown()?;
 
             Ok(())
         })

--- a/sqlx-core/src/mysql/connection/stream.rs
+++ b/sqlx-core/src/mysql/connection/stream.rs
@@ -32,7 +32,7 @@ impl MySqlStream {
     pub(super) async fn connect(options: &MySqlConnectOptions) -> Result<Self, Error> {
         let socket = match options.socket {
             Some(ref path) => Socket::connect_uds(path).await?,
-            None => Socket::connect(&options.host, options.port).await?,
+            None => Socket::connect_tcp(&options.host, options.port).await?,
         };
 
         let mut capabilities = Capabilities::PROTOCOL_41

--- a/sqlx-core/src/net/socket.rs
+++ b/sqlx-core/src/net/socket.rs
@@ -17,20 +17,8 @@ pub enum Socket {
 }
 
 impl Socket {
-    #[cfg(not(unix))]
-    pub async fn connect(host: &str, port: u16) -> io::Result<Self> {
+    pub async fn connect_tcp(host: &str, port: u16) -> io::Result<Self> {
         TcpStream::connect((host, port)).await.map(Socket::Tcp)
-    }
-
-    #[cfg(unix)]
-    pub async fn connect(host: &str, port: u16) -> io::Result<Self> {
-        if host.starts_with('/') {
-            // if the host starts with a forward slash, assume that this is a request
-            // to connect to a local socket
-            Self::connect_uds(&format!("{}/.s.PGSQL.{}", host, port)).await
-        } else {
-            TcpStream::connect((host, port)).await.map(Socket::Tcp)
-        }
     }
 
     #[cfg(unix)]

--- a/sqlx-core/src/postgres/connection/stream.rs
+++ b/sqlx-core/src/postgres/connection/stream.rs
@@ -31,9 +31,15 @@ pub struct PgStream {
 
 impl PgStream {
     pub(super) async fn connect(options: &PgConnectOptions) -> Result<Self, Error> {
-        let inner = BufStream::new(MaybeTlsStream::Raw(
-            Socket::connect(&options.host, options.port).await?,
-        ));
+        let socket = match options.socket {
+            Some(ref path) => {
+                Socket::connect_uds(&format!("{}/.s.PGSQL.{}", path.display(), options.port))
+                    .await?
+            }
+            None => Socket::connect(&options.host, options.port).await?,
+        };
+
+        let inner = BufStream::new(MaybeTlsStream::Raw(socket));
 
         Ok(Self {
             inner,

--- a/sqlx-core/src/postgres/connection/stream.rs
+++ b/sqlx-core/src/postgres/connection/stream.rs
@@ -31,12 +31,9 @@ pub struct PgStream {
 
 impl PgStream {
     pub(super) async fn connect(options: &PgConnectOptions) -> Result<Self, Error> {
-        let socket = match options.socket {
-            Some(ref path) => {
-                Socket::connect_uds(&format!("{}/.s.PGSQL.{}", path.display(), options.port))
-                    .await?
-            }
-            None => Socket::connect(&options.host, options.port).await?,
+        let socket = match options.fetch_socket() {
+            Some(ref path) => Socket::connect_uds(path).await?,
+            None => Socket::connect_tcp(&options.host, options.port).await?,
         };
 
         let inner = BufStream::new(MaybeTlsStream::Raw(socket));

--- a/sqlx-core/src/postgres/options.rs
+++ b/sqlx-core/src/postgres/options.rs
@@ -320,6 +320,22 @@ impl PgConnectOptions {
         self.statement_cache_capacity = capacity;
         self
     }
+
+    /// We try using a socket if hostname starts with `/` or if socket parameter
+    /// is specified.
+    pub(crate) fn fetch_socket(&self) -> Option<String> {
+        match self.socket {
+            Some(ref socket) => {
+                let full_path = format!("{}/.s.PGSQL.{}", socket.display(), self.port);
+                Some(full_path)
+            }
+            None if self.host.starts_with('/') => {
+                let full_path = format!("{}/.s.PGSQL.{}", self.host, self.port);
+                Some(full_path)
+            }
+            _ => None,
+        }
+    }
 }
 
 fn default_host(port: u16) -> String {

--- a/sqlx-core/src/postgres/options.rs
+++ b/sqlx-core/src/postgres/options.rs
@@ -221,18 +221,8 @@ impl PgConnectOptions {
     /// switching the connection method from TCP to the corresponding socket.
     ///
     /// By default set to `None`.
-    #[cfg(unix)]
     pub fn socket(mut self, path: impl AsRef<Path>) -> Self {
         self.socket = Some(path.as_ref().to_path_buf());
-        self
-    }
-
-    /// Sets a custom path to a directory containing a unix domain socket,
-    /// switching the connection method from TCP to the corresponding socket.
-    ///
-    /// By default set to `None`.
-    #[cfg(not(unix))]
-    pub fn socket(mut self, _: impl AsRef<Path>) -> Self {
         self
     }
 


### PR DESCRIPTION
- Adds support for Unix Domain Sockets on MySQL
- Allows setting the socket path in PostgreSQL connection options
- ... and MySQL connection options

Fixes issue https://github.com/launchbadge/sqlx/issues/449