### PR TITLE
Add rename_all to FromRow, add camelCase and PascalCase to all rename_all

### DIFF
--- a/sqlx-core/src/from_row.rs
+++ b/sqlx-core/src/from_row.rs
@@ -53,7 +53,7 @@ use crate::row::Row;
 ///
 /// ```rust,ignore
 /// #[derive(sqlx::FromRow)]
-/// #[sqlx(rename_all = "mixedCase")]
+/// #[sqlx(rename_all = "camelCase")]
 /// struct UserPost {
 ///     id: i32,
 ///     // remapped to "userId"
@@ -63,7 +63,7 @@ use crate::row::Row;
 /// ```
 ///
 /// The supported values are `snake_case` (available if you have non-snake-case field names for some
-/// reason), `lowercase`, `UPPERCASE`, `mixedCase`, `CamelCase`, `SCREAMING_SNAKE_CASE` and `kebab-case`.
+/// reason), `lowercase`, `UPPERCASE`, `camelCase`, `PascalCase`, `SCREAMING_SNAKE_CASE` and `kebab-case`.
 /// The styling of each option is intended to be an example of its behavior.
 ///
 /// #### `default`

--- a/sqlx-core/src/from_row.rs
+++ b/sqlx-core/src/from_row.rs
@@ -53,7 +53,7 @@ use crate::row::Row;
 ///
 /// ```rust,ignore
 /// #[derive(sqlx::FromRow)]
-/// #[sqlx(rename_all = "camelCase")]
+/// #[sqlx(rename_all = "mixedCase")]
 /// struct UserPost {
 ///     id: i32,
 ///     // remapped to "userId"
@@ -63,7 +63,7 @@ use crate::row::Row;
 /// ```
 ///
 /// The supported values are `snake_case` (available if you have non-snake-case field names for some
-/// reason), `lowercase`, `UPPERCASE`, `camelCase`, `SCREAMING_SNAKE_CASE` and `kebab-case`.
+/// reason), `lowercase`, `UPPERCASE`, `mixedCase`, `CamelCase`, `SCREAMING_SNAKE_CASE` and `kebab-case`.
 /// The styling of each option is intended to be an example of its behavior.
 ///
 /// #### `default`

--- a/sqlx-macros/src/derives/attributes.rs
+++ b/sqlx-macros/src/derives/attributes.rs
@@ -33,8 +33,8 @@ pub enum RenameAll {
     UpperCase,
     ScreamingSnakeCase,
     KebabCase,
-    MixedCase,
     CamelCase,
+    PascalCase,
 }
 
 pub struct SqlxContainerAttributes {
@@ -79,8 +79,8 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
                                     "UPPERCASE" => RenameAll::UpperCase,
                                     "SCREAMING_SNAKE_CASE" => RenameAll::ScreamingSnakeCase,
                                     "kebab-case" => RenameAll::KebabCase,
-                                    "mixedCase" => RenameAll::MixedCase,
-                                    "CamelCase" => RenameAll::CamelCase,
+                                    "camelCase" => RenameAll::CamelCase,
+                                    "PascalCase" => RenameAll::PascalCase,
                                     _ => fail!(meta, "unexpected value for rename_all"),
                                 };
 

--- a/sqlx-macros/src/derives/attributes.rs
+++ b/sqlx-macros/src/derives/attributes.rs
@@ -33,6 +33,8 @@ pub enum RenameAll {
     UpperCase,
     ScreamingSnakeCase,
     KebabCase,
+    MixedCase,
+    CamelCase,
 }
 
 pub struct SqlxContainerAttributes {
@@ -77,7 +79,8 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
                                     "UPPERCASE" => RenameAll::UpperCase,
                                     "SCREAMING_SNAKE_CASE" => RenameAll::ScreamingSnakeCase,
                                     "kebab-case" => RenameAll::KebabCase,
-
+                                    "mixedCase" => RenameAll::MixedCase,
+                                    "CamelCase" => RenameAll::CamelCase,
                                     _ => fail!(meta, "unexpected value for rename_all"),
                                 };
 

--- a/sqlx-macros/src/derives/mod.rs
+++ b/sqlx-macros/src/derives/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use r#type::expand_derive_type;
 pub(crate) use row::expand_derive_from_row;
 
 use self::attributes::RenameAll;
-use heck::{KebabCase, ShoutySnakeCase, SnakeCase};
+use heck::{KebabCase, ShoutySnakeCase, SnakeCase, CamelCase, MixedCase};
 use std::iter::FromIterator;
 use syn::DeriveInput;
 
@@ -35,5 +35,8 @@ pub(crate) fn rename_all(s: &str, pattern: RenameAll) -> String {
         RenameAll::UpperCase => s.to_uppercase(),
         RenameAll::ScreamingSnakeCase => s.to_shouty_snake_case(),
         RenameAll::KebabCase => s.to_kebab_case(),
+        RenameAll::MixedCase => s.to_mixed_case(),
+        RenameAll::CamelCase => s.to_camel_case(),
+        
     }
 }

