### PR TITLE
Allow clippy::suspicious_else_formatting when expanding query arguments.

### DIFF
--- a/sqlx-macros/src/query/args.rs
+++ b/sqlx-macros/src/query/args.rs
@@ -74,26 +74,23 @@ pub fn quote_args<DB: DatabaseExt>(
                     };
 
                     Ok(quote_spanned!(expr.span() =>
-                        #[allow(clippy::suspicious_else_formatting)]
-                        {
-                            // this shouldn't actually run
-                            if false {
-                                use sqlx::ty_match::{WrapSameExt as _, MatchBorrowExt as _};
+                        // this shouldn't actually run
+                        if false {
+                            use sqlx::ty_match::{WrapSameExt as _, MatchBorrowExt as _};
 
-                                // evaluate the expression only once in case it contains moves
-                                let _expr = sqlx::ty_match::dupe_value(#name);
+                            // evaluate the expression only once in case it contains moves
+                            let _expr = sqlx::ty_match::dupe_value(#name);
 
-                                // if `_expr` is `Option<T>`, get `Option<$ty>`, otherwise `$ty`
-                                let ty_check = sqlx::ty_match::WrapSame::<#param_ty, _>::new(&_expr).wrap_same();
+                            // if `_expr` is `Option<T>`, get `Option<$ty>`, otherwise `$ty`
+                            let ty_check = sqlx::ty_match::WrapSame::<#param_ty, _>::new(&_expr).wrap_same();
 
-                                // if `_expr` is `&str`, convert `String` to `&str`
-                                let (mut _ty_check, match_borrow) = sqlx::ty_match::MatchBorrow::new(ty_check, &_expr);
+                            // if `_expr` is `&str`, convert `String` to `&str`
+                            let (mut _ty_check, match_borrow) = sqlx::ty_match::MatchBorrow::new(ty_check, &_expr);
 
-                                _ty_check = match_borrow.match_borrow();
+                            _ty_check = match_borrow.match_borrow();
 
-                                // this causes move-analysis to effectively ignore this block
-                                panic!();
-                            }
+                            // this causes move-analysis to effectively ignore this block
+                            panic!();
                         }
                     ))
                 })

--- a/sqlx-macros/src/query/args.rs
+++ b/sqlx-macros/src/query/args.rs
@@ -74,23 +74,26 @@ pub fn quote_args<DB: DatabaseExt>(
                     };
 
                     Ok(quote_spanned!(expr.span() =>
-                        // this shouldn't actually run
-                        if false {
-                            use sqlx::ty_match::{WrapSameExt as _, MatchBorrowExt as _};
+                        #[allow(clippy::suspicious_else_formatting)]
+                        {
+                            // this shouldn't actually run
+                            if false {
+                                use sqlx::ty_match::{WrapSameExt as _, MatchBorrowExt as _};
 
-                            // evaluate the expression only once in case it contains moves
-                            let _expr = sqlx::ty_match::dupe_value(#name);
+                                // evaluate the expression only once in case it contains moves
+                                let _expr = sqlx::ty_match::dupe_value(#name);
 
-                            // if `_expr` is `Option<T>`, get `Option<$ty>`, otherwise `$ty`
-                            let ty_check = sqlx::ty_match::WrapSame::<#param_ty, _>::new(&_expr).wrap_same();
+                                // if `_expr` is `Option<T>`, get `Option<$ty>`, otherwise `$ty`
+                                let ty_check = sqlx::ty_match::WrapSame::<#param_ty, _>::new(&_expr).wrap_same();
 
-                            // if `_expr` is `&str`, convert `String` to `&str`
-                            let (mut _ty_check, match_borrow) = sqlx::ty_match::MatchBorrow::new(ty_check, &_expr);
+                                // if `_expr` is `&str`, convert `String` to `&str`
+                                let (mut _ty_check, match_borrow) = sqlx::ty_match::MatchBorrow::new(ty_check, &_expr);
 
-                            _ty_check = match_borrow.match_borrow();
+                                _ty_check = match_borrow.match_borrow();
 
-                            // this causes move-analysis to effectively ignore this block
-                            panic!();
+                                // this causes move-analysis to effectively ignore this block
+                                panic!();
+                            }
                         }
                     ))
                 })

--- a/sqlx-macros/src/query/mod.rs
+++ b/sqlx-macros/src/query/mod.rs
@@ -271,13 +271,16 @@ where
         record_tokens
     };
 
-    let ret_tokens = quote! {{
-        use sqlx::Arguments as _;
+    let ret_tokens = quote! {
+        #[allow(clippy::all)]
+        {
+            use sqlx::Arguments as _;
 
-        #args_tokens
+            #args_tokens
 
-        #output
-    }};
+            #output
+        }
+    };
 
     // Store query metadata only if offline support is enabled but the current build is online.
     // If the build is offline, the cache is our input so it's pointless to also write data for it.

--- a/sqlx-macros/src/query/mod.rs
+++ b/sqlx-macros/src/query/mod.rs
@@ -272,7 +272,6 @@ where
     };
 
     let ret_tokens = quote! {
-        #[allow(clippy::all)]
         {
             #[allow(clippy::all)]
             {

--- a/sqlx-macros/src/query/mod.rs
+++ b/sqlx-macros/src/query/mod.rs
@@ -273,13 +273,13 @@ where
 
     let ret_tokens = quote! {
         #[allow(clippy::all)]
-        {
+        {{
             use sqlx::Arguments as _;
 
             #args_tokens
 
             #output
-        }
+        }}
     };
 
     // Store query metadata only if offline support is enabled but the current build is online.

--- a/sqlx-macros/src/query/mod.rs
+++ b/sqlx-macros/src/query/mod.rs
@@ -273,13 +273,16 @@ where
 
     let ret_tokens = quote! {
         #[allow(clippy::all)]
-        {{
-            use sqlx::Arguments as _;
+        {
+            #[allow(clippy::all)]
+            {
+                use sqlx::Arguments as _;
 
-            #args_tokens
+                #args_tokens
 
-            #output
-        }}
+                #output
+            }
+        }
     };
 
     // Store query metadata only if offline support is enabled but the current build is online.


### PR DESCRIPTION
Expanding several query arguments in the query! macro creates several `if false { ... }` statements, which in turn trigger clippy's [suspicious_else_formatting](https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_else_formatting).

![image](https://user-images.githubusercontent.com/9465678/99183747-6623a600-273e-11eb-84af-fb3a6258f100.png)


This commit allows the clippy lint so users won't be disturbed by it anymore.

