### PR TITLE
sqlite synchronous setting

### DIFF
--- a/sqlx-core/src/sqlite/mod.rs
+++ b/sqlx-core/src/sqlite/mod.rs
@@ -28,7 +28,7 @@ pub use connection::SqliteConnection;
 pub use database::Sqlite;
 pub use done::SqliteDone;
 pub use error::SqliteError;
-pub use options::{SqliteConnectOptions, SqliteJournalMode};
+pub use options::{SqliteConnectOptions, SqliteJournalMode, SqliteSynchronous};
 pub use row::SqliteRow;
 pub use statement::SqliteStatement;
 pub use transaction::SqliteTransactionManager;

--- a/sqlx-core/src/sqlite/options/connect.rs
+++ b/sqlx-core/src/sqlite/options/connect.rs
@@ -19,9 +19,10 @@ impl ConnectOptions for SqliteConnectOptions {
 
             // send an initial sql statement comprised of options
             let init = format!(
-                "PRAGMA journal_mode = {}; PRAGMA foreign_keys = {};",
+                "PRAGMA journal_mode = {}; PRAGMA foreign_keys = {}; PRAGMA synchronous = {}",
                 self.journal_mode.as_str(),
-                if self.foreign_keys { "ON" } else { "OFF" }
+                if self.foreign_keys { "ON" } else { "OFF" },
+                self.synchronous.as_str(),
             );
 
             conn.execute(&*init).await?;

--- a/sqlx-core/src/sqlite/options/mod.rs
+++ b/sqlx-core/src/sqlite/options/mod.rs
@@ -3,10 +3,12 @@ use std::path::Path;
 mod connect;
 mod journal_mode;
 mod parse;
+mod synchronous;
 
 use crate::connection::LogSettings;
 pub use journal_mode::SqliteJournalMode;
 use std::{borrow::Cow, time::Duration};
+pub use synchronous::SqliteSynchronous;
 
 /// Options and flags which can be used to configure a SQLite connection.
 ///
@@ -53,6 +55,7 @@ pub struct SqliteConnectOptions {
     pub(crate) statement_cache_capacity: usize,
     pub(crate) busy_timeout: Duration,
     pub(crate) log_settings: LogSettings,
+    pub(crate) synchronous: SqliteSynchronous,
 }
 
 impl Default for SqliteConnectOptions {
@@ -74,6 +77,7 @@ impl SqliteConnectOptions {
             journal_mode: SqliteJournalMode::Wal,
             busy_timeout: Duration::from_secs(5),
             log_settings: Default::default(),
+            synchronous: SqliteSynchronous::Full,
         }
     }
 
@@ -133,6 +137,15 @@ impl SqliteConnectOptions {
     /// The default busy timeout is 5 seconds.
     pub fn busy_timeout(mut self, timeout: Duration) -> Self {
         self.busy_timeout = timeout;
+        self
+    }
+
+    /// Sets the [synchronous](https://www.sqlite.org/pragma.html#pragma_synchronous) setting for the database connection.
+    ///
+    /// The default synchronous settings is FULL. However, if durability is not a concern,
+    /// then NORMAL is normally all one needs in WAL mode.
+    pub fn synchronous(mut self, synchronous: SqliteSynchronous) -> Self {
+        self.synchronous = synchronous;
         self
     }
 }

--- a/sqlx-core/src/sqlite/options/synchronous.rs
+++ b/sqlx-core/src/sqlite/options/synchronous.rs
@@ -1,0 +1,49 @@
+use crate::error::Error;
+use std::str::FromStr;
+
+/// Refer to [SQLite documentation] for the meaning of various synchronous settings.
+///
+/// [SQLite documentation]: https://www.sqlite.org/pragma.html#pragma_synchronous
+#[derive(Debug, Clone)]
+pub enum SqliteSynchronous {
+    Off,
+    Normal,
+    Full,
+    Extra,
+}
+
+impl SqliteSynchronous {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            SqliteSynchronous::Off => "OFF",
+            SqliteSynchronous::Normal => "NORMAL",
+            SqliteSynchronous::Full => "FULL",
+            SqliteSynchronous::Extra => "EXTRA",
+        }
+    }
+}
+
+impl Default for SqliteSynchronous {
+    fn default() -> Self {
+        SqliteSynchronous::Full
+    }
+}
+
+impl FromStr for SqliteSynchronous {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Error> {
+        Ok(match &*s.to_ascii_lowercase() {
+            "off" => SqliteSynchronous::Off,
+            "normal" => SqliteSynchronous::Normal,
+            "full" => SqliteSynchronous::Full,
+            "extra" => SqliteSynchronous::Extra,
+
+            _ => {
+                return Err(Error::Configuration(
+                    format!("unknown value {:?} for `synchronous`", s).into(),
+                ));
+            }
+        })
+    }
+}


### PR DESCRIPTION
Add support for "synchronous" setting in SQLite connection options.
This makes changing this setting to NORMAL (from default FULL) easy.
The NORMAL mode is even advised by SQLite documentation (and that is understandable):
> If durability is not a concern, then synchronous=NORMAL is normally all one needs in WAL mode.