### PR TITLE
doc: fix wrong links

### DIFF
--- a/sqlx-core/src/error.rs
+++ b/sqlx-core/src/error.rs
@@ -20,7 +20,7 @@ pub type BoxDynError = Box<dyn StdError + 'static + Send + Sync>;
 
 /// An unexpected `NULL` was encountered during decoding.
 ///
-/// Returned from [`Row::get`] if the value from the database is `NULL`,
+/// Returned from [`Row::get`](sqlx_core::row::Row::get) if the value from the database is `NULL`,
 /// and you are not decoding into an `Option`.
 #[derive(thiserror::Error, Debug)]
 #[error("unexpected null; try decoding as an `Option`")]

--- a/sqlx-core/src/executor.rs
+++ b/sqlx-core/src/executor.rs
@@ -18,9 +18,9 @@ use std::fmt::Debug;
 ///
 /// Implemented for the following:
 ///
-///  * [`&Pool`]
-///  * [`&mut PoolConnection`]
-///  * [`&mut Connection`]
+///  * [`&Pool`](super::pool::Pool)
+///  * [`&mut PoolConnection`](super::pool::PoolConnection)
+///  * [`&mut Connection`](super::connection::Connection)
 ///
 pub trait Executor<'c>: Send + Debug + Sized {
     type Database: Database;
@@ -148,8 +148,8 @@ pub trait Executor<'c>: Send + Debug + Sized {
 ///
 /// Implemented for the following:
 ///
-///  * [`&str`]
-///  * [`Query`]
+///  * [`&str`](std::str)
+///  * [`Query`](super::query::Query)
 ///
 pub trait Execute<'q, DB: Database>: Send + Sized {
     /// Returns the query string that will be executed.

--- a/sqlx-core/src/query.rs
+++ b/sqlx-core/src/query.rs
@@ -76,8 +76,8 @@ where
     ///
     /// See [`try_map`](Query::try_map) for a fallible version of this method.
     ///
-    /// The [`query_as`](crate::query_as::query_as) method will construct a mapped query using
-    /// a [`FromRow`](crate::row::FromRow) implementation.
+    /// The [`query_as`](super::query_as::query_as) method will construct a mapped query using
+    /// a [`FromRow`](super::from_row::FromRow) implementation.
     #[inline]
     pub fn map<F, O>(self, f: F) -> Map<'q, DB, impl TryMapRow<DB, Output = O>, A>
     where
@@ -89,8 +89,8 @@ where
 
     /// Map each row in the result to another type.
     ///
-    /// The [`query_as`](crate::query_as::query_as) method will construct a mapped query using
-    /// a [`FromRow`](crate::row::FromRow) implementation.
+    /// The [`query_as`](super::query_as::query_as) method will construct a mapped query using
+    /// a [`FromRow`](super::from_row::FromRow) implementation.
     #[inline]
     pub fn try_map<F>(self, f: F) -> Map<'q, DB, F, A>
     where

--- a/sqlx-core/src/query_as.rs
+++ b/sqlx-core/src/query_as.rs
@@ -142,7 +142,7 @@ where
 }
 
 /// Make a SQL query that is mapped to a concrete type
-/// using [`FromRow`](crate::row::FromRow).
+/// using [`FromRow`].
 #[inline]
 pub fn query_as<'q, DB, O>(sql: &'q str) -> QueryAs<'q, DB, O, <DB as HasArguments<'q>>::Arguments>
 where
@@ -156,7 +156,7 @@ where
 }
 
 /// Make a SQL query, with the given arguments, that is mapped to a concrete type
-/// using [`FromRow`](crate::row::FromRow).
+/// using [`FromRow`].
 #[inline]
 pub fn query_as_with<'q, DB, O, A>(sql: &'q str, arguments: A) -> QueryAs<'q, DB, O, A>
 where

--- a/sqlx-core/src/query_scalar.rs
+++ b/sqlx-core/src/query_scalar.rs
@@ -130,7 +130,7 @@ where
 }
 
 /// Make a SQL query that is mapped to a single concrete type