--- a/sqlx-macros/src/derives/mod.rs
+++ b/sqlx-macros/src/derives/mod.rs
@@ -35,8 +35,8 @@ pub(crate) fn rename_all(s: &str, pattern: RenameAll) -> String {
         RenameAll::UpperCase => s.to_uppercase(),
         RenameAll::ScreamingSnakeCase => s.to_shouty_snake_case(),
         RenameAll::KebabCase => s.to_kebab_case(),
-        RenameAll::MixedCase => s.to_mixed_case(),
-        RenameAll::CamelCase => s.to_camel_case(),
+        RenameAll::CamelCase => s.to_mixed_case(),
+        RenameAll::PascalCase => s.to_camel_case(),
         
     }
 }

--- a/sqlx-macros/src/derives/mod.rs
+++ b/sqlx-macros/src/derives/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use r#type::expand_derive_type;
 pub(crate) use row::expand_derive_from_row;
 
 use self::attributes::RenameAll;
-use heck::{KebabCase, ShoutySnakeCase, SnakeCase, CamelCase, MixedCase};
+use heck::{CamelCase, KebabCase, MixedCase, ShoutySnakeCase, SnakeCase};
 use std::iter::FromIterator;
 use syn::DeriveInput;
 
@@ -37,6 +37,5 @@ pub(crate) fn rename_all(s: &str, pattern: RenameAll) -> String {
         RenameAll::KebabCase => s.to_kebab_case(),
         RenameAll::CamelCase => s.to_mixed_case(),
         RenameAll::PascalCase => s.to_camel_case(),
-        
     }
 }

--- a/sqlx-macros/src/derives/row.rs
+++ b/sqlx-macros/src/derives/row.rs
@@ -5,7 +5,10 @@ use syn::{
     Fields, FieldsNamed, FieldsUnnamed, Lifetime, Stmt,
 };
 
