### PR TITLE
Fixing don't parse all attributes as `Meta` in parse_container_attrib…

### DIFF
--- a/sqlx-macros/src/derives/attributes.rs
+++ b/sqlx-macros/src/derives/attributes.rs
@@ -55,7 +55,7 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
     let mut rename = None;
     let mut rename_all = None;
 
-    for attr in input {
+    for attr in input.iter().filter(|a| a.path.is_ident("sqlx") || a.path.is_ident("repr")) {
         let meta = attr
             .parse_meta()
             .map_err(|e| syn::Error::new_spanned(attr, e))?;


### PR DESCRIPTION
This is similar too https://github.com/launchbadge/sqlx/pull/791
It is need to have ormx working on 0.4.2, without it when a struct has custom attributes like:
```
#[ormx(table = "visualizations.list", id = id, insertable)]
```
And FromRow sqlx derive it fails with `error: expected literal`