-/// using [`FromRow`](crate::row::FromRow).
+/// using [`FromRow`].
 #[inline]
 pub fn query_scalar<'q, DB, O>(
     sql: &'q str,
@@ -145,7 +145,7 @@ where
 }
 
 /// Make a SQL query, with the given arguments, that is mapped to a single concrete type
-/// using [`FromRow`](crate::row::FromRow).
+/// using [`FromRow`].
 #[inline]
 pub fn query_scalar_with<'q, DB, O, A>(sql: &'q str, arguments: A) -> QueryScalar<'q, DB, O, A>
 where

--- a/sqlx-core/src/row.rs
+++ b/sqlx-core/src/row.rs
@@ -15,9 +15,8 @@ use crate::value::ValueRef;
 ///
 /// This trait is sealed and cannot be implemented for types outside of SQLx.
 ///
-/// [`Row`]: trait.Row.html
-/// [`get`]: trait.Row.html#method.get
-/// [`try_get`]: trait.Row.html#method.try_get
+/// [`get`]: Row::get
+/// [`try_get`]: Row::try_get
 ///
 pub trait ColumnIndex<R: Row + ?Sized>: private_column_index::Sealed + Debug {
     /// Returns a valid positional index into the row, [`ColumnIndexOutOfBounds`], or,
@@ -158,9 +157,9 @@ pub trait Row: private_row::Sealed + Unpin + Send + Sync + 'static {
     ///  * [`ColumnIndexOutOfBounds`] if the `usize` index was greater than the number of columns in the row.
     ///  * [`ColumnDecode`] if the value could not be decoded into the requested type.
     ///
-    /// [`ColumnDecode`]: crate::Error::ColumnDecode
-    /// [`ColumnNotFound`]: crate::Error::ColumnNotFound
-    /// [`ColumnIndexOutOfBounds`]: crate::Error::ColumnIndexOutOfBounds
+    /// [`ColumnDecode`]: Error::ColumnDecode
+    /// [`ColumnNotFound`]: Error::ColumnNotFound
+    /// [`ColumnIndexOutOfBounds`]: Error::ColumnIndexOutOfBounds
     ///
     fn try_get<'r, T, I>(&'r self, index: I) -> Result<T, Error>
     where
@@ -198,9 +197,9 @@ pub trait Row: private_row::Sealed + Unpin + Send + Sync + 'static {
     ///  * [`ColumnIndexOutOfBounds`] if the `usize` index was greater than the number of columns in the row.
     ///  * [`ColumnDecode`] if the value could not be decoded into the requested type.
     ///
-    /// [`ColumnDecode`]: crate::Error::ColumnDecode
-    /// [`ColumnNotFound`]: crate::Error::ColumnNotFound
-    /// [`ColumnIndexOutOfBounds`]: crate::Error::ColumnIndexOutOfBounds
+    /// [`ColumnDecode`]: Error::ColumnDecode
+    /// [`ColumnNotFound`]: Error::ColumnNotFound
+    /// [`ColumnIndexOutOfBounds`]: Error::ColumnIndexOutOfBounds
     ///
     #[inline]
     fn try_get_unchecked<'r, T, I>(&'r self, index: I) -> Result<T, Error>
@@ -223,8 +222,8 @@ pub trait Row: private_row::Sealed + Unpin + Send + Sync + 'static {
     ///  * [`ColumnNotFound`] if the column by the given name was not found.
     ///  * [`ColumnIndexOutOfBounds`] if the `usize` index was greater than the number of columns in the row.
     ///
