### PR TITLE
Fix migrate! macro with no params

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -604,7 +604,7 @@ macro_rules! query_file_as_unchecked (
 /// ```rust,ignore
 /// use sqlx::migrate::Migrator;
 ///
-/// static MIGRATOR: Migrator = sqlx::migrate!(); // defaults to "migrations"
+/// static MIGRATOR: Migrator = sqlx::migrate!(); // defaults to "./migrations"
 /// ```
 ///
 /// The directory must be relative to the project root (the directory containing `Cargo.toml`),
@@ -618,6 +618,6 @@ macro_rules! migrate {
     }};
 
     () => {{
-        $crate::sqlx_macros::migrate!("migrations")
+        $crate::sqlx_macros::migrate!("./migrations")
     }};
 }


### PR DESCRIPTION
Fixes issue experienced in https://github.com/launchbadge/sqlx/issues/746 when using no parameter:

```
error: paths relative to the current file's directory are not currently supported
 --> src/db.rs:7:5
  |
7 |     sqlx::migrate!().run(&conn).await?;
  |     ^^^^^^^^^^^^^^^^
  |
  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```