### PR TITLE
doc: README.md: minor cleanup of section "Cargo Feature Flags"

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,6 @@ sqlx = { version = "0.4.0", features = [ "runtime-async-std-native-tls" ] }
 
 -   `runtime-async-std-rustls`: Use the `async-std` runtime and `rustls` TLS backend.
 
--   `runtime-tokio-native-tls`: Use the `tokio` runtime and `native-tls` TLS backend.
-
 -   `runtime-tokio-rustls`: Use the `tokio` runtime and `rustls` TLS backend.
 
 -   `runtime-actix-native-tls`: Use the `actix` runtime and `native-tls` TLS backend.

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ sqlx = { version = "0.4.0", features = [ "runtime-async-std-native-tls" ] }
 
 -   `runtime-async-std-native-tls` (on by default): Use the `async-std` runtime and `native-tls` TLS backend.
 
--   `runtime-tokio-native-tls`: Use the `tokio` runtime and `native-tls` TLS backend.
-
 -   `runtime-async-std-rustls`: Use the `async-std` runtime and `rustls` TLS backend.
+
+-   `runtime-tokio-native-tls`: Use the `tokio` runtime and `native-tls` TLS backend.
 
 -   `runtime-tokio-rustls`: Use the `tokio` runtime and `rustls` TLS backend.
 


### PR DESCRIPTION
Nothing too crazy: Just removal of a duplicate entry, and then move one item so that the `runtime-foo-*` entries entries for a given runtime are grouped together.