### PR TITLE
Update column.rs

### DIFF
--- a/sqlx-core/src/postgres/column.rs
+++ b/sqlx-core/src/postgres/column.rs
@@ -8,7 +8,9 @@ pub struct PgColumn {
     pub(crate) ordinal: usize,
     pub(crate) name: UStr,
     pub(crate) type_info: PgTypeInfo,
+    #[cfg_attr(feature = "offline", serde(skip))]
     pub(crate) relation_id: Option<i32>,
+    #[cfg_attr(feature = "offline", serde(skip))]
     pub(crate) relation_attribute_no: Option<i16>,
 }
 


### PR DESCRIPTION
Skip serialization of `relation_id` and `relation_attribute_no` so they do not appear in `sqlx-data.json`