### PR TITLE
Caching statement metadata

### DIFF
--- a/sqlx-core/src/common/statement_cache.rs
+++ b/sqlx-core/src/common/statement_cache.rs
@@ -30,7 +30,7 @@ impl<T> StatementCache<T> {
         if self.capacity() == self.len() && !self.contains_key(k) {
             lru_item = self.remove_lru();
         } else if self.contains_key(k) {
-            lru_item = self.inner.remove(k);
+            lru_item = self.remove(k);
         }
 
         self.inner.insert(k.into(), v);
@@ -46,6 +46,11 @@ impl<T> StatementCache<T> {
     /// Removes the least recently used item from the cache.
     pub fn remove_lru(&mut self) -> Option<T> {
         self.inner.remove_lru().map(|(_, v)| v)
+    }
+
+    /// Removes the statement which matches the given query from the cache.
+    pub fn remove(&mut self, k: &str) -> Option<T> {
+        self.inner.remove(k)
     }
 
     /// Clear all cached statements from the cache.

--- a/sqlx-core/src/describe.rs
+++ b/sqlx-core/src/describe.rs
@@ -35,7 +35,7 @@ where
     pub columns: Vec<Column<DB>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 #[cfg_attr(feature = "offline", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(

--- a/sqlx-core/src/executor.rs
+++ b/sqlx-core/src/executor.rs
@@ -123,10 +123,6 @@ pub trait Executor<'c>: Send + Debug + Sized {
 
     /// Prepare the SQL query and return type information about its parameters
     /// and results.
-    ///
-    /// This is used by compile-time verification in the query macros to
-    /// power their type inference.
-    #[doc(hidden)]
     fn describe<'e, 'q: 'e, E: 'q>(
         self,
         query: E,

--- a/sqlx-core/src/mysql/connection/executor.rs
+++ b/sqlx-core/src/mysql/connection/executor.rs
@@ -20,14 +20,15 @@ use crate::mysql::protocol::statement::{
 use crate::mysql::protocol::text::{ColumnDefinition, ColumnFlags, Query, TextRow};
 use crate::mysql::protocol::Packet;
 use crate::mysql::row::MySqlColumn;
+use crate::mysql::statement::Statement;
 use crate::mysql::{
     MySql, MySqlArguments, MySqlConnection, MySqlRow, MySqlTypeInfo, MySqlValueFormat,
 };
 
 impl MySqlConnection {
-    async fn prepare(&mut self, query: &str) -> Result<u32, Error> {
-        if let Some(statement) = self.cache_statement.get_mut(query) {
-            return Ok(*statement);
+    async fn prepare(&mut self, query: &str) -> Result<&mut Statement, Error> {
+        if self.cache_statement.contains_key(query) {
+            return Ok(self.cache_statement.get_mut(query).unwrap());
         }
 
         // https://dev.mysql.com/doc/internals/en/com-stmt-prepare.html
@@ -36,13 +37,14 @@ impl MySqlConnection {
         self.stream.send_packet(Prepare { query }).await?;
 
         let ok: PrepareOk = self.stream.recv().await?;
-
-        // the parameter definitions are very unreliable so we skip over them
-        // as we have little use
+        let mut params = Vec::with_capacity(ok.params as usize);
+        let mut columns = Vec::with_capacity(ok.columns as usize);
 
         if ok.params > 0 {
             for _ in 0..ok.params {
-                let _def: ColumnDefinition = self.stream.recv().await?;
+                let def: ColumnDefinition = self.stream.recv().await?;
+
+                params.push(MySqlTypeInfo::from_column(&def));
             }
 
             self.stream.maybe_recv_eof().await?;
@@ -54,18 +56,38 @@ impl MySqlConnection {
 
         if ok.columns > 0 {
             for _ in 0..(ok.columns as usize) {
-                let _def: ColumnDefinition = self.stream.recv().await?;
+                let def: ColumnDefinition = self.stream.recv().await?;
+                let ty = MySqlTypeInfo::from_column(&def);
+                let alias = def.alias()?;
+
+                columns.push(Column {
+                    name: if alias.is_empty() { def.name()? } else { alias }.to_owned(),
+                    type_info: ty,
+                    not_null: Some(def.flags.contains(ColumnFlags::NOT_NULL)),
+                })
             }
 
             self.stream.maybe_recv_eof().await?;
         }
 
+        let statement = Statement {
+            id: ok.statement_id,
+            params,
+            columns,
+        };
+
         // in case of the cache being full, close the least recently used statement
-        if let Some(statement) = self.cache_statement.insert(query, ok.statement_id) {
-            self.stream.send_packet(StmtClose { statement }).await?;
+        if let Some(statement) = self.cache_statement.insert(query, statement) {
+            self.stream
+                .send_packet(StmtClose {
+                    statement: statement.id,
+                })
+                .await?;
         }
 
-        Ok(ok.statement_id)
+        // We just inserted the statement above, we'll always have it in the
+        // cache at this point.
+        Ok(self.cache_statement.get_mut(query).unwrap())
     }
 
     async fn recv_result_metadata(&mut self, mut packet: Packet<Bytes>) -> Result<(), Error> {
@@ -117,11 +139,12 @@ impl MySqlConnection {
 
         let format = if let Some(arguments) = arguments {
             let statement = self.prepare(query).await?;
+            let statement_id = statement.id;
 
             // https://dev.mysql.com/doc/internals/en/com-stmt-execute.html
             self.stream
                 .send_packet(StatementExecute {
-                    statement,
+                    statement: statement_id,
                     arguments: &arguments,
                 })
                 .await?;
@@ -244,7 +267,6 @@ impl<'c> Executor<'c> for &'c mut MySqlConnection {
         })
     }
 
-    #[doc(hidden)]
     fn describe<'e, 'q: 'e, E: 'q>(self, query: E) -> BoxFuture<'e, Result<Describe<MySql>, Error>>
     where
         'c: 'e,
@@ -253,42 +275,10 @@ impl<'c> Executor<'c> for &'c mut MySqlConnection {
         let query = query.query();
 
         Box::pin(async move {
-            self.stream.send_packet(Prepare { query }).await?;
+            let statement = self.prepare(query).await?;
 
-            let ok: PrepareOk = self.stream.recv().await?;
-
-            let mut params = Vec::with_capacity(ok.params as usize);
-            let mut columns = Vec::with_capacity(ok.columns as usize);
-
-            if ok.params > 0 {
-                for _ in 0..ok.params {
-                    let def: ColumnDefinition = self.stream.recv().await?;
-
-                    params.push(MySqlTypeInfo::from_column(&def));
-                }
-
-                self.stream.maybe_recv_eof().await?;
-            }
-
-            // the column definitions are berefit the type information from the
-            // to-be-bound parameters; we will receive the output column definitions
-            // once more on execute so we wait for that
-
-            if ok.columns > 0 {
-                for _ in 0..(ok.columns as usize) {
-                    let def: ColumnDefinition = self.stream.recv().await?;
-                    let ty = MySqlTypeInfo::from_column(&def);
-                    let alias = def.alias()?;
-
-                    columns.push(Column {
-                        name: if alias.is_empty() { def.name()? } else { alias }.to_owned(),
-                        type_info: ty,
-                        not_null: Some(def.flags.contains(ColumnFlags::NOT_NULL)),
-                    })
-                }
-
-                self.stream.maybe_recv_eof().await?;
-            }
+            let params = statement.params.clone();
+            let columns = statement.columns.clone();
 
             Ok(Describe { params, columns })
         })

--- a/sqlx-core/src/mysql/database.rs
+++ b/sqlx-core/src/mysql/database.rs
@@ -5,7 +5,7 @@ use crate::mysql::{
 };
 
 /// MySQL database driver.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct MySql;
 
 impl Database for MySql {

--- a/sqlx-core/src/mysql/mod.rs
+++ b/sqlx-core/src/mysql/mod.rs
@@ -8,6 +8,7 @@ mod io;
 mod options;
 mod protocol;
 mod row;
+mod statement;
 mod transaction;
 mod type_info;
 pub mod types;

--- a/sqlx-core/src/mysql/statement.rs
+++ b/sqlx-core/src/mysql/statement.rs
@@ -1,0 +1,9 @@
+use super::{MySql, MySqlTypeInfo};
+use crate::describe::Column;
+
+#[derive(Debug)]
+pub struct Statement {
+    pub(crate) id: u32,
+    pub(crate) params: Vec<Option<MySqlTypeInfo>>,
+    pub(crate) columns: Vec<Column<MySql>>,
+}

--- a/sqlx-core/src/postgres/connection/establish.rs
+++ b/sqlx-core/src/postgres/connection/establish.rs
@@ -144,6 +144,7 @@ impl PgConnection {
             cache_type_info: HashMap::new(),
             scratch_row_columns: Default::default(),
             scratch_row_column_names: Default::default(),
+            describe_mode: false,
         })
     }
 }

--- a/sqlx-core/src/postgres/database.rs
+++ b/sqlx-core/src/postgres/database.rs
@@ -4,7 +4,7 @@ use crate::postgres::value::{PgValue, PgValueRef};
 use crate::postgres::{PgArguments, PgConnection, PgRow, PgTransactionManager, PgTypeInfo};
 
 /// PostgreSQL database driver.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Postgres;
 
 impl Database for Postgres {

--- a/sqlx-core/src/postgres/mod.rs
+++ b/sqlx-core/src/postgres/mod.rs
@@ -9,6 +9,7 @@ mod listener;
 mod message;
 mod options;
 mod row;
+mod statement;
 mod transaction;
 mod type_info;
 pub mod types;

--- a/sqlx-core/src/postgres/statement.rs
+++ b/sqlx-core/src/postgres/statement.rs
@@ -1,0 +1,42 @@
+use super::{PgTypeInfo, Postgres};
+use crate::describe::Column;
+
+#[derive(Debug)]
+pub struct Statement {
+    id: u32,
+    params: Vec<Option<PgTypeInfo>>,
+    columns: Vec<Column<Postgres>>,
+    columns_set: bool,
+}
+
+impl Statement {
+    pub fn new(id: u32, params: Vec<Option<PgTypeInfo>>) -> Self {
+        Self {
+            id,
+            params,
+            columns: Vec::new(),
+            columns_set: false,
+        }
+    }
+
+    pub fn id(&self) -> u32 {
+        self.id
+    }
+
+    pub fn params(&self) -> &[Option<PgTypeInfo>] {
+        self.params.as_slice()
+    }
+
+    pub fn columns(&self) -> &[Column<Postgres>] {
+        self.columns.as_slice()
+    }
+
+    pub fn set_columns(&mut self, columns: Vec<Column<Postgres>>) {
+        self.columns = columns;
+        self.columns_set = true;
+    }
+
+    pub fn columns_set(&self) -> bool {
+        self.columns_set
+    }
+}

--- a/sqlx-core/src/sqlite/connection/executor.rs
+++ b/sqlx-core/src/sqlite/connection/executor.rs
@@ -170,7 +170,6 @@ impl<'c> Executor<'c> for &'c mut SqliteConnection {
         })
     }
 
-    #[doc(hidden)]
     fn describe<'e, 'q: 'e, E: 'q>(self, query: E) -> BoxFuture<'e, Result<Describe<Sqlite>, Error>>
     where
         'c: 'e,


### PR DESCRIPTION
My first attempt on solving the issue https://github.com/launchbadge/sqlx/issues/461

We do some things I'm not so sure about:

- Copying the metadata to `Describe`. Adding one extra lifetime parameter to this is going to be tough, and we basically would copy the info anyhow. If we find a nice way of using references here, I'm all ears.
- The postgres state machine was quite tricky to get even working. You see we cut recursion with a flag here, which is not optimal but at least makes the tests green. You also notice how we now cache one extra statement for the describes. Making it to skip caching was again quite tricky, so I hope nothing really breaks if I cache them too (except a bit more waste of space).