### PR TITLE
Add a way to disable query logging programmatically

### DIFF
--- a/sqlx-core/src/connection.rs
+++ b/sqlx-core/src/connection.rs
@@ -166,4 +166,10 @@ pub trait ConnectOptions: 'static + Send + Sync + FromStr<Err = Error> + Debug {
     /// Log executed statements with a duration above the specified `duration`
     /// at the specified `level`.
     fn log_slow_statements(&mut self, level: LevelFilter, duration: Duration) -> &mut Self;
+
+    /// Entirely disables statement logging (both slow and regular).
+    fn disable_statement_logging(&mut self) -> &mut Self {
+        self.log_statements(LevelFilter::Off)
+            .log_slow_statements(LevelFilter::Off, Duration::default())
+    }
 }

--- a/sqlx-macros/src/derives/attributes.rs
+++ b/sqlx-macros/src/derives/attributes.rs
@@ -55,7 +55,10 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
     let mut rename = None;
     let mut rename_all = None;
 
-    for attr in input.iter().filter(|a| a.path.is_ident("sqlx") || a.path.is_ident("repr")) {
+    for attr in input
+        .iter()
+        .filter(|a| a.path.is_ident("sqlx") || a.path.is_ident("repr"))
+    {
         let meta = attr
             .parse_meta()
             .map_err(|e| syn::Error::new_spanned(attr, e))?;


### PR DESCRIPTION
I'd like to disable the query logging entirely due to https://github.com/launchbadge/sqlx/issues/633 and a few other reasons.

Currently, it looks like I can do this two ways:

* set `RUST_LOG` env variable or add more configuration into the logger directly: a fragile indirect way, since can be spoiled too easy and not verifiable by the compiler
* use `ConnectOptions`-like trait for my db and pass the `LevelFilter::Off` there, which is good except for the fact that I use `tracing` instead of `log` and I need to drag in another dependency just to disable the logging.

This PR adds another method to `ConnectOptions` that allows disabling the logs without requiring somebody to use `log` crate for that.