### PR TITLE
fix: compilation error with sqlx-cli "D" to 'D'

### DIFF
--- a/sqlx-cli/src/opt.rs
+++ b/sqlx-cli/src/opt.rs
@@ -5,7 +5,7 @@ pub struct Opt {
     #[clap(subcommand)]
     pub command: Command,
 
-    #[clap(short = "D", long)]
+    #[clap(short = 'D', long)]
     pub database_url: Option<String>,
 }
 


### PR DESCRIPTION
This resolves the compilation error with the clap arg mentioned in #706 