### PR TITLE
Fix NaiveDate parse_from_str argument order

### DIFF
--- a/sqlx-core/src/sqlite/types/chrono.rs
+++ b/sqlx-core/src/sqlite/types/chrono.rs
@@ -169,7 +169,7 @@ impl<'r> Decode<'r, Sqlite> for NaiveDateTime {
 
 impl<'r> Decode<'r, Sqlite> for NaiveDate {
     fn decode(value: SqliteValueRef<'r>) -> Result<Self, BoxDynError> {
-        Ok(NaiveDate::parse_from_str("%F", value.text()?)?)
+        Ok(NaiveDate::parse_from_str(value.text()?, "%F")?)
     }
 }
 


### PR DESCRIPTION
The [documentation](https://docs.rs/chrono/0.4.13/chrono/naive/struct.NaiveDate.html#method.parse_from_str) specifies that `NaiveDate::parse_from_str` takes two arguments: value and format, in respective order. 

Due to this, `DATE` fields could not be read into `NaiveDate`... and I have ptsd.