### PR TITLE
Add support for bstr::BString and git2::Oid, behind feature flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,6 +2206,7 @@ dependencies = [
  "bigdecimal",
  "bit-vec",
  "bitflags",
+ "bstr",
  "byteorder",
  "bytes",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,9 @@ name = "cc"
 version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1770ced377336a88a67c473594ccc14eca6f4559217c34f64aac8f83d641b40"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -989,6 +992,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.13.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca6f1a0238d7f8f8fd5ee642f4ebac4dbc03e03d1f78fbe7a3ede35dcf7e2224"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,6 +1139,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
+name = "jobserver"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,6 +1206,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.12.14+1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f25af58e6495f7caf2919d08f212de550cfa3ed2f5e744988938ea292b9f549"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1230,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64d31059f22935e6c31830db5249ba2b7ecd54fd73a9909286f0a67aa55c2fbd"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2221,6 +2270,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "generic-array",
+ "git2",
  "hex",
  "hmac",
  "ipnetwork",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ uuid = [ "sqlx-core/uuid", "sqlx-macros/uuid" ]
 json = [ "sqlx-core/json", "sqlx-macros/json" ]
 time = [ "sqlx-core/time", "sqlx-macros/time" ]
 bit-vec = [ "sqlx-core/bit-vec", "sqlx-macros/bit-vec"]
+bstr = [ "sqlx-core/bstr" ]
 
 [dependencies]
 sqlx-core = { version = "=0.4.0", path = "sqlx-core", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ json = [ "sqlx-core/json", "sqlx-macros/json" ]
 time = [ "sqlx-core/time", "sqlx-macros/time" ]
 bit-vec = [ "sqlx-core/bit-vec", "sqlx-macros/bit-vec"]
 bstr = [ "sqlx-core/bstr" ]
+git2 = [ "sqlx-core/git2" ]
 
 [dependencies]
 sqlx-core = { version = "=0.4.0", path = "sqlx-core", default-features = false }

--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ sqlx = { version = "0.4.0", features = [ "runtime-async-std-native-tls" ] }
 
 -   `time`: Add support for date and time types from `time` crate (alternative to `chrono`, prefered by `query!` macro, if both enabled)
 
+-   `bstr`: Add support for `bstr::BString`.
+
 -   `bigdecimal`: Add support for `NUMERIC` using the `bigdecimal` crate.
 
 -   `decimal`: Add support for `NUMERIC` using the `rust_decimal` crate.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ sqlx = { version = "0.4.0", features = [ "runtime-async-std-native-tls" ] }
 
 -   `bstr`: Add support for `bstr::BString`.
 
+-   `git2`: Add support for `git2::Oid`.
+
 -   `bigdecimal`: Add support for `NUMERIC` using the `bigdecimal` crate.
 
 -   `decimal`: Add support for `NUMERIC` using the `rust_decimal` crate.

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -107,3 +107,4 @@ webpki-roots = { version = "0.20.0", optional = true }
 whoami = "0.9.0"
 stringprep = "0.1.2"
 lru-cache = "0.1.2"
+bstr = { version = "0.2.14", default-features = false, features = [ "std" ], optional = true }

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -108,3 +108,4 @@ whoami = "0.9.0"
 stringprep = "0.1.2"
 lru-cache = "0.1.2"
 bstr = { version = "0.2.14", default-features = false, features = [ "std" ], optional = true }
+git2 = { version = "0.13.12", default-features = false, optional = true }

--- a/sqlx-core/src/types/bstr.rs
+++ b/sqlx-core/src/types/bstr.rs
@@ -1,0 +1,42 @@
+/// Conversions between `bstr` types and SQL types.
+use crate::database::{Database, HasArguments, HasValueRef};
+use crate::decode::Decode;
+use crate::encode::{Encode, IsNull};
+use crate::error::BoxDynError;
+use crate::types::Type;
+
+pub use bstr::{BString, ByteSlice};
+
+impl<DB> Type<DB> for BString
+where
+    DB: Database,
+    [u8]: Type<DB>,
+{
+    fn type_info() -> DB::TypeInfo {
+        <&[u8] as Type<DB>>::type_info()
+    }
+
+    fn compatible(ty: &DB::TypeInfo) -> bool {
+        <&[u8] as Type<DB>>::compatible(ty)
+    }
+}
+
+impl<'r, DB> Decode<'r, DB> for BString
+where
+    DB: Database,
+    Vec<u8>: Decode<'r, DB>,
+{
+    fn decode(value: <DB as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+        <Vec<u8> as Decode<DB>>::decode(value).map(BString::from)
+    }
+}
+
+impl<'q, DB: Database> Encode<'q, DB> for BString
+where
+    DB: Database,
+    [u8]: Encode<'q, DB>,
+{
+    fn encode_by_ref(&self, buf: &mut <DB as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
+        <[u8] as Encode<DB>>::encode_by_ref(self.as_bytes(), buf)
+    }
+}

--- a/sqlx-core/src/types/git2.rs
+++ b/sqlx-core/src/types/git2.rs
@@ -1,0 +1,42 @@
+/// Conversions between `git2::Oid` and SQL types.
+use crate::database::{Database, HasArguments, HasValueRef};
+use crate::decode::Decode;
+use crate::encode::{Encode, IsNull};
+use crate::error::BoxDynError;
+use crate::types::Type;
+
+pub use git2::Oid;
+
+impl<DB> Type<DB> for Oid
+where
+    DB: Database,
+    [u8]: Type<DB>,
+{
+    fn type_info() -> DB::TypeInfo {
+        <&[u8] as Type<DB>>::type_info()
+    }
+
+    fn compatible(ty: &DB::TypeInfo) -> bool {
+        <&[u8] as Type<DB>>::compatible(ty)
+    }
+}
+
+impl<'r, DB> Decode<'r, DB> for Oid
+where
+    DB: Database,
+    &'r [u8]: Decode<'r, DB>,
+{
+    fn decode(value: <DB as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+        <&[u8] as Decode<DB>>::decode(value).and_then(|bytes| Ok(Oid::from_bytes(bytes)?))
+    }
+}
+
+impl<'q, DB: Database> Encode<'q, DB> for Oid
+where
+    DB: Database,
+    [u8]: Encode<'q, DB>,
+{
+    fn encode_by_ref(&self, buf: &mut <DB as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
+        <[u8] as Encode<DB>>::encode_by_ref(self.as_bytes(), buf)
+    }
+}

--- a/sqlx-core/src/types/mod.rs
+++ b/sqlx-core/src/types/mod.rs
@@ -20,6 +20,10 @@
 
 use crate::database::Database;
 
+#[cfg(feature = "bstr")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bstr")))]
+mod bstr;
+
 #[cfg(feature = "json")]
 #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 mod json;

--- a/sqlx-core/src/types/mod.rs
+++ b/sqlx-core/src/types/mod.rs
@@ -24,6 +24,10 @@ use crate::database::Database;
 #[cfg_attr(docsrs, doc(cfg(feature = "bstr")))]
 mod bstr;
 
+#[cfg(feature = "git2")]
+#[cfg_attr(docsrs, doc(cfg(feature = "git2")))]
+mod git2;
+
 #[cfg(feature = "json")]
 #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 mod json;

--- a/tests/sqlite/types.rs
+++ b/tests/sqlite/types.rs
@@ -118,3 +118,19 @@ mod bstr {
         "x'0001020304'" == BString::from(b"\x00\x01\x02\x03\x04")
     ));
 }
