### PR TITLE
SqliteConnection::as_raw_handle should be unsafe as it returns a raw pointer

### DIFF
--- a/sqlx-core/src/sqlite/connection/mod.rs
+++ b/sqlx-core/src/sqlite/connection/mod.rs
@@ -38,7 +38,7 @@ pub struct SqliteConnection {
 
 impl SqliteConnection {
     /// Returns the underlying sqlite3* connection handle
-    pub fn as_raw_handle(&mut self) -> *mut sqlite3 {
+    pub unsafe fn as_raw_handle(&mut self) -> *mut sqlite3 {
         self.handle.as_ptr()
     }
 


### PR DESCRIPTION
noticed when replying to #814 