### PR TITLE
Remove unused phf dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1811,50 +1811,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
-name = "phf"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
-dependencies = [
- "phf_macros",
- "phf_shared",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6fde18ff429ffc8fe78e2bf7f8b7a5a5a6e2a8b58bc5a9ac69198bbda9189c"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "pin-project"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,7 +1965,6 @@ dependencies = [
  "rand_chacha",
  "rand_core",
  "rand_hc",
- "rand_pcg",
 ]
 
 [[package]]
@@ -2036,15 +1991,6 @@ name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core",
 ]
@@ -2394,12 +2340,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "siphasher"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
-
-[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2562,7 +2502,6 @@ dependencies = [
  "once_cell",
  "parking_lot 0.11.0",
  "percent-encoding 2.1.0",
- "phf",
  "rand",
  "regex",
  "rsa",

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -74,7 +74,6 @@ num-bigint = { version = "0.2.0", default-features = false, optional = true, fea
 once_cell = "1.4.0"
 percent-encoding = "2.1.0"
 parking_lot = "0.11.0"
-phf = { version = "0.8.0", features = [ "macros" ] }
 rand = { version = "0.7.3", default-features = false, optional = true, features = [ "std" ] }
 regex = { version = "1.3.9", optional = true }
 rsa = { version = "0.3.0", optional = true }


### PR DESCRIPTION
I was looking through a project's cargo tree output at usages for the rand crate and noticed that sqlx-core has an indirect dependency on it through the phf crate. When I went to check where this was used, it apparently was not in use anywhere?

A fast commit search shows that it got added with [this commit](https://github.com/launchbadge/sqlx/commit/757a930e21860ab402b5afdf210c5f2a542b1b1d) 2 months ago, but even in it I couldn't see where it was used. 

After I removed it I tried `cargo check  --no-default-features  --features offline,all-databases,all-types,runtime-{tokio, async-std, actix}` and rustc didn't complain. `rg -i --no-ignore-dot "phf"` also returns 0 results. The two macros in phf-macros are defined [here](https://github.com/sfackler/rust-phf/blob/master/phf_macros/src/lib.rs#L228), so the grep should of picked up on them if they existed. 

If its planned to be used sometime in the future, feel free to just comment and close this PR. Similar if I somehow missed where this is being used.