### PR TITLE
Connection refused backoff

### DIFF
--- a/sqlx-core/src/pool/inner.rs
+++ b/sqlx-core/src/pool/inner.rs
@@ -242,7 +242,7 @@ impl<DB: Database> SharedPool<DB> {
             }
 
             // an IO error while connecting is assumed to be the system starting up
-            Ok(Err(Error::Io(_))) => Ok(None),
+            Ok(Err(Error::Io(e))) if e.kind() == std::io::ErrorKind::ConnectionRefused => Ok(None),
 
             // TODO: Handle other database "boot period"s
 

--- a/sqlx-core/src/pool/inner.rs
+++ b/sqlx-core/src/pool/inner.rs
@@ -177,6 +177,7 @@ impl<DB: Database> SharedPool<DB> {
         let start = Instant::now();
         let deadline = start + self.options.connect_timeout;
         let mut waited = !self.options.fair;
+        let mut backoff = 0.01;
 
         // Unless the pool has been closed ...
         while !self.is_closed() {
@@ -196,7 +197,14 @@ impl<DB: Database> SharedPool<DB> {
                 match self.connection(deadline, guard).await {
                     Ok(Some(conn)) => return Ok(conn),
                     // [size] is internally decremented on _retry_ and _error_
-                    Ok(None) => continue,
+                    Ok(None) => {
+                        // If the connection is refused wait in exponentially
+                        // increasing steps for the server to come up, capped by
+                        // two seconds.
+                        sqlx_rt::sleep(std::time::Duration::from_secs_f64(backoff)).await;
+                        backoff = f64::min(backoff * 2.0, 2.0);
+                        continue;
+                    }
                     Err(e) => return Err(e),
                 }
             }


### PR DESCRIPTION
Fixes #848

This implements exponential backoff on reconnect when connect() returns ECONNREFUSED. We start by waiting 10ms, doubling until plateauing at 2seconds. There is nothing magic about these numbers, they somehow seem reasonable to me.


