### PR TITLE
Add DateTime support for Mssql

### DIFF
--- a/sqlx-core/src/mssql/protocol/type_info.rs
+++ b/sqlx-core/src/mssql/protocol/type_info.rs
@@ -521,6 +521,7 @@ impl TypeInfo {
 
     pub(crate) fn fmt(&self, s: &mut String) {
         match self.ty {
+            DataType::DateTime => s.push_str("datetime"),
             DataType::Null => s.push_str("nvarchar(1)"),
             DataType::TinyInt => s.push_str("tinyint"),
             DataType::SmallInt => s.push_str("smallint"),

--- a/sqlx-core/src/mssql/types/chrono.rs
+++ b/sqlx-core/src/mssql/types/chrono.rs
@@ -1,0 +1,75 @@
+use crate::{
+    decode::Decode,
+    encode::{Encode, IsNull},
+    error::BoxDynError,
+    mssql::{
+        protocol::type_info::{DataType, TypeInfo},
+        Mssql, MssqlTypeInfo, MssqlValueRef,
+    },
+    types::Type,
+};
+use bytes::Buf;
+use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+
+impl Type<Mssql> for NaiveDateTime {
+    fn type_info() -> MssqlTypeInfo {
+        MssqlTypeInfo(TypeInfo::new(DataType::DateTime, 8))
+    }
+
+    fn compatible(ty: &MssqlTypeInfo) -> bool {
+        matches!(ty.0.ty, DataType::DateTime | DataType::DateTimeN) && ty.0.size == 8
+    }
+}
+
+impl<'r> Decode<'r, Mssql> for NaiveDateTime {
+    fn decode(value: MssqlValueRef<'r>) -> Result<Self, BoxDynError> {
+        let mut buf = value.as_bytes()?;
+        let days = buf.get_i32_le();
+        let ticks = buf.get_u32_le();
+        Ok(NaiveDateTime::new(
+            from_days(days.into(), 1900),
+            from_sec_fragments(ticks.into()),
+        ))
+    }
+}
+
+impl Encode<'_, Mssql> for NaiveDateTime {
+    fn encode_by_ref(&self, buf: &mut Vec<u8>) -> IsNull {
+        let date = self.date();
+        let time = self.time();
+        let days = to_days(date, 1900) as i32;
+        let seconds_fragments = to_sec_fragments(time);
+        buf.extend_from_slice(&days.to_le_bytes());
+        buf.extend_from_slice(&seconds_fragments.to_le_bytes());
+        IsNull::No
+    }
+
+    fn size_hint(&self) -> usize {
+        8
+    }
+}
+
+#[inline]
+fn from_days(days: i64, start_year: i32) -> NaiveDate {
+    NaiveDate::from_ymd(start_year, 1, 1) + chrono::Duration::days(days as i64)
+}
+
+#[inline]
+fn from_sec_fragments(sec_fragments: i64) -> NaiveTime {
+    NaiveTime::from_hms(0, 0, 0) + chrono::Duration::nanoseconds(sec_fragments * (1e9 as i64) / 300)
+}
+
+#[inline]
+fn to_days(date: NaiveDate, start_year: i32) -> i64 {
+    date.signed_duration_since(NaiveDate::from_ymd(start_year, 1, 1))
+        .num_days()
+}
+
+#[inline]
+fn to_sec_fragments(time: NaiveTime) -> i64 {
+    time.signed_duration_since(NaiveTime::from_hms(0, 0, 0))
+        .num_nanoseconds()
+        .unwrap()
+        * 300
+        / (1e9 as i64)
+}

--- a/sqlx-core/src/mssql/types/mod.rs
+++ b/sqlx-core/src/mssql/types/mod.rs
@@ -3,6 +3,8 @@ use crate::mssql::protocol::type_info::{DataType, TypeInfo};
 use crate::mssql::{Mssql, MssqlTypeInfo};
 
 mod bool;
+#[cfg(feature = "chrono")]
+mod chrono;
 mod float;
 mod int;
 mod str;

--- a/tests/mssql/types.rs
+++ b/tests/mssql/types.rs
@@ -41,3 +41,13 @@ test_type!(bool(
     "CAST(1 as BIT)" == true,
     "CAST(0 as BIT)" == false
 ));
+
+#[cfg(feature = "chrono")]
+mod chrono {
+    use super::*;
+    use sqlx::types::chrono::{NaiveDate, NaiveDateTime};
+
+    test_type!(chrono_date_time<NaiveDateTime>(Mssql,
+        "CAST('2019-01-02 05:10:20' as DATETIME)" == NaiveDate::from_ymd(2019, 1, 2).and_hms(5, 10, 20)
+    ));
+}


### PR DESCRIPTION
Just a basic infrastructure to accommodate more types in the future.

Initially, the implementation itself was challenging because of the lack of documentation but luckily the `tiberius` project already did the heavy lifting.

#### Sources

- https://docs.microsoft.com/en-us/sql/t-sql/functions/date-and-time-data-types-and-functions-transact-sql?view=sql-server-ver15
- https://github.com/prisma/tiberius/blob/849be4d619014e7f7083b17a416c39c301b07884/src/tds/time/chrono.rs