### PR TITLE
sqlx-core/src/mysql/types/str.rs:  + COLLATE_UTF8MB4_GENERAL_CI

### DIFF
--- a/sqlx-core/src/mysql/types/str.rs
+++ b/sqlx-core/src/mysql/types/str.rs
@@ -10,6 +10,7 @@ const COLLATE_UTF8_GENERAL_CI: u16 = 33;
 const COLLATE_UTF8_UNICODE_CI: u16 = 192;
 const COLLATE_UTF8MB4_UNICODE_CI: u16 = 224;
 const COLLATE_UTF8MB4_BIN: u16 = 46;
+const COLLATE_UTF8MB4_GENERAL_CI: u16 = 45;
 
 impl Type<MySql> for str {
     fn type_info() -> MySqlTypeInfo {
@@ -39,6 +40,7 @@ impl Type<MySql> for str {
                 | COLLATE_UTF8_UNICODE_CI
                 | COLLATE_UTF8_GENERAL_CI
                 | COLLATE_UTF8MB4_BIN
+                | COLLATE_UTF8MB4_GENERAL_CI
         )
     }
 }


### PR DESCRIPTION
Just adding support for another collation being considered a string :)