### PR TITLE
Parse additional postgres connection parameters

### DIFF
--- a/sqlx-core/src/postgres/options/mod.rs
+++ b/sqlx-core/src/postgres/options/mod.rs
@@ -26,6 +26,11 @@ pub use ssl_mode::PgSslMode;
 /// | `sslrootcert` | `None` | Sets the name of a file containing a list of trusted SSL Certificate Authorities. |
 /// | `statement-cache-capacity` | `100` | The maximum number of prepared statements stored in the cache. Set to `0` to disable. |
 /// | `host` | `None` | Path to the directory containing a PostgreSQL unix domain socket, which will be used instead of TCP if set. |
+/// | `application-name` | `None` | The name will be displayed in the pg_stat_activity view and included in CSV log entries. |
+/// | `user` | result of `whoami` | PostgreSQL user name to connect as. |
+/// | `password` | `None` | Password to be used if the server demands password authentication. |
+/// | `port` | `5432` | Port number to connect to at the server host, or socket file name extension for Unix-domain connections. |
+/// | `dbname` | `None` | The database name. |
 ///
 /// The URI scheme designator can be either `postgresql://` or `postgres://`.
 /// Each of the URI parts is optional.
@@ -37,6 +42,7 @@ pub use ssl_mode::PgSslMode;
 /// postgresql://localhost/mydb
 /// postgresql://user@localhost
 /// postgresql://user:secret@localhost
+/// postgresql://localhost?dbname=mydb&user=postgres&password=postgres
 /// ```
 ///
 /// # Example

--- a/sqlx-core/src/postgres/options/parse.rs
+++ b/sqlx-core/src/postgres/options/parse.rs
@@ -69,6 +69,16 @@ impl FromStr for PgConnectOptions {
                     options = options.application_name(&*value);
                 }
 
+                "port" => {
+                    options = options.port(value.parse().map_err(Error::config)?);
+                }
+
+                "dbname" => options = options.database(&*value),
+
+                "user" => options = options.username(&*value),
+
+                "password" => options = options.password(&*value),
+
                 _ => {}
             }
         }


### PR DESCRIPTION
This adds the ability to parse additional parameters, mentioned in #501. It does not add the complete set of acceptable parameters from the Postgres spec, but it adds parsing capabilities for all the options sqlx supports today relating to postgres. Also adds documentation for the new parameters, as well as an example connection string that utilizes parameters as that was missing before.