### PR TITLE
match libpq treatment of null byte in message header

### DIFF
--- a/sqlx-core/src/postgres/connection/stream.rs
+++ b/sqlx-core/src/postgres/connection/stream.rs
@@ -87,7 +87,10 @@ impl PgStream {
     // May wait for more data from the server
     pub(crate) async fn recv(&mut self) -> Result<Message, Error> {
         loop {
-            let message = self.recv_unchecked().await?;
+            let message = match self.recv_unchecked().await {
+                Ok(m) => m,
+                _ => continue,
+            };
 
             match message.format {
                 MessageFormat::ErrorResponse => {


### PR DESCRIPTION
This is a partial fix for #886.  Under a load of 128 concurrent queries, I see 90% fewer failed queries with this change.

This changes the behavior of the driver to match that of libpq.  Namely, if a message header starts with a null byte, discard the message and continue without signaling an error.

This is only a partial fix.  With this, I still see 1% of queries fail.  That's better than 10%, but there's still an issue somewhere.

The issue is not due to dropping PgStream or BufStream.  That is not occurring.  I instrumented a Drop implementation for them and they are not dropped while the failed queries occur.
