### PR TITLE
Expose HasStatement

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub use sqlx_core::arguments::{Arguments, IntoArguments};
 pub use sqlx_core::column::Column;
 pub use sqlx_core::column::ColumnIndex;
 pub use sqlx_core::connection::{ConnectOptions, Connection};
-pub use sqlx_core::database::{self, Database};
+pub use sqlx_core::database::{self, Database, HasStatement};
 pub use sqlx_core::describe::Describe;
 pub use sqlx_core::done::Done;
 pub use sqlx_core::executor::{Execute, Executor};


### PR DESCRIPTION
In my projects I need to wrap `Executor`s in order to track query counts and query time. Recently `HasStatement` became part of the `Executor` trait interface, so `HasStatement` needs to be exposed for other projects to implement `Executor`