### PR TITLE
Fix typo: add missing &pool parameter in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ WHERE organization = ?
         ",
         organization
     )
-    .fetch_all() // -> Vec<Country>
+    .fetch_all(&pool) // -> Vec<Country>
     .await?;
 
 // countries[0].country


### PR DESCRIPTION
Hi, I think I found a typo in a code example of the readme while getting started with SQLx.