### PR TITLE
Allow configuring the log level of query logging

### DIFF
--- a/sqlx-core/src/any/options.rs
+++ b/sqlx-core/src/any/options.rs
@@ -2,7 +2,9 @@ use crate::any::AnyConnection;
 use crate::connection::ConnectOptions;
 use crate::error::Error;
 use futures_core::future::BoxFuture;
+use log::LevelFilter;
 use std::str::FromStr;
+use std::time::Duration;
 
 #[cfg(feature = "postgres")]
 use crate::postgres::PgConnectOptions;
@@ -119,5 +121,55 @@ impl ConnectOptions for AnyConnectOptions {
     #[inline]
     fn connect(&self) -> BoxFuture<'_, Result<AnyConnection, Error>> {
         Box::pin(AnyConnection::establish(self))
+    }
+
+    fn log_statements(&mut self, level: LevelFilter) -> &mut Self {
+        match &mut self.0 {
+            #[cfg(feature = "postgres")]
+            AnyConnectOptionsKind::Postgres(o) => {
+                o.log_statements(level);
+            }
+
+            #[cfg(feature = "mysql")]
+            AnyConnectOptionsKind::MySql(o) => {
+                o.log_statements(level);
+            }
+
+            #[cfg(feature = "sqlite")]
+            AnyConnectOptionsKind::Sqlite(o) => {
+                o.log_statements(level);
+            }
+
+            #[cfg(feature = "mssql")]
+            AnyConnectOptionsKind::Mssql(o) => {
+                o.log_statements(level);
+            }
+        };
+        self
+    }
+
+    fn log_slow_statements(&mut self, level: LevelFilter, duration: Duration) -> &mut Self {
+        match &mut self.0 {
+            #[cfg(feature = "postgres")]
+            AnyConnectOptionsKind::Postgres(o) => {
+                o.log_slow_statements(level, duration);
+            }
+
+            #[cfg(feature = "mysql")]
+            AnyConnectOptionsKind::MySql(o) => {
+                o.log_slow_statements(level, duration);
+            }
+
+            #[cfg(feature = "sqlite")]
+            AnyConnectOptionsKind::Sqlite(o) => {
+                o.log_slow_statements(level, duration);
+            }
+
+            #[cfg(feature = "mssql")]
+            AnyConnectOptionsKind::Mssql(o) => {
+                o.log_slow_statements(level, duration);
+            }
+        };
+        self
     }
 }

--- a/sqlx-core/src/mssql/connection/establish.rs
+++ b/sqlx-core/src/mssql/connection/establish.rs
@@ -82,6 +82,7 @@ impl MssqlConnection {
         Ok(Self {
             stream,
             cache_statement: StatementCache::new(1024),
+            log_settings: options.log_settings.clone(),
         })
     }
 }

