### PR TITLE
Remove unused features from time crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ sqlx-macros = { version = "=0.4.0-beta.1", path = "sqlx-macros", default-feature
 
 [dev-dependencies]
 anyhow = "1.0.31"
-time_ = { version = "0.2.16", package = "time" }
+time_ = { version = "0.2.16", default-features = false, package = "time" }
 futures = "0.3.5"
 env_logger = "0.7.1"
 async-std = { version = "1.6.0", features = [ "attributes" ] }

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -83,7 +83,7 @@ sha-1 = { version = "0.9.0", default-features = false, optional = true }
 sha2 = { version = "0.9.0", default-features = false, optional = true }
 sqlformat = "0.1.0"
 thiserror = "1.0.19"
-time = { version = "0.2.16", optional = true }
+time = { version = "0.2.16", default-features = false, optional = true }
 smallvec = "1.4.0"
 url = { version = "2.1.1", default-features = false }
 uuid = { version = "0.8.1", default-features = false, optional = true, features = [ "std" ] }


### PR DESCRIPTION
This eliminates the deprecated APIs, which are not used. Additionally, libc/winapi (target-dependent) from the dependency tree (at least from time's side of things — they may be used elsewhere).