### PR TITLE
Improves error handling in the case of missing type

### DIFF
--- a/sqlx-core/src/error.rs
+++ b/sqlx-core/src/error.rs
@@ -57,6 +57,10 @@ pub enum Error {
     #[error("no rows returned by a query that expected to return at least one row")]
     RowNotFound,
 
+    /// Type in query doesn't exist. Likely due to typo or missing user type.
+    #[error("type named {type_name} not found")]
+    TypeNotFound { type_name: String },
+
     /// Column index was out of bounds.
     #[error("column index out of bounds: the len is {len}, but the index is {index}")]
     ColumnIndexOutOfBounds { index: usize, len: usize },

--- a/sqlx-core/src/postgres/connection/describe.rs
+++ b/sqlx-core/src/postgres/connection/describe.rs
@@ -235,11 +235,13 @@ SELECT oid FROM pg_catalog.pg_type WHERE typname ILIKE $1
                 ",
         )
         .bind(name)
-        .fetch_one(&mut *self)
-        .await?;
+        .fetch_optional(&mut *self)
+        .await?
+        .ok_or_else(|| Error::TypeNotFound {
+            type_name: String::from(name),
+        })?;
 
         self.cache_type_oid.insert(name.to_string().into(), oid);
-
         Ok(oid)
     }
 


### PR DESCRIPTION
This is for  https://github.com/launchbadge/sqlx/issues/239. 

I didn't use the proposed error message in the issue because I'm not sure if there's an easy way differentiate between a missing user type and a typo. Although it does like that method should only be called in the context of new type names. 

I haven't written much Rust and definitely have a couple of questions. 

I don't really understand what's going on with the `?` macro that pulls the `oid` out of the tuple automatically. I think my code would be a little clearer if I didn't need to leave the `oid` in a tuple

I'm also not sure if using `map_error` to mutate the error to the new `TypeNotFound` error is idiomatic

I'm not sure if this is worthy of a new error, and organizationally I'm not sure if it makes sense to have that type in `sql-core` when it currently only applies to postgres although i believe sql server also supports user defined types. 

CC: @mehcode 