### PR TITLE
Improve SQLX_OFFLINE / cargo sqlx prepare workflow

### DIFF
--- a/sqlx-cli/src/prepare.rs
+++ b/sqlx-cli/src/prepare.rs
@@ -104,6 +104,7 @@ fn run_prepare_step(cargo_args: Vec<String>) -> anyhow::Result<QueryData> {
             "__sqlx_recompile_trigger=\"{}\"",
             SystemTime::UNIX_EPOCH.elapsed()?.as_millis()
         ))
+        .env("SQLX_OFFLINE", "false")
         .status()?;
 
     if !check_status.success() {

--- a/sqlx-cli/src/prepare.rs
+++ b/sqlx-cli/src/prepare.rs
@@ -81,7 +81,7 @@ pub fn check(url: &str, cargo_args: Vec<String>) -> anyhow::Result<()> {
 fn run_prepare_step(cargo_args: Vec<String>) -> anyhow::Result<QueryData> {
     // path to the Cargo executable
     let cargo = env::var("CARGO")
-        .context("`prepare` subcommand may only be invoked as `cargo sqlx prepare``")?;
+        .context("`prepare` subcommand may only be invoked as `cargo sqlx prepare`")?;
 
     let metadata = MetadataCommand::new()
         .cargo_path(&cargo)

--- a/sqlx-core/src/common/statement_cache.rs
+++ b/sqlx-core/src/common/statement_cache.rs
@@ -65,6 +65,7 @@ impl<T> StatementCache<T> {
     }
 
     /// Returns true if the cache capacity is more than 0.
+    #[allow(dead_code)] // Only used for some `cfg`s
     pub fn is_enabled(&self) -> bool {
         self.capacity() > 0
     }

--- a/sqlx-macros/src/query/mod.rs
+++ b/sqlx-macros/src/query/mod.rs
@@ -187,7 +187,7 @@ impl<DB: Database> DescribeExt for Describe<DB> {}
 fn expand_with_data<DB: DatabaseExt>(
     input: QueryMacroInput,
     data: QueryData<DB>,
-    offline: bool,
+    #[allow(unused_variables)] offline: bool,
 ) -> crate::Result<TokenStream>
 where
     Describe<DB>: DescribeExt,


### PR DESCRIPTION
I've transitioned to a workflow where `SQLX_OFFLINE` is the default because it improves compile times substantially. However, it feels like this workflow is not well supported with `cargo sqlx prepare` writing the cache from cache data if `SQLX_OFFLINE` is `true`. Luckily, after #732, there's an easy way to overwrite `SQLX_OFFLINE` (before, you could only unset the env variable but that wouldn't help when it was set in `.env`).

The last commit should allow running multiple cargo commands (e.g. IDE-spawned `cargo check` + `cargo sqlx prepare`) without the risk for broken query metadata files, as long as only one of them is running in online mode.