### PR TITLE
Make query logging an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,10 @@ features = [ "all" ]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = [ "macros", "runtime-async-std", "migrate" ]
+default = [ "macros", "runtime-async-std", "migrate", "querylog" ]
 macros = [ "sqlx-macros" ]
 migrate = [ "sqlx-macros/migrate", "sqlx-core/migrate" ]
+querylog = []
 
 # [deprecated] TLS is not possible to disable due to it being conditional on multiple features
 #              Hopefully Cargo can handle this in the future
@@ -47,7 +48,7 @@ tls = [ ]
 offline = [ "sqlx-macros/offline", "sqlx-core/offline" ]
 
 # intended mainly for CI and docs
-all = [ "tls", "all-databases", "all-types" ]
+all = [ "tls", "all-databases", "all-types", "querylog" ]
 all-databases = [ "mysql", "sqlite", "postgres", "mssql", "any" ]
 all-types = [ "bigdecimal", "decimal", "json", "time", "chrono", "ipnetwork", "uuid", "bit-vec" ]
 


### PR DESCRIPTION
Not everyone wants or needs all queries output to the log, while it could be filtered out in the log target, it is more efficient to not generate the query log if it is not needed.

In this implementation I have just configured out the non trivial parts of the QueryLogger, one could also have chosen to configure out the usages of the QueryLogger. Alternatively I could also have configured out the entier definition of the QueryLogger and defined in an empty stub.

If you want the feature, I am willing to implement it any way you want.