### PR TITLE
Support percent-encoded socket files and more parameters in postgres connect URIs

### DIFF
--- a/sqlx-core/src/postgres/options/mod.rs
+++ b/sqlx-core/src/postgres/options/mod.rs
@@ -26,6 +26,7 @@ pub use ssl_mode::PgSslMode;
 /// | `sslrootcert` | `None` | Sets the name of a file containing a list of trusted SSL Certificate Authorities. |
 /// | `statement-cache-capacity` | `100` | The maximum number of prepared statements stored in the cache. Set to `0` to disable. |
 /// | `host` | `None` | Path to the directory containing a PostgreSQL unix domain socket, which will be used instead of TCP if set. |
+/// | `hostaddr` | `None` | Same as `host`, but only accepts IP addresses. |
 /// | `application-name` | `None` | The name will be displayed in the pg_stat_activity view and included in CSV log entries. |
 /// | `user` | result of `whoami` | PostgreSQL user name to connect as. |
 /// | `password` | `None` | Password to be used if the server demands password authentication. |


### PR DESCRIPTION
This PR improves the parsing of `PgConnectOptions` to more accurately support less common forms described by the postgres documentation, including:
- Specifying a socket path with percent encoding in the host position (e.g. `postgres://user@%2Fvar%2Flib%2Fpostgres/database`)
- Supporting more connection parameters
  - `user`
  - `password`
  - `hostaddr` (functions the same as `host`, but with an additional assertion that it must parse as an `IpAddr`)
    - The postgres documentation allows specifying multiple values for `hostaddr` which will be tried in order, but this implementation only allows one value
  - `port`
  - `dbname`

These changes allow some use cases that were previously impossible without manipulating environment variables - for example, there was previously no way to specify a socket and user at the same time.

This partially addresses #501.