### PR TITLE
add supports the utf8mb4_bin collation

### DIFF
--- a/sqlx-core/src/mysql/types/str.rs
+++ b/sqlx-core/src/mysql/types/str.rs
@@ -9,6 +9,9 @@ use crate::types::Type;
 const COLLATE_UTF8_UNICODE_CI: u16 = 192;
 const COLLATE_UTF8MB4_UNICODE_CI: u16 = 224;
 
+// The default collation of utf8mb4 in TiDB.
+const COLLATE_UTF8MB4_BIN: u16 = 46;
+
 impl Type<MySql> for str {
     fn type_info() -> MySqlTypeInfo {
         MySqlTypeInfo {

--- a/sqlx-core/src/mysql/types/str.rs
+++ b/sqlx-core/src/mysql/types/str.rs
@@ -35,7 +35,8 @@ impl Type<MySql> for str {
                 | ColumnType::VarString
                 | ColumnType::Enum
         ) && (ty.char_set == COLLATE_UTF8MB4_UNICODE_CI as u16
-            || ty.char_set == COLLATE_UTF8_UNICODE_CI as u16)
+            || ty.char_set == COLLATE_UTF8_UNICODE_CI as u16
+            || ty.char_set == COLLATE_UTF8MB4_BIN as u16)
     }
 }
 


### PR DESCRIPTION
The default collation of utf8mb4 in TiDB is utf8mb4_bin.