### PR TITLE
Add a compatible option to pg to handle extra_float_digits

### DIFF
--- a/sqlx-core/src/postgres/connection/establish.rs
+++ b/sqlx-core/src/postgres/connection/establish.rs
@@ -22,6 +22,11 @@ impl PgConnection {
         // To begin a session, a frontend opens a connection to the server
         // and sends a startup message.
 
+        let extra_float_digits = options
+            .compatible
+            .map(|version| if version < 9_f32 { "2" } else { "3" })
+            .unwrap_or("3");
+
         let mut params = vec![
             // Sets the display format for date and time values,
             // as well as the rules for interpreting ambiguous date input values.
@@ -33,7 +38,7 @@ impl PgConnection {
             ("TimeZone", "UTC"),
             // Adjust postgres to return precise values for floats
             // NOTE: This is default in postgres 12+
-            ("extra_float_digits", "3"),
+            ("extra_float_digits", extra_float_digits),
         ];
 
         if let Some(ref application_name) = options.application_name {

--- a/sqlx-core/src/postgres/options/mod.rs
+++ b/sqlx-core/src/postgres/options/mod.rs
@@ -32,6 +32,8 @@ pub use ssl_mode::PgSslMode;
 /// | `password` | `None` | Password to be used if the server demands password authentication. |
 /// | `port` | `5432` | Port number to connect to at the server host, or socket file name extension for Unix-domain connections. |
 /// | `dbname` | `None` | The database name. |
+/// | `compatible` | `None` | Act like an older version of the driver to retain compatibility with older applications. At the moment this controls the number of `extra_float_digits` set at startup. |
+
 ///
 /// The URI scheme designator can be either `postgresql://` or `postgres://`.
 /// Each of the URI parts is optional.
@@ -86,6 +88,7 @@ pub struct PgConnectOptions {
     pub(crate) statement_cache_capacity: usize,
     pub(crate) application_name: Option<String>,
     pub(crate) log_settings: LogSettings,
+    pub(crate) compatible: Option<f32>,
 }
 
 impl Default for PgConnectOptions {
@@ -138,6 +141,7 @@ impl PgConnectOptions {
             statement_cache_capacity: 100,
             application_name: var("PGAPPNAME").ok(),
             log_settings: Default::default(),
+            compatible: None,
         }
     }
 
@@ -293,6 +297,20 @@ impl PgConnectOptions {
     /// ```
     pub fn application_name(mut self, application_name: &str) -> Self {
         self.application_name = Some(application_name.to_owned());
+        self
+    }
+
+    /// Sets the compatibility to a specific version of postgres. Defaults to None
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use sqlx_core::postgres::PgConnectOptions;
+    /// let options = PgConnectOptions::new()
+    ///     .compatible(81);
+    /// ```
+    pub fn compatible(mut self, version: f32) -> Self {
+        self.compatible = Some(version.to_owned());
         self
     }
 

--- a/sqlx-core/src/postgres/options/mod.rs
+++ b/sqlx-core/src/postgres/options/mod.rs
@@ -307,7 +307,7 @@ impl PgConnectOptions {
     /// ```rust
     /// # use sqlx_core::postgres::PgConnectOptions;
     /// let options = PgConnectOptions::new()
-    ///     .compatible(81);
+    ///     .compatible(8.1);
     /// ```
     pub fn compatible(mut self, version: f32) -> Self {
         self.compatible = Some(version.to_owned());

--- a/sqlx-core/src/postgres/options/parse.rs
+++ b/sqlx-core/src/postgres/options/parse.rs
@@ -85,6 +85,10 @@ impl FromStr for PgConnectOptions {
 
                 "application_name" => options = options.application_name(&*value),
 
+                "compatible" => {
+                    options = options.compatible(value.parse::<f32>().map_err(Error::config)?)
+                }
+
                 _ => log::warn!("ignoring unrecognized connect parameter: {}={}", key, value),
             }
         }


### PR DESCRIPTION
Postgres versions older than 9 don't support `extra_float_digits` greater than 2, causing sqlx to fail connecting to those dbs.
Amazon Redshift happens to be one of those database, which is quite widely used.

At the moment we're sending `extra_float_digits 3`

This PR adds a `compatible` query string option for the connection string, so that users have a way to connect to older databases or Redshift.

I was inspired by the `compatible` option that JDBC uses: https://jdbc.postgresql.org/documentation/94/connect.html

Sample usage:
```
DATABASE_URL=postgres://my-db.com/db_name?compatible=8.5 # sends extra_float_digits 2
DATABASE_URL=postgres://my-db.com/db_name?compatible=9    # sends extra_float_digits 3
DATABASE_URL=postgres://my-db.com/db_name                             # sends extra_float_digits 3
```
