### PR TITLE
Resume read_package after drop.

### DIFF
--- a/sqlx-core/src/io/buf_stream.rs
+++ b/sqlx-core/src/io/buf_stream.rs
@@ -82,6 +82,17 @@ where
     pub async fn read_raw_into(&mut self, buf: &mut BytesMut, cnt: usize) -> Result<(), Error> {
         read_raw_into(&mut self.stream, buf, cnt).await
     }
+
+    /// Read data from stream into buf
+    /// * On success: The number of bytes read (> 0) is returned
+    /// * On error: The error is returned, no bytes will have been read from the stream
+    /// * When dropped: No bytes will have been read from the stream
+    pub async fn read_some(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+        match self.stream.read(buf).await? {
+            0 => Err(io::Error::from(io::ErrorKind::ConnectionAborted).into()),
+            v => Ok(v),
+        }
+    }
 }
 
 impl<S> Deref for BufStream<S>

--- a/sqlx-macros/src/derives/attributes.rs
+++ b/sqlx-macros/src/derives/attributes.rs
@@ -55,7 +55,10 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
     let mut rename = None;
     let mut rename_all = None;
 
-    for attr in input.iter().filter(|a| a.path.is_ident("sqlx") || a.path.is_ident("repr")) {
+    for attr in input
+        .iter()
+        .filter(|a| a.path.is_ident("sqlx") || a.path.is_ident("repr"))
+    {
         let meta = attr
             .parse_meta()
             .map_err(|e| syn::Error::new_spanned(attr, e))?;

--- a/tests/mysql/mysql.rs
+++ b/tests/mysql/mysql.rs
@@ -334,6 +334,107 @@ async fn it_can_prepare_then_execute() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn drop_test() -> anyhow::Result<()> {
+    const CNT: usize = 222;
+    const POOL_SIZE: u32 = 2;
+
+    setup_if_needed();
+
+    let pool = MySqlPoolOptions::new()
+        .max_connections(POOL_SIZE)
+        .connect(&std::env::var("DATABASE_URL").unwrap())
+        .await?;
+    // Create a temporery table and insert a lot of stuff
+    {
+        let mut conn = pool.acquire().await.unwrap();
+        sqlx::query("DROP TABLE IF EXISTS drop_test")
+            .execute(&mut conn)
+            .await?;
+        sqlx::query("CREATE TABLE drop_test (id BIGINT PRIMARY KEY AUTO_INCREMENT)")
+            .execute(&mut conn)
+            .await?;
+        let mut q = "INSERT INTO drop_test () VALUES ()".to_string();
+        for _ in 0..CNT {
+            q.push_str(", ()");
+        }
+        sqlx::query(&q).execute(&mut conn).await?;
+    }
+
+    // It is somewhat tricky to get the timing right for failures to occur
+    // so we repeat the test a number of times
+    for _ in 0..50 {
+        // Create a bunch of long running jobs
+        // that hopefully will be dropped in read
+        let s = std::time::Instant::now();
+        let mut futures = vec![];
+        for i in 0..POOL_SIZE {
+            let s = s.clone();
+            let pool = pool.clone();
+            futures.push(async move {
+                let mut conn = pool.acquire().await.unwrap();
+                {
+                    let mut stream = sqlx::query("SELECT 1 FROM drop_test AS a, drop_test AS b")
+                        .fetch(&mut conn);
+                    while let Some(_) = stream.try_next().await? {}
+                }
+                println!("Thread {} finished {}", i, s.elapsed().as_secs_f64());
+                Result::<(), anyhow::Error>::Ok(())
+            });
+        }
+
+        /// Some "feature" in tokio causes the timeout to never occur if the
+        /// sleep time is more than one
+        #[cfg(feature = "_rt-tokio")]
+        fn drop_test_timeout() -> u64 {
+            1
+        }
+
+        #[cfg(not(feature = "_rt-tokio"))]
+        fn drop_test_timeout() -> u64 {
+            23
+        }
+
+        if let Ok(_) = sqlx_rt::timeout(
+            std::time::Duration::from_millis(drop_test_timeout()),
+            futures::future::join_all(futures),
+        )
+        .await
+        {
+            println!(
+                "All queries finished before timeout, this should not happen. We waited {}s",
+                s.elapsed().as_secs_f64()
+            );
+            continue;
+        }
+        println!("Timeout after {}s", s.elapsed().as_secs_f64());
+
+        // Perform some query and check the result
+        let pool = pool.clone();
+        let f = async move {
+            let mut conn = pool.acquire().await.unwrap();
+            let row = sqlx::query("SELECT CAST(SUM(id) AS UNSIGNED) AS s FROM drop_test")
+                .fetch_one(&mut conn)
+                .await?;
+            let s: u64 = row.try_get("s")?;
+            assert_eq!(s, ((CNT + 1) * (CNT + 2) / 2) as u64);
+            Result::<(), anyhow::Error>::Ok(())
+        };
+        // We add a timeout here as bugs in the drop handling can cause us to
+        // wait for gigabytes of data to be pushed from mysql
+        sqlx_rt::timeout(std::time::Duration::from_secs(7), f).await??;
+    }
+
+    {
+        let mut conn = pool.acquire().await.unwrap();
+        sqlx::query("DROP TABLE IF EXISTS drop_test")
+            .execute(&mut conn)
+            .await?;
+    }
+
+    Ok(())
+}
+
 // repro is more reliable with the basic scheduler used by `#[tokio::test]`
 #[cfg(feature = "_rt-tokio")]
 #[tokio::test]


### PR DESCRIPTION
Fixes #563 

As detailed in #563, dropping MySQL future, such as `fetch_many` while it is within `read_package`, puts the stream in an invalid state, which causes the next user of a stream in the pool to get garbage. This is because a package has some length, stopping in the middle of `read_package` might have only read part of the package. When `read_package` is then called again it will attempt to read the header of the next package from the data in the middle of the latter. 

This pull requests tries to fix this issue, by essentially storing the state of the `read_package` future within the stream it self, such that calling `read_package` again will start it from the same position, and return the full package that `read_package` had partially read before.

To do this a `read_some` call is added to the `BufStream`. The assumption for this call is that if it succeeded it will tell how much data has been read, and if it is dropped til will have read *NO* data.





