### PR TITLE
Adding support for vector of bytea type in postgres

### DIFF
--- a/sqlx-macros/src/database/postgres.rs
+++ b/sqlx-macros/src/database/postgres.rs
@@ -68,6 +68,7 @@ impl_database_ext! {
 
         Vec<bool> | &[bool],
         Vec<String> | &[String],
+        Vec<Vec<u8>> | &[Vec<u8>],
         Vec<i8> | &[i8],
         Vec<i16> | &[i16],
         Vec<i32> | &[i32],


### PR DESCRIPTION
Adding support in macros for arrays of `bytea` in Postgres.

Closes #873 