### PR TITLE
Embedded migrations

### DIFF
--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -48,14 +48,14 @@ jobs:
           args: >
             --manifest-path sqlx-core/Cargo.toml
             --no-default-features
-            --features offline,all-databases,all-types,runtime-${{ matrix.runtime }}
+            --features offline,all-databases,all-types,migrate,runtime-${{ matrix.runtime }}
 
       - uses: actions-rs/cargo@v1
         with:
           command: check
           args: >
             --no-default-features
-            --features offline,all-databases,all-types,runtime-${{ matrix.runtime }},macros
+            --features offline,all-databases,all-types,migrate,runtime-${{ matrix.runtime }},macros
 
   test:
     name: Unit Test
@@ -97,7 +97,7 @@ jobs:
           command: test
           args: >
             --no-default-features
-            --features any,macros,sqlite,all-types,runtime-${{ matrix.runtime }}
+            --features any,macros,migrate,sqlite,all-types,runtime-${{ matrix.runtime }}
             --
             --test-threads=1
         env:
@@ -143,7 +143,7 @@ jobs:
           command: test
           args: >
             --no-default-features
-            --features any,postgres,macros,all-types,runtime-${{ matrix.runtime }}
+            --features any,postgres,macros,migrate,all-types,runtime-${{ matrix.runtime }}
         env:
           DATABASE_URL: postgres://postgres:password@localhost:5432/sqlx?sslmode=verify-ca&sslrootcert=.%2Ftests%2Fcerts%2Fca.crt
 
@@ -178,7 +178,7 @@ jobs:
           command: test
           args: >
             --no-default-features
-            --features any,mysql,macros,all-types,runtime-${{ matrix.runtime }}
+            --features any,mysql,macros,migrate,all-types,runtime-${{ matrix.runtime }}
         env:
           DATABASE_URL: mysql://root:password@localhost:3306/sqlx
 
@@ -213,7 +213,7 @@ jobs:
           command: test
           args: >
             --no-default-features
-            --features any,mysql,macros,all-types,runtime-${{ matrix.runtime }}
+            --features any,mysql,macros,migrate,all-types,runtime-${{ matrix.runtime }}
         env:
           DATABASE_URL: mysql://root:password@localhost:3306/sqlx
 
@@ -248,6 +248,6 @@ jobs:
           command: test
           args: >
             --no-default-features
-            --features any,mssql,macros,all-types,runtime-${{ matrix.runtime }}
+            --features any,mssql,macros,migrate,all-types,runtime-${{ matrix.runtime }}
         env:
           DATABASE_URL: mssql://sa:Password123!@localhost/sqlx

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,15 @@ path = "tests/any/pool.rs"
 required-features = [ "any" ]
 
 #
+# Migrations
+#
+
+[[test]]
+name = "migrate-macro"
+path = "tests/migrate/macro.rs"
+required-features = [ "macros", "migrate" ]
+
+#
 # SQLite
 #
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = [ "macros", "runtime-async-std", "migrate" ]
 macros = [ "sqlx-macros" ]
-migrate = [ "sqlx-core/migrate" ]
+migrate = [ "sqlx-macros/migrate", "sqlx-core/migrate" ]
 
 # [deprecated] TLS is not possible to disable due to it being conditional on multiple features
 #              Hopefully Cargo can handle this in the future

