### PR TITLE
Allow decoding a `YEAR` value as uint from MySQL

### DIFF
--- a/sqlx-core/src/mysql/types/uint.rs
+++ b/sqlx-core/src/mysql/types/uint.rs
@@ -25,6 +25,7 @@ fn uint_compatible(ty: &MySqlTypeInfo) -> bool {
             | ColumnType::Long
             | ColumnType::Int24
             | ColumnType::LongLong
+            | ColumnType::Year
     ) && ty.flags.contains(ColumnFlags::UNSIGNED)
 }
 


### PR DESCRIPTION
https://dev.mysql.com/doc/refman/5.7/en/year.html