### PR TITLE
`sqlx migration` subcommand does not exist but `sqlx migrate` does

### DIFF
--- a/sqlx-cli/README.md
+++ b/sqlx-cli/README.md
@@ -46,7 +46,7 @@ this new file.
 
 ---
 ```bash
-$ sqlx migration run
+$ sqlx migrate run
 ```
 Compares the migration history of the running database against the `migrations/` folder and runs
 any scripts that are still pending.


### PR DESCRIPTION
The docs mentions `sqlx migration run`, but the `migration` subcommand does not exist. `sqlx migrate run` does exist and is probably meant.