### PR TITLE
Fix README.md to include mysql feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ sqlx = { version = "0.4.2", features = [ "runtime-async-std-native-tls" ] }
 
 -   `postgres`: Add support for the Postgres database server.
 
+-   `mysql`: Add support for the MySQL/MariaDB database server.
+
 -   `mssql`: Add support for the MSSQL database server.
 
 -   `sqlite`: Add support for the self-contained [SQLite](https://sqlite.org/) database engine.


### PR DESCRIPTION
Added mention to the `mysql` feature flag, as it is required for MySQL support but not mentioned in `README.md`.