### PR TITLE
 fix: allow queries that select just void to pass through macros as `()` instead of `struct { _1: () }`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ categories = [ "database", "asynchronous" ]
 authors = [
     "Ryan Leckey <leckey.ryan@gmail.com>", # ryan@launchbadge.com
     "Austin Bonander <austin.bonander@gmail.com>", # austin@launchbadge.com
-    "Chloe Ross <orangesnowfox@gmail.com>", # zach@launchbadge.com
+    "Chloe Ross <orangesnowfox@gmail.com>", # chloe@launchbadge.com
     "Daniel Akhterov <akhterovd@gmail.com>", # daniel@launchbadge.com
 ]
 

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 authors = [
     "Ryan Leckey <leckey.ryan@gmail.com>",
     "Austin Bonander <austin.bonander@gmail.com>",
-    "Zachery Gyurkovitz <zgyurkovitz@gmail.com>",
+    "Chloe Ross <orangesnowfox@gmail.com>",
     "Daniel Akhterov <akhterovd@gmail.com>",
 ]
 

--- a/sqlx-core/src/postgres/type_info.rs
+++ b/sqlx-core/src/postgres/type_info.rs
@@ -755,6 +755,10 @@ impl TypeInfo for PgTypeInfo {
     fn is_null(&self) -> bool {
         false
     }
+
+    fn is_void(&self) -> bool {
+        matches!(self.0, PgType::Void)
+    }
 }
 
 impl PartialEq<PgCustomType> for PgCustomType {

--- a/sqlx-core/src/type_info.rs
+++ b/sqlx-core/src/type_info.rs
@@ -8,4 +8,9 @@ pub trait TypeInfo: Debug + Display + Clone + PartialEq<Self> + Send + Sync {
     /// Common type names are `VARCHAR`, `TEXT`, or `INT`. Type names should be uppercase. They
     /// should be a rough approximation of how they are written in SQL in the given database.
     fn name(&self) -> &str;
+
+    #[doc(hidden)]
+    fn is_void(&self) -> bool {
+        false
+    }
 }

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 authors = [
     "Ryan Leckey <leckey.ryan@gmail.com>", # ryan@launchbadge.com
     "Austin Bonander <austin.bonander@gmail.com>", # austin@launchbadge.com
-    "Zachery Gyurkovitz <zgyurkovitz@gmail.com>", # zach@launchbadge.com
+    "Chloe Ross <orangesnowfox@gmail.com>", # chloe@launchbadge.com
     "Daniel Akhterov <akhterovd@gmail.com>", # daniel@launchbadge.com
 ]
 

--- a/sqlx-macros/src/query/mod.rs
+++ b/sqlx-macros/src/query/mod.rs
@@ -9,7 +9,7 @@ pub use input::QueryMacroInput;
 use quote::{format_ident, quote};
 use sqlx_core::connection::Connection;
 use sqlx_core::database::Database;
-use sqlx_core::describe::Describe;
+use sqlx_core::{column::Column, describe::Describe, type_info::TypeInfo};
 use sqlx_rt::block_on;
 
 use crate::database::DatabaseExt;
@@ -208,7 +208,7 @@ where
 
     let query_args = format_ident!("query_args");
 
-    let output = if data.describe.columns().is_empty() {
+    let output = if data.describe.columns().iter().all(|it| it.type_info().is_void()) {
         let db_path = DB::db_path();
         let sql = &input.src;
 

--- a/sqlx-macros/src/query/mod.rs
+++ b/sqlx-macros/src/query/mod.rs
@@ -208,7 +208,12 @@ where
 
     let query_args = format_ident!("query_args");
 
-    let output = if data.describe.columns().iter().all(|it| it.type_info().is_void()) {
+    let output = if data
+        .describe
+        .columns()
+        .iter()
+        .all(|it| it.type_info().is_void())
+    {
         let db_path = DB::db_path();
         let sql = &input.src;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,7 +1,7 @@
 /// Statically checked SQL query with `println!()` style syntax.
 ///
 /// This expands to an instance of [`query::Map`][crate::query::Map] that outputs an ad-hoc anonymous
-/// struct type, if the query has output columns, or `()` (unit) otherwise:
+/// struct type, if the query has at least one output column that is not `Void`, or `()` (unit) otherwise:
 ///
 /// ```rust,ignore
 /// # use sqlx::Connect;

--- a/tests/postgres/macros.rs
+++ b/tests/postgres/macros.rs
@@ -89,11 +89,9 @@ async fn test_text_var_char_char_n() -> anyhow::Result<()> {
 async fn test_void() -> anyhow::Result<()> {
     let mut conn = new::<Postgres>().await?;
 
-    let record = sqlx::query!(r#"select pg_notify('chan', 'message') as _1"#)
-        .fetch_one(&mut conn)
+    let _ = sqlx::query!(r#"select pg_notify('chan', 'message')"#)
+        .execute(&mut conn)
         .await?;
-
-    assert_eq!(record._1, Some(()));
 
     Ok(())
 }


### PR DESCRIPTION
Closes #544