### PR TITLE
sqlx-cli: Exit with code 1 on error.

### DIFF
--- a/sqlx-cli/src/bin/sqlx.rs
+++ b/sqlx-cli/src/bin/sqlx.rs
@@ -9,5 +9,6 @@ async fn main() {
     // no special handling here
     if let Err(error) = sqlx_cli::run(Opt::from_arg_matches(&matches)).await {
         println!("{} {}", style("error:").bold().red(), error);
+        std::process::exit(1);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/launchbadge/sqlx/issues/582

This will make sqlx-cli exit with an error code of 1 if it errors. Why? Because CI, that's why.