### PR TITLE
Bump version in sqlx-cli README to 0.2.0

### DIFF
--- a/sqlx-cli/README.md
+++ b/sqlx-cli/README.md
@@ -9,10 +9,10 @@ mode with `sqlx::query!()` and friends.
 
 ```bash
 # supports all databases supported by SQLx
-$ cargo install --version=0.1.0-beta.1 sqlx-cli
+$ cargo install --version=0.2.0 sqlx-cli
 
 # only for postgres
-$ cargo install --version=0.1.0-beta.1 sqlx-cli --no-default-features --features postgres
+$ cargo install --version=0.2.0 sqlx-cli --no-default-features --features postgres
 ```
 
 ### Usage


### PR DESCRIPTION
I was getting an error while running `cargo sqlx prepare` while on `sqlx` version 0.4.1:

```
error: EOF while parsing an object at line 34 column 6
```

Then I realized that I had version 0.1.0-beta.1 of sqlx-cli but 0.2.0 was released on cargo.

I upgraded to 0.2.0 and the command succeeded.

I figured that the README was mistakenly not updated with the release.