### PR TITLE
Allow query_as! to convert types with .into()

### DIFF
--- a/sqlx-macros/src/query/output.rs
+++ b/sqlx-macros/src/query/output.rs
@@ -169,7 +169,7 @@ pub fn quote_query_as<DB: DatabaseExt>(
 
             #(#instantiations)*
 
-            Ok(#out_ty { #(#ident: #ident),* })
+            Ok(#out_ty { #(#ident: #ident.into()),* })
         })
     }
 }


### PR DESCRIPTION
Thank you for the nice crate.
I've been using it only 2 days, so I am still earning, but I like the ideas that sqlx embraces.

### Motivation

I would like to use the [newtype pattern](https://doc.rust-lang.org/1.0.0/style/features/types/newtype.html) for my data models to explicitly distinguish between different ID types.

Here is a snippet from my code base:
```rust
use derive_more::From;

#[derive(Debug, From)]
pub struct TopicId(i64);

#[derive(Debug, From)]
pub struct UserId(i64);

#[derive(Debug)]
pub struct Topic {
    pub id: TopicId,
    pub name: String,
    pub is_active: bool
}

#[derive(Debug)]
struct User {
    id: UserId,
    email: String,
    topic_id: TopicId
}
```

I use `derive_more` trait here to derive implementations of `From<i64>` for `TopicId` and `UserId`.
Having `From<i64>` for `TopicId` and `UserId` we get automatically `Into<TopicId>` and `Into<UserId` for `i64`.

My fetch code looks like:

```rust
pub async fn fetch_topics(pool: &DbPool) -> anyhow::Result<Vec<Topic>> {
    let topics =
        sqlx::query_as!(Topic, "SELECT * FROM topics WHERE is_active = true")
        .fetch_all(pool)
        .await?;
    Ok(topics)
}
```
So invoking `.into()` on initializing the struct (Topic) makes the conversion from `i64` into `TopicId` automatically if it's possible.

### Error message

In case there is uncovertible type the following error message appears (i replaced `id: TopicId` with `id: String`)

![image](https://user-images.githubusercontent.com/113512/99454775-2cfa5a00-2927-11eb-8685-4f534d28b318.png)


That must be sufficient to understand the source of problem.