### PR TITLE
Allow chaining map / try_map

### DIFF
--- a/sqlx-cli/src/migration.rs
+++ b/sqlx-cli/src/migration.rs
@@ -3,7 +3,7 @@ use console::style;
 use std::fs::{self, File};
 use std::io::{Read, Write};
 
-const MIGRATION_FOLDER: &'static str = "migrations";
+const MIGRATION_FOLDER: &str = "migrations";
 
 pub struct Migration {
     pub name: String,

--- a/sqlx-core/src/any/mod.rs
+++ b/sqlx-core/src/any/mod.rs
@@ -54,7 +54,6 @@ impl_acquire!(Any, AnyConnection);
 impl_column_index_for_row!(AnyRow);
 impl_column_index_for_statement!(AnyStatement);
 impl_into_maybe_pool!(Any, AnyConnection);
-impl_map_row!(Any, AnyRow);
 
 // required because some databases have a different handling of NULL
 impl_encode_for_option!(Any);

--- a/sqlx-core/src/ext/async_stream.rs
+++ b/sqlx-core/src/ext/async_stream.rs
@@ -54,7 +54,7 @@ impl<'a, T> Stream for TryAsyncStream<'a, T> {
         pin_mut!(receiver);
 
         // then we check to see if we have anything to return
-        return receiver.poll_next(cx);
+        receiver.poll_next(cx)
     }
 }
 

--- a/sqlx-core/src/mssql/mod.rs
+++ b/sqlx-core/src/mssql/mod.rs
@@ -36,7 +36,6 @@ pub type MssqlPool = crate::pool::Pool<Mssql>;
 impl_into_arguments_for_arguments!(MssqlArguments);
 impl_executor_for_pool_connection!(Mssql, MssqlConnection, MssqlRow);
 impl_executor_for_transaction!(Mssql, MssqlRow);
-impl_map_row!(Mssql, MssqlRow);
 impl_acquire!(Mssql, MssqlConnection);
 impl_column_index_for_row!(MssqlRow);
 impl_column_index_for_statement!(MssqlStatement);

--- a/sqlx-core/src/mysql/mod.rs
+++ b/sqlx-core/src/mysql/mod.rs
@@ -43,7 +43,6 @@ pub type MySqlPoolOptions = crate::pool::PoolOptions<MySql>;
 impl_into_arguments_for_arguments!(MySqlArguments);
 impl_executor_for_pool_connection!(MySql, MySqlConnection, MySqlRow);
 impl_executor_for_transaction!(MySql, MySqlRow);
-impl_map_row!(MySql, MySqlRow);
 impl_acquire!(MySql, MySqlConnection);
 impl_column_index_for_row!(MySqlRow);
 impl_column_index_for_statement!(MySqlStatement);

--- a/sqlx-core/src/mysql/types/int.rs
+++ b/sqlx-core/src/mysql/types/int.rs
@@ -122,6 +122,6 @@ impl Decode<'_, MySql> for i32 {
 
 impl Decode<'_, MySql> for i64 {
     fn decode(value: MySqlValueRef<'_>) -> Result<Self, BoxDynError> {
-        int_decode(value)?.try_into().map_err(Into::into)
+        int_decode(value)
     }
 }

--- a/sqlx-core/src/mysql/types/uint.rs
+++ b/sqlx-core/src/mysql/types/uint.rs
@@ -145,6 +145,6 @@ impl Decode<'_, MySql> for u32 {
 
 impl Decode<'_, MySql> for u64 {
     fn decode(value: MySqlValueRef<'_>) -> Result<Self, BoxDynError> {
-        uint_decode(value)?.try_into().map_err(Into::into)
+        uint_decode(value)
     }
 }

--- a/sqlx-core/src/postgres/arguments.rs
+++ b/sqlx-core/src/postgres/arguments.rs
@@ -33,7 +33,7 @@ pub struct PgArgumentBuffer {
     patches: Vec<(
         usize, // offset
         usize, // argument index
-        Box<dyn Fn(&mut [u8], &PgTypeInfo) -> () + 'static + Send + Sync>,
+        Box<dyn Fn(&mut [u8], &PgTypeInfo) + 'static + Send + Sync>,
     )>,
 
     // Whenever an `Encode` impl encounters a `PgTypeInfo` object that does not have an OID

--- a/sqlx-core/src/postgres/connection/executor.rs
+++ b/sqlx-core/src/postgres/connection/executor.rs
@@ -317,10 +317,10 @@ impl PgConnection {
                     }
 
                     _ => {
-                        Err(err_protocol!(
+                        return Err(err_protocol!(
                             "execute: unexpected message: {:?}",
                             message.format
-                        ))?;
+                        ));
                     }
                 }
             }

