### PR TITLE
Implementing support for pg TIMETZ type

### DIFF
--- a/sqlx-core/src/postgres/types/chrono.rs
+++ b/sqlx-core/src/postgres/types/chrono.rs
@@ -156,12 +156,7 @@ impl<'r> Decode<'r, Postgres> for PgTimeTz {
                 // See `timetz_in` in `adt/date.c` and `ParseDateTime` in
                 // `dt_common.c`.
 
-                let error = io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "Reading a `TIMETZ` value in text format is not supported.",
-                );
-
-                Err(Box::new(error))
+                Err("Reading a `TIMETZ` value in text format is not supported.".into())
             }
         }
     }

--- a/sqlx-core/src/postgres/types/mod.rs
+++ b/sqlx-core/src/postgres/types/mod.rs
@@ -45,6 +45,9 @@
 //! | `chrono::NaiveDateTime`               | TIMESTAMP                                            |
 //! | `chrono::NaiveDate`                   | DATE                                                 |
 //! | `chrono::NaiveTime`                   | TIME                                                 |
+//! | [`PgTimeTz`]                          | TIMETZ                                               |
+//!
+//! [`PgTimeTz`]: struct.PgTimeTz.html
 //!
 //! ### [`time`](https://crates.io/crates/time)
 //!
@@ -189,6 +192,8 @@ mod json;
 #[cfg(feature = "ipnetwork")]
 mod ipnetwork;
 
+#[cfg(feature = "chrono")]
+pub use self::chrono::PgTimeTz;
 pub use interval::PgInterval;
 pub use money::PgMoney;
 pub use range::PgRange;

--- a/sqlx-core/src/types/mod.rs
+++ b/sqlx-core/src/types/mod.rs
@@ -24,6 +24,9 @@ pub use uuid::Uuid;
 #[cfg(feature = "chrono")]
 #[cfg_attr(docsrs, doc(cfg(feature = "chrono")))]
 pub mod chrono {
+    #[cfg(feature = "postgres")]
+    pub use crate::postgres::types::PgTimeTz;
+
     pub use chrono::{
         DateTime, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc,
     };

--- a/sqlx-macros/src/database/postgres.rs
+++ b/sqlx-macros/src/database/postgres.rs
@@ -29,6 +29,9 @@ impl_database_ext! {
         #[cfg(feature = "chrono")]
         sqlx::types::chrono::DateTime<sqlx::types::chrono::Utc> | sqlx::types::chrono::DateTime<_>,
 
+        #[cfg(feature = "chrono")]
+        sqlx::types::chrono::PgTimeTz,
+
         #[cfg(feature = "time")]
         sqlx::types::time::Time,
 

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -179,7 +179,9 @@ test_type!(ipnetwork_vec<Vec<sqlx::types::ipnetwork::IpNetwork>>(Postgres,
 #[cfg(feature = "chrono")]
 mod chrono {
     use super::*;
-    use sqlx::types::chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+    use sqlx::types::chrono::{
+        DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, PgTimeTz, Utc,
+    };
 
     test_type!(chrono_date<NaiveDate>(Postgres,
         "DATE '2001-01-05'" == NaiveDate::from_ymd(2001, 1, 5),
@@ -215,6 +217,13 @@ mod chrono {
                     Utc,
                 )
             ]
+    ));
+
+    test_prepared_type!(chrono_time_tz<PgTimeTz>(Postgres,
+        "TIMETZ '05:10:20.115100+00'" == PgTimeTz::new(NaiveTime::from_hms_micro(5, 10, 20, 115100), FixedOffset::east(0)),
+        "TIMETZ '05:10:20.115100+06:30'" == PgTimeTz::new(NaiveTime::from_hms_micro(5, 10, 20, 115100), FixedOffset::east(23400)),
+        "TIMETZ '05:10:20.115100-05'" == PgTimeTz::new(NaiveTime::from_hms_micro(5, 10, 20, 115100), FixedOffset::west(18000)),
+        "TIMETZ '05:10:20+02'" == PgTimeTz::new(NaiveTime::from_hms(5, 10, 20), FixedOffset::east(3600 * 2))
     ));
 }
 

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -221,9 +221,9 @@ mod chrono {
 
     test_prepared_type!(chrono_time_tz<PgTimeTz>(Postgres,
         "TIMETZ '05:10:20.115100+00'" == PgTimeTz::new(NaiveTime::from_hms_micro(5, 10, 20, 115100), FixedOffset::east(0)),
-        "TIMETZ '05:10:20.115100+06:30'" == PgTimeTz::new(NaiveTime::from_hms_micro(5, 10, 20, 115100), FixedOffset::east(23400)),
-        "TIMETZ '05:10:20.115100-05'" == PgTimeTz::new(NaiveTime::from_hms_micro(5, 10, 20, 115100), FixedOffset::west(18000)),
-        "TIMETZ '05:10:20+02'" == PgTimeTz::new(NaiveTime::from_hms(5, 10, 20), FixedOffset::east(3600 * 2))
+        "TIMETZ '05:10:20.115100+06:30'" == PgTimeTz::new(NaiveTime::from_hms_micro(5, 10, 20, 115100), FixedOffset::east(60 * 60 * 6 + 1800)),
+        "TIMETZ '05:10:20.115100-05'" == PgTimeTz::new(NaiveTime::from_hms_micro(5, 10, 20, 115100), FixedOffset::west(60 * 60 * 5)),
+        "TIMETZ '05:10:20+02'" == PgTimeTz::new(NaiveTime::from_hms(5, 10, 20), FixedOffset::east(60 * 60 * 2))
     ));
 }
 


### PR DESCRIPTION
Only binary protocol is supported for now due to a proper time with timezone type missing from Rust/Chrono.