### PR TITLE
Add support for passing in-memory trusted certificates in addition to…

### DIFF
--- a/sqlx-core/src/mysql/connection/tls.rs
+++ b/sqlx-core/src/mysql/connection/tls.rs
@@ -52,7 +52,7 @@ async fn upgrade(stream: &mut MySqlStream, options: &MySqlConnectOptions) -> Res
             &options.host,
             accept_invalid_certs,
             accept_invalid_host_names,
-            options.ssl_ca.as_deref(),
+            options.ssl_ca.as_ref(),
         )
         .await?;
 

--- a/sqlx-core/src/mysql/options/mod.rs
+++ b/sqlx-core/src/mysql/options/mod.rs
@@ -4,7 +4,7 @@ mod connect;
 mod parse;
 mod ssl_mode;
 
-use crate::connection::LogSettings;
+use crate::{connection::LogSettings, net::CertificateInput};
 pub use ssl_mode::MySqlSslMode;
 
 /// Options and flags which can be used to configure a MySQL connection.
@@ -62,7 +62,7 @@ pub struct MySqlConnectOptions {
     pub(crate) password: Option<String>,
     pub(crate) database: Option<String>,
     pub(crate) ssl_mode: MySqlSslMode,
-    pub(crate) ssl_ca: Option<PathBuf>,
+    pub(crate) ssl_ca: Option<CertificateInput>,
     pub(crate) statement_cache_capacity: usize,
     pub(crate) charset: String,
     pub(crate) collation: Option<String>,
@@ -167,7 +167,22 @@ impl MySqlConnectOptions {
     ///     .ssl_ca("path/to/ca.crt");
     /// ```
     pub fn ssl_ca(mut self, file_name: impl AsRef<Path>) -> Self {
-        self.ssl_ca = Some(file_name.as_ref().to_owned());
+        self.ssl_ca = Some(CertificateInput::File(file_name.as_ref().to_owned()));
+        self
+    }
+
+    /// Sets PEM encoded list of trusted SSL Certificate Authorities.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use sqlx_core::mysql::{MySqlSslMode, MySqlConnectOptions};
+    /// let options = MySqlConnectOptions::new()
+    ///     .ssl_mode(MySqlSslMode::VerifyCa)
+    ///     .ssl_ca_from_pem(vec![]);
+    /// ```
+    pub fn ssl_ca_from_pem(mut self, pem_certificate: Vec<u8>) -> Self {
+        self.ssl_ca = Some(CertificateInput::Inline(pem_certificate));
         self
     }
 

--- a/sqlx-core/src/net/mod.rs
+++ b/sqlx-core/src/net/mod.rs
@@ -2,4 +2,4 @@ mod socket;
 mod tls;
 
 pub use socket::Socket;
-pub use tls::MaybeTlsStream;
+pub use tls::{CertificateInput, MaybeTlsStream};

--- a/sqlx-core/src/net/tls/rustls.rs
+++ b/sqlx-core/src/net/tls/rustls.rs
@@ -1,11 +1,11 @@
+use crate::net::CertificateInput;
 use rustls::{
     Certificate, ClientConfig, RootCertStore, ServerCertVerified, ServerCertVerifier, TLSError,
     WebPKIVerifier,
 };
+use std::io::Cursor;
 use std::sync::Arc;
-use std::{io::Cursor};
 use webpki::DNSNameRef;
-use crate::net::CertificateInput;
 
 use crate::error::Error;
 
@@ -28,9 +28,10 @@ pub async fn configure_tls_connector(
         if let Some(ca) = root_cert_path {
             let data = ca.data().await?;
             let mut cursor = Cursor::new(data);
-            config.root_store.add_pem_file(&mut cursor).map_err(|_| {
-                Error::Tls(format!("Invalid certificate {}", ca).into())
-            })?;
+            config
+                .root_store
+                .add_pem_file(&mut cursor)
+                .map_err(|_| Error::Tls(format!("Invalid certificate {}", ca).into()))?;
         }
 
         if accept_invalid_hostnames {

--- a/sqlx-core/src/postgres/connection/tls.rs
+++ b/sqlx-core/src/postgres/connection/tls.rs
@@ -70,7 +70,7 @@ async fn upgrade(stream: &mut PgStream, options: &PgConnectOptions) -> Result<bo
             &options.host,
             accept_invalid_certs,
             accept_invalid_hostnames,
-            options.ssl_root_cert.as_deref(),
+            options.ssl_root_cert.as_ref(),
         )
         .await?;
 


### PR DESCRIPTION
Add support for passing in-memory trusted certificates in addition to the already supported path to trusted certificates. 

## Background 

We have use cases where the actually connect/pool configuration including trusted certificates is loaded from parameters stores (e.g. AWS SecretsManager) and we don't want to bother with writing and keeping track of temporary files respectively we have not reasonable filesystem at all (e.g. AWS Lambda or Docker containers with read-only filesystems).