### PR TITLE
Added missing target for query logger

### DIFF
--- a/sqlx-core/src/logger.rs
+++ b/sqlx-core/src/logger.rs
@@ -58,6 +58,7 @@ impl<'q> QueryLogger<'q> {
                     ))
                     .level(lvl)
                     .module_path_static(Some("sqlx::query"))
+                    .target("sqlx::query")
                     .build(),
             );
         }


### PR DESCRIPTION
The query log did not have a `target` property, which led to it not being affected by log filters (e.g. in `env_logger`)