### PR TITLE
cargo-sqlx-cli: Fix exiting with 0 on failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,18 +454,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clicolors-control"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e"
-dependencies = [
- "atty",
- "lazy_static",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,23 +478,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83c06aff61f2d899eb87c379df3cbf7876f14471dcab474e0b6dc90ab96c080"
 dependencies = [
  "cache-padded",
-]
-
-[[package]]
-name = "console"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586208b33573b7f76ccfbe5adb076394c88deaf81b84d7213969805b0a952a7"
-dependencies = [
- "clicolors-control",
- "encode_unicode",
- "lazy_static",
- "libc",
- "regex",
- "terminal_size",
- "termios",
- "unicode-width",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -738,7 +709,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4aa86af7b19b40ef9cbef761ed411a49f0afa06b7b6dcd3dfe2f96a3c546138"
 dependencies = [
- "console 0.11.3",
+ "console",
  "lazy_static",
  "tempfile",
 ]
@@ -2452,7 +2423,7 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "clap 3.0.0-beta.1",
- "console 0.10.3",
+ "console",
  "dialoguer",
  "dotenv",
  "futures 0.3.5",

--- a/sqlx-cli/Cargo.toml
+++ b/sqlx-cli/Cargo.toml
@@ -34,7 +34,7 @@ chrono = "0.4"
 anyhow = "1.0"
 url = { version = "2.1.1", default-features = false }
 async-trait = "0.1.30"
-console = "0.10.0"
+console = "0.11.3"
 dialoguer = "0.6.2"
 serde_json = { version = "1.0.53", features = ["preserve_order"] }
 serde = "1.0.110"

--- a/sqlx-cli/src/bin/cargo-sqlx.rs
+++ b/sqlx-cli/src/bin/cargo-sqlx.rs
@@ -1,7 +1,7 @@
 use clap::{crate_version, AppSettings, FromArgMatches, IntoApp};
 use console::style;
 use sqlx_cli::Opt;
-use std::env;
+use std::{env, process};
 
 #[tokio::main]
 async fn main() {
@@ -17,5 +17,6 @@ async fn main() {
 
     if let Err(error) = sqlx_cli::run(Opt::from_arg_matches(&matches)).await {
         println!("{} {}", style("error:").bold().red(), error);
+        process::exit(1);
     }
 }


### PR DESCRIPTION
And also update the console dependency so it no longer gets compiled twice (0.10 direct, 0.11 indirect).