--- a/sqlx-core/src/mssql/connection/executor.rs
+++ b/sqlx-core/src/mssql/connection/executor.rs
@@ -78,7 +78,7 @@ impl<'c> Executor<'c> for &'c mut MssqlConnection {
     {
         let sql = query.sql();
         let arguments = query.take_arguments();
-        let mut logger = QueryLogger::new(sql);
+        let mut logger = QueryLogger::new(sql, self.log_settings.clone());
 
         Box::pin(try_stream! {
             self.run(sql, arguments).await?;

--- a/sqlx-core/src/mssql/connection/mod.rs
+++ b/sqlx-core/src/mssql/connection/mod.rs
@@ -1,5 +1,5 @@
 use crate::common::StatementCache;
-use crate::connection::Connection;
+use crate::connection::{Connection, LogSettings};
 use crate::error::Error;
 use crate::executor::Executor;
 use crate::mssql::connection::stream::MssqlStream;
@@ -20,6 +20,7 @@ mod stream;
 pub struct MssqlConnection {
     pub(crate) stream: MssqlStream,
     pub(crate) cache_statement: StatementCache<Arc<MssqlStatementMetadata>>,
+    log_settings: LogSettings,
 }
 
 impl Debug for MssqlConnection {

--- a/sqlx-core/src/mssql/options/connect.rs
+++ b/sqlx-core/src/mssql/options/connect.rs
@@ -2,6 +2,8 @@ use crate::connection::ConnectOptions;
 use crate::error::Error;
 use crate::mssql::{MssqlConnectOptions, MssqlConnection};
 use futures_core::future::BoxFuture;
+use log::LevelFilter;
+use std::time::Duration;
 
 impl ConnectOptions for MssqlConnectOptions {
     type Connection = MssqlConnection;
@@ -11,5 +13,15 @@ impl ConnectOptions for MssqlConnectOptions {
         Self::Connection: Sized,
     {
         Box::pin(MssqlConnection::establish(self))
+    }
+
+    fn log_statements(&mut self, level: LevelFilter) -> &mut Self {
+        self.log_settings.log_statements(level);
+        self
+    }
+
+    fn log_slow_statements(&mut self, level: LevelFilter, duration: Duration) -> &mut Self {
+        self.log_settings.log_slow_statements(level, duration);
+        self
     }
 }

--- a/sqlx-core/src/mssql/options/mod.rs
+++ b/sqlx-core/src/mssql/options/mod.rs
@@ -1,3 +1,5 @@
+use crate::connection::LogSettings;
+
 mod connect;
 mod parse;
 
@@ -8,6 +10,7 @@ pub struct MssqlConnectOptions {
     pub(crate) username: String,
     pub(crate) database: String,
     pub(crate) password: Option<String>,
+    pub(crate) log_settings: LogSettings,
 }
 
 impl Default for MssqlConnectOptions {
@@ -24,6 +27,7 @@ impl MssqlConnectOptions {
             database: String::from("master"),
             username: String::from("sa"),
             password: None,
+            log_settings: Default::default(),
         }
     }
 

--- a/sqlx-core/src/mysql/connection/establish.rs
+++ b/sqlx-core/src/mysql/connection/establish.rs
@@ -129,6 +129,7 @@ impl MySqlConnection {
             stream,
             transaction_depth: 0,
             cache_statement: StatementCache::new(options.statement_cache_capacity),
+            log_settings: options.log_settings.clone(),
         })
     }
 }

--- a/sqlx-core/src/mysql/connection/executor.rs
+++ b/sqlx-core/src/mysql/connection/executor.rs
@@ -89,7 +89,7 @@ impl MySqlConnection {
         arguments: Option<MySqlArguments>,
         persistent: bool,
     ) -> Result<impl Stream<Item = Result<Either<MySqlDone, MySqlRow>, Error>> + 'e, Error> {
-        let mut logger = QueryLogger::new(sql);
+        let mut logger = QueryLogger::new(sql, self.log_settings.clone());
 
         self.stream.wait_until_ready().await?;
         self.stream.busy = Busy::Result;

--- a/sqlx-core/src/mysql/connection/mod.rs
+++ b/sqlx-core/src/mysql/connection/mod.rs
@@ -1,5 +1,5 @@
 use crate::common::StatementCache;
-use crate::connection::Connection;
+use crate::connection::{Connection, LogSettings};
 use crate::error::Error;
 use crate::mysql::protocol::statement::StmtClose;
 use crate::mysql::protocol::text::{Ping, Quit};
@@ -32,6 +32,8 @@ pub struct MySqlConnection {
 
     // cache by query string to the statement id and metadata
     cache_statement: StatementCache<(u32, MySqlStatementMetadata)>,
+
+    log_settings: LogSettings,
 }
 
 impl Debug for MySqlConnection {

--- a/sqlx-core/src/mysql/options/connect.rs
+++ b/sqlx-core/src/mysql/options/connect.rs
@@ -3,6 +3,8 @@ use crate::error::Error;
 use crate::executor::Executor;
 use crate::mysql::{MySqlConnectOptions, MySqlConnection};
 use futures_core::future::BoxFuture;
+use log::LevelFilter;
+use std::time::Duration;
 
 impl ConnectOptions for MySqlConnectOptions {
     type Connection = MySqlConnection;
@@ -52,5 +54,15 @@ impl ConnectOptions for MySqlConnectOptions {
 
             Ok(conn)
         })
+    }
+
+    fn log_statements(&mut self, level: LevelFilter) -> &mut Self {
+        self.log_settings.log_statements(level);
+        self
+    }
+
+    fn log_slow_statements(&mut self, level: LevelFilter, duration: Duration) -> &mut Self {
+        self.log_settings.log_slow_statements(level, duration);
+        self
     }
 }

--- a/sqlx-core/src/mysql/options/mod.rs
+++ b/sqlx-core/src/mysql/options/mod.rs
@@ -4,6 +4,7 @@ mod connect;
 mod parse;
 mod ssl_mode;
 
+use crate::connection::LogSettings;
 pub use ssl_mode::MySqlSslMode;
 
 /// Options and flags which can be used to configure a MySQL connection.
@@ -65,6 +66,7 @@ pub struct MySqlConnectOptions {
     pub(crate) statement_cache_capacity: usize,
     pub(crate) charset: String,
     pub(crate) collation: Option<String>,
+    pub(crate) log_settings: LogSettings,
 }
 
 impl Default for MySqlConnectOptions {
@@ -88,6 +90,7 @@ impl MySqlConnectOptions {
             ssl_mode: MySqlSslMode::Preferred,
             ssl_ca: None,
             statement_cache_capacity: 100,
+            log_settings: Default::default(),
         }
     }
 

--- a/sqlx-core/src/postgres/connection/establish.rs
+++ b/sqlx-core/src/postgres/connection/establish.rs
@@ -142,6 +142,7 @@ impl PgConnection {
             cache_statement: StatementCache::new(options.statement_cache_capacity),
             cache_type_oid: HashMap::new(),
             cache_type_info: HashMap::new(),
+            log_settings: options.log_settings.clone(),
         })
     }
 }

