### PR TITLE
Correct PgConnectOptions to MySql in mysql docs

### DIFF
--- a/sqlx-core/src/mysql/options/mod.rs
+++ b/sqlx-core/src/mysql/options/mod.rs
@@ -8,7 +8,7 @@ pub use ssl_mode::MySqlSslMode;
 
 /// Options and flags which can be used to configure a MySQL connection.
 ///
-/// A value of `PgConnectOptions` can be parsed from a connection URI,
+/// A value of `MySqlConnectOptions` can be parsed from a connection URI,
 /// as described by [MySQL](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-jdbc-url-format.html).
 ///
 /// The generic format of the connection URL:


### PR DESCRIPTION
I'm using this library for the first time, and I noticed this small oversight in the docs.