### PR TITLE
Fixing the quickstart example

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ Add dependencies to `Cargo.toml`
 
 ```toml
 [dependencies]
-async-std = { version = "1.7.0", features = ["attributes"] }
-anyhow = "1.0"
+anyhow = "1.0" # For error handling
+async-std = { version = "1.7.0", features = ["attributes"] } 
 sqlx = { version = "0.4.0", features = ["runtime-async-std-native-tls", "postgres"]}
 ```
 
@@ -207,10 +207,10 @@ async fn main() -> anyhow::Result<()> {
 }
 ```
 
-Run with relevant `DATABASE_URL` in environment, e.g.
+Run with relevant `DATABASE_URL` for you as an environment variable, e.g.
 
 ```bash
->> DATABASE_URL=postgres://username:password@localhost/sqlx_quickstart cargo run
+>> DATABASE_URL=postgres://<your_username>:<your_password>@localhost/<your_database> cargo run
 ```
 
 ### Connecting

--- a/README.md
+++ b/README.md
@@ -166,6 +166,22 @@ sqlx = { version = "0.4.0", features = [ "runtime-async-std-native-tls" ] }
 
 ### Quickstart
 
+```bash
+>> cargo new --bin sqlx_quickstart
+>> cd sqlx_quickstart
+```
+
+Add dependencies to `Cargo.toml`
+
+```toml
+[dependencies]
+async-std = { version = "1.7.0", features = ["attributes"] }
+anyhow = "1.0"
+sqlx = { version = "0.4.0", features = ["runtime-async-std-native-tls", "postgres"]}
+```
+
+Update `src/main.rs`
+
 ```rust
 use std::env;
 
@@ -174,7 +190,7 @@ use sqlx::postgres::PgPoolOptions;
 // etc.
 
 #[async_std::main] // or #[tokio::main]
-async fn main() -> Result<(), sqlx::Error> {
+async fn main() -> anyhow::Result<()> {
     // Create a connection pool
     let pool = PgPoolOptions::new()
         .max_connections(5)
@@ -189,6 +205,12 @@ async fn main() -> Result<(), sqlx::Error> {
 
     Ok(())
 }
+```
+
+Run with relevant `DATABASE_URL` in environment, e.g.
+
+```bash
+>> DATABASE_URL=postgres://username:password@localhost/sqlx_quickstart cargo run
 ```
 
 ### Connecting


### PR DESCRIPTION
As referenced in #883, here is a PR which fixes the quickstart example and makes it more self-contained.

Unsure if better to do this or just strip down to getting it working (i.e. use `anyhow::Result`) and leave the setup and dependencies to the user. Figured I'd do more rather than less here and can take out later.