--- a/sqlx-core/src/postgres/connection/executor.rs
+++ b/sqlx-core/src/postgres/connection/executor.rs
@@ -199,7 +199,7 @@ impl PgConnection {
         persistent: bool,
         metadata_opt: Option<Arc<PgStatementMetadata>>,
     ) -> Result<impl Stream<Item = Result<Either<PgDone, PgRow>, Error>> + 'e, Error> {
-        let mut logger = QueryLogger::new(query);
+        let mut logger = QueryLogger::new(query, self.log_settings.clone());
 
         // before we continue, wait until we are "ready" to accept more queries
         self.wait_until_ready().await?;

--- a/sqlx-core/src/postgres/connection/mod.rs
+++ b/sqlx-core/src/postgres/connection/mod.rs
@@ -6,7 +6,7 @@ use futures_util::{FutureExt, TryFutureExt};
 use hashbrown::HashMap;
 
 use crate::common::StatementCache;
-use crate::connection::Connection;
+use crate::connection::{Connection, LogSettings};
 use crate::error::Error;
 use crate::executor::Executor;
 use crate::ext::ustr::UStr;
@@ -60,6 +60,8 @@ pub struct PgConnection {
     // current transaction status
     transaction_status: TransactionStatus,
     pub(crate) transaction_depth: usize,
+
+    log_settings: LogSettings,
 }
 
 impl PgConnection {

--- a/sqlx-core/src/postgres/options/connect.rs
+++ b/sqlx-core/src/postgres/options/connect.rs
@@ -2,6 +2,8 @@ use crate::connection::ConnectOptions;
 use crate::error::Error;
 use crate::postgres::{PgConnectOptions, PgConnection};
 use futures_core::future::BoxFuture;
+use log::LevelFilter;
+use std::time::Duration;
 
 impl ConnectOptions for PgConnectOptions {
     type Connection = PgConnection;
@@ -11,5 +13,15 @@ impl ConnectOptions for PgConnectOptions {
         Self::Connection: Sized,
     {
         Box::pin(PgConnection::establish(self))
+    }
+
+    fn log_statements(&mut self, level: LevelFilter) -> &mut Self {
+        self.log_settings.log_statements(level);
+        self
+    }
+
+    fn log_slow_statements(&mut self, level: LevelFilter, duration: Duration) -> &mut Self {
+        self.log_settings.log_slow_statements(level, duration);
+        self
     }
 }

--- a/sqlx-core/src/postgres/options/mod.rs
+++ b/sqlx-core/src/postgres/options/mod.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 mod connect;
 mod parse;
 mod ssl_mode;
-
+use crate::connection::LogSettings;
 pub use ssl_mode::PgSslMode;
 
 /// Options and flags which can be used to configure a PostgreSQL connection.
@@ -84,6 +84,7 @@ pub struct PgConnectOptions {
     pub(crate) ssl_root_cert: Option<PathBuf>,
     pub(crate) statement_cache_capacity: usize,
     pub(crate) application_name: Option<String>,
+    pub(crate) log_settings: LogSettings,
 }
 
 impl Default for PgConnectOptions {
@@ -135,6 +136,7 @@ impl PgConnectOptions {
                 .unwrap_or_default(),
             statement_cache_capacity: 100,
             application_name: var("PGAPPNAME").ok(),
+            log_settings: Default::default(),
         }
     }
 

--- a/sqlx-core/src/sqlite/connection/establish.rs
+++ b/sqlx-core/src/sqlite/connection/establish.rs
@@ -114,5 +114,6 @@ pub(crate) async fn establish(options: &SqliteConnectOptions) -> Result<SqliteCo
         statements: StatementCache::new(options.statement_cache_capacity),
         statement: None,
         transaction_depth: 0,
+        log_settings: options.log_settings.clone(),
     })
 }

