### PR TITLE
sqlx-cli: Add `--fake` flag to update the migration state without changing the database

### DIFF
--- a/sqlx-cli/src/lib.rs
+++ b/sqlx-cli/src/lib.rs
@@ -21,7 +21,7 @@ pub async fn run(opt: Opt) -> anyhow::Result<()> {
     match opt.command {
         Command::Migrate(migrate) => match migrate.command {
             MigrateCommand::Add { description } => migrate::add(&description)?,
-            MigrateCommand::Run => migrate::run(&database_url).await?,
+            MigrateCommand::Run { fake } => migrate::run(&database_url, fake).await?,
             MigrateCommand::Info => migrate::info(&database_url).await?,
         },
 

--- a/sqlx-cli/src/migrate.rs
+++ b/sqlx-cli/src/migrate.rs
@@ -57,7 +57,7 @@ pub async fn info(uri: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn run(uri: &str) -> anyhow::Result<()> {
+pub async fn run(uri: &str, fake: bool) -> anyhow::Result<()> {
     let migrator = Migrator::new(Path::new(MIGRATION_FOLDER)).await?;
     let mut conn = AnyConnection::connect(uri).await?;
 
@@ -71,7 +71,7 @@ pub async fn run(uri: &str) -> anyhow::Result<()> {
 
     for migration in migrator.iter() {
         if migration.version > version {
-            let elapsed = conn.apply(migration).await?;
+            let elapsed = conn.apply(migration, fake).await?;
 
             println!(
                 "{}/{} {} {}",

--- a/sqlx-cli/src/migration.rs
+++ b/sqlx-cli/src/migration.rs
@@ -34,7 +34,7 @@ pub fn add_file(name: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn run() -> anyhow::Result<()> {
+pub async fn run(fake: bool) -> anyhow::Result<()> {
     let migrator = crate::migrator::get()?;
 
     if !migrator.can_migrate_database() {

--- a/sqlx-cli/src/opt.rs
+++ b/sqlx-cli/src/opt.rs
@@ -70,7 +70,12 @@ pub enum MigrateCommand {
     Add { description: String },
 
     /// Run all pending migrations.
-    Run,
+    Run {
+        /// Don't run any migrations, but update the state as if we did. This is intended to
+        /// resolve situations where you've applied the migration elsewhere.
+        #[clap(long)]
+        fake: bool,
+    },
 
     /// List all available migrations.
     Info,

--- a/sqlx-core/src/any/migrate.rs
+++ b/sqlx-core/src/any/migrate.rs
@@ -150,16 +150,17 @@ impl Migrate for AnyConnection {
     fn apply<'e: 'm, 'm>(
         &'e mut self,
         migration: &'m Migration,
+        fake: bool,
     ) -> BoxFuture<'m, Result<Duration, MigrateError>> {
         match &mut self.0 {
             #[cfg(feature = "postgres")]
-            AnyConnectionKind::Postgres(conn) => conn.apply(migration),
+            AnyConnectionKind::Postgres(conn) => conn.apply(migration, fake),
 
             #[cfg(feature = "sqlite")]
-            AnyConnectionKind::Sqlite(conn) => conn.apply(migration),
+            AnyConnectionKind::Sqlite(conn) => conn.apply(migration, fake),
 
             #[cfg(feature = "mysql")]
-            AnyConnectionKind::MySql(conn) => conn.apply(migration),
+            AnyConnectionKind::MySql(conn) => conn.apply(migration, fake),
 
             #[cfg(feature = "mssql")]
             AnyConnectionKind::Mssql(conn) => unimplemented!(),

--- a/sqlx-core/src/migrate/migrate.rs
+++ b/sqlx-core/src/migrate/migrate.rs
@@ -49,5 +49,6 @@ pub trait Migrate {
     fn apply<'e: 'm, 'm>(
         &'e mut self,
         migration: &'m Migration,
+        fake: bool,
     ) -> BoxFuture<'m, Result<Duration, MigrateError>>;
 }

--- a/sqlx-core/src/migrate/migrator.rs
+++ b/sqlx-core/src/migrate/migrator.rs
@@ -43,7 +43,7 @@ impl Migrator {
 
     /// Run any pending migrations against the database; and, validate previously applied migrations
     /// against the current migration source to detect accidental changes in previously-applied migrations.
-    pub async fn run<'a, A>(&self, migrator: A) -> Result<(), MigrateError>
+    pub async fn run<'a, A>(&self, migrator: A, fake: bool) -> Result<(), MigrateError>
     where
         A: Acquire<'a>,
         <A::Connection as Deref>::Target: Migrate,
@@ -65,7 +65,7 @@ impl Migrator {
 
         for migration in self.iter() {
             if migration.version > version {
-                conn.apply(migration).await?;
+                conn.apply(migration, fake).await?;
             } else {
                 conn.validate(migration).await?;
             }

--- a/sqlx-core/src/mysql/migrate.rs
+++ b/sqlx-core/src/mysql/migrate.rs
@@ -185,18 +185,15 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
             let _ = query(
                 r#"
     INSERT INTO _sqlx_migrations ( version, description, success, checksum, execution_time )
-    VALUES ( ?, ?, ?, ?, ? )
+    VALUES ( ?, ?, TRUE, ?, ? )
                 "#,
             )
             .bind(migration.version)
             .bind(&*migration.description)
-            .bind(res.is_ok())
             .bind(&*migration.checksum)
             .bind(elapsed.as_nanos() as i64)
             .execute(self)
             .await?;
-
-            res?;
 
             Ok(elapsed)
         })

--- a/sqlx-core/src/mysql/migrate.rs
+++ b/sqlx-core/src/mysql/migrate.rs
@@ -173,11 +173,14 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
     fn apply<'e: 'm, 'm>(
         &'e mut self,
         migration: &'m Migration,
+        fake: bool,
     ) -> BoxFuture<'m, Result<Duration, MigrateError>> {
         Box::pin(async move {
             let start = Instant::now();
 
-            let res = self.execute(&*migration.sql).await;
+            if !fake {
+                let _ = self.execute(&*migration.sql).await?;
+            }
 
             let elapsed = start.elapsed();
 

--- a/sqlx-core/src/postgres/migrate.rs
+++ b/sqlx-core/src/postgres/migrate.rs
@@ -183,12 +183,15 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
     fn apply<'e: 'm, 'm>(
         &'e mut self,
         migration: &'m Migration,
+        fake: bool,
     ) -> BoxFuture<'m, Result<Duration, MigrateError>> {
         Box::pin(async move {
             let mut tx = self.begin().await?;
             let start = Instant::now();
 
-            let _ = tx.execute(&*migration.sql).await?;
+            if !fake {
+                let _ = tx.execute(&*migration.sql).await?;
+            }
 
             tx.commit().await?;
 

--- a/sqlx-core/src/sqlite/migrate.rs
+++ b/sqlx-core/src/sqlite/migrate.rs
@@ -122,12 +122,15 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
     fn apply<'e: 'm, 'm>(
         &'e mut self,
         migration: &'m Migration,
+        fake: bool,
     ) -> BoxFuture<'m, Result<Duration, MigrateError>> {
         Box::pin(async move {
             let mut tx = self.begin().await?;
             let start = Instant::now();
 
-            let _ = tx.execute(&*migration.sql).await?;
+            if !fake {
+                let _ = tx.execute(&*migration.sql).await?;
+            }
 
             tx.commit().await?;
 


### PR DESCRIPTION
This adds a `--fake` flag to the migrate run command.

This allowed me to take the migrations previously generated by diesel, and have sqlx insert the appropriate rows to let me use sqlx going forward.

This is modelled as an option to each run rather than as a one-off import, since I've previously used https://docs.djangoproject.com/en/3.1/ref/django-admin/#cmdoption-migrate-fake with real-life production databases where you occasionally run into things that you theoretically shouldn't - where the migration contains the steps you want to apply, but the production database doesn't look like it should or postgres takes locks you didn't expect.