### PR TITLE
sqlx-cli: adds the db reset and setup command

### DIFF
--- a/sqlx-cli/src/database.rs
+++ b/sqlx-cli/src/database.rs
@@ -1,3 +1,4 @@
+use crate::migrate;
 use console::style;
 use dialoguer::Confirm;
 use sqlx::any::Any;
@@ -29,4 +30,14 @@ pub async fn drop(uri: &str, confirm: bool) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+pub async fn reset(uri: &str, confirm: bool) -> anyhow::Result<()> {
+    drop(uri, confirm).await?;
+    setup(uri).await
+}
+
+pub async fn setup(uri: &str) -> anyhow::Result<()> {
+    create(uri).await?;
+    migrate::run(uri).await
 }

--- a/sqlx-cli/src/lib.rs
+++ b/sqlx-cli/src/lib.rs
@@ -39,6 +39,11 @@ hint: This command only works in the manifest directory of a Cargo package."#
         Command::Database(database) => match database.command {
             DatabaseCommand::Create => database::create(&database_url).await?,
             DatabaseCommand::Drop { yes } => database::drop(&database_url, !yes).await?,
+            DatabaseCommand::Reset { yes } => {
+                database::drop(&database_url, yes).await?;
+                database::create(&database_url).await?;
+                migrate::run(&database_url).await?;
+            }
         },
 
         Command::Prepare { check: false, args } => prepare::run(&database_url, args)?,

--- a/sqlx-cli/src/lib.rs
+++ b/sqlx-cli/src/lib.rs
@@ -39,11 +39,8 @@ hint: This command only works in the manifest directory of a Cargo package."#
         Command::Database(database) => match database.command {
             DatabaseCommand::Create => database::create(&database_url).await?,
             DatabaseCommand::Drop { yes } => database::drop(&database_url, !yes).await?,
-            DatabaseCommand::Reset { yes } => {
-                database::drop(&database_url, yes).await?;
-                database::create(&database_url).await?;
-                migrate::run(&database_url).await?;
-            }
+            DatabaseCommand::Reset { yes } => database::reset(&database_url, yes).await?,
+            DatabaseCommand::Setup => database::setup(&database_url).await?,
         },
 
         Command::Prepare { check: false, args } => prepare::run(&database_url, args)?,

--- a/sqlx-cli/src/opt.rs
+++ b/sqlx-cli/src/opt.rs
@@ -64,6 +64,8 @@ pub enum DatabaseCommand {
         #[clap(short)]
         yes: bool,
     },
+    /// Creates the database specified in your DATABASE_URL and runs any pending migrations.
+    Setup,
 }
 
 /// Group of commands for creating and running migrations.

--- a/sqlx-cli/src/opt.rs
+++ b/sqlx-cli/src/opt.rs
@@ -57,6 +57,13 @@ pub enum DatabaseCommand {
         #[clap(short)]
         yes: bool,
     },
+    /// Drops the database specified in your DATABASE_URL, re-creates it, and runs any pending migrations.
+    Reset {
+        /// Automatic confirmation. Without this option, you will be prompted before dropping
+        /// your database.
+        #[clap(short)]
+        yes: bool,
+    },
 }
 
 /// Group of commands for creating and running migrations.


### PR DESCRIPTION
Addresses #596 - Similar to the way [Phoenix](https://github.com/phoenixframework/phoenix/pull/1202/commits/502e06b521b014c6423fbd26859c21b2057fb23c) has aliases for common database operations, this adds the following commands following the same terminology.

- `sqlx db reset` - Runs the equivalent of `sqlx db drop`, `sqlx db create`, and `sqlx migrate run`. Useful when developing.
- `sqlx db setup` - Runs the equivalent of `sqlx db create` and `sqlx migrate run`. Useful when pulling an existing project with many migrations already created.