### PR TITLE
test interleaved reading of result streams

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ features = [ "all", "runtime-async-std-native-tls" ]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = [ "macros", "migrate" ]
+default = [ "macros", "migrate", "postgres", "runtime-actix-rustls", "json" ]
 macros = [ "sqlx-macros" ]
 migrate = [ "sqlx-macros/migrate", "sqlx-core/migrate" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ features = [ "all", "runtime-async-std-native-tls" ]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = [ "macros", "migrate", "postgres", "runtime-actix-rustls", "json" ]
+default = [ "macros", "migrate" ]
 macros = [ "sqlx-macros" ]
 migrate = [ "sqlx-macros/migrate", "sqlx-core/migrate" ]
 

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -513,12 +513,12 @@ async fn pool_smoke_test() -> anyhow::Result<()> {
 #[ignore]
 #[sqlx_macros::test]
 async fn drop_query_test() -> anyhow::Result<()> {
-    #[cfg(any(feature = "_rt-tokio", feature = "_rt-actix"))]
-    use tokio::time::timeout;
     #[cfg(feature = "_rt-async-std")]
     use async_std::future::timeout;
     use futures::prelude::*;
     use serde::{Deserialize, Serialize};
+    #[cfg(any(feature = "_rt-tokio", feature = "_rt-actix"))]
+    use tokio::time::timeout;
 
     eprintln!("starting pool");
     let max_conns = 4;
@@ -568,15 +568,13 @@ async fn drop_query_test() -> anyhow::Result<()> {
                 {
                     Ok(list) => {
                         if list.len() != NROWS {
-                            return Err(sqlx::Error::Protocol(
-                                format!(
-                                    "query returned incorrect result. got {} rows out of {}",
-                                    list.len(),
-                                    NROWS
-                                )
-                            ));
+                            return Err(sqlx::Error::Protocol(format!(
+                                "query returned incorrect result. got {} rows out of {}",
+                                list.len(),
+                                NROWS
+                            )));
                         }
-                    },
+                    }
                     Err(e) => return Err(e),
                 }
             }
@@ -584,12 +582,11 @@ async fn drop_query_test() -> anyhow::Result<()> {
         }
     };
     for _i in 0..3 {
-        match
-            timeout(
-                Duration::from_millis(100), // NB may need to adjust timing slower?
-                make_query_fut(&pool)
-            )
-            .await
+        match timeout(
+            Duration::from_millis(100),
+            make_query_fut(&pool),
+        )
+        .await
         {
             Ok(Ok(_)) => Ok(()),
             Ok(Err(e)) => Err(e),

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -521,9 +521,10 @@ async fn drop_query_test() -> anyhow::Result<()> {
     use tokio::time::timeout;
 
     eprintln!("starting pool");
-    let max_conns = 4;
+    let max_conns = 1;
     let pool = PgPoolOptions::new()
         .min_connections(max_conns)
+        .max_connections(max_conns)
         .test_before_acquire(false) // false is required to reproduce protocol errors
         .connect(&dotenv::var("DATABASE_URL")?)
         .await?;

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -530,7 +530,7 @@ async fn pool_interleave_test() -> anyhow::Result<()> {
     use serde::{Deserialize, Serialize,};
 
     eprintln!("starting pool");
-    let max_conns = 300;        // NB: use value from postgres config
+    let max_conns = 90;        // the default connection limit is 100.
     let pool = PgPoolOptions::new()
         .min_connections(max_conns)
         .max_connections(max_conns)

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -574,7 +574,7 @@ async fn drop_query_test() -> anyhow::Result<()> {
                                 )));
                             }
                         }
-                        Err(e) => return Err::<(),sqlx::Error>(e),
+                        Err(e) => return Err::<(), sqlx::Error>(e),
                     }
                 }
             }

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -582,12 +582,7 @@ async fn drop_query_test() -> anyhow::Result<()> {
         }
     };
     for _i in 0..3 {
-        match timeout(
-            Duration::from_millis(100),
-            make_query_fut(&pool),
-        )
-        .await
-        {
+        match timeout(Duration::from_millis(100), make_query_fut(&pool)).await {
             Ok(Ok(_)) => Ok(()),
             Ok(Err(e)) => Err(e),
             Err(_) => Ok(()),


### PR DESCRIPTION
This tests tries to induce interleaved reading of result streams.

The test:
creates a pool of 90 connections. (postgres default max is 100).
spawns 180 threads that read a table of 100 rows.
in each thread:
   collect a stream of results to an array.
   for each item in the stream, wait one millisecond  (the tokio sleep granularity).

The wait should induce interleaved reading of result streams.

The intent here was to try to reproduce postgres null MessageFormat errors; however, the test shows no such errors.