### PR TITLE
(BREAKING: 0.5) patch nullable inference in Postgres using EXPLAIN

### DIFF
--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -18,7 +18,7 @@ migrate = [ "sha2", "crc" ]
 
 # databases
 all-databases = [ "postgres", "mysql", "sqlite", "mssql", "any" ]
-postgres = [ "md-5", "sha2", "base64", "sha-1", "rand", "hmac", "futures-channel/sink", "futures-util/sink" ]
+postgres = [ "md-5", "sha2", "base64", "sha-1", "rand", "hmac", "futures-channel/sink", "futures-util/sink", "json" ]
 mysql = [ "sha-1", "sha2", "generic-array", "num-bigint", "base64", "digest", "rand", "rsa" ]
 sqlite = [ "libsqlite3-sys" ]
 mssql = [ "uuid", "encoding_rs", "regex" ]

--- a/sqlx-core/src/postgres/connection/executor.rs
+++ b/sqlx-core/src/postgres/connection/executor.rs
@@ -415,9 +415,9 @@ impl<'c> Executor<'c> for &'c mut PgConnection {
         Box::pin(async move {
             self.wait_until_ready().await?;
 
-            let (_, metadata) = self.get_or_prepare(sql, &[], true, None).await?;
+            let (stmt_id, metadata) = self.get_or_prepare(sql, &[], true, None).await?;
 
-            let nullable = self.get_nullable_for_columns(&metadata.columns).await?;
+            let nullable = self.get_nullable_for_columns(stmt_id, &metadata).await?;
 
             Ok(Describe {
                 columns: metadata.columns.clone(),

--- a/sqlx-core/src/postgres/io/buf_mut.rs
+++ b/sqlx-core/src/postgres/io/buf_mut.rs
@@ -30,6 +30,7 @@ impl PgBufMutExt for Vec<u8> {
     // writes a statement name by ID
     #[inline]
     fn put_statement_name(&mut self, id: u32) {
+        // N.B. if you change this don't forget to update it in ../describe.rs
         self.extend(b"sqlx_s_");
 
         itoa::write(&mut *self, id).unwrap();

--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -196,12 +196,18 @@ async fn it_describes_left_join() -> anyhow::Result<()> {
     assert_eq!(d.column(0).type_info().name(), "INTEGER");
     assert_eq!(d.nullable(0), Some(false));
 
-    let d = conn.describe("select tweet.id from accounts left join tweet on owner_id = accounts.id").await?;
+    let d = conn
+        .describe("select tweet.id from accounts left join tweet on owner_id = accounts.id")
+        .await?;
 
     assert_eq!(d.column(0).type_info().name(), "INTEGER");
     assert_eq!(d.nullable(0), Some(true));
 
-    let d = conn.describe("select tweet.id, accounts.id from accounts left join tweet on owner_id = accounts.id").await?;
+    let d = conn
+        .describe(
+            "select tweet.id, accounts.id from accounts left join tweet on owner_id = accounts.id",
+        )
+        .await?;
 
     assert_eq!(d.column(0).type_info().name(), "INTEGER");
     assert_eq!(d.nullable(0), Some(true));
@@ -209,7 +215,11 @@ async fn it_describes_left_join() -> anyhow::Result<()> {
     assert_eq!(d.column(1).type_info().name(), "INTEGER");
     assert_eq!(d.nullable(1), Some(false));
 
-    let d = conn.describe("select tweet.id, accounts.id from accounts inner join tweet on owner_id = accounts.id").await?;
+    let d = conn
+        .describe(
+            "select tweet.id, accounts.id from accounts inner join tweet on owner_id = accounts.id",
+        )
+        .await?;
 
     assert_eq!(d.column(0).type_info().name(), "INTEGER");
     assert_eq!(d.nullable(0), Some(false));


### PR DESCRIPTION
BREAKING CHANGE: some columns emitted by `query!()` and `query_as!()`, primarily those brought in by a `[LEFT | RIGHT | FULL] JOIN` will become `Option<T>` where they were `T` before.

In practice breakage should be minimal as these would result in `UnexpectedNull` errors at runtime unless they were manually overridden with `foo as "foo?"` already.

However, I expect there to be edge cases that aren't covered yet, thus why we've chosen to land this in 0.5 and kick out an early alpha for testing.

* requires the `json` feature (and thus the `serde` and `serde_json` features) to always be on for `postgres` (to parse `EXPLAIN VERBOSE` output, possible formats are JSON, XML, YAML or text)

closes #367 