### PR TITLE
sqlx-core/src/mysql/types/str.rs:  str::compatible():  Added support for charset number 33 (utf8 COLLATE utf8_general_ci)

### DIFF
--- a/sqlx-core/src/mysql/types/str.rs
+++ b/sqlx-core/src/mysql/types/str.rs
@@ -6,6 +6,7 @@ use crate::mysql::protocol::text::{ColumnFlags, ColumnType};
 use crate::mysql::{MySql, MySqlTypeInfo, MySqlValueRef};
 use crate::types::Type;
 
+const COLLATE_UTF8_GENERAL_CI: u16 = 33;
 const COLLATE_UTF8_UNICODE_CI: u16 = 192;
 const COLLATE_UTF8MB4_UNICODE_CI: u16 = 224;
 
@@ -31,8 +32,12 @@ impl Type<MySql> for str {
                 | ColumnType::String
                 | ColumnType::VarString
                 | ColumnType::Enum
-        ) && (ty.char_set == COLLATE_UTF8MB4_UNICODE_CI as u16
-            || ty.char_set == COLLATE_UTF8_UNICODE_CI as u16)
+        ) && matches!(
+            ty.char_set,
+            COLLATE_UTF8MB4_UNICODE_CI
+                | COLLATE_UTF8_UNICODE_CI
+                | COLLATE_UTF8_GENERAL_CI
+        )
     }
 }
 

--- a/sqlx-core/src/mysql/types/str.rs
+++ b/sqlx-core/src/mysql/types/str.rs
@@ -34,9 +34,7 @@ impl Type<MySql> for str {
                 | ColumnType::Enum
         ) && matches!(
             ty.char_set,
-            COLLATE_UTF8MB4_UNICODE_CI
-                | COLLATE_UTF8_UNICODE_CI
-                | COLLATE_UTF8_GENERAL_CI
+            COLLATE_UTF8MB4_UNICODE_CI | COLLATE_UTF8_UNICODE_CI | COLLATE_UTF8_GENERAL_CI
         )
     }
 }


### PR DESCRIPTION
I also switched that bit of the conditional to use `matches!()`, as it seemed like 3+ allowed values was starting to get a little unwieldy for a `||` chain, but I can always switch that back if desired

The actual purpose is that it enables compiling against a Vitess database :) although in theory, I'd imagine it would also enable people using `utf8 COLLATE utf8_general_ci` on a `TEXT` column with vanilla MySQL/MariaDB