### PR TITLE
gh actions: sprinkle use of runtime feature name matrix to allow successful run of all jobs

### DIFF
--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -346,7 +346,7 @@ jobs:
         with:
           command: build
           args: >
-            --features mssql,all-types
+            --features mssql,all-types,runtime-${{ matrix.runtime }}
 
       - run: docker-compose -f tests/docker-compose.yml run -d -p 1433:1433 mssql_${{ matrix.mssql }}
       - run: sleep 80 # MSSQL takes a "bit" to startup

--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -207,7 +207,7 @@ jobs:
         with:
           command: build
           args: >
-            --features postgres,all-types
+            --features postgres,all-types,runtime-${{ matrix.runtime }}
 
       - run: docker-compose -f tests/docker-compose.yml run -d -p 5432:5432 postgres_${{ matrix.postgres }}
       - run: sleep 10

--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -259,7 +259,7 @@ jobs:
         with:
           command: build
           args: >
-            --features mysql,all-types
+            --features mysql,all-types,runtime-${{ matrix.runtime }}
 
       - run: docker-compose -f tests/docker-compose.yml run -d -p 3306:3306 mysql_${{ matrix.mysql }}
       - run: sleep 60

--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -303,7 +303,7 @@ jobs:
         with:
           command: build
           args: >
-            --features mysql,all-types
+            --features mysql,all-types,runtime-${{ matrix.runtime }}
 
       - run: docker-compose -f tests/docker-compose.yml run -d -p 3306:3306 mariadb_${{ matrix.mariadb }}
       - run: sleep 30

--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -68,6 +68,9 @@ jobs:
   test:
     name: Unit Test
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        runtime: [async-std-native-tls, tokio-native-tls, actix-native-tls, async-std-rustls, tokio-rustls, actix-rustls]
     steps:
       - uses: actions/checkout@v2
 
@@ -90,7 +93,7 @@ jobs:
           command: test
           args: >
             --manifest-path sqlx-core/Cargo.toml
-            --features offline,all-databases,all-types
+            --features offline,all-databases,all-types,runtime-${{ matrix.runtime }}
 
   cli:
     name: CLI Binaries


### PR DESCRIPTION
In the wake of submitting PR #808 I saw that the GitHub Actions workflow was failing. Though it was unrelated to the changes in that specific PR, the failure messages were similar to what I was seeing building locally, so I decided to take a look:
```
 Error:   --> sqlx-rt/src/lib.rs:9:1
   |
9  | / compile_error!(
10 | |     "one of the features ['runtime-actix-native-tls', 'runtime-async-std-native-tls', \
11 | |      'runtime-tokio-native-tls', 'runtime-actix-rustls', 'runtime-async-std-rustls', \
12 | |      'runtime-tokio-rustls'] must be enabled"
13 | | );
   | |__^

```

The current PR sprinkles-in the use of the feature name matrix in the handful of obvious places needed to allow `cargo build` invocation to succeed (by explicitly naming 'runtime${foo}').

I tested these changes one at at time (one change for each of the jobs 'test', 'postgres', 'mysql', 'mariadb', and 'mssql') in my feature branch, and confirmed that each was working before moving on to the next. In the end, the full workflow was working for all jobs.

Note that the 'mysql' test failed once (due to being a deadlock victim) during testing of of the downstream tests, but since I saw successful runs of the 'mysql' jobs both before and after that failure, I'm chalking that problem up to something unrelated. Sorry that I cannot provide additional details on it, but I didn't realize that the GitHub Actions log for that run would be deleted out from underneath me (at least not so quickly...).
