### PR TITLE
`PgAny` marker to allow untyped parameters

### DIFF
--- a/sqlx-core/src/postgres/type_info.rs
+++ b/sqlx-core/src/postgres/type_info.rs
@@ -24,6 +24,7 @@ impl Deref for PgTypeInfo {
 #[cfg_attr(feature = "offline", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u32)]
 pub enum PgType {
+    Any,
     Bool,
     Bytea,
     Char,
@@ -232,6 +233,7 @@ impl PgType {
     /// Returns the corresponding `PgType` if the OID is a built-in type and recognized by SQLx.
     pub(crate) fn try_from_oid(oid: u32) -> Option<Self> {
         Some(match oid {
+            0 => PgType::Any,
             16 => PgType::Bool,
             17 => PgType::Bytea,
             18 => PgType::Char,
@@ -340,6 +342,7 @@ impl PgType {
 
     pub(crate) fn try_oid(&self) -> Option<u32> {
         Some(match self {
+            PgType::Any => 0,
             PgType::Bool => 16,
             PgType::Bytea => 17,
             PgType::Char => 18,
@@ -443,6 +446,7 @@ impl PgType {
 
     pub(crate) fn display_name(&self) -> &str {
         match self {
+            PgType::Any => "ANY",
             PgType::Bool => "BOOL",
             PgType::Bytea => "BYTEA",
             PgType::Char => "\"CHAR\"",
@@ -543,6 +547,7 @@ impl PgType {
 
     pub(crate) fn name(&self) -> &str {
         match self {
+            PgType::Any => "any",
             PgType::Bool => "bool",
             PgType::Bytea => "bytea",
             PgType::Char => "char",
@@ -735,6 +740,7 @@ impl PgType {
             PgType::Money => &PgTypeKind::Simple,
             PgType::MoneyArray => &PgTypeKind::Array(PgTypeInfo(PgType::Money)),
 
+            PgType::Any => &PgTypeKind::Pseudo,
             PgType::Void => &PgTypeKind::Pseudo,
 
             PgType::Custom(ty) => &ty.kind,
@@ -977,6 +983,7 @@ impl PgTypeInfo {
     //
 
     pub(crate) const VOID: Self = Self(PgType::Void);
+    pub(crate) const ANY: Self = Self(PgType::Any);
 }
 
 impl Display for PgTypeInfo {

--- a/sqlx-core/src/postgres/types/any.rs
+++ b/sqlx-core/src/postgres/types/any.rs
@@ -37,3 +37,29 @@ where
         true
     }
 }
+
+impl<T> Type<Postgres> for [PgAny<T>]
+where
+    T: for<'e> Encode<'e, Postgres>,
+{
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::ANY
+    }
+
+    fn compatible(_: &PgTypeInfo) -> bool {
+        true
+    }
+}
+
+impl<T> Type<Postgres> for Vec<PgAny<T>>
+where
+    T: for<'e> Encode<'e, Postgres>,
+{
+    fn type_info() -> PgTypeInfo {
+        <[PgAny<T>] as Type<Postgres>>::type_info()
+    }
+
+    fn compatible(_: &PgTypeInfo) -> bool {
+        true
+    }
+}

--- a/sqlx-core/src/postgres/types/any.rs
+++ b/sqlx-core/src/postgres/types/any.rs
@@ -1,0 +1,39 @@
+use crate::{
+    encode::Encode,
+    postgres::{PgArgumentBuffer, PgTypeInfo, Postgres},
+    types::Type,
+};
+
+/// Specifies the given argument to be untyped, allowing statements with
+/// varying types.
+///
+/// Wrapping a parameter to `PgAny` will not trigger any type checks when
+/// preparing the statement.
+///
+/// `PgAny` is meant to be used when needing to write data without declaring the
+/// type in the statement, and cannot be used for reading.
+pub struct PgAny<T>(pub T)
+where
+    T: for<'e> Encode<'e, Postgres>;
+
+impl<T> Encode<'_, Postgres> for PgAny<T>
+where
+    T: for<'e> Encode<'e, Postgres>,
+{
+    fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> crate::encode::IsNull {
+        <T as Encode<'_, Postgres>>::encode_by_ref(&self.0, buf)
+    }
+}
+
+impl<T> Type<Postgres> for PgAny<T>
+where
+    T: for<'e> Encode<'e, Postgres>,
+{
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::ANY
+    }
+
+    fn compatible(_: &PgTypeInfo) -> bool {
+        true
+    }
+}

--- a/sqlx-core/src/postgres/types/mod.rs
+++ b/sqlx-core/src/postgres/types/mod.rs
@@ -153,6 +153,7 @@ use crate::postgres::type_info::PgTypeKind;
 use crate::postgres::{PgTypeInfo, Postgres};
 use crate::types::Type;
 
+mod any;
 mod array;
 mod bool;
 mod bytes;
@@ -193,6 +194,7 @@ mod json;
 #[cfg(feature = "ipnetwork")]
 mod ipnetwork;
 
+pub use any::PgAny;
 pub use interval::PgInterval;
 pub use money::PgMoney;
 pub use range::PgRange;

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -1,8 +1,8 @@
 use futures::TryStreamExt;
+use sqlx::postgres::{types::PgAny, PgPoolOptions, PgRow, Postgres};
 use sqlx::postgres::{
     PgConnectOptions, PgConnection, PgDatabaseError, PgErrorPosition, PgSeverity,
 };
-use sqlx::postgres::{PgPoolOptions, PgRow, Postgres};
 use sqlx::{Column, Connection, Done, Executor, Row, Statement, TypeInfo};
 use sqlx_test::{new, setup_if_needed};
 use std::env;
@@ -277,6 +277,18 @@ async fn it_can_query_scalar() -> anyhow::Result<()> {
 
     let scalar: Option<i16> = sqlx::query_scalar("").fetch_optional(&mut conn).await?;
     assert_eq!(scalar, None);
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
+async fn it_can_query_with_untyped_parameters() -> anyhow::Result<()> {
+    let mut conn = new::<Postgres>().await?;
+
+    let scalar: i32 = sqlx::query_scalar("SELECT $1::int")
+        .bind(PgAny(32i32))
+        .fetch_one(&mut conn)
+        .await?;
 
     Ok(())
 }


### PR DESCRIPTION
Binding a value wrapped in `PgAny` sets the type of that value in the statement to be `ANY` (OID 0), allowing loosening the type restrictions in certain more dynamic queries.