### PR TITLE
Allow decoding `BIT` to `Vec<u8>` in MySQL

### DIFF
--- a/sqlx-core/src/mysql/types/bytes.rs
+++ b/sqlx-core/src/mysql/types/bytes.rs
@@ -22,6 +22,7 @@ impl Type<MySql> for [u8] {
                 | ColumnType::String
                 | ColumnType::VarString
                 | ColumnType::Enum
+                | ColumnType::Bit
         )
     }
 }


### PR DESCRIPTION
This is a reminder PR we need some solution for this. For us, right now this works. But it's not the best solution.

I tried to fit `BitVec` into MySQL, but in responses MySQL does not tell the number of bits in the response, and loading the data as bytes will add extra zeroes to the end if the number of bits is not full bytes, causing wrong data and it being quite impossible to guess how many zeroes to chop from the end.