--- a/sqlx-core/src/sqlite/connection/executor.rs
+++ b/sqlx-core/src/sqlite/connection/executor.rs
@@ -72,7 +72,7 @@ impl<'c> Executor<'c> for &'c mut SqliteConnection {
         E: Execute<'q, Self::Database>,
     {
         let sql = query.sql();
-        let mut logger = QueryLogger::new(sql);
+        let mut logger = QueryLogger::new(sql, self.log_settings.clone());
         let arguments = query.take_arguments();
         let persistent = query.persistent() && arguments.is_some();
 

--- a/sqlx-core/src/sqlite/connection/mod.rs
+++ b/sqlx-core/src/sqlite/connection/mod.rs
@@ -1,5 +1,5 @@
 use crate::common::StatementCache;
-use crate::connection::Connection;
+use crate::connection::{Connection, LogSettings};
 use crate::error::Error;
 use crate::sqlite::statement::{StatementWorker, VirtualStatement};
 use crate::sqlite::{Sqlite, SqliteConnectOptions};
@@ -32,6 +32,8 @@ pub struct SqliteConnection {
 
     // most recent non-persistent statement
     pub(crate) statement: Option<VirtualStatement>,
+
+    log_settings: LogSettings,
 }
 
 impl SqliteConnection {

--- a/sqlx-core/src/sqlite/options/connect.rs
+++ b/sqlx-core/src/sqlite/options/connect.rs
@@ -4,6 +4,8 @@ use crate::executor::Executor;
 use crate::sqlite::connection::establish::establish;
 use crate::sqlite::{SqliteConnectOptions, SqliteConnection};
 use futures_core::future::BoxFuture;
+use log::LevelFilter;
+use std::time::Duration;
 
 impl ConnectOptions for SqliteConnectOptions {
     type Connection = SqliteConnection;
@@ -26,5 +28,15 @@ impl ConnectOptions for SqliteConnectOptions {
 
             Ok(conn)
         })
+    }
+
+    fn log_statements(&mut self, level: LevelFilter) -> &mut Self {
+        self.log_settings.log_statements(level);
+        self
+    }
+
+    fn log_slow_statements(&mut self, level: LevelFilter, duration: Duration) -> &mut Self {
+        self.log_settings.log_slow_statements(level, duration);
+        self
     }
 }

--- a/sqlx-core/src/sqlite/options/mod.rs
+++ b/sqlx-core/src/sqlite/options/mod.rs
@@ -4,6 +4,7 @@ mod connect;
 mod journal_mode;
 mod parse;
 
+use crate::connection::LogSettings;
 pub use journal_mode::SqliteJournalMode;
 use std::{borrow::Cow, time::Duration};
 
@@ -51,6 +52,7 @@ pub struct SqliteConnectOptions {
     pub(crate) shared_cache: bool,
     pub(crate) statement_cache_capacity: usize,
     pub(crate) busy_timeout: Duration,
+    pub(crate) log_settings: LogSettings,
 }
 
 impl Default for SqliteConnectOptions {
@@ -71,6 +73,7 @@ impl SqliteConnectOptions {
             statement_cache_capacity: 100,
             journal_mode: SqliteJournalMode::Wal,
             busy_timeout: Duration::from_secs(5),
+            log_settings: Default::default(),
         }
     }
 


### PR DESCRIPTION
Allow dynamically configuring the log level of the query log. 

This is an alternative to #601.