### PR TITLE
fix(macros) - use re-exported Error type from sqlx crate

### DIFF
--- a/sqlx-macros/src/derives/row.rs
+++ b/sqlx-macros/src/derives/row.rs
@@ -84,7 +84,7 @@ fn expand_derive_from_row_struct(
         if attributes.default {
             Some(
                 parse_quote!(let #id: #ty = row.try_get(#id_s).or_else(|e| match e {
-                sqlx_core::error::Error::ColumnNotFound(_) => {
+                sqlx::Error::ColumnNotFound(_) => {
                     Ok(Default::default())
                 },
                 e => Err(e)


### PR DESCRIPTION
A remnant from #495 that used sqlx_core directly requiring end-user to add it as a dependency from the expanded macro.