--- a/sqlx-core/src/postgres/mod.rs
+++ b/sqlx-core/src/postgres/mod.rs
@@ -44,7 +44,6 @@ pub type PgPoolOptions = crate::pool::PoolOptions<Postgres>;
 impl_into_arguments_for_arguments!(PgArguments);
 impl_executor_for_pool_connection!(Postgres, PgConnection, PgRow);
 impl_executor_for_transaction!(Postgres, PgRow);
-impl_map_row!(Postgres, PgRow);
 impl_acquire!(Postgres, PgConnection);
 impl_column_index_for_row!(PgRow);
 impl_column_index_for_statement!(PgStatement);

--- a/sqlx-core/src/postgres/type_info.rs
+++ b/sqlx-core/src/postgres/type_info.rs
@@ -995,20 +995,18 @@ impl PartialEq<PgType> for PgType {
         if let (Some(a), Some(b)) = (self.try_oid(), other.try_oid()) {
             // If there are OIDs available, use OIDs to perform a direct match
             a == b
+        } else if (matches!(self, PgType::DeclareWithName(_))
+            && matches!(other, PgType::DeclareWithOid(_)))
+            || (matches!(other, PgType::DeclareWithName(_))
+                && matches!(self, PgType::DeclareWithOid(_)))
+        {
+            // One is a declare-with-name and the other is a declare-with-id
+            // This only occurs in the TEXT protocol with custom types
+            // Just opt-out of type checking here
+            true
         } else {
-            if (matches!(self, PgType::DeclareWithName(_))
-                && matches!(other, PgType::DeclareWithOid(_)))
-                || (matches!(other, PgType::DeclareWithName(_))
-                    && matches!(self, PgType::DeclareWithOid(_)))
-            {
-                // One is a declare-with-name and the other is a declare-with-id
-                // This only occurs in the TEXT protocol with custom types
-                // Just opt-out of type checking here
-                true
-            } else {
-                // Otherwise, perform a match on the name
-                self.name().eq_ignore_ascii_case(other.name())
-            }
+            // Otherwise, perform a match on the name
+            self.name().eq_ignore_ascii_case(other.name())
         }
     }
 }

--- a/sqlx-core/src/query.rs
+++ b/sqlx-core/src/query.rs
@@ -114,12 +114,15 @@ where
     /// The [`query_as`](super::query_as::query_as) method will construct a mapped query using
     /// a [`FromRow`](super::from_row::FromRow) implementation.
     #[inline]
-    pub fn map<F, O>(self, f: F) -> Map<'q, DB, impl TryMapRow<DB, Output = O>, A>
+    pub fn map<F, O>(
+        self,
+        mut f: F,
+    ) -> Map<'q, DB, impl Send + FnMut(DB::Row) -> Result<O, Error>, A>
     where
-        F: MapRow<DB, Output = O>,
+        F: Send + FnMut(DB::Row) -> O,
         O: Unpin,
     {
-        self.try_map(MapRowAdapter(f))
+        self.try_map(move |row| Ok(f(row)))
     }
 
     /// Map each row in the result to another type.
@@ -127,9 +130,10 @@ where
     /// The [`query_as`](super::query_as::query_as) method will construct a mapped query using
     /// a [`FromRow`](super::from_row::FromRow) implementation.
     #[inline]
-    pub fn try_map<F>(self, f: F) -> Map<'q, DB, F, A>
+    pub fn try_map<F, O>(self, f: F) -> Map<'q, DB, F, A>
     where
-        F: TryMapRow<DB>,
+        F: Send + FnMut(DB::Row) -> Result<O, Error>,
+        O: Unpin,
     {
         Map {
             inner: self,
@@ -251,7 +255,7 @@ where
 impl<'q, DB, F, O, A> Map<'q, DB, F, A>
 where
     DB: Database,
-    F: TryMapRow<DB, Output = O>,
+    F: Send + FnMut(DB::Row) -> Result<O, Error>,
     O: Send + Unpin,
     A: 'q + Send + IntoArguments<'q, DB>,
 {
@@ -294,7 +298,7 @@ where
                 r#yield!(match v {
                     Either::Left(v) => Either::Left(v),
                     Either::Right(row) => {
-                        Either::Right(self.mapper.try_map_row(row)?)
+                        Either::Right((self.mapper)(row)?)
                     }
                 });
             }
@@ -344,44 +348,10 @@ where
         let row = executor.fetch_optional(self.inner).await?;
 
         if let Some(row) = row {
-            self.mapper.try_map_row(row).map(Some)
+            (self.mapper)(row).map(Some)
         } else {
             Ok(None)
         }
