### PR TITLE
Add support for pooling in-memory sqlite DB, enabling shared cache

### DIFF
--- a/sqlx-core/src/sqlite/options/mod.rs
+++ b/sqlx-core/src/sqlite/options/mod.rs
@@ -48,6 +48,7 @@ pub struct SqliteConnectOptions {
     pub(crate) create_if_missing: bool,
     pub(crate) journal_mode: SqliteJournalMode,
     pub(crate) foreign_keys: bool,
+    pub(crate) shared_cache: bool,
     pub(crate) statement_cache_capacity: usize,
     pub(crate) busy_timeout: Duration,
 }
@@ -66,6 +67,7 @@ impl SqliteConnectOptions {
             read_only: false,
             create_if_missing: false,
             foreign_keys: true,
+            shared_cache: false,
             statement_cache_capacity: 100,
             journal_mode: SqliteJournalMode::Wal,
             busy_timeout: Duration::from_secs(5),


### PR DESCRIPTION
This addresses issue #362 by enabling the shared cache for in-memory sqlite databases and generating a new unique filename per in-memory pool config. The existing implementation returns a blank database when opening a connection to the pool that has not been reused.