### PR TITLE
docs(macros): Add missing closing bracket in docs code example

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -442,7 +442,7 @@ macro_rules! query_file_unchecked (
 ///
 /// ```rust,ignore
 /// #[derive(sqlx::Type)]
-/// #[sqlx(transparent)
+/// #[sqlx(transparent)]
 /// struct MyInt4(i32);
 ///
 /// struct Record {


### PR DESCRIPTION
Just a tiny fix to add a missing bracket which caused the syntax highlighting to fail on docs.rs.