### PR TITLE
Support for `money` type in Postgres

### DIFF
--- a/sqlx-core/src/postgres/type_info.rs
+++ b/sqlx-core/src/postgres/type_info.rs
@@ -113,6 +113,8 @@ pub enum PgType {
     Int8RangeArray,
     Jsonpath,
     JsonpathArray,
+    Money,
+    MoneyArray,
 
     // A realized user-defined type. When a connection sees a DeclareXX variant it resolves
     // into this one before passing it along to `accepts` or inside of `Value` objects.
@@ -254,6 +256,8 @@ impl PgType {
             719 => PgType::CircleArray,
             774 => PgType::Macaddr8,
             775 => PgType::Macaddr8Array,
+            790 => PgType::Money,
+            791 => PgType::MoneyArray,
             829 => PgType::Macaddr,
             869 => PgType::Inet,
             1000 => PgType::BoolArray,
@@ -359,6 +363,8 @@ impl PgType {
             PgType::CircleArray => 719,
             PgType::Macaddr8 => 774,
             PgType::Macaddr8Array => 775,
+            PgType::Money => 790,
+            PgType::MoneyArray => 791,
             PgType::Macaddr => 829,
             PgType::Inet => 869,
             PgType::BoolArray => 1000,
@@ -521,6 +527,8 @@ impl PgType {
             PgType::Int8RangeArray => "INT8RANGE[]",
             PgType::Jsonpath => "JSONPATH",
             PgType::JsonpathArray => "JSONPATH[]",
+            PgType::Money => "MONEY",
+            PgType::MoneyArray => "MONEY[]",
             PgType::Custom(ty) => &*ty.name,
             PgType::DeclareWithOid(_) => "?",
             PgType::DeclareWithName(name) => name,
@@ -618,6 +626,8 @@ impl PgType {
             PgType::Int8RangeArray => "_int8range",
             PgType::Jsonpath => "jsonpath",
             PgType::JsonpathArray => "_jsonpath",
+            PgType::Money => "money",
+            PgType::MoneyArray => "_money",
             PgType::Custom(ty) => &*ty.name,
             PgType::DeclareWithOid(_) => "?",
             PgType::DeclareWithName(name) => name,
@@ -715,6 +725,8 @@ impl PgType {
             PgType::Int8RangeArray => &PgTypeKind::Array(PgTypeInfo(PgType::Int8Range)),
             PgType::Jsonpath => &PgTypeKind::Simple,
             PgType::JsonpathArray => &PgTypeKind::Array(PgTypeInfo(PgType::Jsonpath)),
+            PgType::Money => &PgTypeKind::Simple,
+            PgType::MoneyArray => &PgTypeKind::Array(PgTypeInfo(PgType::Money)),
             PgType::Custom(ty) => &ty.kind,
 
             PgType::DeclareWithOid(_) | PgType::DeclareWithName(_) => {
@@ -844,6 +856,10 @@ impl PgTypeInfo {
     // user-specified precision, exact
     pub(crate) const NUMERIC: Self = Self(PgType::Numeric);
     pub(crate) const NUMERIC_ARRAY: Self = Self(PgType::NumericArray);
+
+    // user-specified precision, exact
+    pub(crate) const MONEY: Self = Self(PgType::Money);
+    pub(crate) const MONEY_ARRAY: Self = Self(PgType::MoneyArray);
 
     //
     // date/time types

--- a/sqlx-core/src/postgres/types/int.rs
+++ b/sqlx-core/src/postgres/types/int.rs
@@ -148,19 +148,11 @@ impl Type<Postgres> for i64 {
     fn type_info() -> PgTypeInfo {
         PgTypeInfo::INT8
     }
-
-    fn compatible(ty: &PgTypeInfo) -> bool {
-        *ty == PgTypeInfo::INT8 || *ty == PgTypeInfo::MONEY
-    }
 }
 
 impl Type<Postgres> for [i64] {
     fn type_info() -> PgTypeInfo {
         PgTypeInfo::INT8_ARRAY
-    }
-
-    fn compatible(ty: &PgTypeInfo) -> bool {
-        *ty == PgTypeInfo::INT8_ARRAY || *ty == PgTypeInfo::MONEY_ARRAY
     }
 }
 

--- a/sqlx-core/src/postgres/types/int.rs
+++ b/sqlx-core/src/postgres/types/int.rs
@@ -148,11 +148,19 @@ impl Type<Postgres> for i64 {
     fn type_info() -> PgTypeInfo {
         PgTypeInfo::INT8
     }
+
+    fn compatible(ty: &PgTypeInfo) -> bool {
+        *ty == PgTypeInfo::INT8 || *ty == PgTypeInfo::MONEY
+    }
 }
 
 impl Type<Postgres> for [i64] {
     fn type_info() -> PgTypeInfo {
         PgTypeInfo::INT8_ARRAY
+    }
+
+    fn compatible(ty: &PgTypeInfo) -> bool {
+        *ty == PgTypeInfo::INT8_ARRAY || *ty == PgTypeInfo::MONEY_ARRAY
     }
 }
 

--- a/sqlx-core/src/postgres/types/mod.rs
+++ b/sqlx-core/src/postgres/types/mod.rs
@@ -14,9 +14,11 @@
 //! | `&[u8]`, `Vec<u8>`                    | BYTEA                                                |
 //! | [`PgInterval`]                        | INTERVAL                                             |
 //! | [`PgRange<T>`]                        | INT8RANGE, INT4RANGE, TSRANGE, TSTZTRANGE, DATERANGE, NUMRANGE |
+//! | [`PgMoney`]                           | MONEY                                                |
 //!
 //! [`PgInterval`]: struct.PgInterval.html
 //! [`PgRange<T>`]: struct.PgRange.html
+//! [`PgMoney`]: struct.PgMoney.html
 //!
 //! ### [`chrono`](https://crates.io/crates/chrono)
 //!
@@ -143,6 +145,7 @@ mod bytes;
 mod float;
 mod int;
 mod interval;
+mod money;
 mod range;
 mod record;
 mod str;
@@ -170,6 +173,7 @@ mod json;
 mod ipnetwork;
 
 pub use interval::PgInterval;
+pub use money::PgMoney;
 pub use range::PgRange;
 
 // used in derive(Type) for `struct`

--- a/sqlx-core/src/postgres/types/money.rs
+++ b/sqlx-core/src/postgres/types/money.rs
@@ -30,7 +30,7 @@ impl PgMoney {
     ///
     /// [`BigDecimal`]: ../../types/struct.BigDecimal.html
     #[cfg(feature = "bigdecimal")]
-    pub fn as_bigdecimal(self, scale: i64) -> bigdecimal::BigDecimal {
+    pub fn to_bigdecimal(self, scale: i64) -> bigdecimal::BigDecimal {
         let digits = num_bigint::BigInt::from(self.0);
 
         bigdecimal::BigDecimal::new(digits, scale)
@@ -211,7 +211,7 @@ mod tests {
 
         assert_eq!(
             bigdecimal::BigDecimal::new(num_bigint::BigInt::from(12345), 2),
-            money.as_bigdecimal(2)
+            money.to_bigdecimal(2)
         );
     }
 }

--- a/sqlx-core/src/postgres/types/money.rs
+++ b/sqlx-core/src/postgres/types/money.rs
@@ -1,0 +1,217 @@
+use crate::{
+    decode::Decode,
+    encode::{Encode, IsNull},
+    error::BoxDynError,
+    postgres::{PgArgumentBuffer, PgTypeInfo, PgValueFormat, PgValueRef, Postgres},
+    types::Type,
+};
+use byteorder::{BigEndian, ByteOrder};
+use std::{
+    io,
+    ops::{Add, AddAssign, Sub, SubAssign},
+};
+
+/// The PostgreSQL [`MONEY`] type stores a currency amount with a fixed fractional
+/// precision. The fractional precision is determined by the database's
+/// `lc_monetary` setting.
+///
+/// Data is read and written as 64-bit signed integers, and conversion into a
+/// decimal should be done using the right precision.
+///
+/// Reading `MONEY` value in text format is not supported and will cause an error.
+///
+/// [`MONEY`]: https://www.postgresql.org/docs/current/datatype-money.html
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct PgMoney(pub i64);
+
+impl PgMoney {
+    /// Convert the money value into a [`BigDecimal`] using the correct precision
+    /// defined in the PostgreSQL settings. The default precision is two.
+    ///
+    /// [`BigDecimal`]: ../../types/struct.BigDecimal.html
+    #[cfg(feature = "bigdecimal")]
+    pub fn as_bigdecimal(&self, scale: i64) -> bigdecimal::BigDecimal {
+        let digits = num_bigint::BigInt::from(self.0);
+
+        bigdecimal::BigDecimal::new(digits, scale)
+    }
+}
+
+impl Type<Postgres> for PgMoney {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::MONEY
+    }
+}
+
+impl Type<Postgres> for [PgMoney] {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::MONEY_ARRAY
+    }
+}
+
+impl Type<Postgres> for Vec<PgMoney> {
+    fn type_info() -> PgTypeInfo {
+        <[PgMoney] as Type<Postgres>>::type_info()
+    }
+}
+
+impl<T> From<T> for PgMoney
+where
+    T: Into<i64>,
+{
+    fn from(num: T) -> Self {
+        Self(num.into())
+    }
+}
+
+impl Encode<'_, Postgres> for PgMoney {
+    fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> IsNull {
+        buf.extend(&self.0.to_be_bytes());
+
+        IsNull::No
+    }
+}
+
+impl Decode<'_, Postgres> for PgMoney {
+    fn decode(value: PgValueRef<'_>) -> Result<Self, BoxDynError> {
+        match value.format() {
+            PgValueFormat::Binary => {
+                let cents = BigEndian::read_i64(value.as_bytes()?);
+
+                Ok(PgMoney(cents))
+            }
+            PgValueFormat::Text => {
+                let error = io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Reading a `MONEY` value in text format is not supported.",
+                );
+
+                Err(Box::new(error))
+            }
+        }
+    }
+}
+
+impl Add<PgMoney> for PgMoney {
+    type Output = PgMoney;
+
+    /// Adds two monetary values.
+    ///
+    /// # Panics
+    /// Panics if overflowing the `i64::MAX`.
+    fn add(self, rhs: PgMoney) -> Self::Output {
+        self.0
+            .checked_add(rhs.0)
+            .map(PgMoney)
+            .expect("overflow adding money amounts")
+    }
+}
+
+impl AddAssign<PgMoney> for PgMoney {
+    /// An assigning add for two monetary values.
+    ///
+    /// # Panics
+    /// Panics if overflowing the `i64::MAX`.
+    fn add_assign(&mut self, rhs: PgMoney) {
+        self.0 = self
+            .0
+            .checked_add(rhs.0)
+            .expect("overflow adding money amounts")
+    }
+}
+
+impl Sub<PgMoney> for PgMoney {
+    type Output = PgMoney;
+
+    /// Subtracts two monetary values.
+    ///
+    /// # Panics
+    /// Panics if underflowing the `i64::MIN`.
+    fn sub(self, rhs: PgMoney) -> Self::Output {
+        self.0
+            .checked_sub(rhs.0)
+            .map(PgMoney)
+            .expect("overflow subtracting money amounts")
+    }
+}
+
+impl SubAssign<PgMoney> for PgMoney {
+    /// An assigning subtract for two monetary values.
+    ///
+    /// # Panics
+    /// Panics if underflowing the `i64::MIN`.
+    fn sub_assign(&mut self, rhs: PgMoney) {
+        self.0 = self
+            .0
+            .checked_sub(rhs.0)
+            .expect("overflow subtracting money amounts")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PgMoney;
+
+    #[test]
+    fn adding_works() {
+        assert_eq!(PgMoney(3), PgMoney(1) + PgMoney(2))
+    }
+
+    #[test]
+    fn add_assign_works() {
+        let mut money = PgMoney(1);
+        money += PgMoney(2);
+
+        assert_eq!(PgMoney(3), money);
+    }
+
+    #[test]
+    fn subtracting_works() {
+        assert_eq!(PgMoney(4), PgMoney(5) - PgMoney(1))
+    }
+
+    #[test]
+    fn sub_assign_works() {
+        let mut money = PgMoney(1);
+        money -= PgMoney(2);
+
+        assert_eq!(PgMoney(-1), money);
+    }
+
+    #[test]
+    #[should_panic]
+    fn add_overflow_panics() {
+        let _ = PgMoney(i64::MAX) + PgMoney(1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn add_assign_overflow_panics() {
+        let mut money = PgMoney(i64::MAX);
+        money += PgMoney(1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn sub_overflow_panics() {
+        let _ = PgMoney(i64::MIN) - PgMoney(1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn sub_assign_overflow_panics() {
+        let mut money = PgMoney(i64::MIN);
+        money -= PgMoney(1);
+    }
+
+    #[test]
+    #[cfg(feature = "bigdecimal")]
+    fn conversion_to_bigdecimal_works() {
+        let money = PgMoney(12345);
+
+        assert_eq!(
+            bigdecimal::BigDecimal::new(num_bigint::BigInt::from(12345), 2),
+            money.as_bigdecimal(2)
+        );
+    }
+}

--- a/sqlx-core/src/postgres/types/money.rs
+++ b/sqlx-core/src/postgres/types/money.rs
@@ -21,7 +21,7 @@ use std::{
 /// Reading `MONEY` value in text format is not supported and will cause an error.
 ///
 /// [`MONEY`]: https://www.postgresql.org/docs/current/datatype-money.html
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct PgMoney(pub i64);
 
 impl PgMoney {
@@ -30,7 +30,7 @@ impl PgMoney {
     ///
     /// [`BigDecimal`]: ../../types/struct.BigDecimal.html
     #[cfg(feature = "bigdecimal")]
-    pub fn as_bigdecimal(&self, scale: i64) -> bigdecimal::BigDecimal {
+    pub fn as_bigdecimal(self, scale: i64) -> bigdecimal::BigDecimal {
         let digits = num_bigint::BigInt::from(self.0);
 
         bigdecimal::BigDecimal::new(digits, scale)

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -2,7 +2,7 @@ extern crate time_ as time;
 
 use std::ops::Bound;
 
-use sqlx::postgres::types::{PgInterval, PgRange};
+use sqlx::postgres::types::{PgInterval, PgMoney, PgRange};
 use sqlx::postgres::Postgres;
 use sqlx_test::{test_decode_type, test_prepared_type, test_type};
 
@@ -387,4 +387,10 @@ test_prepared_type!(interval<PgInterval>(
             days: 0,
             microseconds: (3 * 3_600 + 10 * 60 + 20) * 1_000_000 + 116100
         },
+));
+
+test_prepared_type!(money<PgMoney>(Postgres, "123.45::money" == PgMoney(12345)));
+
+test_prepared_type!(money_vec<Vec<PgMoney>>(Postgres,
+    "array[123.45,420.00,666.66]::money[]" == vec![PgMoney(12345), PgMoney(42000), PgMoney(66666)],
 ));


### PR DESCRIPTION
Reading is possible as `i64`, presenting the number of cents with the default setting. The fractional precision depends on the `lc_monetary` setting. By default the setting gives a fractional precision of 2.

Writing works with `i32`, `i64` or a numeric type such as `BigDecimal`. When using an integer to write, it is not possible to represent cents. Writing `123` to a money field stores a value of 12300.

When writing with a numeric type, cents can be represented. Reading should still be done to an integer and if needed, converted to a numeric type in the application to get the correct fractional precision.