### PR TITLE
Enable all features for `sqlx-core` on docs.rs

### DIFF
--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -12,6 +12,9 @@ authors = [
     "Daniel Akhterov <akhterovd@gmail.com>",
 ]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 default = [ "runtime-async-std", "migrate" ]
 migrate = [ "sha2", "crc" ]


### PR DESCRIPTION
This should fix the broken links to `src` on https://docs.rs/sqlx/0.4.0-beta.1/sqlx/postgres/struct.PgDone.html. I haven't tested, though.