### PR TITLE
Fix auth switch failure on MySQL 8

### DIFF
--- a/sqlx-core/src/mysql/protocol/connect/auth_switch.rs
+++ b/sqlx-core/src/mysql/protocol/connect/auth_switch.rs
@@ -25,7 +25,16 @@ impl Decode<'_> for AuthSwitchRequest {
         }
 
         let plugin = buf.get_str_nul()?.parse()?;
-        let data = buf.get_bytes(buf.len());
+
+        // See: https://github.com/mysql/mysql-server/blob/ea7d2e2d16ac03afdd9cb72a972a95981107bf51/sql/auth/sha2_password.cc#L942
+        if buf.len() != 21 {
+            return Err(err_protocol!(
+                "expected 21 bytes but found {} bytes",
+                buf.len()
+            ));
+        }
+        let data = buf.get_bytes(20);
+        buf.advance(1); // NUL-terminator
 
         Ok(Self { plugin, data })
     }


### PR DESCRIPTION
The current implementation fails to connect a MySQL 8 server if the authentication plugin of the user has been changed from the default  `caching_sha2_password` (related issue: https://github.com/launchbadge/sqlx/issues/779).

This PR addresses the problem.

Note that I'm not familiar with MySQL and not sure this patch is the correct solution to address this issue, so any advice is very welcomed.

## Commands to reproduce the problem

Starts a MySQL server:
```
$ docker run -e MYSQL_DATABASE=db -e MYSQL_USER=foo \
    -e MYSQL_PASSWORD=password -e MYSQL_ROOT_PASSWORD=password -p 3306:3306 --rm mysql:8.0.22
```

Connects to the server with `foo` user (this will be succeeded):
```rust
use sqlx::Connection;

#[async_std::main]
async fn main() -> anyhow::Result<()> {
    let url = "mysql://foo:password@127.0.0.1/db";
    sqlx::mysql::MySqlConnection::connect(url).await?;
    Ok(())
}
```

Changes the auth plugin from the default to `mysql_native_password`:
```rust
use sqlx::Connection;

#[async_std::main]
async fn main() -> anyhow::Result<()> {
    let url = "mysql://root:password@127.0.0.1/db";
    let mut connection = sqlx::mysql::MySqlConnection::connect(url).await?;
    sqlx::query("ALTER USER 'foo' IDENTIFIED WITH mysql_native_password BY 'password'")
        .execute(&mut connection)
        .await?;
    Ok(())
}
```

Again, connects to the server with `foo` user (this will be failed):
```rust
use sqlx::Connection;

#[async_std::main]
async fn main() -> anyhow::Result<()> {
    let url = "mysql://foo:password@127.0.0.1/db";
    sqlx::mysql::MySqlConnection::connect(url).await?;
    Ok(())
}
// => Error: error returned from database: 1045 (28000): Access denied for user 'foo'@'172.17.0.1' (using password: YES)
```

Once the patch of this PR is applied, the above script can be executed without errors.