### PR TITLE
Support $NNN bind parameters for sqlite

### DIFF
--- a/sqlx-core/src/sqlite/arguments.rs
+++ b/sqlx-core/src/sqlite/arguments.rs
@@ -61,6 +61,14 @@ impl SqliteArguments<'_> {
                 if name.starts_with('?') {
                     // parameter should have the form ?NNN
                     atoi(name[1..].as_bytes()).expect("parameter of the form ?NNN")
+                } else if name.starts_with('$') {
+                    // parameter should have the form $NNN
+                    atoi(name[1..].as_bytes()).ok_or_else(|| {
+                        err_protocol!(
+                            "parameters with non-integer names are not currently supported: {}",
+                            name
+                        )
+                    })?
                 } else {
                     return Err(err_protocol!("unsupported SQL parameter format: {}", name));
                 }

--- a/tests/sqlite/sqlite.rs
+++ b/tests/sqlite/sqlite.rs
@@ -270,6 +270,22 @@ fn it_binds_parameters() -> anyhow::Result<()> {
 }
 
 #[sqlx_macros::test]
+fn it_binds_dollar_parameters() -> anyhow::Result<()> {
+    let mut conn = new::<Sqlite>().await?;
+
+    let v: (i32, i32) = sqlx::query_as("SELECT $1, $2")
+        .bind(10_i32)
+        .bind(11_i32)
+        .fetch_one(&mut conn)
+        .await?;
+
+    assert_eq!(v.0, 10);
+    assert_eq!(v.1, 11);
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
 async fn it_executes_queries() -> anyhow::Result<()> {
     let mut conn = new::<Sqlite>().await?;
 


### PR DESCRIPTION
The sqlite driver for sqlx currently supports only the `?` and `?NNN` bind parameter formats. However, sqlite supports additional formats as specified here: https://sqlite.org/c3ref/bind_blob.html. With this change, I propose adding support for `$NNN`, which is a subset of `$VVV`. This will make it easier for sqlx users to write queries that are supported by both sqlite and postgres.