### PR TITLE
Add SCREAMING_SNAKE_CASE rename_all option

### DIFF
--- a/sqlx-macros/src/derives/attributes.rs
+++ b/sqlx-macros/src/derives/attributes.rs
@@ -73,8 +73,8 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
                                 let val = match &*val.value() {
                                     "lowercase" => RenameAll::LowerCase,
                                     "snake_case" => RenameAll::SnakeCase,
-                                    "uppercase" => RenameAll::UpperCase,
-                                    "screaming_snake_case" => RenameAll::ScreamingSnakeCase,
+                                    "UPPERCASE" => RenameAll::UpperCase,
+                                    "SCREAMING_SNAKE_CASE" => RenameAll::ScreamingSnakeCase,
 
                                     _ => fail!(meta, "unexpected value for rename_all"),
                                 };

--- a/sqlx-macros/src/derives/attributes.rs
+++ b/sqlx-macros/src/derives/attributes.rs
@@ -31,6 +31,7 @@ pub enum RenameAll {
     LowerCase,
     SnakeCase,
     UpperCase,
+    ScreamingSnakeCase,
 }
 
 pub struct SqlxContainerAttributes {
@@ -73,6 +74,7 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
                                     "lowercase" => RenameAll::LowerCase,
                                     "snake_case" => RenameAll::SnakeCase,
                                     "uppercase" => RenameAll::UpperCase,
+                                    "screaming_snake_case" => RenameAll::ScreamingSnakeCase,
 
                                     _ => fail!(meta, "unexpected value for rename_all"),
                                 };

--- a/sqlx-macros/src/derives/mod.rs
+++ b/sqlx-macros/src/derives/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use r#type::expand_derive_type;
 pub(crate) use row::expand_derive_from_row;
 
 use self::attributes::RenameAll;
-use heck::SnakeCase;
+use heck::{ShoutySnakeCase, SnakeCase};
 use std::iter::FromIterator;
 use syn::DeriveInput;
 
@@ -33,5 +33,6 @@ pub(crate) fn rename_all(s: &str, pattern: RenameAll) -> String {
         RenameAll::LowerCase => s.to_lowercase(),
         RenameAll::SnakeCase => s.to_snake_case(),
         RenameAll::UpperCase => s.to_uppercase(),
+        RenameAll::ScreamingSnakeCase => s.to_shouty_snake_case(),
     }
 }

--- a/tests/postgres/derives.rs
+++ b/tests/postgres/derives.rs
@@ -51,7 +51,7 @@ enum ColorSnake {
 
 #[derive(PartialEq, Debug, sqlx::Type)]
 #[sqlx(rename = "color_upper")]
-#[sqlx(rename_all = "uppercase")]
+#[sqlx(rename_all = "UPPERCASE")]
 enum ColorUpper {
     Red,
     Green,
@@ -60,7 +60,7 @@ enum ColorUpper {
 
 #[derive(PartialEq, Debug, sqlx::Type)]
 #[sqlx(rename = "color_screaming_snake")]
-#[sqlx(rename_all = "screaming_snake_case")]
+#[sqlx(rename_all = "SCREAMING_SNAKE_CASE")]
 enum ColorScreamingSnake {
     RedGreen,
     BlueBlack,


### PR DESCRIPTION
This mirrors the addition of `uppercase` in https://github.com/launchbadge/sqlx/pull/304, but for all uppercase snake case.