-    }
-}
-
-// A (hopefully) temporary workaround for an internal compiler error (ICE) involving higher-ranked
-// trait bounds (HRTBs), associated types and closures.
-//
-// See https://github.com/rust-lang/rust/issues/62529
-
-pub trait TryMapRow<DB: Database>: Send {
-    type Output: Unpin;
-
-    fn try_map_row(&mut self, row: DB::Row) -> Result<Self::Output, Error>;
-}
-
-pub trait MapRow<DB: Database>: Send {
-    type Output: Unpin;
-
-    fn map_row(&mut self, row: DB::Row) -> Self::Output;
-}
-
-// A private adapter that implements [MapRow] in terms of [TryMapRow]
-// Just ends up Ok wrapping it
-
-struct MapRowAdapter<F>(F);
-
-impl<DB: Database, O, F> TryMapRow<DB> for MapRowAdapter<F>
-where
-    O: Unpin,
-    F: MapRow<DB, Output = O>,
-{
-    type Output = O;
-
-    fn try_map_row(&mut self, row: DB::Row) -> Result<Self::Output, Error> {
-        Ok(self.0.map_row(row))
     }
 }
 
@@ -442,31 +412,4 @@ where
         statement: Either::Left(sql),
         persistent: true,
     }
-}
-
-#[allow(unused_macros)]
-macro_rules! impl_map_row {
-    ($DB:ident, $R:ident) => {
-        impl<O: Unpin, F> crate::query::MapRow<$DB> for F
-        where
-            F: Send + FnMut($R) -> O,
-        {
-            type Output = O;
-
-            fn map_row(&mut self, row: $R) -> O {
-                (self)(row)
-            }
-        }
-
-        impl<O: Unpin, F> crate::query::TryMapRow<$DB> for F
-        where
-            F: Send + FnMut($R) -> Result<O, crate::error::Error>,
-        {
-            type Output = O;
-
-            fn try_map_row(&mut self, row: $R) -> Result<O, crate::error::Error> {
-                (self)(row)
-            }
-        }
-    };
 }

