### PR TITLE
mysql: Fix decoding of TIME '00:00:00.000000'

### DIFF
--- a/sqlx-core/src/mysql/types/chrono.rs
+++ b/sqlx-core/src/mysql/types/chrono.rs
@@ -78,6 +78,13 @@ impl<'r> Decode<'r, MySql> for NaiveTime {
                 // data length, expecting 8 or 12 (fractional seconds)
                 let len = buf.get_u8();
 
+                // MySQL specifies that if all of hours, minutes, seconds, microseconds
+                // are 0 then the length is 0 and no further data is send
+                // https://dev.mysql.com/doc/internals/en/binary-protocol-value.html
+                if len == 0 {
+                    return Ok(NaiveTime::from_hms_micro(0, 0, 0, 0));
+                }
+
                 // is negative : int<1>
                 let is_negative = buf.get_u8();
                 debug_assert_eq!(is_negative, 0, "Negative dates/times are not supported");

--- a/sqlx-core/src/mysql/types/time.rs
+++ b/sqlx-core/src/mysql/types/time.rs
@@ -83,6 +83,13 @@ impl<'r> Decode<'r, MySql> for Time {
                 // data length, expecting 8 or 12 (fractional seconds)
                 let len = buf.get_u8();
 
+                // MySQL specifies that if all of hours, minutes, seconds, microseconds
+                // are 0 then the length is 0 and no further data is send
+                // https://dev.mysql.com/doc/internals/en/binary-protocol-value.html
+                if len == 0 {
+                    return Ok(Time::try_from_hms_micro(0, 0, 0, 0).unwrap());
+                }
+
                 // is negative : int<1>
                 let is_negative = buf.get_u8();
                 assert_eq!(is_negative, 0, "Negative dates/times are not supported");

--- a/tests/mysql/types.rs
+++ b/tests/mysql/types.rs
@@ -49,6 +49,11 @@ mod chrono {
         "DATE '2050-11-23'" == NaiveDate::from_ymd(2050, 11, 23)
     ));
 
+    test_type!(chrono_time_zero<NaiveTime>(
+        MySql,
+        "TIME '00:00:00.000000'" == NaiveTime::from_hms_micro(0, 0, 0, 0)
+    ));
+
     test_type!(chrono_time<NaiveTime>(
         MySql,
         "TIME '05:10:20.115100'" == NaiveTime::from_hms_micro(5, 10, 20, 115100)
@@ -79,6 +84,11 @@ mod time_tests {
         MySql,
         "DATE '2001-01-05'" == date!(2001 - 1 - 5),
         "DATE '2050-11-23'" == date!(2050 - 11 - 23)
+    ));
+
+    test_type!(time_time_zero<Time>(
+        MySql,
+        "TIME '00:00:00.000000'" == time!(00:00:00.000000)
     ));
 
     test_type!(time_time<Time>(


### PR DESCRIPTION
Fixes #418