-use super::{attributes::{parse_child_attributes, parse_container_attributes}, rename_all};
+use super::{
+    attributes::{parse_child_attributes, parse_container_attributes},
+    rename_all,
+};
 
 pub fn expand_derive_from_row(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     match &input.data {
@@ -72,18 +75,17 @@ fn expand_derive_from_row_struct(
     let container_attributes = parse_container_attributes(&input.attrs)?;
 
     let reads = fields.iter().filter_map(|field| -> Option<Stmt> {
-        
-        
         let id = &field.ident.as_ref()?;
         let attributes = parse_child_attributes(&field.attrs).unwrap();
-        let id_s = attributes.rename
+        let id_s = attributes
+            .rename
             .or_else(|| Some(id.to_string().trim_start_matches("r#").to_owned()))
             .map(|s| match container_attributes.rename_all {
                 Some(pattern) => rename_all(&s, pattern),
-                None => s
+                None => s,
             })
             .unwrap();
-        
+
         let ty = &field.ty;
 
         if attributes.default {

--- a/tests/postgres/derives.rs
+++ b/tests/postgres/derives.rs
@@ -486,7 +486,7 @@ async fn test_from_row_with_rename_all() -> anyhow::Result<()> {
     let mut conn = new::<Postgres>().await?;
 
     let account: AccountKeyword = sqlx::query_as(
-        r#"SELECT * from (VALUES (1, 'foo', 'bar')) accounts(userId, userName, userSurname)"#
+        r#"SELECT * from (VALUES (1, 'foo', 'bar')) accounts(userId, userName, userSurname)"#,
     )
     .fetch_one(&mut conn)
     .await?;
@@ -495,7 +495,6 @@ async fn test_from_row_with_rename_all() -> anyhow::Result<()> {
     assert_eq!(1, account.user_id);
     assert_eq!("foo", account.user_name);
     assert_eq!("bar8", account.user_surname);
-
 
     Ok(())
 }

--- a/tests/postgres/derives.rs
+++ b/tests/postgres/derives.rs
@@ -76,16 +76,16 @@ enum ColorKebabCase {
 
 #[derive(PartialEq, Debug, sqlx::Type)]
 #[sqlx(rename = "color_mixed_case")]
-#[sqlx(rename_all = "mixedCase")]
-enum ColorMixedCase {
+#[sqlx(rename_all = "camelCase")]
+enum ColorCamelCase {
     RedGreen,
     BlueBlack,
 }
 
 #[derive(PartialEq, Debug, sqlx::Type)]
 #[sqlx(rename = "color_camel_case")]
-#[sqlx(rename_all = "CamelCase")]
-enum ColorCamelCase {
+#[sqlx(rename_all = "PascalCase")]
+enum ColorPascalCase {
     RedGreen,
     BlueBlack,
 }
@@ -308,21 +308,9 @@ SELECT id, mood FROM people WHERE id = $1
     assert!(rec.0);
     assert_eq!(rec.1, ColorKebabCase::RedGreen);
 
-    let rec: (bool, ColorMixedCase) = sqlx::query_as(
-        "
-    SELECT $1 = 'redGreen'::color_mixed_case, $1
-            ",
-    )
-    .bind(&ColorMixedCase::RedGreen)
-    .fetch_one(&mut conn)
-    .await?;
-
-    assert!(rec.0);
-    assert_eq!(rec.1, ColorMixedCase::RedGreen);
-
     let rec: (bool, ColorCamelCase) = sqlx::query_as(
         "
-    SELECT $1 = 'RedGreen'::color_camel_case, $1
+    SELECT $1 = 'redGreen'::color_mixed_case, $1
             ",
     )
     .bind(&ColorCamelCase::RedGreen)
@@ -331,6 +319,18 @@ SELECT id, mood FROM people WHERE id = $1
 
     assert!(rec.0);
     assert_eq!(rec.1, ColorCamelCase::RedGreen);
+
+    let rec: (bool, ColorPascalCase) = sqlx::query_as(
+        "
+    SELECT $1 = 'RedGreen'::color_camel_case, $1
+            ",
+    )
+    .bind(&ColorPascalCase::RedGreen)
+    .fetch_one(&mut conn)
+    .await?;
+
+    assert!(rec.0);
+    assert_eq!(rec.1, ColorPascalCase::RedGreen);
 
     Ok(())
 }
@@ -476,7 +476,7 @@ async fn test_from_row_with_rename() -> anyhow::Result<()> {
 #[sqlx_macros::test]
 async fn test_from_row_with_rename_all() -> anyhow::Result<()> {
     #[derive(Debug, sqlx::FromRow)]
-    #[sqlx(rename_all = "mixedCase")]
+    #[sqlx(rename_all = "camelCase")]
     struct AccountKeyword {
         user_id: i32,
         user_name: String,

--- a/tests/postgres/derives.rs
+++ b/tests/postgres/derives.rs
@@ -166,7 +166,7 @@ CREATE TYPE color_lower AS ENUM ( 'red', 'green', 'blue' );
 CREATE TYPE color_snake AS ENUM ( 'red_green', 'blue_black' );
 CREATE TYPE color_upper AS ENUM ( 'RED', 'GREEN', 'BLUE' );
 CREATE TYPE color_screaming_snake AS ENUM ( 'RED_GREEN', 'BLUE_BLACK' );
-CREATE TYPE color_kebab_case" AS ENUM ( 'red-green', 'blue-black' );
+CREATE TYPE color_kebab_case AS ENUM ( 'red-green', 'blue-black' );
 CREATE TYPE color_mixed_case AS ENUM ( 'redGreen', 'blueBlack' );
 CREATE TYPE color_camel_case AS ENUM ( 'RedGreen', 'BlueBlack' );
 

--- a/tests/postgres/derives.rs
+++ b/tests/postgres/derives.rs
@@ -486,7 +486,7 @@ async fn test_from_row_with_rename_all() -> anyhow::Result<()> {
     let mut conn = new::<Postgres>().await?;
 
     let account: AccountKeyword = sqlx::query_as(
-        r#"SELECT * from (VALUES (1, 'foo', 'bar')) accounts(\"userId\", \"userName\", \"userSurname\")"#,
+        r#"SELECT * from (VALUES (1, 'foo', 'bar')) accounts("userId", "userName", "userSurname")"#,
     )
     .fetch_one(&mut conn)
     .await?;

--- a/tests/postgres/derives.rs
+++ b/tests/postgres/derives.rs
@@ -486,7 +486,7 @@ async fn test_from_row_with_rename_all() -> anyhow::Result<()> {
     let mut conn = new::<Postgres>().await?;
 
     let account: AccountKeyword = sqlx::query_as(
-        r#"SELECT * from (VALUES (1, 'foo', 'bar')) accounts(userId, userName, userSurname)"#,
+        r#"SELECT * from (VALUES (1, 'foo', 'bar')) accounts(\"userId\", \"userName\", \"userSurname\")"#,
     )
     .fetch_one(&mut conn)
     .await?;
@@ -494,7 +494,7 @@ async fn test_from_row_with_rename_all() -> anyhow::Result<()> {
 
     assert_eq!(1, account.user_id);
     assert_eq!("foo", account.user_name);
-    assert_eq!("bar8", account.user_surname);
+    assert_eq!("bar", account.user_surname);
 
     Ok(())
 }


### PR DESCRIPTION
As per title.

Sample usage (from test)
```rust
#[derive(Debug, sqlx::FromRow)]
#[sqlx(rename_all = "camelCase")]
struct AccountKeyword {
    user_id: i32,
    user_name: String,
    user_surname: String,
}
```

It looks like this feature was present in a previous version / someone's intention because it was already documented (but not working).

The choice of using `camelCase` and `PascalCase` was taken for consistency with `serde` and with the existing documentation, even though heck's terminology is `mixedCase` and `CamelCase`