### PR TITLE
Remove hashbrown dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,9 +42,13 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.4.5"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0adac150c2dd5a9c864d054e07bda5e6bc010cd10036ea5f17e82a2f5867f735"
+checksum = "f166b31431056f04477a03e281aed5655a3fb751c67cd82f70761fe062896d37"
+dependencies = [
+ "getrandom 0.2.0",
+ "lazy_static",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -855,6 +859,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,9 +899,6 @@ name = "hashbrown"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "heck"
@@ -1561,7 +1573,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.14",
  "libc",
  "rand_chacha",
  "rand_core",
@@ -1584,7 +1596,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.14",
 ]
 
 [[package]]
@@ -2015,6 +2027,7 @@ dependencies = [
 name = "sqlx-core"
 version = "0.4.0-beta.1"
 dependencies = [
+ "ahash",
  "atoi",
  "base64 0.13.0",
  "bigdecimal",
@@ -2034,7 +2047,6 @@ dependencies = [
  "futures-core",
  "futures-util",
  "generic-array",
- "hashbrown",
  "hex",
  "hmac",
  "ipnetwork",

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -39,6 +39,7 @@ runtime-actix = [ "sqlx-rt/runtime-actix" ]
 offline = [ "serde", "either/serde" ]
 
 [dependencies]
+ahash = "0.5"
 atoi = "0.3.2"
 sqlx-rt = { path = "../sqlx-rt", version = "0.1.1" }
 base64 = { version = "0.13.0", default-features = false, optional = true, features = [ "std" ] }
@@ -60,7 +61,6 @@ futures-channel = { version = "0.3.5", default-features = false, features = [ "s
 futures-core = { version = "0.3.5", default-features = false }
 futures-util = { version = "0.3.5", features = [ "sink" ] }
 generic-array = { version = "0.14.2", default-features = false, optional = true }
-hashbrown = "0.9.0"
 hex = "0.4.2"
 hmac = { version = "0.9.0", default-features = false, optional = true }
 itoa = "0.4.5"

--- a/sqlx-core/src/any/statement.rs
+++ b/sqlx-core/src/any/statement.rs
@@ -3,8 +3,8 @@ use crate::column::ColumnIndex;
 use crate::error::Error;
 use crate::ext::ustr::UStr;
 use crate::statement::Statement;
+use crate::HashMap;
 use either::Either;
-use hashbrown::HashMap;
 use std::borrow::Cow;
 use std::sync::Arc;
 

--- a/sqlx-core/src/lib.rs
+++ b/sqlx-core/src/lib.rs
@@ -99,3 +99,7 @@ pub mod mysql;
 #[cfg(feature = "mssql")]
 #[cfg_attr(docsrs, doc(cfg(feature = "mssql")))]
 pub mod mssql;
+
+/// sqlx uses ahash for increased performance, at the cost of reduced DoS resistance.
+use ahash::AHashMap as HashMap;
+//type HashMap<K, V> = std::collections::HashMap<K, V, ahash::RandomState>;

--- a/sqlx-core/src/mssql/connection/stream.rs
+++ b/sqlx-core/src/mssql/connection/stream.rs
@@ -20,7 +20,7 @@ use crate::mssql::protocol::return_value::ReturnValue;
 use crate::mssql::protocol::row::Row;
 use crate::mssql::{MssqlColumn, MssqlConnectOptions, MssqlDatabaseError};
 use crate::net::MaybeTlsStream;
-use hashbrown::HashMap;
+use crate::HashMap;
 use std::sync::Arc;
 
 pub(crate) struct MssqlStream {

--- a/sqlx-core/src/mssql/protocol/col_meta_data.rs
+++ b/sqlx-core/src/mssql/protocol/col_meta_data.rs
@@ -6,7 +6,7 @@ use crate::ext::ustr::UStr;
 use crate::mssql::io::MssqlBufExt;
 use crate::mssql::protocol::type_info::TypeInfo;
 use crate::mssql::MssqlColumn;
-use hashbrown::HashMap;
+use crate::HashMap;
 
 #[derive(Debug)]
 pub(crate) struct ColMetaData;

--- a/sqlx-core/src/mssql/row.rs
+++ b/sqlx-core/src/mssql/row.rs
@@ -4,7 +4,7 @@ use crate::ext::ustr::UStr;
 use crate::mssql::protocol::row::Row as ProtocolRow;
 use crate::mssql::{Mssql, MssqlColumn, MssqlValueRef};
 use crate::row::Row;
-use hashbrown::HashMap;
+use crate::HashMap;
 use std::sync::Arc;
 
 pub struct MssqlRow {

--- a/sqlx-core/src/mssql/statement.rs
+++ b/sqlx-core/src/mssql/statement.rs
@@ -3,8 +3,8 @@ use crate::error::Error;
 use crate::ext::ustr::UStr;
 use crate::mssql::{Mssql, MssqlArguments, MssqlColumn, MssqlTypeInfo};
 use crate::statement::Statement;
+use crate::HashMap;
 use either::Either;
-use hashbrown::HashMap;
 use std::borrow::Cow;
 use std::sync::Arc;
 

--- a/sqlx-core/src/mysql/connection/executor.rs
+++ b/sqlx-core/src/mysql/connection/executor.rs
@@ -16,12 +16,12 @@ use crate::mysql::{
     MySql, MySqlArguments, MySqlColumn, MySqlConnection, MySqlDone, MySqlRow, MySqlTypeInfo,
     MySqlValueFormat,
 };
+use crate::HashMap;
 use either::Either;
 use futures_core::future::BoxFuture;
 use futures_core::stream::BoxStream;
 use futures_core::Stream;
 use futures_util::{pin_mut, TryStreamExt};
-use hashbrown::HashMap;
 use std::{borrow::Cow, sync::Arc};
 
 impl MySqlConnection {

--- a/sqlx-core/src/mysql/row.rs
+++ b/sqlx-core/src/mysql/row.rs
@@ -3,7 +3,7 @@ use crate::error::Error;
 use crate::ext::ustr::UStr;
 use crate::mysql::{protocol, MySql, MySqlColumn, MySqlValueFormat, MySqlValueRef};
 use crate::row::Row;
-use hashbrown::HashMap;
+use crate::HashMap;
 use std::sync::Arc;
 
 /// Implementation of [`Row`] for MySQL.

--- a/sqlx-core/src/mysql/statement.rs
+++ b/sqlx-core/src/mysql/statement.rs
@@ -4,8 +4,8 @@ use crate::error::Error;
 use crate::ext::ustr::UStr;
 use crate::mysql::{MySql, MySqlArguments, MySqlTypeInfo};
 use crate::statement::Statement;
+use crate::HashMap;
 use either::Either;
-use hashbrown::HashMap;
 use std::borrow::Cow;
 use std::sync::Arc;
 

--- a/sqlx-core/src/postgres/connection/describe.rs
+++ b/sqlx-core/src/postgres/connection/describe.rs
@@ -5,8 +5,8 @@ use crate::postgres::type_info::{PgCustomType, PgType, PgTypeKind};
 use crate::postgres::{PgArguments, PgColumn, PgConnection, PgTypeInfo};
 use crate::query_as::query_as;
 use crate::query_scalar::{query_scalar, query_scalar_with};
+use crate::HashMap;
 use futures_core::future::BoxFuture;
-use hashbrown::HashMap;
 use std::fmt::Write;
 use std::sync::Arc;
 

--- a/sqlx-core/src/postgres/connection/establish.rs
+++ b/sqlx-core/src/postgres/connection/establish.rs
@@ -1,4 +1,4 @@
-use hashbrown::HashMap;
+use crate::HashMap;
 
 use crate::common::StatementCache;
 use crate::error::Error;

--- a/sqlx-core/src/postgres/connection/mod.rs
+++ b/sqlx-core/src/postgres/connection/mod.rs
@@ -1,9 +1,9 @@
 use std::fmt::{self, Debug, Formatter};
 use std::sync::Arc;
 
+use crate::HashMap;
 use futures_core::future::BoxFuture;
 use futures_util::{FutureExt, TryFutureExt};
-use hashbrown::HashMap;
 
 use crate::common::StatementCache;
 use crate::connection::Connection;

--- a/sqlx-core/src/postgres/statement.rs
+++ b/sqlx-core/src/postgres/statement.rs
@@ -4,8 +4,8 @@ use crate::error::Error;
 use crate::ext::ustr::UStr;
 use crate::postgres::{PgArguments, Postgres};
 use crate::statement::Statement;
+use crate::HashMap;
 use either::Either;
-use hashbrown::HashMap;
 use std::borrow::Cow;
 use std::sync::Arc;
 

--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -2,7 +2,7 @@ use crate::error::Error;
 use crate::query_as::query_as;
 use crate::sqlite::type_info::DataType;
 use crate::sqlite::{SqliteConnection, SqliteTypeInfo};
-use hashbrown::HashMap;
+use crate::HashMap;
 use std::str::from_utf8;
 
 // affinity
@@ -136,7 +136,8 @@ pub(super) async fn explain(
                 } else if let Some(v) = r.get(&p2).copied() {
                     // r[p3] = AGG ( r[p2] )
                     r.insert(p3, v);
-                    n.insert(p3, n.get(&p2).copied().unwrap_or(true));
+                    let val = n.get(&p2).copied().unwrap_or(true);
+                    n.insert(p3, val);
                 }
             }
 
@@ -151,7 +152,8 @@ pub(super) async fn explain(
                 // r[p2] = r[p1]
                 if let Some(v) = r.get(&p1).copied() {
                     r.insert(p2, v);
-                    n.insert(p2, n.get(&p1).copied().unwrap_or(true));
+                    let val = n.get(&p1).copied().unwrap_or(true);
+                    n.insert(p2, val);
                 }
             }
 
@@ -165,7 +167,8 @@ pub(super) async fn explain(
                 // r[p2] = NOT r[p1]
                 if let Some(a) = r.get(&p1).copied() {
                     r.insert(p2, a);
-                    n.insert(p2, n.get(&p1).copied().unwrap_or(true));
+                    let val = n.get(&p1).copied().unwrap_or(true);
+                    n.insert(p2, val);
                 }
             }
 

--- a/sqlx-core/src/sqlite/row.rs
+++ b/sqlx-core/src/sqlite/row.rs
@@ -3,7 +3,7 @@ use std::slice;
 use std::sync::atomic::{AtomicPtr, Ordering};
 use std::sync::{Arc, Weak};
 
-use hashbrown::HashMap;
+use crate::HashMap;
 
 use crate::column::ColumnIndex;
 use crate::error::Error;

--- a/sqlx-core/src/sqlite/statement/mod.rs
+++ b/sqlx-core/src/sqlite/statement/mod.rs
@@ -3,8 +3,8 @@ use crate::error::Error;
 use crate::ext::ustr::UStr;
 use crate::sqlite::{Sqlite, SqliteArguments, SqliteColumn, SqliteTypeInfo};
 use crate::statement::Statement;
+use crate::HashMap;
 use either::Either;
-use hashbrown::HashMap;
 use std::borrow::Cow;
 use std::sync::Arc;
 

--- a/sqlx-core/src/sqlite/statement/virtual.rs
+++ b/sqlx-core/src/sqlite/statement/virtual.rs
@@ -3,8 +3,8 @@ use crate::ext::ustr::UStr;
 use crate::sqlite::connection::ConnectionHandle;
 use crate::sqlite::statement::StatementHandle;
 use crate::sqlite::{SqliteColumn, SqliteError, SqliteRow, SqliteValue};
+use crate::HashMap;
 use bytes::{Buf, Bytes};
-use hashbrown::HashMap;
 use libsqlite3_sys::{
     sqlite3, sqlite3_clear_bindings, sqlite3_finalize, sqlite3_prepare_v3, sqlite3_reset,
     sqlite3_stmt, SQLITE_OK, SQLITE_PREPARE_PERSISTENT,


### PR DESCRIPTION
Hashbrown is now the hashmap used in the standard library, so no need to
pull in an external dependency.

Closes https://github.com/launchbadge/sqlx/issues/731