+
+#[cfg(feature = "git2")]
+mod git2 {
+    use super::*;
+    use sqlx::types::git2::Oid;
+
+    test_type!(Oid(
+        Sqlite,
+        "x'0000000000000000000000000000000000000000'" == Oid::zero()
+    ));
+    test_type!(Oid(
+        Sqlite,
+        "x'000102030405060708090a0b0c0d0e0f10111213'"
+            == Oid::from_str("000102030405060708090a0b0c0d0e0f10111213")
+    ));
+}

--- a/tests/sqlite/types.rs
+++ b/tests/sqlite/types.rs
@@ -106,3 +106,15 @@ mod chrono {
         "datetime('2016-11-08T03:50:23-05:00')" == FixedOffset::west(5 * 3600).ymd(2016, 11, 08).and_hms(3, 50, 23)
     ));
 }
+
+#[cfg(feature = "bstr")]
+mod bstr {
+    use super::*;
+    use sqlx::types::bstr::BString;
+
+    test_type!(BString(Sqlite, "'abc123'" == BString::from(b"abc123")));
+    test_type!(BString(
+        Sqlite,
+        "x'0001020304'" == BString::from(b"\x00\x01\x02\x03\x04")
+    ));
+}


### PR DESCRIPTION
This adds support for SQL conversions for the bstr::BString binary
string type, and for the git2::Oid object ID type. Both types are
encoded and decoded as bytes.

These types are database-independent and work with any database that can
handle bytes, so add tests that work with sqlite.