### PR TITLE
Store offline data in one file per query / remove sqlx-data.json

### DIFF
--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -1,7 +1,7 @@
 name: SQLx
 
 on:
-  pull_request:
+  #pull_request:
   push:
     branches:
       - master

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1897,18 +1897,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "remove_dir_all"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b19f5c2df95a07275e7224924cc62f76f04525f4fda801473f85e325e81977"
-dependencies = [
- "log",
- "num_cpus",
- "rayon",
- "winapi",
-]
-
-[[package]]
 name = "ring"
 version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2249,7 +2237,6 @@ dependencies = [
  "futures",
  "glob",
  "openssl",
- "remove_dir_all 0.6.1",
  "serde",
  "serde_json",
  "sqlx",
@@ -2399,6 +2386,7 @@ dependencies = [
  "sqlx-core",
  "sqlx-rt",
  "syn",
+ "tempfile",
  "url",
 ]
 
@@ -2586,7 +2574,7 @@ dependencies = [
  "libc",
  "rand",
  "redox_syscall",
- "remove_dir_all 0.5.3",
+ "remove_dir_all",
  "winapi",
 ]
 

--- a/sqlx-cli/Cargo.toml
+++ b/sqlx-cli/Cargo.toml
@@ -40,8 +40,6 @@ serde_json = { version = "1.0.53", features = ["preserve_order"] }
 serde = { version = "1.0.110", features = ["derive"] }
 glob = "0.3.0"
 openssl = { version = "0.10.30", optional = true }
-# workaround for https://github.com/rust-lang/rust/issues/29497
-remove_dir_all = "0.6.0"
 
 [features]
 default = [ "postgres", "sqlite", "mysql" ]

--- a/sqlx-cli/src/cargo.rs
+++ b/sqlx-cli/src/cargo.rs
@@ -1,0 +1,34 @@
+use anyhow::Context;
+use serde::Deserialize;
+use std::env;
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
+use std::process::Command;
+
+#[derive(Deserialize)]
+pub struct CargoMetadata {
+    pub target_directory: PathBuf,
+    pub workspace_root: PathBuf,
+}
+
+/// Path to the `cargo` executable
+pub fn cargo_path() -> anyhow::Result<OsString> {
+    env::var_os("CARGO").context("Failed to obtain value of `CARGO`")
+}
+
+pub fn manifest_dir() -> anyhow::Result<PathBuf> {
+    Ok(env::var_os("CARGO_MANIFEST_DIR")
+        .context("Failed to obtain value of `CARGO_MANIFEST_DIR`")?
+        .into())
+}
+
+pub fn metadata(cargo: &OsStr) -> anyhow::Result<CargoMetadata> {
+    let output = Command::new(&cargo)
+        .args(&["metadata", "--format-version=1"])
+        .output()
+        .context("Could not fetch metadata")?;
+
+    serde_json::from_slice(&output.stdout)
+        .context("Invalid `cargo metadata` output")
+        .map_err(Into::into)
+}

--- a/sqlx-cli/src/lib.rs
+++ b/sqlx-cli/src/lib.rs
@@ -1,8 +1,10 @@
 use crate::opt::{Command, DatabaseCommand, MigrateCommand};
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use dotenv::dotenv;
+use prepare::PrepareCtx;
 use std::env;
 
+mod cargo;
 mod database;
 // mod migration;
 // mod migrator;
@@ -46,16 +48,30 @@ pub async fn run(opt: Opt) -> anyhow::Result<()> {
         },
 
         Command::Prepare {
-            check: false,
-            merged,
+            check,
+            workspace,
             args,
-        } => prepare::run(&database_url, merged, args)?,
+        } => {
+            let cargo_path = cargo::cargo_path()?;
+            let manifest_dir = cargo::manifest_dir()?;
+            let metadata = cargo::metadata(&cargo_path)
+                .context("`prepare` subcommand may only be invoked as `cargo sqlx prepare`")?;
 
-        Command::Prepare {
-            check: true,
-            merged,
-            args,
-        } => prepare::check(&database_url, merged, args)?,
+            let ctx = PrepareCtx {
+                workspace,
+                cargo: cargo_path,
+                cargo_args: args,
+                manifest_dir,
+                target_dir: metadata.target_directory,
+                workspace_root: metadata.workspace_root,
+            };
+
+            if check {
+                prepare::check(&ctx)?
+            } else {
+                prepare::run(&ctx)?
+            }
+        }
     };
 
     Ok(())

