### PR TITLE
Expose HasStatement

### DIFF
--- a/sqlx-core/src/mysql/connection/establish.rs
+++ b/sqlx-core/src/mysql/connection/establish.rs
@@ -9,11 +9,12 @@ use crate::mysql::protocol::connect::{
 use crate::mysql::protocol::Capabilities;
 use crate::mysql::{MySqlConnectOptions, MySqlConnection, MySqlSslMode};
 use bytes::buf::BufExt;
+use log::info;
 
 impl MySqlConnection {
     pub(crate) async fn establish(options: &MySqlConnectOptions) -> Result<Self, Error> {
         let mut stream: MySqlStream = MySqlStream::connect(options).await?;
-
+        info!("establish:1 @{}", stream.id);
         // https://dev.mysql.com/doc/dev/mysql-server/8.0.12/page_protocol_connection_phase.html
         // https://mariadb.com/kb/en/connection/
 
@@ -124,6 +125,7 @@ impl MySqlConnection {
                 }
             }
         }
+        info!("establish:2 @{}", stream.id);
 
         Ok(Self {
             stream,

--- a/sqlx-core/src/mysql/connection/mod.rs
+++ b/sqlx-core/src/mysql/connection/mod.rs
@@ -15,6 +15,7 @@ mod establish;
 mod executor;
 mod stream;
 mod tls;
+use log::info;
 
 pub(crate) use stream::{Busy, MySqlStream};
 
@@ -55,11 +56,15 @@ impl Connection for MySqlConnection {
     }
 
     fn ping(&mut self) -> BoxFuture<'_, Result<(), Error>> {
+        info!("ping:0 @{}", self.stream.id);
         Box::pin(async move {
+            info!("ping:1 @{}", self.stream.id);
             self.stream.wait_until_ready().await?;
+            info!("ping:2 @{}", self.stream.id);
             self.stream.send_packet(Ping).await?;
+            info!("ping:3 @{}", self.stream.id);
             self.stream.recv_ok().await?;
-
+            info!("ping:4 @{}", self.stream.id);
             Ok(())
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub use sqlx_core::arguments::{Arguments, IntoArguments};
 pub use sqlx_core::column::Column;
 pub use sqlx_core::column::ColumnIndex;
 pub use sqlx_core::connection::{ConnectOptions, Connection};
-pub use sqlx_core::database::{self, Database};
+pub use sqlx_core::database::{self, Database, HasStatement};
 pub use sqlx_core::describe::Describe;
 pub use sqlx_core::done::Done;
 pub use sqlx_core::executor::{Execute, Executor};


### PR DESCRIPTION
In my projects I need to wrap `Executor`s in order to track query counts and query time. Recently `HasStatement` became part of the `Executor` trait interface, so `HasStatement` needs to be exposed for other projects to implement `Executor`