-    /// [`ColumnNotFound`]: crate::Error::ColumnNotFound
-    /// [`ColumnIndexOutOfBounds`]: crate::Error::ColumnIndexOutOfBounds
+    /// [`ColumnNotFound`]: Error::ColumnNotFound
+    /// [`ColumnIndexOutOfBounds`]: Error::ColumnIndexOutOfBounds
     ///
     fn try_get_raw<I>(
         &self,

--- a/sqlx-core/src/value.rs
+++ b/sqlx-core/src/value.rs
@@ -56,7 +56,7 @@ pub trait Value {
     ///
     ///  * [`Decode`] if the value could not be decoded into the requested type.
     ///
-    /// [`Decode`]: crate::Error::Decode
+    /// [`Decode`]: Error::Decode
     ///
     #[inline]
     fn try_decode<'r, T>(&'r self) -> Result<T, Error>
@@ -83,7 +83,7 @@ pub trait Value {
     ///
     ///  * [`Decode`] if the value could not be decoded into the requested type.
     ///
-    /// [`Decode`]: crate::Error::Decode
+    /// [`Decode`]: Error::Decode
     ///
     #[inline]
     fn try_decode_unchecked<'r, T>(&'r self) -> Result<T, Error>

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,6 +1,6 @@
 /// Statically checked SQL query with `println!()` style syntax.
 ///
-/// This expands to an instance of [QueryAs][crate::QueryAs] that outputs an ad-hoc anonymous struct type,
+/// This expands to an instance of [`QueryAs`](sqlx_core::query_as::QueryAs) that outputs an ad-hoc anonymous struct type,
 /// if the query has output columns, or `()` (unit) otherwise:
 ///
 /// ```rust,ignore


### PR DESCRIPTION
When we generate docs of the current master branch (dad1356147235ab9057f262743dc72a3bcf793f1), the following 20 warnings are reported:


<details><summary>click me to see the warnings</summary>
<p>

#### command

```
cargo +nightly doc
```

#### output

```
warning: `[Row::get]` cannot be resolved, ignoring it.
  --> sqlx-core/src/error.rs:23:20
   |
23 | /// Returned from [`Row::get`] if the value from the database is `NULL`,
   |                    ^^^^^^^^^^ cannot be resolved, ignoring
   |
   = note: `#[warn(intra_doc_link_resolution_failure)]` on by default
   = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[crate::row::FromRow]` cannot be resolved, ignoring it.
  --> sqlx-core/src/query.rs:80:23
   |
80 |     /// a [`FromRow`](crate::row::FromRow) implementation.
   |                       ^^^^^^^^^^^^^^^^^^^ cannot be resolved, ignoring
   |
   = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[crate::row::FromRow]` cannot be resolved, ignoring it.
  --> sqlx-core/src/query.rs:93:23
   |
93 |     /// a [`FromRow`](crate::row::FromRow) implementation.
   |                       ^^^^^^^^^^^^^^^^^^^ cannot be resolved, ignoring
   |
   = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[Query]` cannot be resolved, ignoring it.
   --> sqlx-core/src/executor.rs:152:9
    |
152 | ///  * [`Query`]
    |         ^^^^^^^ cannot be resolved, ignoring
    |
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[crate::row::FromRow]` cannot be resolved, ignoring it.
   --> sqlx-core/src/query_as.rs:145:23
    |
145 | /// using [`FromRow`](crate::row::FromRow).
    |                       ^^^^^^^^^^^^^^^^^^^ cannot be resolved, ignoring
    |
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[crate::row::FromRow]` cannot be resolved, ignoring it.
   --> sqlx-core/src/query_as.rs:159:23
    |
159 | /// using [`FromRow`](crate::row::FromRow).
    |                       ^^^^^^^^^^^^^^^^^^^ cannot be resolved, ignoring
    |
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[crate::row::FromRow]` cannot be resolved, ignoring it.
   --> sqlx-core/src/query_scalar.rs:133:23
    |
133 | /// using [`FromRow`](crate::row::FromRow).
    |                       ^^^^^^^^^^^^^^^^^^^ cannot be resolved, ignoring
    |
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[crate::row::FromRow]` cannot be resolved, ignoring it.
   --> sqlx-core/src/query_scalar.rs:148:23
    |
148 | /// using [`FromRow`](crate::row::FromRow).
    |                       ^^^^^^^^^^^^^^^^^^^ cannot be resolved, ignoring
    |
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[crate::Error::ColumnNotFound]` cannot be resolved, ignoring it.
   --> sqlx-core/src/row.rs:162:29
    |
162 |     /// [`ColumnNotFound`]: crate::Error::ColumnNotFound
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot be resolved, ignoring
    |
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[crate::Error::ColumnIndexOutOfBounds]` cannot be resolved, ignoring it.
   --> sqlx-core/src/row.rs:163:37
    |
163 |     /// [`ColumnIndexOutOfBounds`]: crate::Error::ColumnIndexOutOfBounds
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot be resolved, ignoring
    |
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[crate::Error::ColumnDecode]` cannot be resolved, ignoring it.
   --> sqlx-core/src/row.rs:161:27
    |
161 |     /// [`ColumnDecode`]: crate::Error::ColumnDecode
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot be resolved, ignoring
    |
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[crate::Error::ColumnNotFound]` cannot be resolved, ignoring it.
   --> sqlx-core/src/row.rs:202:29
    |
202 |     /// [`ColumnNotFound`]: crate::Error::ColumnNotFound
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot be resolved, ignoring
    |
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[crate::Error::ColumnIndexOutOfBounds]` cannot be resolved, ignoring it.
   --> sqlx-core/src/row.rs:203:37
    |
203 |     /// [`ColumnIndexOutOfBounds`]: crate::Error::ColumnIndexOutOfBounds
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot be resolved, ignoring
    |
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[crate::Error::ColumnDecode]` cannot be resolved, ignoring it.
   --> sqlx-core/src/row.rs:201:27
    |
201 |     /// [`ColumnDecode`]: crate::Error::ColumnDecode
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot be resolved, ignoring
    |
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[crate::Error::ColumnNotFound]` cannot be resolved, ignoring it.
   --> sqlx-core/src/row.rs:226:29
    |
226 |     /// [`ColumnNotFound`]: crate::Error::ColumnNotFound
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot be resolved, ignoring
    |
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[crate::Error::ColumnIndexOutOfBounds]` cannot be resolved, ignoring it.
   --> sqlx-core/src/row.rs:227:37
    |
227 |     /// [`ColumnIndexOutOfBounds`]: crate::Error::ColumnIndexOutOfBounds
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot be resolved, ignoring
    |
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[crate::Error::Decode]` cannot be resolved, ignoring it.
  --> sqlx-core/src/value.rs:59:21
   |
59 |     /// [`Decode`]: crate::Error::Decode
   |                     ^^^^^^^^^^^^^^^^^^^^ cannot be resolved, ignoring
   |
   = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[crate::Error::Decode]` cannot be resolved, ignoring it.
  --> sqlx-core/src/value.rs:86:21
   |
86 |     /// [`Decode`]: crate::Error::Decode
   |                     ^^^^^^^^^^^^^^^^^^^^ cannot be resolved, ignoring
   |
   = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: 18 warnings emitted

warning: `[crate::QueryAs]` cannot be resolved, ignoring it.
 --> src/macros.rs:3:46
  |
3 | /// This expands to an instance of [QueryAs][crate::QueryAs] that outputs an ad-hoc anonymous struct type,
  |                                              ^^^^^^^^^^^^^^ cannot be resolved, ignoring
  |
  = note: `#[warn(intra_doc_link_resolution_failure)]` on by default
  = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: `[crate::QueryAs]` cannot be resolved, ignoring it.
 --> src/macros.rs:3:46
  |
3 | /// This expands to an instance of [QueryAs][crate::QueryAs] that outputs an ad-hoc anonymous struct type,
  |                                              ^^^^^^^^^^^^^^ cannot be resolved, ignoring
  |
  = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

warning: 2 warnings emitted

    Finished dev [unoptimized + debuginfo] target(s) in 0.46s

```

</p>
</details>

In fact, the links where the warnings are reported are not working at all. 
So this PR fixes these warnings.