### PR TITLE
Add support of kebab-case enum with Postgres

### DIFF
--- a/sqlx-macros/src/derives/attributes.rs
+++ b/sqlx-macros/src/derives/attributes.rs
@@ -32,6 +32,7 @@ pub enum RenameAll {
     SnakeCase,
     UpperCase,
     ScreamingSnakeCase,
+    KebabCase,
 }
 
 pub struct SqlxContainerAttributes {
@@ -75,6 +76,7 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
                                     "snake_case" => RenameAll::SnakeCase,
                                     "UPPERCASE" => RenameAll::UpperCase,
                                     "SCREAMING_SNAKE_CASE" => RenameAll::ScreamingSnakeCase,
+                                    "kebab-case" => RenameAll::KebabCase,
 
                                     _ => fail!(meta, "unexpected value for rename_all"),
                                 };

--- a/sqlx-macros/src/derives/mod.rs
+++ b/sqlx-macros/src/derives/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use r#type::expand_derive_type;
 pub(crate) use row::expand_derive_from_row;
 
 use self::attributes::RenameAll;
-use heck::{ShoutySnakeCase, SnakeCase, KebabCase};
+use heck::{KebabCase, ShoutySnakeCase, SnakeCase};
 use std::iter::FromIterator;
 use syn::DeriveInput;
 

--- a/sqlx-macros/src/derives/mod.rs
+++ b/sqlx-macros/src/derives/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use r#type::expand_derive_type;
 pub(crate) use row::expand_derive_from_row;
 
 use self::attributes::RenameAll;
-use heck::{ShoutySnakeCase, SnakeCase};
+use heck::{ShoutySnakeCase, SnakeCase, KebabCase};
 use std::iter::FromIterator;
 use syn::DeriveInput;
 
@@ -34,5 +34,6 @@ pub(crate) fn rename_all(s: &str, pattern: RenameAll) -> String {
         RenameAll::SnakeCase => s.to_snake_case(),
         RenameAll::UpperCase => s.to_uppercase(),
         RenameAll::ScreamingSnakeCase => s.to_shouty_snake_case(),
+        RenameAll::KebabCase => s.to_kebab_case(),
     }
 }

--- a/tests/postgres/derives.rs
+++ b/tests/postgres/derives.rs
@@ -141,13 +141,13 @@ DROP TYPE IF EXISTS color_lower CASCADE;
 DROP TYPE IF EXISTS color_snake CASCADE;
 DROP TYPE IF EXISTS color_upper CASCADE;
 DROP TYPE IF EXISTS color_screaming_snake CASCADE;
-DROP TYPE IF EXISTS color-kebab-case CASCADE;
+DROP TYPE IF EXISTS "color-kebab-case" CASCADE;
 
 CREATE TYPE color_lower AS ENUM ( 'red', 'green', 'blue' );
 CREATE TYPE color_snake AS ENUM ( 'red_green', 'blue_black' );
 CREATE TYPE color_upper AS ENUM ( 'RED', 'GREEN', 'BLUE' );
 CREATE TYPE color_screaming_snake AS ENUM ( 'RED_GREEN', 'BLUE_BLACK' );
-CREATE TYPE color-kebab-case AS ENUM ( 'red-green', 'blue-black' );
+CREATE TYPE "color-kebab-case" AS ENUM ( 'red-green', 'blue-black' );
 
 CREATE TABLE people (
     id      serial PRIMARY KEY,

--- a/tests/postgres/derives.rs
+++ b/tests/postgres/derives.rs
@@ -276,7 +276,7 @@ SELECT id, mood FROM people WHERE id = $1
 
     let rec: (bool, ColorKebabCase) = sqlx::query_as(
         "
-    SELECT $1 = 'red-green'::color-kebab-case, $1
+    SELECT $1 = 'red-green'::\"color-kebab-case\", $1
             ",
     )
     .bind(&ColorKebabCase::RedGreen)

--- a/tests/postgres/derives.rs
+++ b/tests/postgres/derives.rs
@@ -66,6 +66,14 @@ enum ColorScreamingSnake {
     BlueBlack,
 }
 
+#[derive(PartialEq, Debug, sqlx::Type)]
+#[sqlx(rename = "color-kebab-case")]
+#[sqlx(rename_all = "kebab-case")]
+enum ColorKebabCase {
+    RedGreen,
+    BlueBlack,
+}
+
 // "Strong" enum can map to a custom type
 #[derive(PartialEq, Debug, sqlx::Type)]
 #[sqlx(rename = "mood")]
@@ -133,11 +141,13 @@ DROP TYPE IF EXISTS color_lower CASCADE;
 DROP TYPE IF EXISTS color_snake CASCADE;
 DROP TYPE IF EXISTS color_upper CASCADE;
 DROP TYPE IF EXISTS color_screaming_snake CASCADE;
+DROP TYPE IF EXISTS color-kebab-case CASCADE;
 
 CREATE TYPE color_lower AS ENUM ( 'red', 'green', 'blue' );
 CREATE TYPE color_snake AS ENUM ( 'red_green', 'blue_black' );
 CREATE TYPE color_upper AS ENUM ( 'RED', 'GREEN', 'BLUE' );
 CREATE TYPE color_screaming_snake AS ENUM ( 'RED_GREEN', 'BLUE_BLACK' );
+CREATE TYPE color-kebab-case AS ENUM ( 'red-green', 'blue-black' );
 
 CREATE TABLE people (
     id      serial PRIMARY KEY,
@@ -263,6 +273,18 @@ SELECT id, mood FROM people WHERE id = $1
 
     assert!(rec.0);
     assert_eq!(rec.1, ColorScreamingSnake::RedGreen);
+
+    let rec: (bool, ColorKebabCase) = sqlx::query_as(
+        "
+    SELECT $1 = 'red-green'::color-kebab-case, $1
+            ",
+    )
+    .bind(&ColorKebabCase::RedGreen)
+    .fetch_one(&mut conn)
+    .await?;
+
+    assert!(rec.0);
+    assert_eq!(rec.1, ColorKebabCase::RedGreen);
 
     Ok(())
 }


### PR DESCRIPTION
Here, adding an option to have `kebab-case` as enum in postgres `TYPE`.

Linking to issue [#752](https://github.com/launchbadge/sqlx/issues/752).

Let me know if anything else is required.