### PR TITLE
Uuid support for Sqlite.

### DIFF
--- a/sqlx-core/src/sqlite/types/mod.rs
+++ b/sqlx-core/src/sqlite/types/mod.rs
@@ -23,6 +23,15 @@
 //! | `chrono::DateTime<Utc>`               | DATETIME                                             |
 //! | `chrono::DateTime<Local>`             | DATETIME                                             |
 //!
+//! ### [`uuid`](https://crates.io/crates/uuid)
+//!
+//! Requires the `uuid` Cargo feature flag.
+//!
+//! | Rust type                             | Sqlite type(s)                                       |
+//! |---------------------------------------|------------------------------------------------------|
+//! | `uuid::Uuid`                          | BLOB, TEXT                                           |
+//! | `uuid::adapter::Hyphenated`           | TEXT                                                 |
+//!
 //! # Nullable
 //!
 //! In addition, `Option<T>` is supported where `T` implements `Type`. An `Option<T>` represents
@@ -33,6 +42,8 @@ mod bool;
 mod bytes;
 #[cfg(feature = "chrono")]
 mod chrono;
+#[cfg(feature = "uuid")]
+mod uuid;
 mod float;
 mod int;
 mod str;

--- a/sqlx-core/src/sqlite/types/mod.rs
+++ b/sqlx-core/src/sqlite/types/mod.rs
@@ -42,8 +42,8 @@ mod bool;
 mod bytes;
 #[cfg(feature = "chrono")]
 mod chrono;
-#[cfg(feature = "uuid")]
-mod uuid;
 mod float;
 mod int;
 mod str;
+#[cfg(feature = "uuid")]
+mod uuid;

--- a/sqlx-core/src/sqlite/types/uuid.rs
+++ b/sqlx-core/src/sqlite/types/uuid.rs
@@ -1,20 +1,20 @@
-use uuid::{adapter::Hyphenated, Uuid};
-use std::borrow::Cow;
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
 use crate::error::BoxDynError;
 use crate::sqlite::type_info::DataType;
 use crate::sqlite::{Sqlite, SqliteArgumentValue, SqliteTypeInfo, SqliteValueRef};
 use crate::types::Type;
+use std::borrow::Cow;
+use uuid::{adapter::Hyphenated, Uuid};
 
 impl Type<Sqlite> for Uuid {
     fn type_info() -> SqliteTypeInfo {
         SqliteTypeInfo(DataType::Blob)
     }
-    
+
     fn compatible(ty: &SqliteTypeInfo) -> bool {
         matches!(ty.0, DataType::Blob | DataType::Text)
-    }    
+    }
 }
 
 impl<'q> Encode<'q, Sqlite> for &'q Uuid {
@@ -48,7 +48,8 @@ impl<'q> Encode<'q, Sqlite> for &'q Hyphenated {
 
 impl Decode<'_, Sqlite> for Hyphenated {
     fn decode(value: SqliteValueRef<'_>) -> Result<Self, BoxDynError> {
-        let uuid: Result<Uuid, BoxDynError> = Uuid::parse_str(&value.text().map(ToOwned::to_owned)?).map_err(Into::into);
+        let uuid: Result<Uuid, BoxDynError> =
+            Uuid::parse_str(&value.text().map(ToOwned::to_owned)?).map_err(Into::into);
         Ok(uuid?.to_hyphenated())
     }
 }

--- a/sqlx-core/src/sqlite/types/uuid.rs
+++ b/sqlx-core/src/sqlite/types/uuid.rs
@@ -1,0 +1,54 @@
+use uuid::{adapter::Hyphenated, Uuid};
+use std::borrow::Cow;
+use crate::decode::Decode;
+use crate::encode::{Encode, IsNull};
+use crate::error::BoxDynError;
+use crate::sqlite::type_info::DataType;
+use crate::sqlite::{Sqlite, SqliteArgumentValue, SqliteTypeInfo, SqliteValueRef};
+use crate::types::Type;
+
+impl Type<Sqlite> for Uuid {
+    fn type_info() -> SqliteTypeInfo {
+        SqliteTypeInfo(DataType::Blob)
+    }
+    
+    fn compatible(ty: &SqliteTypeInfo) -> bool {
+        matches!(ty.0, DataType::Blob | DataType::Text)
+    }    
+}
+
+impl<'q> Encode<'q, Sqlite> for &'q Uuid {
+    fn encode_by_ref(&self, args: &mut Vec<SqliteArgumentValue<'q>>) -> IsNull {
+        args.push(SqliteArgumentValue::Blob(Cow::Borrowed(self.as_bytes())));
+
+        IsNull::No
+    }
+}
+
+impl Decode<'_, Sqlite> for Uuid {
+    fn decode(value: SqliteValueRef<'_>) -> Result<Self, BoxDynError> {
+        // construct a Uuid from the returned bytes
+        Uuid::from_slice(value.blob()).map_err(Into::into)
+    }
+}
+
+impl Type<Sqlite> for Hyphenated {
+    fn type_info() -> SqliteTypeInfo {
+        SqliteTypeInfo(DataType::Text)
+    }
+}
+
+impl<'q> Encode<'q, Sqlite> for &'q Hyphenated {
+    fn encode_by_ref(&self, args: &mut Vec<SqliteArgumentValue<'q>>) -> IsNull {
+        args.push(SqliteArgumentValue::Text(Cow::Owned(self.to_string())));
+
+        IsNull::No
+    }
+}
+
+impl Decode<'_, Sqlite> for Hyphenated {
+    fn decode(value: SqliteValueRef<'_>) -> Result<Self, BoxDynError> {
+        let uuid: Result<Uuid, BoxDynError> = Uuid::parse_str(&value.text().map(ToOwned::to_owned)?).map_err(Into::into);
+        Ok(uuid?.to_hyphenated())
+    }
+}

--- a/tests/sqlite/types.rs
+++ b/tests/sqlite/types.rs
@@ -49,3 +49,19 @@ mod chrono {
         "datetime('2016-11-08T03:50:23-05:00')" == FixedOffset::west(5 * 3600).ymd(2016, 11, 08).and_hms(3, 50, 23)
     ));
 }
+
+#[cfg(feature = "uuid")]
+test_type!(uuid<sqlx::types::Uuid>(Sqlite,
+    "x'b731678f636f4135bc6f19440c13bd19'"
+        == sqlx::types::Uuid::parse_str("b731678f-636f-4135-bc6f-19440c13bd19").unwrap(),
+    "x'00000000000000000000000000000000'"
+        == sqlx::types::Uuid::parse_str("00000000-0000-0000-0000-000000000000").unwrap()
+));
+
+#[cfg(feature = "uuid")]
+test_type!(uuid_hyphenated<sqlx::types::uuid::adapter::Hyphenated>(Sqlite,
+    "'b731678f-636f-4135-bc6f-19440c13bd19'"
+        == sqlx::types::Uuid::parse_str("b731678f-636f-4135-bc6f-19440c13bd19").unwrap().to_hyphenated(),
+    "'00000000-0000-0000-0000-000000000000'"
+        == sqlx::types::Uuid::parse_str("00000000-0000-0000-0000-000000000000").unwrap().to_hyphenated()
+));


### PR DESCRIPTION
Includes the same support for the Hyphenated adapter as the MySQL Uuid support.

I'm pretty new to Rust and based this heavily off #536;  hopefully it is useful!