### PR TITLE
fix: whoami crash on FreeBSD aarch platform

### DIFF
--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -104,6 +104,6 @@ url = { version = "2.1.1", default-features = false }
 uuid = { version = "0.8.1", default-features = false, optional = true, features = [ "std" ] }
 webpki = { version = "0.21.3", optional = true }
 webpki-roots = { version = "0.20.0", optional = true }
-whoami = "0.9.0"
+whoami = "1.0.1"
 stringprep = "0.1.2"
 hashlink = "0.6.0"


### PR DESCRIPTION
Fixed: https://github.com/launchbadge/sqlx/issues/903