### PR TITLE
Add postgres example with test of business logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2278,6 +2278,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlx-example-postgres-mockable-todos"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-std",
+ "dotenv",
+ "futures",
+ "paw",
+ "sqlx",
+ "structopt",
+]
+
+[[package]]
 name = "sqlx-example-postgres-todos"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,6 +727,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +752,12 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "downcast"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 
 [[package]]
 name = "either"
@@ -800,6 +812,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +850,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -1339,6 +1366,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cabea45a7fc0e37093f4f30a5e2b62602253f91791c057d5f0470c63260c3d"
+dependencies = [
+ "cfg-if 0.1.10",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c461918bf7f59eefb1459252756bf2351a995d6bd510d0b2061bd86bcdabfa6"
+dependencies = [
+ "cfg-if 0.1.10",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1376,6 +1430,12 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-bigint"
@@ -1675,6 +1735,35 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "predicates"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96bfead12e90dccead362d62bb2c90a5f6fc4584963645bc7f71a735e0b0735a"
+dependencies = [
+ "difference",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
+dependencies = [
+ "predicates-core",
+ "treeline",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -2286,6 +2375,7 @@ dependencies = [
  "async-trait",
  "dotenv",
  "futures",
+ "mockall",
  "paw",
  "sqlx",
  "structopt",
@@ -2735,6 +2825,12 @@ checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "treeline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
 name = "trybuild"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2283,6 +2283,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-std",
+ "async-trait",
  "dotenv",
  "futures",
  "paw",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "examples/postgres/json",
     "examples/postgres/listen",
     "examples/postgres/todos",
+    "examples/postgres/mockable-todos",
     "examples/sqlite/todos",
 ]
 

--- a/examples/postgres/mockable-todos/.env.example
+++ b/examples/postgres/mockable-todos/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL="postgres://postgres:password@localhost/todos"

--- a/examples/postgres/mockable-todos/Cargo.toml
+++ b/examples/postgres/mockable-todos/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sqlx-example-postgres-todos"
+name = "sqlx-example-postgres-mockable-todos"
 version = "0.1.0"
 edition = "2018"
 workspace = "../../../"
@@ -9,6 +9,6 @@ anyhow = "1.0"
 async-std = { version = "1.4.0", features = [ "attributes" ] }
 futures = "0.3"
 paw = "1.0"
-sqlx = { path = "../../../", features = ["postgres", "offline"] }
+sqlx = { path = "../../../", features = ["postgres", "offline", "runtime-async-std-native-tls"] }
 structopt = { version = "0.3", features = ["paw"] }
 dotenv = "0.15.0"

--- a/examples/postgres/mockable-todos/Cargo.toml
+++ b/examples/postgres/mockable-todos/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sqlx-example-postgres-todos"
+version = "0.1.0"
+edition = "2018"
+workspace = "../../../"
+
+[dependencies]
+anyhow = "1.0"
+async-std = { version = "1.4.0", features = [ "attributes" ] }
+futures = "0.3"
+paw = "1.0"
+sqlx = { path = "../../../", features = ["postgres", "offline"] }
+structopt = { version = "0.3", features = ["paw"] }
+dotenv = "0.15.0"

--- a/examples/postgres/mockable-todos/Cargo.toml
+++ b/examples/postgres/mockable-todos/Cargo.toml
@@ -13,3 +13,4 @@ sqlx = { path = "../../../", features = ["postgres", "offline", "runtime-async-s
 structopt = { version = "0.3", features = ["paw"] }
 dotenv = "0.15.0"
 async-trait = "0.1.41"
+mockall = "0.8.3"

--- a/examples/postgres/mockable-todos/Cargo.toml
+++ b/examples/postgres/mockable-todos/Cargo.toml
@@ -12,3 +12,4 @@ paw = "1.0"
 sqlx = { path = "../../../", features = ["postgres", "offline", "runtime-async-std-native-tls"] }
 structopt = { version = "0.3", features = ["paw"] }
 dotenv = "0.15.0"
+async-trait = "0.1.41"

--- a/examples/postgres/mockable-todos/README.md
+++ b/examples/postgres/mockable-todos/README.md
@@ -1,0 +1,41 @@
+# TODOs Example
+
+## Setup
+
+1. Declare the database URL
+
+    ```
+    export DATABASE_URL="postgres://postgres:password@localhost/todos"
+    ```
+
+2. Create the database.
+
+    ```
+    $ sqlx db create
+    ```
+
+3. Run sql migrations
+
+    ```
+    $ sqlx migrate run
+    ```
+
+## Usage
+
+Add a todo 
+
+```
+cargo run -- add "todo description"
+```
+
+Complete a todo.
+
+```
+cargo run -- done <todo id>
+```
+
+List all todos
+
+```
+cargo run
+```

--- a/examples/postgres/mockable-todos/README.md
+++ b/examples/postgres/mockable-todos/README.md
@@ -6,19 +6,27 @@ This example is based on the ideas in [this blog post](https://medium.com/better
 
 ## Setup
 
-1. Declare the database URL
+1. Run `docker-compose up -d` to run Postgres in the background.
+
+2. Declare the database URL, either by exporting it:
 
     ```
     export DATABASE_URL="postgres://postgres:password@localhost/todos"
     ```
 
-2. Create the database.
+    or by making a `.env` file:
+
+    ```
+    cp .env.example .env
+    ```
+
+3. Create the database.
 
     ```
     $ sqlx db create
     ```
 
-3. Run sql migrations
+4. Run sql migrations
 
     ```
     $ sqlx migrate run
@@ -42,4 +50,12 @@ List all todos
 
 ```
 cargo run
+```
+
+## Cleanup
+
+To destroy the Postgres database, run:
+
+```
+docker-compose down --volumes
 ```

--- a/examples/postgres/mockable-todos/README.md
+++ b/examples/postgres/mockable-todos/README.md
@@ -1,4 +1,8 @@
-# TODOs Example
+# Mockable TODOs Example
+
+## Description
+
+This example is based on the ideas in [this blog post](https://medium.com/better-programming/structuring-rust-project-for-testability-18207b5d0243). The value here is that the business logic can be unit tested independently from the database layer. Otherwise it is identical to the todos example.
 
 ## Setup
 
@@ -22,7 +26,7 @@
 
 ## Usage
 
-Add a todo 
+Add a todo
 
 ```
 cargo run -- add "todo description"

--- a/examples/postgres/mockable-todos/docker-compose.yml
+++ b/examples/postgres/mockable-todos/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3"
+
+services:
+  database:
+    image: "postgres"
+    ports:
+      - "5432:5432"
+    restart: always
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=todos
+    volumes:
+      - database_data:/var/lib/postgresql/data
+volumes:
+  database_data:
+    driver: local

--- a/examples/postgres/mockable-todos/migrations/20200718111257_todos.sql
+++ b/examples/postgres/mockable-todos/migrations/20200718111257_todos.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS todos
+(
+    id          BIGSERIAL PRIMARY KEY,
+    description TEXT    NOT NULL,
+    done        BOOLEAN NOT NULL DEFAULT FALSE
+);

--- a/examples/postgres/mockable-todos/src/main.rs
+++ b/examples/postgres/mockable-todos/src/main.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use dotenv;
 use sqlx::postgres::PgPool;
 use sqlx::Done;
 use std::{env, io::Write, sync::Arc};
@@ -19,6 +20,7 @@ enum Command {
 #[async_std::main]
 #[paw::main]
 async fn main(args: Args) -> anyhow::Result<()> {
+    dotenv::dotenv().ok();
     let pool = PgPool::connect(&env::var("DATABASE_URL")?).await?;
     let todo_repo = PostgresTodoRepo::new(pool);
     let mut writer = std::io::stdout();

--- a/examples/postgres/mockable-todos/src/main.rs
+++ b/examples/postgres/mockable-todos/src/main.rs
@@ -1,0 +1,98 @@
+use sqlx::postgres::PgPool;
+use sqlx::Done;
+use std::env;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct Args {
+    #[structopt(subcommand)]
+    cmd: Option<Command>,
+}
+
+#[derive(StructOpt)]
+enum Command {
+    Add { description: String },
+    Done { id: i64 },
+}
+
+#[async_std::main]
+#[paw::main]
+async fn main(args: Args) -> anyhow::Result<()> {
+    let pool = PgPool::connect(&env::var("DATABASE_URL")?).await?;
+
+    match args.cmd {
+        Some(Command::Add { description }) => {
+            println!("Adding new todo with description '{}'", &description);
+            let todo_id = add_todo(&pool, description).await?;
+            println!("Added new todo with id {}", todo_id);
+        }
+        Some(Command::Done { id }) => {
+            println!("Marking todo {} as done", id);
+            if complete_todo(&pool, id).await? {
+                println!("Todo {} is marked as done", id);
+            } else {
+                println!("Invalid id {}", id);
+            }
+        }
+        None => {
+            println!("Printing list of all todos");
+            list_todos(&pool).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn add_todo(pool: &PgPool, description: String) -> anyhow::Result<i64> {
+    let rec = sqlx::query!(
+        r#"
+INSERT INTO todos ( description )
+VALUES ( $1 )
+RETURNING id
+        "#,
+        description
+    )
+    .fetch_one(pool)
+    .await?;
+
+    Ok(rec.id)
+}
+
+async fn complete_todo(pool: &PgPool, id: i64) -> anyhow::Result<bool> {
+    let rows_affected = sqlx::query!(
+        r#"
+UPDATE todos
+SET done = TRUE
+WHERE id = $1
+        "#,
+        id
+    )
+    .execute(pool)
+    .await?
+    .rows_affected();
+
+    Ok(rows_affected > 0)
+}
+
+async fn list_todos(pool: &PgPool) -> anyhow::Result<()> {
+    let recs = sqlx::query!(
+        r#"
+SELECT id, description, done
+FROM todos
+ORDER BY id
+        "#
+    )
+    .fetch_all(pool)
+    .await?;
+
+    for rec in recs {
+        println!(
+            "- [{}] {}: {}",
+            if rec.done { "x" } else { " " },
+            rec.id,
+            &rec.description,
+        );
+    }
+
+    Ok(())
+}

--- a/examples/postgres/mockable-todos/src/main.rs
+++ b/examples/postgres/mockable-todos/src/main.rs
@@ -1,6 +1,6 @@
 use sqlx::postgres::PgPool;
 use sqlx::Done;
-use std::env;
+use std::{env, sync::Arc};
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -19,16 +19,21 @@ enum Command {
 #[paw::main]
 async fn main(args: Args) -> anyhow::Result<()> {
     let pool = PgPool::connect(&env::var("DATABASE_URL")?).await?;
+    let todo_repo = PostgresTodoRepo::new(pool);
 
+    handle_command(args, todo_repo).await
+}
+
+async fn handle_command(args: Args, todo_repo: PostgresTodoRepo) -> anyhow::Result<()> {
     match args.cmd {
         Some(Command::Add { description }) => {
             println!("Adding new todo with description '{}'", &description);
-            let todo_id = add_todo(&pool, description).await?;
+            let todo_id = todo_repo.add_todo(description).await?;
             println!("Added new todo with id {}", todo_id);
         }
         Some(Command::Done { id }) => {
             println!("Marking todo {} as done", id);
-            if complete_todo(&pool, id).await? {
+            if todo_repo.complete_todo(id).await? {
                 println!("Todo {} is marked as done", id);
             } else {
                 println!("Invalid id {}", id);
@@ -36,63 +41,75 @@ async fn main(args: Args) -> anyhow::Result<()> {
         }
         None => {
             println!("Printing list of all todos");
-            list_todos(&pool).await?;
+            todo_repo.list_todos().await?;
         }
     }
 
     Ok(())
 }
 
-async fn add_todo(pool: &PgPool, description: String) -> anyhow::Result<i64> {
-    let rec = sqlx::query!(
-        r#"
+struct PostgresTodoRepo {
+    pg_pool: Arc<PgPool>,
+}
+
+impl PostgresTodoRepo {
+    fn new(pg_pool: PgPool) -> Self {
+        Self {
+            pg_pool: Arc::new(pg_pool),
+        }
+    }
+
+    async fn add_todo(&self, description: String) -> anyhow::Result<i64> {
+        let rec = sqlx::query!(
+            r#"
 INSERT INTO todos ( description )
 VALUES ( $1 )
 RETURNING id
         "#,
-        description
-    )
-    .fetch_one(pool)
-    .await?;
+            description
+        )
+        .fetch_one(&*self.pg_pool)
+        .await?;
 
-    Ok(rec.id)
-}
+        Ok(rec.id)
+    }
 
-async fn complete_todo(pool: &PgPool, id: i64) -> anyhow::Result<bool> {
-    let rows_affected = sqlx::query!(
-        r#"
+    async fn complete_todo(&self, id: i64) -> anyhow::Result<bool> {
+        let rows_affected = sqlx::query!(
+            r#"
 UPDATE todos
 SET done = TRUE
 WHERE id = $1
         "#,
-        id
-    )
-    .execute(pool)
-    .await?
-    .rows_affected();
+            id
+        )
+        .execute(&*self.pg_pool)
+        .await?
+        .rows_affected();
 
-    Ok(rows_affected > 0)
-}
+        Ok(rows_affected > 0)
+    }
 
-async fn list_todos(pool: &PgPool) -> anyhow::Result<()> {
-    let recs = sqlx::query!(
-        r#"
+    async fn list_todos(&self) -> anyhow::Result<()> {
+        let recs = sqlx::query!(
+            r#"
 SELECT id, description, done
 FROM todos
 ORDER BY id
         "#
-    )
-    .fetch_all(pool)
-    .await?;
+        )
+        .fetch_all(&*self.pg_pool)
+        .await?;
 
-    for rec in recs {
-        println!(
-            "- [{}] {}: {}",
-            if rec.done { "x" } else { " " },
-            rec.id,
-            &rec.description,
-        );
+        for rec in recs {
+            println!(
+                "- [{}] {}: {}",
+                if rec.done { "x" } else { " " },
+                rec.id,
+                &rec.description,
+            );
+        }
+
+        Ok(())
     }
-
-    Ok(())
 }

--- a/examples/postgres/todos/Cargo.toml
+++ b/examples/postgres/todos/Cargo.toml
@@ -9,6 +9,6 @@ anyhow = "1.0"
 async-std = { version = "1.4.0", features = [ "attributes" ] }
 futures = "0.3"
 paw = "1.0"
-sqlx = { path = "../../../", features = ["postgres", "offline"] }
+sqlx = { path = "../../../", features = ["postgres", "offline", "runtime-async-std-native-tls"] }
 structopt = { version = "0.3", features = ["paw"] }
 dotenv = "0.15.0"


### PR DESCRIPTION
This PR adds a Postgres example based on the ideas in [this blog post](https://medium.com/better-programming/structuring-rust-project-for-testability-18207b5d0243).

We also fixed the existing postgres/todos example (2nd commit).  If you want us to pull this out into a separate PR then we can do.

If this PR is ok, then we have a stab at making an example for transactions as well, potentially using the `Acquire` trait.