### PR TITLE
Allow MigrationSource to be implemented externally

### DIFF
--- a/sqlx-core/src/migrate/migration.rs
+++ b/sqlx-core/src/migrate/migration.rs
@@ -1,9 +1,24 @@
 use std::borrow::Cow;
 
+use sha2::{Digest, Sha384};
+
 #[derive(Debug, Clone)]
 pub struct Migration {
     pub version: i64,
     pub description: Cow<'static, str>,
     pub sql: Cow<'static, str>,
     pub checksum: Cow<'static, [u8]>,
+}
+
+impl Migration {
+    pub fn new(version: i64, description: Cow<'static, str>, sql: Cow<'static, str>) -> Self {
+        let checksum = Cow::Owned(Vec::from(Sha384::digest(sql.as_bytes()).as_slice()));
+
+        Migration {
+            version,
+            description,
+            sql,
+            checksum,
+        }
+    }
 }

--- a/sqlx-core/src/migrate/source.rs
+++ b/sqlx-core/src/migrate/source.rs
@@ -2,7 +2,6 @@ use crate::error::BoxDynError;
 use crate::migrate::Migration;
 use futures_core::future::BoxFuture;
 use futures_util::TryStreamExt;
-use sha2::{Digest, Sha384};
 use sqlx_rt::fs;
 use std::borrow::Cow;
 use std::fmt::Debug;
@@ -44,14 +43,11 @@ impl<'s> MigrationSource<'s> for &'s Path {
 
                 let sql = fs::read_to_string(&entry.path()).await?;
 
-                let checksum = Vec::from(Sha384::digest(sql.as_bytes()).as_slice());
-
-                migrations.push(Migration {
+                migrations.push(Migration::new(
                     version,
-                    description: Cow::Owned(description),
-                    sql: Cow::Owned(sql),
-                    checksum: Cow::Owned(checksum),
-                })
+                    Cow::Owned(description),
+                    Cow::Owned(sql),
+                ));
             }
 
             // ensure that we are sorted by `VERSION ASC`


### PR DESCRIPTION
This simply adds constructors for Migration. I don't think this is a great API, but it works for my cases. This allows for fully embedding the migrations in the binary rather than having to ship the migrations and the binary. Below is an example of how I plan to use it (they're simple migrations for an IRC bot):

```
#[derive(Debug)]
struct IntegratedMigrations(Vec<Migration>);

impl IntegratedMigrations {
    fn new() -> Self {
        IntegratedMigrations(vec![
            Migration::new(1, "karma".into(), include_str!("1_karma.sql").into()),
            Migration::new(2, "bucket".into(), include_str!("2_bucket.sql").into()),
            Migration::new(3, "noaa".into(), include_str!("3_noaa.sql").into()),
            Migration::new(4, "forecast".into(), include_str!("4_forecast.sql").into()),
        ])
    }
}

impl MigrationSource<'static> for IntegratedMigrations {
    fn resolve(
        self,
    ) -> future::BoxFuture<'static, std::result::Result<Vec<Migration>, BoxDynError>> {
        future::ok(self.0).boxed()
    }
}
```

I think long term, it would be nice if something like this was built-in to the migrations system, as that would allow for using sqlx-cli and integrated migrations in a way that doesn't conflict.