### PR TITLE
Allow symlinks to be followed for migration files

### DIFF
--- a/sqlx-macros/src/migrate.rs
+++ b/sqlx-macros/src/migrate.rs
@@ -61,7 +61,7 @@ pub(crate) fn expand_migrator_from_dir(dir: LitStr) -> crate::Result<proc_macro2
 
     for entry in fs::read_dir(path)? {
         let entry = entry?;
-        if !entry.metadata()?.is_file() {
+        if !fs::metadata(entry.path())?.is_file() {
             // not a file; ignore
             continue;
         }


### PR DESCRIPTION
entry.metadata() does not follow symlinks, while fs::metadata() does. This allows for greater compatibility with the bazel build system which uses symlinks for data files such as migrations.

Fixes #614 