### PR TITLE
Revertable migrations

### DIFF
--- a/sqlx-cli/src/lib.rs
+++ b/sqlx-cli/src/lib.rs
@@ -31,7 +31,7 @@ hint: This command only works in the manifest directory of a Cargo package."#
 
     match opt.command {
         Command::Migrate(migrate) => match migrate.command {
-            MigrateCommand::Add { description } => migrate::add(&description)?,
+            MigrateCommand::Add { description, non_revertable } => migrate::add(&description, non_revertable)?,
             MigrateCommand::Run => migrate::run(&database_url).await?,
             MigrateCommand::Info => migrate::info(&database_url).await?,
         },

--- a/sqlx-cli/src/lib.rs
+++ b/sqlx-cli/src/lib.rs
@@ -31,7 +31,7 @@ hint: This command only works in the manifest directory of a Cargo package."#
 
     match opt.command {
         Command::Migrate(migrate) => match migrate.command {
-            MigrateCommand::Add { description, non_revertable } => migrate::add(&description, non_revertable)?,
+            MigrateCommand::Add { description, not_revertable } => migrate::add(&description, not_revertable)?,
             MigrateCommand::Run => migrate::run(&database_url).await?,
             MigrateCommand::Info => migrate::info(&database_url).await?,
         },

--- a/sqlx-cli/src/migrate.rs
+++ b/sqlx-cli/src/migrate.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 const MIGRATION_FOLDER: &'static str = "migrations";
 
-pub fn add(description: &str) -> anyhow::Result<()> {
+pub fn add(description: &str, non_revertable: bool) -> anyhow::Result<()> {
     use chrono::prelude::*;
     use std::path::PathBuf;
 

--- a/sqlx-cli/src/opt.rs
+++ b/sqlx-cli/src/opt.rs
@@ -79,7 +79,13 @@ pub struct MigrateOpt {
 pub enum MigrateCommand {
     /// Create a new migration with the given description,
     /// and the current time as the version.
-    Add { description: String },
+    Add {
+        description: String,
+        /// Creates a migration that can't be reverted
+        /// (doesn't create up / down files)
+        #[clap(short, long)]
+        not_revertable: bool,
+    },
 
     /// Run all pending migrations.
     Run,


### PR DESCRIPTION
In analogy to how Rust lets us explicitly panic with `.unwrap()`, it would be nice if `sqlx migrate add` lets us explicitly opt into non-revertable migrations with a flag. This would prevent people from painting themselves into a corner by making the default command for adding migrations create revertable migrations.

This PR is a proof of concept of the discussion in #356. It currently only includes the functionality to create the files, it doesn't yet let you run or revert migrations.