--- a/sqlx-core/src/query.rs
+++ b/sqlx-core/src/query.rs
@@ -259,6 +259,44 @@ where
     O: Send + Unpin,
     A: 'q + Send + IntoArguments<'q, DB>,
 {
+    /// Map each row in the result to another type.
+    ///
+    /// See [`try_map`](Map::try_map) for a fallible version of this method.
+    ///
+    /// The [`query_as`](super::query_as::query_as) method will construct a mapped query using
+    /// a [`FromRow`](super::from_row::FromRow) implementation.
+    #[inline]
+    pub fn map<G, P>(
+        self,
+        mut g: G,
+    ) -> Map<'q, DB, impl Send + FnMut(DB::Row) -> Result<P, Error>, A>
+    where
+        G: Send + FnMut(O) -> P,
+        P: Unpin,
+    {
+        self.try_map(move |data| Ok(g(data)))
+    }
+
+    /// Map each row in the result to another type.
+    ///
+    /// The [`query_as`](super::query_as::query_as) method will construct a mapped query using
+    /// a [`FromRow`](super::from_row::FromRow) implementation.
+    #[inline]
+    pub fn try_map<G, P>(
+        self,
+        mut g: G,
+    ) -> Map<'q, DB, impl Send + FnMut(DB::Row) -> Result<P, Error>, A>
+    where
+        G: Send + FnMut(O) -> Result<P, Error>,
+        P: Unpin,
+    {
+        let mut f = self.mapper;
+        Map {
+            inner: self.inner,
+            mapper: move |row| f(row).and_then(|o| g(o)),
+        }
+    }
+
     /// Execute the query and return the generated results as a stream.
     pub fn fetch<'e, 'c: 'e, E>(self, executor: E) -> BoxStream<'e, Result<O, Error>>
     where

--- a/sqlx-core/src/sqlite/mod.rs
+++ b/sqlx-core/src/sqlite/mod.rs
@@ -45,7 +45,6 @@ pub type SqlitePoolOptions = crate::pool::PoolOptions<Sqlite>;
 impl_into_arguments_for_arguments!(SqliteArguments<'q>);
 impl_executor_for_pool_connection!(Sqlite, SqliteConnection, SqliteRow);
 impl_executor_for_transaction!(Sqlite, SqliteRow);
-impl_map_row!(Sqlite, SqliteRow);
 impl_column_index_for_row!(SqliteRow);
 impl_column_index_for_statement!(SqliteStatement);
 impl_acquire!(Sqlite, SqliteConnection);

--- a/sqlx-macros/src/derives/attributes.rs
+++ b/sqlx-macros/src/derives/attributes.rs
@@ -177,7 +177,7 @@ pub fn check_transparent_attributes(
     Ok(attributes)
 }
 
-pub fn check_enum_attributes<'a>(input: &'a DeriveInput) -> syn::Result<SqlxContainerAttributes> {
+pub fn check_enum_attributes(input: &DeriveInput) -> syn::Result<SqlxContainerAttributes> {
     let attributes = parse_container_attributes(&input.attrs)?;
 
     assert_attribute!(

--- a/sqlx-macros/src/migrate.rs
+++ b/sqlx-macros/src/migrate.rs
@@ -38,11 +38,9 @@ impl ToTokens for QuotedMigration {
 // mostly copied from sqlx-core/src/migrate/source.rs
 pub(crate) fn expand_migrator_from_dir(dir: LitStr) -> crate::Result<proc_macro2::TokenStream> {
     let path = crate::common::resolve_path(&dir.value(), dir.span())?;
-    let mut s = fs::read_dir(path)?;
-
     let mut migrations = Vec::new();
 
-    while let Some(entry) = s.next() {
+    for entry in fs::read_dir(path)? {
         let entry = entry?;
         if !entry.metadata()?.is_file() {
             // not a file; ignore

--- a/sqlx-macros/src/query/mod.rs
+++ b/sqlx-macros/src/query/mod.rs
@@ -86,7 +86,7 @@ fn expand_from_db(input: QueryMacroInput, db_url: &str) -> crate::Result<TokenSt
         },
 
         #[cfg(not(feature = "postgres"))]
-        "postgres" | "postgresql" => Err(format!("database URL has the scheme of a PostgreSQL database but the `postgres` feature is not enabled").into()),
+        "postgres" | "postgresql" => Err("database URL has the scheme of a PostgreSQL database but the `postgres` feature is not enabled".into()),
 
         #[cfg(feature = "mssql")]
         "mssql" | "sqlserver" => {
@@ -99,7 +99,7 @@ fn expand_from_db(input: QueryMacroInput, db_url: &str) -> crate::Result<TokenSt
         },
 
         #[cfg(not(feature = "mssql"))]
-        "mssql" | "sqlserver" => Err(format!("database URL has the scheme of a MSSQL database but the `mssql` feature is not enabled").into()),
+        "mssql" | "sqlserver" => Err("database URL has the scheme of a MSSQL database but the `mssql` feature is not enabled".into()),
 
         #[cfg(feature = "mysql")]
         "mysql" | "mariadb" => {
@@ -112,7 +112,7 @@ fn expand_from_db(input: QueryMacroInput, db_url: &str) -> crate::Result<TokenSt
         },
 
         #[cfg(not(feature = "mysql"))]
-        "mysql" | "mariadb" => Err(format!("database URL has the scheme of a MySQL/MariaDB database but the `mysql` feature is not enabled").into()),
+        "mysql" | "mariadb" => Err("database URL has the scheme of a MySQL/MariaDB database but the `mysql` feature is not enabled".into()),
 
         #[cfg(feature = "sqlite")]
         "sqlite" => {
@@ -125,7 +125,7 @@ fn expand_from_db(input: QueryMacroInput, db_url: &str) -> crate::Result<TokenSt
         },
 
         #[cfg(not(feature = "sqlite"))]
-        "sqlite" => Err(format!("database URL has the scheme of a SQLite database but the `sqlite` feature is not enabled").into()),
+        "sqlite" => Err("database URL has the scheme of a SQLite database but the `sqlite` feature is not enabled".into()),
 
         scheme => Err(format!("unknown database URL scheme {:?}", scheme).into())
     }

--- a/sqlx-macros/src/query/output.rs
+++ b/sqlx-macros/src/query/output.rs
@@ -25,10 +25,7 @@ pub(super) enum ColumnType {
 
 impl ColumnType {
     pub(super) fn is_wildcard(&self) -> bool {
-        match self {
-            ColumnType::Exact(_) => false,
-            _ => true,
-        }
+        !matches!(self, ColumnType::Exact(_))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,6 @@ pub use self::decode::Decode;
 /// Types and traits for the `query` family of functions and macros.
 pub mod query {
     pub use sqlx_core::query::{Map, Query};
-    pub use sqlx_core::query::{MapRow, TryMapRow};
     pub use sqlx_core::query_as::QueryAs;
     pub use sqlx_core::query_scalar::QueryScalar;
 }


### PR DESCRIPTION
This is a breaking change, since `MapRow` and `TryMapRow` were parts of the public API. (should I add a changelog entry?)