### PR TITLE
Close open portals after receiving PortalSuspended

### DIFF
--- a/sqlx-core/src/postgres/io/buf_mut.rs
+++ b/sqlx-core/src/postgres/io/buf_mut.rs
@@ -48,5 +48,4 @@ impl PgBufMutExt for Vec<u8> {
 
         self.push(0);
     }
-
 }

--- a/sqlx-core/src/postgres/io/buf_mut.rs
+++ b/sqlx-core/src/postgres/io/buf_mut.rs
@@ -48,4 +48,5 @@ impl PgBufMutExt for Vec<u8> {
 
         self.push(0);
     }
+
 }


### PR DESCRIPTION
I used some printf debugging to determine that `PortalSuspended` message is received during a call to `wait_until_ready()`. This probably means that `wait_until_ready()` is being called at the wrong time? However, handling `PortalSuspended` here by sending another `Execute` command, as the psql spec suggests, solves the multiple-portal issue we see with CockroachDB.

@robo-corg and I are working on a similar patch that puts the handler in a less surprising place. But I'm opening this PR in case you're interested in a quick fix, or in case this helps us see how the protocol handling should be changed.

Fixes #933 and subsumes #944