### PR TITLE
Remove rust_decimal unnecessary dependency num-traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,7 +2067,6 @@ dependencies = [
  "md-5",
  "memchr",
  "num-bigint",
- "num-traits",
  "once_cell",
  "parking_lot",
  "percent-encoding",

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -27,7 +27,7 @@ any = []
 # types
 all-types = [ "chrono", "time", "bigdecimal", "decimal", "ipnetwork", "json", "uuid", "bit-vec" ]
 bigdecimal = [ "bigdecimal_", "num-bigint" ]
-decimal = [ "rust_decimal", "num-bigint", "num-traits" ]
+decimal = [ "rust_decimal", "num-bigint" ]
 json = [ "serde", "serde_json" ]
 
 # runtimes
@@ -43,8 +43,7 @@ atoi = "0.3.2"
 sqlx-rt = { path = "../sqlx-rt", version = "0.1.1" }
 base64 = { version = "0.12.1", default-features = false, optional = true, features = [ "std" ] }
 bigdecimal_ = { version = "0.1.0", optional = true, package = "bigdecimal" }
-rust_decimal = { version = "1.6.0", optional = true }
-num-traits = { version = "0.2.12", optional = true }
+rust_decimal = { version = "1.7.0", optional = true }
 bit-vec = { version = "0.6.2", optional = true }
 bitflags = { version = "1.2.1", default-features = false }
 bytes = "0.5.4"

--- a/sqlx-core/src/postgres/types/decimal.rs
+++ b/sqlx-core/src/postgres/types/decimal.rs
@@ -1,5 +1,8 @@
 use num_bigint::{BigInt, Sign};
-use rust_decimal::{Decimal, prelude::{Zero, ToPrimitive}};
+use rust_decimal::{
+    prelude::{ToPrimitive, Zero},
+    Decimal,
+};
 use std::convert::{TryFrom, TryInto};
 
 use crate::decode::Decode;

--- a/sqlx-core/src/postgres/types/decimal.rs
+++ b/sqlx-core/src/postgres/types/decimal.rs
@@ -1,6 +1,5 @@
 use num_bigint::{BigInt, Sign};
-use num_traits::ToPrimitive;
-use rust_decimal::{prelude::Zero, Decimal};
+use rust_decimal::{Decimal, prelude::{Zero, ToPrimitive}};
 use std::convert::{TryFrom, TryInto};
 
 use crate::decode::Decode;


### PR DESCRIPTION
num_bigint::BigInt, rust_decimal::Decimal use same trait ToPrimitive from crate nums-traits(0.2).

https://github.com/launchbadge/sqlx/blob/9ea5ce01a2b04779203bd086e7eb1358ada70ec1/sqlx-core/src/postgres/types/decimal.rs#L2

`use rust_decimal::prelude::ToPrimitive;` is as same as `use num_traits::ToPrimitive;`

The num_traits dependency is unnecessary.

https://github.com/launchbadge/sqlx/blob/9ea5ce01a2b04779203bd086e7eb1358ada70ec1/sqlx-core/src/postgres/types/decimal.rs#L71