--- a/sqlx-cli/src/migrate.rs
+++ b/sqlx-cli/src/migrate.rs
@@ -44,8 +44,8 @@ pub async fn info(uri: &str) -> anyhow::Result<()> {
     for migration in migrator.iter() {
         println!(
             "{}/{} {}",
-            style(migration.version()).cyan(),
-            if version >= migration.version() {
+            style(migration.version).cyan(),
+            if version >= migration.version {
                 style("installed").green()
             } else {
                 style("pending").yellow()
@@ -70,12 +70,12 @@ pub async fn run(uri: &str) -> anyhow::Result<()> {
     }
 
     for migration in migrator.iter() {
-        if migration.version() > version {
+        if migration.version > version {
             let elapsed = conn.apply(migration).await?;
 
             println!(
                 "{}/{} {} {}",
-                style(migration.version()).cyan(),
+                style(migration.version).cyan(),
                 style("migrate").green(),
                 migration.description,
                 style(format!("({:?})", elapsed)).dim()

--- a/sqlx-cli/src/migrate.rs
+++ b/sqlx-cli/src/migrate.rs
@@ -50,7 +50,7 @@ pub async fn info(uri: &str) -> anyhow::Result<()> {
             } else {
                 style("pending").yellow()
             },
-            migration.description(),
+            migration.description,
         );
     }
 
@@ -77,7 +77,7 @@ pub async fn run(uri: &str) -> anyhow::Result<()> {
                 "{}/{} {} {}",
                 style(migration.version()).cyan(),
                 style("migrate").green(),
-                migration.description(),
+                migration.description,
                 style(format!("({:?})", elapsed)).dim()
             );
         } else {

--- a/sqlx-core/src/migrate/migration.rs
+++ b/sqlx-core/src/migrate/migration.rs
@@ -2,18 +2,8 @@ use std::borrow::Cow;
 
 #[derive(Debug, Clone)]
 pub struct Migration {
-    pub(crate) version: i64,
-    pub(crate) description: Cow<'static, str>,
-    pub(crate) sql: Cow<'static, str>,
-    pub(crate) checksum: Cow<'static, [u8]>,
-}
-
-impl Migration {
-    pub fn version(&self) -> i64 {
-        self.version
-    }
-
-    pub fn description(&self) -> &str {
-        &*self.description
-    }
+    pub version: i64,
+    pub description: Cow<'static, str>,
+    pub sql: Cow<'static, str>,
+    pub checksum: Cow<'static, [u8]>,
 }

--- a/sqlx-core/src/migrate/migrator.rs
+++ b/sqlx-core/src/migrate/migrator.rs
@@ -71,7 +71,7 @@ impl Migrator {
         }
 
         for migration in self.iter() {
-            if migration.version() > version {
+            if migration.version > version {
                 conn.apply(migration).await?;
             } else {
                 conn.validate(migration).await?;

--- a/sqlx-core/src/migrate/migrator.rs
+++ b/sqlx-core/src/migrate/migrator.rs
@@ -6,7 +6,7 @@ use std::slice;
 
 #[derive(Debug)]
 pub struct Migrator {
-    migrations: Cow<'static, [Migration]>,
+    pub migrations: Cow<'static, [Migration]>,
 }
 
 impl Migrator {
@@ -34,13 +34,6 @@ impl Migrator {
         Ok(Self {
             migrations: Cow::Owned(source.resolve().await.map_err(MigrateError::Source)?),
         })
-    }
-
-    /// Creates a new instance from a static slice of migrations.
-    pub fn from_static(migrations: &'static [Migration]) -> Self {
-        Self {
-            migrations: Cow::Borrowed(migrations),
-        }
     }
 
     /// Get an iterator over all known migrations.

--- a/sqlx-core/src/migrate/migrator.rs
+++ b/sqlx-core/src/migrate/migrator.rs
@@ -37,7 +37,7 @@ impl Migrator {
     }
 
     /// Creates a new instance from a static slice of migrations.
-    pub async fn from_static(migrations: &'static [Migration]) -> Self {
+    pub fn from_static(migrations: &'static [Migration]) -> Self {
         Self {
             migrations: Cow::Borrowed(migrations),
         }

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -16,7 +16,8 @@ authors = [
 proc-macro = true
 
 [features]
-default = [ "runtime-async-std" ]
+default = [ "runtime-async-std", "migrate" ]
+migrate = [ "sha2" ]
 
 # runtimes
 runtime-async-std = [ "sqlx-core/runtime-async-std", "sqlx-rt/runtime-async-std" ]

--- a/sqlx-macros/src/common.rs
+++ b/sqlx-macros/src/common.rs
@@ -1,0 +1,37 @@
+use proc_macro2::Span;
+use std::env;
+use std::path::{Path, PathBuf};
+
+pub(crate) fn resolve_path(path: &str, err_span: Span) -> syn::Result<PathBuf> {
+    let path = Path::new(path);
+
+    if path.is_absolute() {
+        return Err(syn::Error::new(
+            err_span,
+            "absolute paths will only work on the current machine",
+        ));
+    }
+
+    // requires `proc_macro::SourceFile::path()` to be stable
+    // https://github.com/rust-lang/rust/issues/54725
+    if path.is_relative()
+        && !path
+            .parent()
+            .map_or(false, |parent| !parent.as_os_str().is_empty())
+    {
+        return Err(syn::Error::new(
+            err_span,
+            "paths relative to the current file's directory are not currently supported",
+        ));
+    }
+
+    let base_dir = env::var("CARGO_MANIFEST_DIR").map_err(|_| {
+        syn::Error::new(
+            err_span,
+            "CARGO_MANIFEST_DIR is not set; please use Cargo to build",
+        )
+    })?;
+    let base_dir_path = Path::new(&base_dir);
+
+    Ok(base_dir_path.join(path))
+}

--- a/sqlx-macros/src/lib.rs
+++ b/sqlx-macros/src/lib.rs
@@ -16,6 +16,8 @@ mod database;
 mod derives;
 mod query;
 
+mod common;
+
 #[cfg(feature = "migrate")]
 mod migrate;
 
@@ -88,7 +90,7 @@ pub fn migrate(input: TokenStream) -> TokenStream {
     use syn::LitStr;
 
     let input = syn::parse_macro_input!(input as LitStr);
-    match migrate::expand_migrator_from_dir(input.value()) {
+    match migrate::expand_migrator_from_dir(input) {
         Ok(ts) => ts.into(),
         Err(e) => {
             if let Some(parse_err) = e.downcast_ref::<syn::Error>() {

--- a/sqlx-macros/src/lib.rs
+++ b/sqlx-macros/src/lib.rs
@@ -87,12 +87,8 @@ pub fn derive_from_row(input: TokenStream) -> TokenStream {
 pub fn migrate(input: TokenStream) -> TokenStream {
     use syn::LitStr;
 
-    let input = syn::parse_macro_input!(input as Option<LitStr>);
-    let dir = input
-        .as_ref()
-        .map_or("migrations".to_owned(), LitStr::value);
-
-    match migrate::expand_migrator_from_dir(dir) {
+    let input = syn::parse_macro_input!(input as LitStr);
+    match migrate::expand_migrator_from_dir(input.value()) {
         Ok(ts) => ts.into(),
         Err(e) => {
             if let Some(parse_err) = e.downcast_ref::<syn::Error>() {

--- a/sqlx-macros/src/migrate.rs
+++ b/sqlx-macros/src/migrate.rs
@@ -83,8 +83,12 @@ pub(crate) fn expand_migrator_from_dir<P: AsRef<Path>>(
     migrations.sort_by_key(|m| m.version);
 
     Ok(quote! {
-        sqlx::migrate::Migrator::from_static(&[
-            #(#migrations),*
-        ])
+        macro_rules! macro_result {
+            () => {
+                sqlx::migrate::Migrator::from_static(&[
+                    #(#migrations),*
+                ])
+            }
+        }
     })
 }

--- a/sqlx-macros/src/migrate.rs
+++ b/sqlx-macros/src/migrate.rs
@@ -2,7 +2,6 @@ use proc_macro2::TokenStream;
 use quote::{quote, ToTokens, TokenStreamExt};
 use sha2::{Digest, Sha384};
 use std::fs;
-use std::fs::DirEntry;
 use std::path::Path;
 
 struct QuotedMigration {

--- a/sqlx-macros/src/migrate.rs
+++ b/sqlx-macros/src/migrate.rs
@@ -3,6 +3,7 @@ use quote::{quote, ToTokens, TokenStreamExt};
 use sha2::{Digest, Sha384};
 use std::fs;
 use std::path::Path;
+use syn::LitStr;
 
 struct QuotedMigration {
     version: i64,
@@ -36,10 +37,10 @@ impl ToTokens for QuotedMigration {
 }
 
 // mostly copied from sqlx-core/src/migrate/source.rs
-pub(crate) fn expand_migrator_from_dir<P: AsRef<Path>>(
-    dir: P,
-) -> crate::Result<proc_macro2::TokenStream> {
-    let mut s = fs::read_dir(dir.as_ref().canonicalize()?)?;
+pub(crate) fn expand_migrator_from_dir(dir: LitStr) -> crate::Result<proc_macro2::TokenStream> {
+    let path = crate::common::resolve_path(&dir.value(), dir.span())?;
+    let mut s = fs::read_dir(path)?;
+
     let mut migrations = Vec::new();
 
     while let Some(entry) = s.next() {

--- a/sqlx-macros/src/migrate.rs
+++ b/sqlx-macros/src/migrate.rs
@@ -1,0 +1,91 @@
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens, TokenStreamExt};
+use sha2::{Digest, Sha384};
+use std::fs;
+use std::fs::DirEntry;
+use std::path::Path;
+
+struct QuotedMigration {
+    version: i64,
+    description: String,
+    sql: String,
+    checksum: Vec<u8>,
+}
+
+impl ToTokens for QuotedMigration {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let QuotedMigration {
+            version,
+            description,
+            sql,
+            checksum,
+        } = &self;
+
+        let ts = quote! {
+            sqlx::migrate::Migration {
+                version: #version,
+                description: std::borrow::Cow::Borrowed(#description),
+                sql: std::borrow::Cow::Borrowed(#sql),
+                checksum: std::borow::Cow::Borrowed(&[
+                    #(#checksum),*
+                ]),
+            }
+        };
+
+        tokens.append_all(ts.into_iter());
+    }
+}
+
+// mostly copied from sqlx-core/src/migrate/source.rs
+pub(crate) fn expand_migrator_from_dir<P: AsRef<Path>>(
+    dir: P,
+) -> crate::Result<proc_macro2::TokenStream> {
+    let mut s = fs::read_dir(dir.as_ref().canonicalize()?)?;
+    let mut migrations = Vec::new();
+
+    while let Some(entry) = s.next() {
+        let entry = entry?;
+        if !entry.metadata()?.is_file() {
+            // not a file; ignore
+            continue;
+        }
+
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+
+        let parts = file_name.splitn(2, '_').collect::<Vec<_>>();
+
+        if parts.len() != 2 || !parts[1].ends_with(".sql") {
+            // not of the format: <VERSION>_<DESCRIPTION>.sql; ignore
+            continue;
+        }
+
+        let version: i64 = parts[0].parse()?;
+
+        // remove the `.sql` and replace `_` with ` `
+        let description = parts[1]
+            .trim_end_matches(".sql")
+            .replace('_', " ")
+            .to_owned();
+
+        let sql = fs::read_to_string(&entry.path())?;
+
+        let checksum = Vec::from(Sha384::digest(sql.as_bytes()).as_slice());
+
+        migrations.push(QuotedMigration {
+            version,
+            description,
+            sql,
+            checksum,
+        })
+    }
+
+    // ensure that we are sorted by `VERSION ASC`
+    migrations.sort_by_key(|m| m.version);
+
+    Ok(quote! {
+        sqlx::migrate::Migrator::from_static(&[
+            #(#migrations),*
+        ])
+    })
+}

--- a/sqlx-macros/src/migrate.rs
+++ b/sqlx-macros/src/migrate.rs
@@ -2,7 +2,6 @@ use proc_macro2::TokenStream;
 use quote::{quote, ToTokens, TokenStreamExt};
 use sha2::{Digest, Sha384};
 use std::fs;
-use std::path::Path;
 use syn::LitStr;
 
 struct QuotedMigration {
@@ -26,7 +25,7 @@ impl ToTokens for QuotedMigration {
                 version: #version,
                 description: std::borrow::Cow::Borrowed(#description),
                 sql: std::borrow::Cow::Borrowed(#sql),
-                checksum: std::borow::Cow::Borrowed(&[
+                checksum: std::borrow::Cow::Borrowed(&[
                     #(#checksum),*
                 ]),
             }

--- a/sqlx-macros/src/migrate.rs
+++ b/sqlx-macros/src/migrate.rs
@@ -85,9 +85,11 @@ pub(crate) fn expand_migrator_from_dir(dir: LitStr) -> crate::Result<proc_macro2
     Ok(quote! {
         macro_rules! macro_result {
             () => {
-                sqlx::migrate::Migrator::from_static(&[
-                    #(#migrations),*
-                ])
+                sqlx::migrate::Migrator {
+                    migrations: std::borrow::Cow::Borrowed(&[
+                        #(#migrations),*
+                    ])
+                }
             }
         }
     })

--- a/sqlx-macros/src/query/input.rs
+++ b/sqlx-macros/src/query/input.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::fs;
 
 use proc_macro2::{Ident, Span};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,10 @@ pub extern crate sqlx_macros;
 #[doc(hidden)]
 pub use sqlx_macros::{FromRow, Type};
 
+// embedded migrations
+#[cfg(all(feature = "migrate", features = "macros"))]
+pub use sqlx_macros::migrate;
+
 #[cfg(feature = "macros")]
 mod macros;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,10 +61,6 @@ pub extern crate sqlx_macros;
 #[doc(hidden)]
 pub use sqlx_macros::{FromRow, Type};
 
-// embedded migrations
-#[cfg(all(feature = "migrate", features = "macros"))]
-pub use sqlx_macros::migrate;
-
 #[cfg(feature = "macros")]
 mod macros;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -574,23 +574,23 @@ macro_rules! query_file_as_unchecked (
     })
 );
 
-/// Creates a static [Migrator][crate::migrate::Migrator] by embedding the migrations in the binary.
-///
-/// The macro takes an optional migrations directory and defaults to `"migrations"` if it's not specified.
+/// Embeds migrations into the binary by expanding to a static instance of [Migrator][crate::migrate::Migrator].
 ///
 /// ```rust,ignore
-/// sqlx::migrate!("migrations") // same as sqlx::migrate!()
+/// sqlx::migrate!("db/migrations")
 ///     .run(&pool)
 ///     .await?;
 /// ```
 ///
-/// It can also be used as a static constructor.
-///
 /// ```rust,ignore
 /// use sqlx::migrate::Migrator;
 ///
-/// static MIGRATOR: Migrator = sqlx::migrate!();
+/// static MIGRATOR: Migrator = sqlx::migrate!(); // defaults to "migrations"
 /// ```
+///
+/// The directory must be relative to the project root (the directory containing `Cargo.toml`),
+/// unlike `include_str!()` which uses compiler internals to get the path of the file where it
+/// was invoked.
 #[cfg(feature = "migrate")]
 #[macro_export]
 macro_rules! migrate {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -594,25 +594,19 @@ macro_rules! query_file_as_unchecked (
 #[cfg(feature = "migrate")]
 #[macro_export]
 macro_rules! migrate {
-    ($dir:literal) => {
-        #[allow(dead_code)]
-        {
-            #[macro_use]
-            mod _macro_result {
-                $crate::sqlx_macros::migrate!($dir);
-            }
-            macro_result!()
+    ($dir:literal) => {{
+        #[macro_use]
+        mod _macro_result {
+            $crate::sqlx_macros::migrate!($dir);
         }
-    };
+        macro_result!()
+    }};
 
-    () => {
-        #[allow(dead_code)]
-        {
-            #[macro_use]
-            mod _macro_result {
-                $crate::sqlx_macros::migrate!("migrations");
-            }
-            macro_result!()
+    () => {{
+        #[macro_use]
+        mod _macro_result {
+            $crate::sqlx_macros::migrate!("migrations");
         }
-    };
+        macro_result!()
+    }};
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -573,3 +573,46 @@ macro_rules! query_file_as_unchecked (
         macro_result!($($args),*)
     })
 );
+
+/// Creates a static [Migrator][crate::migrate::Migrator] by embedding the migrations in the binary.
+///
+/// The macro takes an optional migrations directory and defaults to `"migrations"` if it's not specified.
+///
+/// ```rust,ignore
+/// sqlx::migrate!("migrations") // same as sqlx::migrate!()
+///     .run(&pool)
+///     .await?;
+/// ```
+///
+/// It can also be used as a static constructor.
+///
+/// ```rust,ignore
+/// use sqlx::migrate::Migrator;
+///
+/// static MIGRATOR: Migrator = sqlx::migrate!();
+/// ```
+#[cfg(feature = "migrate")]
+#[macro_export]
+macro_rules! migrate {
+    ($dir:literal) => {
+        #[allow(dead_code)]
+        {
+            #[macro_use]
+            mod _macro_result {
+                $crate::sqlx_macros::migrate!($dir);
+            }
+            macro_result!()
+        }
+    };
+
+    () => {
+        #[allow(dead_code)]
+        {
+            #[macro_use]
+            mod _macro_result {
+                $crate::sqlx_macros::migrate!("migrations");
+            }
+            macro_result!()
+        }
+    };
+}

--- a/tests/migrate/macro.rs
+++ b/tests/migrate/macro.rs
@@ -1,0 +1,17 @@
+use sqlx::migrate::Migrator;
+use std::path::Path;
+
+#[sqlx_macros::test]
+async fn same_output() -> anyhow::Result<()> {
+    let embedded = sqlx::migrate!("tests/migrate/migrations");
+    let runtime = Migrator::new(Path::new("tests/migrate/migrations")).await?;
+
+    for (e, r) in embedded.iter().zip(runtime.iter()) {
+        assert_eq!(e.version, r.version);
+        assert_eq!(e.description, r.description);
+        assert_eq!(e.sql, r.sql);
+        assert_eq!(e.checksum, r.checksum);
+    }
+
+    Ok(())
+}

--- a/tests/migrate/macro.rs
+++ b/tests/migrate/macro.rs
@@ -1,12 +1,13 @@
 use sqlx::migrate::Migrator;
 use std::path::Path;
 
+static EMBEDDED: Migrator = sqlx::migrate!("tests/migrate/migrations");
+
 #[sqlx_macros::test]
 async fn same_output() -> anyhow::Result<()> {
-    let embedded = sqlx::migrate!("tests/migrate/migrations");
     let runtime = Migrator::new(Path::new("tests/migrate/migrations")).await?;
 
-    for (e, r) in embedded.iter().zip(runtime.iter()) {
+    for (e, r) in EMBEDDED.iter().zip(runtime.iter()) {
         assert_eq!(e.version, r.version);
         assert_eq!(e.description, r.description);
         assert_eq!(e.sql, r.sql);

--- a/tests/migrate/migrations/20200723212833_tweet.sql
+++ b/tests/migrate/migrations/20200723212833_tweet.sql
@@ -1,0 +1,6 @@
+CREATE TABLE tweet (
+    id BIGINT NOT NULL PRIMARY KEY,
+    text TEXT NOT NULL,
+    is_sent BOOLEAN NOT NULL DEFAULT TRUE,
+    owner_id BIGINT
+);

--- a/tests/migrate/migrations/20200723212841_accounts.sql
+++ b/tests/migrate/migrations/20200723212841_accounts.sql
@@ -1,0 +1,5 @@
+CREATE TABLE accounts (
+    id INTEGER NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL,
+    is_active BOOLEAN
+);


### PR DESCRIPTION
This PR implements embedded migrations with a new `migrate!` macro. The macro takes an optional string literal for specifying the migrations directory, which defaults to `"migrations"`. It expands to a static instance of `Migrator`.

```rust
sqlx::migrate!().run(&pool).await?;
```

Addresses #550
