### PR TITLE
Add a flag for overriding number of rows to fetch

### DIFF
--- a/sqlx-core/src/postgres/connection/establish.rs
+++ b/sqlx-core/src/postgres/connection/establish.rs
@@ -143,6 +143,7 @@ impl PgConnection {
             cache_type_oid: HashMap::new(),
             cache_type_info: HashMap::new(),
             log_settings: options.log_settings.clone(),
+            override_row_limit: options.override_row_limit,
         })
     }
 }

--- a/sqlx-core/src/postgres/connection/executor.rs
+++ b/sqlx-core/src/postgres/connection/executor.rs
@@ -232,7 +232,7 @@ impl PgConnection {
             // the protocol-level limit acts nearly identically to the `LIMIT` in SQL
             self.stream.write(message::Execute {
                 portal: None,
-                limit: limit.into(),
+                limit: if self.override_row_limit { 0 } else { limit.into() },
             });
 
             // finally, [Sync] asks postgres to process the messages that we sent and respond with

--- a/sqlx-core/src/postgres/connection/executor.rs
+++ b/sqlx-core/src/postgres/connection/executor.rs
@@ -232,7 +232,11 @@ impl PgConnection {
             // the protocol-level limit acts nearly identically to the `LIMIT` in SQL
             self.stream.write(message::Execute {
                 portal: None,
-                limit: if self.override_row_limit { 0 } else { limit.into() },
+                limit: if self.override_row_limit {
+                    0
+                } else {
+                    limit.into()
+                },
             });
 
             // finally, [Sync] asks postgres to process the messages that we sent and respond with

--- a/sqlx-core/src/postgres/connection/mod.rs
+++ b/sqlx-core/src/postgres/connection/mod.rs
@@ -62,6 +62,8 @@ pub struct PgConnection {
     pub(crate) transaction_depth: usize,
 
     log_settings: LogSettings,
+
+    override_row_limit: bool,
 }
 
 impl PgConnection {

--- a/sqlx-core/src/postgres/options/mod.rs
+++ b/sqlx-core/src/postgres/options/mod.rs
@@ -86,6 +86,7 @@ pub struct PgConnectOptions {
     pub(crate) statement_cache_capacity: usize,
     pub(crate) application_name: Option<String>,
     pub(crate) log_settings: LogSettings,
+    pub(crate) override_row_limit: bool,
 }
 
 impl Default for PgConnectOptions {
@@ -138,6 +139,7 @@ impl PgConnectOptions {
             statement_cache_capacity: 100,
             application_name: var("PGAPPNAME").ok(),
             log_settings: Default::default(),
+            override_row_limit: false,
         }
     }
 
@@ -293,6 +295,17 @@ impl PgConnectOptions {
     /// ```
     pub fn application_name(mut self, application_name: &str) -> Self {
         self.application_name = Some(application_name.to_owned());
+        self
+    }
+
+    /// Request all rows from the backend when calling `fetch_one` and
+    /// `fetch_optional`. This is a workaround for a issue in which
+    /// CockroachDB reports that sqlx is using multiple portals.
+    /// See https://github.com/launchbadge/sqlx/issues/933 anad
+    /// https://github.com/cockroachdb/cockroach/issues/40195?version=v20.1 for
+    /// more details.
+    pub fn override_row_limit(&mut self, override_row_limit: bool) -> &mut Self {
+        self.override_row_limit = override_row_limit;
         self
     }
 


### PR DESCRIPTION
Addresses #933

I didn't want to add tests before seeing if the approach is something you'd be willing to merge. But if that's something you'd like, I could try to get a CockroachDB instance running in the test suite.

We did test this locally and it gets around the CockroachDB portals issue discussed in #933 (and in https://github.com/cockroachdb/cockroach/issues/40195?version=v20.1)