### PR TITLE
Add 'flatten' attribute for FromRow derive

### DIFF
--- a/sqlx-macros/src/derives/attributes.rs
+++ b/sqlx-macros/src/derives/attributes.rs
@@ -47,6 +47,7 @@ pub struct SqlxContainerAttributes {
 pub struct SqlxChildAttributes {
     pub rename: Option<String>,
     pub default: bool,
+    pub flatten: bool,
 }
 
 pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContainerAttributes> {
@@ -128,6 +129,7 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
 pub fn parse_child_attributes(input: &[Attribute]) -> syn::Result<SqlxChildAttributes> {
     let mut rename = None;
     let mut default = false;
+    let mut flatten = false;
 
     for attr in input.iter().filter(|a| a.path.is_ident("sqlx")) {
         let meta = attr
@@ -144,6 +146,7 @@ pub fn parse_child_attributes(input: &[Attribute]) -> syn::Result<SqlxChildAttri
                             ..
                         }) if path.is_ident("rename") => try_set!(rename, val.value(), value),
                         Meta::Path(path) if path.is_ident("default") => default = true,
+                        Meta::Path(path) if path.is_ident("flatten") => flatten = true,
                         u => fail!(u, "unexpected attribute"),
                     },
                     u => fail!(u, "unexpected attribute"),
@@ -152,7 +155,7 @@ pub fn parse_child_attributes(input: &[Attribute]) -> syn::Result<SqlxChildAttri
         }
     }
 
-    Ok(SqlxChildAttributes { rename, default })
+    Ok(SqlxChildAttributes { rename, default, flatten })
 }
 
 pub fn check_transparent_attributes(


### PR DESCRIPTION
This is my attempt at implementing a flatten attribute for fields when deriving `FromRow`. I don't really expect this to be merged because it has a few issues, but I was hoping it would spark some discussion that possibly results in a complete implementation.

The issues I see with this right now are:

- `flatten` and `default` cannot be used at the same time. The obvious behavior would be to use the default value when none of the fields of the flattened struct are present, but I am not sure how to determine that, or even if that is the ideal behavior.
- Having field names duplicated between a parent struct and its child would cause issues. I don't know how this would be avoided either. My ideal implementation would check that each field after flattening to ensure there are no duplicates, but I don't know of a way to inspect the fields of one struct from a derive macro of another. It might be helpful to check how serde handles this, but that project is a beast that I am not ready to challenge right now.
- It needs some tests and docs.