--- a/sqlx-cli/src/opt.rs
+++ b/sqlx-cli/src/opt.rs
@@ -29,9 +29,12 @@ pub enum Command {
         #[clap(long)]
         check: bool,
 
-        /// Generate a single top-level `sqlx-data.json` file when using a cargo workspace.
+        /// Do a clean build of all crates in the workspace.
+        ///
+        /// This option is intended for workspaces where multiple crates use SQLx; if there is only
+        /// one, it is better to run `cargo sqlx prepare` without this option inside of that crate.
         #[clap(long)]
-        merged: bool,
+        workspace: bool,
 
         /// Arguments to be passed to `cargo rustc ...`.
         #[clap(last = true)]

--- a/sqlx-cli/src/prepare.rs
+++ b/sqlx-cli/src/prepare.rs
@@ -1,138 +1,80 @@
-use anyhow::{bail, Context};
-use console::style;
-use remove_dir_all::remove_dir_all;
-use serde::Deserialize;
-use sqlx::any::{AnyConnectOptions, AnyKind};
-use std::collections::BTreeMap;
-use std::fs::File;
-use std::io::{BufReader, BufWriter};
-use std::path::{Path, PathBuf};
+use anyhow::bail;
+use std::ffi::OsString;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
-use std::str::FromStr;
 use std::time::SystemTime;
-use std::{env, fs};
 
-type QueryData = BTreeMap<String, serde_json::Value>;
-type JsonObject = serde_json::Map<String, serde_json::Value>;
+pub struct PrepareCtx {
+    pub workspace: bool,
+    pub cargo: OsString,
+    pub cargo_args: Vec<String>,
+    pub manifest_dir: PathBuf,
+    pub target_dir: PathBuf,
+    pub workspace_root: PathBuf,
+}
 
-pub fn run(url: &str, merge: bool, cargo_args: Vec<String>) -> anyhow::Result<()> {
-    #[derive(serde::Serialize)]
-    struct DataFile {
-        db: &'static str,
-        #[serde(flatten)]
-        data: QueryData,
-    }
+pub fn run(ctx: &PrepareCtx) -> anyhow::Result<()> {
+    let root = if ctx.workspace {
+        &ctx.workspace_root
+    } else {
+        &ctx.manifest_dir
+    };
 
-    let db_kind = get_db_kind(url)?;
-    let data = run_prepare_step(merge, cargo_args)?;
-
-    if data.is_empty() {
-        println!(
-            "{} no queries found; do you have the `offline` feature enabled in sqlx?",
-            style("warning:").yellow()
-        );
-    }
-
-    serde_json::to_writer_pretty(
-        BufWriter::new(
-            File::create("sqlx-data.json").context("failed to create/open `sqlx-data.json`")?,
-        ),
-        &DataFile { db: db_kind, data },
-    )
-    .context("failed to write to `sqlx-data.json`")?;
+    run_prepare_step(ctx, &root.join(".sqlx"))?;
 
     println!(
-        "query data written to `sqlx-data.json` in the current directory; \
+        "query data written to `.sqlx` in the current directory; \
          please check this into version control"
     );
 
     Ok(())
 }
 
-pub fn check(url: &str, merge: bool, cargo_args: Vec<String>) -> anyhow::Result<()> {
-    let db_kind = get_db_kind(url)?;
-    let data = run_prepare_step(merge, cargo_args)?;
+pub fn check(ctx: &PrepareCtx) -> anyhow::Result<()> {
+    let cache_dir = ctx.target_dir.join("sqlx");
+    run_prepare_step(ctx, &cache_dir)?;
 
-    let data_file = File::open("sqlx-data.json").context(
-        "failed to open `sqlx-data.json`; you may need to run `cargo sqlx prepare` first",
-    )?;
-
-    let mut saved_data: QueryData = serde_json::from_reader(BufReader::new(data_file))?;
-
-    let expected_db = saved_data
-        .remove("db")
-        .context("expected key `db` in data file")?;
-
-    let expected_db = expected_db
-        .as_str()
-        .context("expected key `db` to be a string")?;
-
-    if db_kind != expected_db {
-        bail!(
-            "saved prepare data is for {}, not {} (inferred from `DATABASE_URL`)",
-            expected_db,
-            db_kind
-        )
-    }
-
-    if data != saved_data {
-        bail!("`cargo sqlx prepare` needs to be rerun")
-    }
+    // TODO: Compare .sqlx to target/sqlx
+    // * For files thta are only in the former, raise a warning
+    // * For files that are only in the latter, raise an error
 
     Ok(())
 }
 
-fn run_prepare_step(merge: bool, cargo_args: Vec<String>) -> anyhow::Result<QueryData> {
+fn run_prepare_step(ctx: &PrepareCtx, cache_dir: &Path) -> anyhow::Result<()> {
     anyhow::ensure!(
         Path::new("Cargo.toml").exists(),
         r#"Failed to read `Cargo.toml`.
 hint: This command only works in the manifest directory of a Cargo package."#
     );
 
-    // path to the Cargo executable
-    let cargo = env::var("CARGO")
-        .context("`prepare` subcommand may only be invoked as `cargo sqlx prepare`")?;
-
-    let output = Command::new(&cargo)
-        .args(&["metadata", "--format-version=1"])
-        .output()
-        .context("Could not fetch metadata")?;
-
-    #[derive(Deserialize)]
-    struct Metadata {
-        target_directory: PathBuf,
+    if cache_dir.exists() {
+        clear_cache_dir(cache_dir)?;
+    } else {
+        fs::create_dir(cache_dir)?;
     }
 
-    let metadata: Metadata =
-        serde_json::from_slice(&output.stdout).context("Invalid `cargo metadata` output")?;
-
-    // try removing the target/sqlx directory before running, as stale files
-    // have repeatedly caused issues in the past.
-    let _ = remove_dir_all(metadata.target_directory.join("sqlx"));
-
-    let check_status = if merge {
-        let check_status = Command::new(&cargo).arg("clean").status()?;
+    let mut check_cmd = Command::new(&ctx.cargo);
+    if ctx.workspace {
+        let check_status = Command::new(&ctx.cargo).arg("clean").status()?;
 
         if !check_status.success() {
             bail!("`cargo clean` failed with status: {}", check_status);
         }
 
-        Command::new(&cargo)
-            .arg("check")
-            .args(cargo_args)
-            .env(
-                "RUSTFLAGS",
-                format!(
-                    "--cfg __sqlx_recompile_trigger=\"{}\"",
-                    SystemTime::UNIX_EPOCH.elapsed()?.as_millis()
-                ),
-            )
-            .env("SQLX_OFFLINE", "false")
-            .status()?
+        check_cmd.arg("check").args(&ctx.cargo_args).env(
+            "RUSTFLAGS",
+            format!(
+                "--cfg __sqlx_recompile_trigger=\"{}\"",
+                SystemTime::UNIX_EPOCH.elapsed()?.as_millis()
+            ),
+        );
     } else {
-        Command::new(&cargo)
+        check_cmd
             .arg("rustc")
-            .args(cargo_args)
+            .args(&ctx.cargo_args)
             .arg("--")
             .arg("--emit")
             .arg("dep-info,metadata")
@@ -141,65 +83,25 @@ hint: This command only works in the manifest directory of a Cargo package."#
             .arg(format!(
                 "__sqlx_recompile_trigger=\"{}\"",
                 SystemTime::UNIX_EPOCH.elapsed()?.as_millis()
-            ))
-            .env("SQLX_OFFLINE", "false")
-            .status()?
-    };
+            ));
+    }
+
+    let check_status = check_cmd
+        .env("SQLX_OFFLINE", "false")
+        .env("SQLX_OFFLINE_DIR", cache_dir)
+        .status()?;
 
     if !check_status.success() {
         bail!("`cargo check` failed with status: {}", check_status);
     }
 
-    let pattern = metadata.target_directory.join("sqlx/query-*.json");
-
-    let mut data = BTreeMap::new();
-
-    for path in glob::glob(
-        pattern
-            .to_str()
-            .context("CARGO_TARGET_DIR not valid UTF-8")?,
-    )? {
-        let path = path?;
-        let contents = fs::read(&*path)?;
-        let mut query_data: JsonObject = serde_json::from_slice(&contents)?;
-
-        // we lift the `hash` key to the outer map
-        let hash = query_data
-            .remove("hash")
-            .context("expected key `hash` in query data")?;
-
-        if let serde_json::Value::String(hash) = hash {
-            data.insert(hash, serde_json::Value::Object(query_data));
-        } else {
-            bail!(
-                "expected key `hash` in query data to be string, was {:?} instead; file: {}",
-                hash,
-                path.display()
-            )
-        }
-
-        // lazily remove the file, we don't care too much if we can't
-        let _ = fs::remove_file(&path);
-    }
-
-    Ok(data)
+    Ok(())
 }
 
-fn get_db_kind(url: &str) -> anyhow::Result<&'static str> {
-    let options = AnyConnectOptions::from_str(&url)?;
-
-    // these should match the values of `DatabaseExt::NAME` in `sqlx-macros`
-    match options.kind() {
-        #[cfg(feature = "postgres")]
-        AnyKind::Postgres => Ok("PostgreSQL"),
-
-        #[cfg(feature = "mysql")]
-        AnyKind::MySql => Ok("MySQL"),
-
-        #[cfg(feature = "sqlite")]
-        AnyKind::Sqlite => Ok("SQLite"),
-
-        #[cfg(feature = "mssql")]
-        AnyKind::Mssql => Ok("MSSQL"),
+fn clear_cache_dir(path: &Path) -> anyhow::Result<()> {
+    for entry in fs::read_dir(path)? {
+        fs::remove_file(entry?.path())?;
     }
+
+    Ok(())
 }

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -34,7 +34,7 @@ _rt-async-std = []
 _rt-tokio = []
 
 # offline building support
-offline = ["sqlx-core/offline", "hex", "serde", "serde_json", "sha2"]
+offline = ["sqlx-core/offline", "hex", "serde", "serde_json", "sha2", "tempfile"]
 
 # database
 mysql = [ "sqlx-core/mysql" ]
@@ -66,5 +66,6 @@ serde = { version = "1.0.111", features = ["derive"], optional = true }
 serde_json = { version = "1.0.30", features = ["preserve_order"], optional = true }
 sha2 = { version = "0.9.1", optional = true }
 syn = { version = "1.0.30", default-features = false, features = [ "full" ] }
+tempfile = { version = "3.1.0", optional = true }
 quote = { version = "1.0.6", default-features = false }
 url = { version = "2.1.1", default-features = false }

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -34,7 +34,7 @@ _rt-async-std = []
 _rt-tokio = []
 
 # offline building support
-offline = ["sqlx-core/offline", "hex", "once_cell", "serde", "serde_json", "sha2"]
+offline = ["sqlx-core/offline", "hex", "serde", "serde_json", "sha2"]
 
 # database
 mysql = [ "sqlx-core/mysql" ]
@@ -58,7 +58,7 @@ futures = { version = "0.3.4", default-features = false, features = [ "executor"
 hex = { version = "0.4.2", optional = true }
 heck = "0.3.1"
 either = "1.5.3"
-once_cell = { version = "1.5.2", optional = true }
+once_cell = "1.5.2"
 proc-macro2 = { version = "1.0.9", default-features = false }
 sqlx-core = { version = "0.4.2", default-features = false, path = "../sqlx-core" }
 sqlx-rt = { version = "0.2.0", default-features = false, path = "../sqlx-rt" }

--- a/sqlx-macros/src/query/input.rs
+++ b/sqlx-macros/src/query/input.rs
@@ -10,7 +10,6 @@ use syn::{ExprArray, Type};
 pub struct QueryMacroInput {
     pub(super) src: String,
 
-    #[cfg_attr(not(feature = "offline"), allow(dead_code))]
     pub(super) src_span: Span,
 
     pub(super) record_type: RecordType,


### PR DESCRIPTION
Query data is now stored in .sqlx/{query_hash}.json directly by the macro invocations, rather than first writing to target/sqlx/{input_span_hash}.json and then collecting those into sqlx-data.json separately.

* [x] save offline data (if `.sqlx` exists)
* [ ] load offline data
* [x] create `.sqlx` when running `cargo sqlx prepare`
* [ ] diff `target/sqlx` with `.sqlx` in `cargo sqlx prepare --check`
* [ ] update documentation

Closes #570.