### PR TITLE
[MySQL] Fix minor issue in execute statement packet

### DIFF
--- a/sqlx-core/src/mysql/protocol/statement/execute.rs
+++ b/sqlx-core/src/mysql/protocol/statement/execute.rs
@@ -16,7 +16,7 @@ impl<'q> Encode<'_, Capabilities> for Execute<'q> {
         buf.push(0x17); // COM_STMT_EXECUTE
         buf.extend(&self.statement.to_le_bytes());
         buf.push(0); // NO_CURSOR
-        buf.extend(&0_u32.to_le_bytes()); // iterations (always 1): int<4>
+        buf.extend(&1_u32.to_le_bytes()); // iterations (always 1): int<4>
 
         if !self.arguments.types.is_empty() {
             buf.extend(&*self.arguments.null_bitmap);


### PR DESCRIPTION
The MySQL protocol [specifies that the `iteration-count` field should always be set to 1](https://dev.mysql.com/doc/internals/en/com-stmt-execute.html), but MySQL itself [ignores the field entirely](https://github.com/mysql/mysql-server/blob/f8cdce86448a211511e8a039c62580ae16cb96f5/sql/protocol_classic.cc#L2628,L2640).  Vitess is more strict and will reject execute packets with `iteration-count` set to anything other than 1.

It sounds like they may change to mimic actual MySQL behavior, but I figured you would like to also have the protocol correction on your end, even if it is borderline pedantic :)