### PR TITLE
Replace unsafe take packet or buffer,prevent panic  on under 'mysql:8'!

### DIFF
--- a/sqlx-core/src/mssql/connection/prepare.rs
+++ b/sqlx-core/src/mssql/connection/prepare.rs
@@ -31,7 +31,7 @@ pub(crate) async fn prepare(
             params.push_str(",");
         }
 
-        params.push_str(&m[0]);
+        params.push_str(&m.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))??);
 
         // NOTE: this means that a query! of `SELECT @p1` will have the macros believe
         //       it will return nvarchar(1); this is a greater issue with `query!` that we

--- a/sqlx-core/src/mssql/connection/prepare.rs
+++ b/sqlx-core/src/mssql/connection/prepare.rs
@@ -30,7 +30,9 @@ pub(crate) async fn prepare(
         if !params.is_empty() {
             params.push_str(",");
         }
-        let m0=m.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?;
+        let m0 = m
+            .get(0)
+            .ok_or_else(|| Error::Protocol("unexpected packet index:0".to_string()))?;
         params.push_str(m0.as_str());
 
         // NOTE: this means that a query! of `SELECT @p1` will have the macros believe

--- a/sqlx-core/src/mssql/connection/prepare.rs
+++ b/sqlx-core/src/mssql/connection/prepare.rs
@@ -30,8 +30,8 @@ pub(crate) async fn prepare(
         if !params.is_empty() {
             params.push_str(",");
         }
-
-        params.push_str(&m.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))??);
+        let m0=m.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?;
+        params.push_str(m0.as_str());
 
         // NOTE: this means that a query! of `SELECT @p1` will have the macros believe
         //       it will return nvarchar(1); this is a greater issue with `query!` that we

--- a/sqlx-core/src/mssql/types/bool.rs
+++ b/sqlx-core/src/mssql/types/bool.rs
@@ -1,6 +1,6 @@
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
-use crate::error::BoxDynError;
+use crate::error::{BoxDynError, Error};
 use crate::mssql::protocol::type_info::{DataType, TypeInfo};
 use crate::mssql::{Mssql, MssqlTypeInfo, MssqlValueRef};
 use crate::types::Type;
@@ -25,6 +25,6 @@ impl Encode<'_, Mssql> for bool {
 
 impl Decode<'_, Mssql> for bool {
     fn decode(value: MssqlValueRef<'_>) -> Result<Self, BoxDynError> {
-        Ok(value.as_bytes()?[0] == 1)
+        Ok(value.as_bytes()?.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? == 1)
     }
 }

--- a/sqlx-core/src/mssql/types/bool.rs
+++ b/sqlx-core/src/mssql/types/bool.rs
@@ -25,6 +25,10 @@ impl Encode<'_, Mssql> for bool {
 
 impl Decode<'_, Mssql> for bool {
     fn decode(value: MssqlValueRef<'_>) -> Result<Self, BoxDynError> {
-        Ok(*value.as_bytes()?.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? == 1)
+        Ok(*value
+            .as_bytes()?
+            .get(0)
+            .ok_or_else(|| Error::Protocol("unexpected packet index:0".to_string()))?
+            == 1)
     }
 }

--- a/sqlx-core/src/mssql/types/bool.rs
+++ b/sqlx-core/src/mssql/types/bool.rs
@@ -25,6 +25,6 @@ impl Encode<'_, Mssql> for bool {
 
 impl Decode<'_, Mssql> for bool {
     fn decode(value: MssqlValueRef<'_>) -> Result<Self, BoxDynError> {
-        Ok(value.as_bytes()?.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? == 1)
+        Ok(*value.as_bytes()?.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? == 1)
     }
 }

--- a/sqlx-core/src/mssql/types/int.rs
+++ b/sqlx-core/src/mssql/types/int.rs
@@ -2,7 +2,7 @@ use byteorder::{ByteOrder, LittleEndian};
 
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
-use crate::error::BoxDynError;
+use crate::error::{BoxDynError, Error};
 use crate::mssql::protocol::type_info::{DataType, TypeInfo};
 use crate::mssql::{Mssql, MssqlTypeInfo, MssqlValueRef};
 use crate::types::Type;
@@ -27,7 +27,7 @@ impl Encode<'_, Mssql> for i8 {
 
 impl Decode<'_, Mssql> for i8 {
     fn decode(value: MssqlValueRef<'_>) -> Result<Self, BoxDynError> {
-        Ok(value.as_bytes()?[0] as i8)
+        Ok(value.as_bytes()?.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? as i8)
     }
 }
 

--- a/sqlx-core/src/mssql/types/int.rs
+++ b/sqlx-core/src/mssql/types/int.rs
@@ -27,7 +27,11 @@ impl Encode<'_, Mssql> for i8 {
 
 impl Decode<'_, Mssql> for i8 {
     fn decode(value: MssqlValueRef<'_>) -> Result<Self, BoxDynError> {
-        Ok(*value.as_bytes()?.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? as i8)
+        Ok(*value
+            .as_bytes()?
+            .get(0)
+            .ok_or_else(|| Error::Protocol("unexpected packet index:0".to_string()))?
+            as i8)
     }
 }
 

--- a/sqlx-core/src/mssql/types/int.rs
+++ b/sqlx-core/src/mssql/types/int.rs
@@ -27,7 +27,7 @@ impl Encode<'_, Mssql> for i8 {
 
 impl Decode<'_, Mssql> for i8 {
     fn decode(value: MssqlValueRef<'_>) -> Result<Self, BoxDynError> {
-        Ok(value.as_bytes()?.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? as i8)
+        Ok(*value.as_bytes()?.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? as i8)
     }
 }
 

--- a/sqlx-core/src/mysql/connection/auth.rs
+++ b/sqlx-core/src/mysql/connection/auth.rs
@@ -37,9 +37,11 @@ impl AuthPlugin {
         password: &str,
         nonce: &Chain<Bytes, Bytes>,
     ) -> Result<bool, Error> {
-        let packet0=packet.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?;
+        let packet0 = packet
+            .get(0)
+            .ok_or_else(|| Error::Protocol("unexpected packet index:0".to_string()))?;
         match self {
-            AuthPlugin::CachingSha2Password if *packet0==0x01 => {
+            AuthPlugin::CachingSha2Password if *packet0 == 0x01 => {
                 match packet.get(1).ok_or(Error::Protocol("unexpected packet index:0".to_string()))? {
                     // AUTH_OK
                     0x03 => Ok(true),
@@ -62,7 +64,9 @@ impl AuthPlugin {
 
             _ => Err(err_protocol!(
                 "unexpected packet 0x{:02x} for auth plugin '{}' during authentication",
-                packet.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?,
+                packet
+                    .get(0)
+                    .ok_or_else(|| Error::Protocol("unexpected packet index:0".to_string()))?,
                 self.name()
             )),
         }

--- a/sqlx-core/src/mysql/connection/auth.rs
+++ b/sqlx-core/src/mysql/connection/auth.rs
@@ -38,8 +38,8 @@ impl AuthPlugin {
         nonce: &Chain<Bytes, Bytes>,
     ) -> Result<bool, Error> {
         match self {
-            AuthPlugin::CachingSha2Password if packet[0] == 0x01 => {
-                match packet[1] {
+            AuthPlugin::CachingSha2Password if packet.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? == 0x01 => {
+                match packet.get(1).ok_or(Error::Protocol("unexpected packet index:0".to_string()))? {
                     // AUTH_OK
                     0x03 => Ok(true),
 
@@ -61,7 +61,7 @@ impl AuthPlugin {
 
             _ => Err(err_protocol!(
                 "unexpected packet 0x{:02x} for auth plugin '{}' during authentication",
-                packet[0],
+                packet.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?,
                 self.name()
             )),
         }

--- a/sqlx-core/src/mysql/connection/auth.rs
+++ b/sqlx-core/src/mysql/connection/auth.rs
@@ -37,8 +37,9 @@ impl AuthPlugin {
         password: &str,
         nonce: &Chain<Bytes, Bytes>,
     ) -> Result<bool, Error> {
+        let packet0=packet.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?;
         match self {
-            AuthPlugin::CachingSha2Password if packet.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? == 0x01 => {
+            AuthPlugin::CachingSha2Password if *packet0==0x01 => {
                 match packet.get(1).ok_or(Error::Protocol("unexpected packet index:0".to_string()))? {
                     // AUTH_OK
                     0x03 => Ok(true),

--- a/sqlx-core/src/mysql/connection/establish.rs
+++ b/sqlx-core/src/mysql/connection/establish.rs
@@ -81,7 +81,7 @@ impl MySqlConnection {
 
         loop {
             let packet = stream.recv_packet().await?;
-            match packet[0] {
+            match packet.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? {
                 0x00 => {
                     let _ok = packet.ok()?;
 

--- a/sqlx-core/src/mysql/connection/establish.rs
+++ b/sqlx-core/src/mysql/connection/establish.rs
@@ -81,7 +81,10 @@ impl MySqlConnection {
 
         loop {
             let packet = stream.recv_packet().await?;
-            match packet.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? {
+            match packet
+                .get(0)
+                .ok_or_else(|| Error::Protocol("unexpected packet index:0".to_string()))?
+            {
                 0x00 => {
                     let _ok = packet.ok()?;
 

--- a/sqlx-core/src/mysql/connection/executor.rs
+++ b/sqlx-core/src/mysql/connection/executor.rs
@@ -128,7 +128,7 @@ impl MySqlConnection {
                 //  Ok, Err, ResultSet, or (unhandled) LocalInfileRequest
                 let mut packet = self.stream.recv_packet().await?;
 
-                if packet[0] == 0x00 || packet[0] == 0xff {
+                if packet.ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? == 0x00 || packet.ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? == 0xff {
                     // first packet in a query response is OK or ERR
                     // this indicates either a successful query with no rows at all or a failed query
                     let ok = packet.ok()?;
@@ -168,7 +168,7 @@ impl MySqlConnection {
                 loop {
                     let packet = self.stream.recv_packet().await?;
 
-                    if packet[0] == 0xfe && packet.len() < 9 {
+                    if packet.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? == 0xfe && packet.len() < 9 {
                         let eof = packet.eof(self.stream.capabilities)?;
 
                         r#yield!(Either::Left(MySqlDone {

--- a/sqlx-core/src/mysql/connection/stream.rs
+++ b/sqlx-core/src/mysql/connection/stream.rs
@@ -84,7 +84,7 @@ impl MySqlStream {
             while self.busy == Busy::Row {
                 let packet = self.recv_packet().await?;
 
-                if packet[0] == 0xfe && packet.len() < 9 {
+                if packet.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? == 0xfe && packet.len() < 9 {
                     let eof = packet.eof(self.capabilities)?;
 
                     self.busy = if eof.status.contains(Status::SERVER_MORE_RESULTS_EXISTS) {
@@ -98,7 +98,7 @@ impl MySqlStream {
             while self.busy == Busy::Result {
                 let packet = self.recv_packet().await?;
 
-                if packet[0] == 0x00 || packet[0] == 0xff {
+                if packet.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? == 0x00 || packet.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? == 0xff {
                     let ok = packet.ok()?;
 
                     if !ok.status.contains(Status::SERVER_MORE_RESULTS_EXISTS) {

--- a/sqlx-core/src/mysql/connection/stream.rs
+++ b/sqlx-core/src/mysql/connection/stream.rs
@@ -149,7 +149,18 @@ impl MySqlStream {
         // TODO: packet compression
         // TODO: packet joining
 
-        if payload[0] == 0xff {
+        // no data returned
+        if payload.is_empty(){
+            return Err(
+                MySqlDatabaseError(ErrPacket{
+                    error_code: -1,
+                    sql_state: None,
+                    error_message: "MySqlDatabase no data returned".to_string()
+                }).into(),
+            );
+        }
+
+        if let Some(0xff) = payload.get(0){
             self.busy = Busy::NotBusy;
 
             // instead of letting this packet be looked at everywhere, we check here

--- a/sqlx-core/src/mysql/connection/stream.rs
+++ b/sqlx-core/src/mysql/connection/stream.rs
@@ -84,7 +84,12 @@ impl MySqlStream {
             while self.busy == Busy::Row {
                 let packet = self.recv_packet().await?;
 
-                if *packet.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? == 0xfe && packet.len() < 9 {
+                if *packet
+                    .get(0)
+                    .ok_or_else(|| Error::Protocol("unexpected packet index:0".to_string()))?
+                    == 0xfe
+                    && packet.len() < 9
+                {
                     let eof = packet.eof(self.capabilities)?;
 
                     self.busy = if eof.status.contains(Status::SERVER_MORE_RESULTS_EXISTS) {
@@ -97,7 +102,9 @@ impl MySqlStream {
 
             while self.busy == Busy::Result {
                 let packet = self.recv_packet().await?;
-                let packet0=packet.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?;
+                let packet0 = packet
+                    .get(0)
+                    .ok_or_else(|| Error::Protocol("unexpected packet index:0".to_string()))?;
                 if *packet0 == 0x00 || *packet0 == 0xff {
                     let ok = packet.ok()?;
 
@@ -149,7 +156,11 @@ impl MySqlStream {
         // TODO: packet compression
         // TODO: packet joining
 
-        if let Some(0xff) = Some(payload.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?){
+        if let Some(0xff) = Some(
+            payload
+                .get(0)
+                .ok_or_else(|| Error::Protocol("unexpected packet index:0".to_string()))?,
+        ) {
             self.busy = Busy::NotBusy;
 
             // instead of letting this packet be looked at everywhere, we check here

--- a/sqlx-core/src/mysql/protocol/statement/row.rs
+++ b/sqlx-core/src/mysql/protocol/statement/row.rs
@@ -73,7 +73,7 @@ impl<'de> Decode<'de, &'de [MySqlColumn]> for BinaryRow {
                 | ColumnType::Date
                 | ColumnType::Datetime => {
                     // The size of this type is important for decoding
-                    buf[0] as usize + 1
+                    buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? as usize + 1
                 }
 
                 // NOTE: MySQL will never generate NULL types for non-NULL values

--- a/sqlx-core/src/mysql/protocol/statement/row.rs
+++ b/sqlx-core/src/mysql/protocol/statement/row.rs
@@ -73,7 +73,10 @@ impl<'de> Decode<'de, &'de [MySqlColumn]> for BinaryRow {
                 | ColumnType::Date
                 | ColumnType::Datetime => {
                     // The size of this type is important for decoding
-                    *buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? as usize + 1
+                    *buf.get(0)
+                        .ok_or_else(|| Error::Protocol("unexpected packet index:0".to_string()))?
+                        as usize
+                        + 1
                 }
 
                 // NOTE: MySQL will never generate NULL types for non-NULL values

--- a/sqlx-core/src/mysql/protocol/statement/row.rs
+++ b/sqlx-core/src/mysql/protocol/statement/row.rs
@@ -73,7 +73,7 @@ impl<'de> Decode<'de, &'de [MySqlColumn]> for BinaryRow {
                 | ColumnType::Date
                 | ColumnType::Datetime => {
                     // The size of this type is important for decoding
-                    buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? as usize + 1
+                    *buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? as usize + 1
                 }
 
                 // NOTE: MySQL will never generate NULL types for non-NULL values

--- a/sqlx-core/src/mysql/protocol/text/row.rs
+++ b/sqlx-core/src/mysql/protocol/text/row.rs
@@ -17,7 +17,7 @@ impl<'de> Decode<'de, &'de [MySqlColumn]> for TextRow {
         let mut values = Vec::with_capacity(columns.len());
 
         for _ in columns {
-            if buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? == 0xfb {
+            if *buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? == 0xfb {
                 // NULL is sent as 0xfb
                 values.push(None);
                 buf.advance(1);

--- a/sqlx-core/src/mysql/protocol/text/row.rs
+++ b/sqlx-core/src/mysql/protocol/text/row.rs
@@ -17,7 +17,11 @@ impl<'de> Decode<'de, &'de [MySqlColumn]> for TextRow {
         let mut values = Vec::with_capacity(columns.len());
 
         for _ in columns {
-            if *buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? == 0xfb {
+            if *buf
+                .get(0)
+                .ok_or_else(|| Error::Protocol("unexpected packet index:0".to_string()))?
+                == 0xfb
+            {
                 // NULL is sent as 0xfb
                 values.push(None);
                 buf.advance(1);

--- a/sqlx-core/src/mysql/protocol/text/row.rs
+++ b/sqlx-core/src/mysql/protocol/text/row.rs
@@ -17,7 +17,7 @@ impl<'de> Decode<'de, &'de [MySqlColumn]> for TextRow {
         let mut values = Vec::with_capacity(columns.len());
 
         for _ in columns {
-            if buf[0] == 0xfb {
+            if buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? == 0xfb {
                 // NULL is sent as 0xfb
                 values.push(None);
                 buf.advance(1);

--- a/sqlx-core/src/mysql/types/chrono.rs
+++ b/sqlx-core/src/mysql/types/chrono.rs
@@ -187,7 +187,7 @@ impl<'r> Decode<'r, MySql> for NaiveDateTime {
             MySqlValueFormat::Binary => {
                 let buf = value.as_bytes()?;
 
-                let len = buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?;
+                let len = *buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?;
                 let date = decode_date(&buf[1..]).ok_or(UnexpectedNullError)?;
 
                 let dt = if len > 4 {
@@ -225,8 +225,8 @@ fn decode_date(mut buf: &[u8]) -> Option<NaiveDate> {
         let year = buf.get_u16_le();
         Some(NaiveDate::from_ymd(
             year as i32,
-            buf.get(0).ok_or(Error::Protocol("unexpected packet index:0".to_string()))? as u32,
-            buf.get(1).ok_or(Error::Protocol("unexpected packet index:1".to_string()))? as u32,
+            buf[0] as u32,
+            buf[0] as u32,
         ))
     }
 }

--- a/sqlx-core/src/mysql/types/chrono.rs
+++ b/sqlx-core/src/mysql/types/chrono.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike, 
 
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
-use crate::error::{BoxDynError, UnexpectedNullError};
+use crate::error::{BoxDynError, UnexpectedNullError, Error};
 use crate::mysql::protocol::text::ColumnType;
 use crate::mysql::type_info::MySqlTypeInfo;
 use crate::mysql::{MySql, MySqlValueFormat, MySqlValueRef};
@@ -187,7 +187,7 @@ impl<'r> Decode<'r, MySql> for NaiveDateTime {
             MySqlValueFormat::Binary => {
                 let buf = value.as_bytes()?;
 
-                let len = buf[0];
+                let len = buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?;
                 let date = decode_date(&buf[1..]).ok_or(UnexpectedNullError)?;
 
                 let dt = if len > 4 {
@@ -225,8 +225,8 @@ fn decode_date(mut buf: &[u8]) -> Option<NaiveDate> {
         let year = buf.get_u16_le();
         Some(NaiveDate::from_ymd(
             year as i32,
-            buf[0] as u32,
-            buf[1] as u32,
+            buf.get(0).ok_or(Error::Protocol("unexpected packet index:0".to_string()))? as u32,
+            buf.get(1).ok_or(Error::Protocol("unexpected packet index:1".to_string()))? as u32,
         ))
     }
 }

--- a/sqlx-core/src/mysql/types/chrono.rs
+++ b/sqlx-core/src/mysql/types/chrono.rs
@@ -228,7 +228,7 @@ fn decode_date(mut buf: &[u8]) -> Option<NaiveDate> {
         Some(NaiveDate::from_ymd(
             year as i32,
             buf[0] as u32,
-            buf[0] as u32,
+            buf[1] as u32,
         ))
     }
 }

--- a/sqlx-core/src/mysql/types/chrono.rs
+++ b/sqlx-core/src/mysql/types/chrono.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike, 
 
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
-use crate::error::{BoxDynError, UnexpectedNullError, Error};
+use crate::error::{BoxDynError, Error, UnexpectedNullError};
 use crate::mysql::protocol::text::ColumnType;
 use crate::mysql::type_info::MySqlTypeInfo;
 use crate::mysql::{MySql, MySqlValueFormat, MySqlValueRef};
@@ -187,7 +187,9 @@ impl<'r> Decode<'r, MySql> for NaiveDateTime {
             MySqlValueFormat::Binary => {
                 let buf = value.as_bytes()?;
 
-                let len = *buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?;
+                let len = *buf
+                    .get(0)
+                    .ok_or_else(|| Error::Protocol("unexpected packet index:0".to_string()))?;
                 let date = decode_date(&buf[1..]).ok_or(UnexpectedNullError)?;
 
                 let dt = if len > 4 {

--- a/sqlx-core/src/mysql/types/time.rs
+++ b/sqlx-core/src/mysql/types/time.rs
@@ -7,7 +7,7 @@ use time::{Date, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
 
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
-use crate::error::{BoxDynError, UnexpectedNullError};
+use crate::error::{BoxDynError, UnexpectedNullError, Error};
 use crate::mysql::protocol::text::ColumnType;
 use crate::mysql::type_info::MySqlTypeInfo;
 use crate::mysql::{MySql, MySqlValueFormat, MySqlValueRef};
@@ -196,7 +196,7 @@ impl<'r> Decode<'r, MySql> for PrimitiveDateTime {
         match value.format() {
             MySqlValueFormat::Binary => {
                 let buf = value.as_bytes()?;
-                let len = buf[0];
+                let len = buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?;
                 let date = decode_date(&buf[1..])?.ok_or(UnexpectedNullError)?;
 
                 let dt = if len > 4 {

--- a/sqlx-core/src/mysql/types/time.rs
+++ b/sqlx-core/src/mysql/types/time.rs
@@ -196,7 +196,7 @@ impl<'r> Decode<'r, MySql> for PrimitiveDateTime {
         match value.format() {
             MySqlValueFormat::Binary => {
                 let buf = value.as_bytes()?;
-                let len = buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?;
+                let len = *buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?;
                 let date = decode_date(&buf[1..])?.ok_or(UnexpectedNullError)?;
 
                 let dt = if len > 4 {

--- a/sqlx-core/src/mysql/types/time.rs
+++ b/sqlx-core/src/mysql/types/time.rs
@@ -7,7 +7,7 @@ use time::{Date, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
 
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
-use crate::error::{BoxDynError, UnexpectedNullError, Error};
+use crate::error::{BoxDynError, Error, UnexpectedNullError};
 use crate::mysql::protocol::text::ColumnType;
 use crate::mysql::type_info::MySqlTypeInfo;
 use crate::mysql::{MySql, MySqlValueFormat, MySqlValueRef};
@@ -196,7 +196,9 @@ impl<'r> Decode<'r, MySql> for PrimitiveDateTime {
         match value.format() {
             MySqlValueFormat::Binary => {
                 let buf = value.as_bytes()?;
-                let len = *buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?;
+                let len = *buf
+                    .get(0)
+                    .ok_or_else(|| Error::Protocol("unexpected packet index:0".to_string()))?;
                 let date = decode_date(&buf[1..])?.ok_or(UnexpectedNullError)?;
 
                 let dt = if len > 4 {

--- a/sqlx-core/src/postgres/connection/tls.rs
+++ b/sqlx-core/src/postgres/connection/tls.rs
@@ -41,7 +41,12 @@ async fn upgrade(stream: &mut PgStream, options: &PgConnectOptions) -> Result<bo
     // The server then responds with a single byte containing S or N, indicating that
     // it is willing or unwilling to perform SSL, respectively.
 
-    match stream.read::<Bytes>(1).await?.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? {
+    match stream
+        .read::<Bytes>(1)
+        .await?
+        .get(0)
+        .ok_or_else(|| Error::Protocol("unexpected packet index:0".to_string()))?
+    {
         b'S' => {
             // The server is ready and willing to accept an SSL connection
         }

--- a/sqlx-core/src/postgres/connection/tls.rs
+++ b/sqlx-core/src/postgres/connection/tls.rs
@@ -41,7 +41,7 @@ async fn upgrade(stream: &mut PgStream, options: &PgConnectOptions) -> Result<bo
     // The server then responds with a single byte containing S or N, indicating that
     // it is willing or unwilling to perform SSL, respectively.
 
-    match stream.read::<Bytes>(1).await?[0] {
+    match stream.read::<Bytes>(1).await?.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? {
         b'S' => {
             // The server is ready and willing to accept an SSL connection
         }

--- a/sqlx-core/src/postgres/message/ready_for_query.rs
+++ b/sqlx-core/src/postgres/message/ready_for_query.rs
@@ -23,7 +23,7 @@ pub struct ReadyForQuery {
 
 impl Decode<'_> for ReadyForQuery {
     fn decode_with(buf: Bytes, _: ()) -> Result<Self, Error> {
-        let status = match buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? {
+        let status = match *buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? {
             b'I' => TransactionStatus::Idle,
             b'T' => TransactionStatus::Transaction,
             b'E' => TransactionStatus::Error,

--- a/sqlx-core/src/postgres/message/ready_for_query.rs
+++ b/sqlx-core/src/postgres/message/ready_for_query.rs
@@ -23,7 +23,7 @@ pub struct ReadyForQuery {
 
 impl Decode<'_> for ReadyForQuery {
     fn decode_with(buf: Bytes, _: ()) -> Result<Self, Error> {
-        let status = match buf[0] {
+        let status = match buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? {
             b'I' => TransactionStatus::Idle,
             b'T' => TransactionStatus::Transaction,
             b'E' => TransactionStatus::Error,

--- a/sqlx-core/src/postgres/message/ready_for_query.rs
+++ b/sqlx-core/src/postgres/message/ready_for_query.rs
@@ -23,7 +23,10 @@ pub struct ReadyForQuery {
 
 impl Decode<'_> for ReadyForQuery {
     fn decode_with(buf: Bytes, _: ()) -> Result<Self, Error> {
-        let status = match *buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? {
+        let status = match *buf
+            .get(0)
+            .ok_or_else(|| Error::Protocol("unexpected packet index:0".to_string()))?
+        {
             b'I' => TransactionStatus::Idle,
             b'T' => TransactionStatus::Transaction,
             b'E' => TransactionStatus::Error,

--- a/sqlx-core/src/postgres/types/bool.rs
+++ b/sqlx-core/src/postgres/types/bool.rs
@@ -33,7 +33,13 @@ impl Encode<'_, Postgres> for bool {
 impl Decode<'_, Postgres> for bool {
     fn decode(value: PgValueRef<'_>) -> Result<Self, BoxDynError> {
         Ok(match value.format() {
-            PgValueFormat::Binary => *value.as_bytes()?.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? != 0,
+            PgValueFormat::Binary => {
+                *value
+                    .as_bytes()?
+                    .get(0)
+                    .ok_or_else(|| Error::Protocol("unexpected packet index:0".to_string()))?
+                    != 0
+            }
 
             PgValueFormat::Text => match value.as_str()? {
                 "t" => true,

--- a/sqlx-core/src/postgres/types/bool.rs
+++ b/sqlx-core/src/postgres/types/bool.rs
@@ -33,7 +33,7 @@ impl Encode<'_, Postgres> for bool {
 impl Decode<'_, Postgres> for bool {
     fn decode(value: PgValueRef<'_>) -> Result<Self, BoxDynError> {
         Ok(match value.format() {
-            PgValueFormat::Binary => value.as_bytes()?.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? != 0,
+            PgValueFormat::Binary => *value.as_bytes()?.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? != 0,
 
             PgValueFormat::Text => match value.as_str()? {
                 "t" => true,

--- a/sqlx-core/src/postgres/types/bool.rs
+++ b/sqlx-core/src/postgres/types/bool.rs
@@ -1,6 +1,6 @@
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
-use crate::error::BoxDynError;
+use crate::error::{BoxDynError, Error};
 use crate::postgres::{PgArgumentBuffer, PgTypeInfo, PgValueFormat, PgValueRef, Postgres};
 use crate::types::Type;
 
@@ -33,7 +33,7 @@ impl Encode<'_, Postgres> for bool {
 impl Decode<'_, Postgres> for bool {
     fn decode(value: PgValueRef<'_>) -> Result<Self, BoxDynError> {
         Ok(match value.format() {
-            PgValueFormat::Binary => value.as_bytes()?[0] != 0,
+            PgValueFormat::Binary => value.as_bytes()?.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? != 0,
 
             PgValueFormat::Text => match value.as_str()? {
                 "t" => true,

--- a/sqlx-core/src/postgres/types/json.rs
+++ b/sqlx-core/src/postgres/types/json.rs
@@ -50,7 +50,7 @@ where
         // we have a tiny amount of dynamic behavior depending if we are resolved to be JSON
         // instead of JSONB
         buf.patch(|buf, ty: &PgTypeInfo| {
-            if buf.is_empty(){
+            if buf.is_empty() {
                 return;
             }
             if *ty == PgTypeInfo::JSON || *ty == PgTypeInfo::JSON_ARRAY {
@@ -78,9 +78,12 @@ where
 
         if value.format() == PgValueFormat::Binary && value.type_info == PgTypeInfo::JSONB {
             assert_eq!(
-                *buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?, 1,
+                *buf.get(0)
+                    .ok_or_else(|| Error::Protocol("unexpected packet index:0".to_string()))?,
+                1,
                 "unsupported JSONB format version {}; please open an issue",
-                *buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?
+                *buf.get(0)
+                    .ok_or_else(|| Error::Protocol("unexpected packet index:0".to_string()))?
             );
 
             buf = &buf[1..];

--- a/sqlx-core/src/postgres/types/json.rs
+++ b/sqlx-core/src/postgres/types/json.rs
@@ -50,8 +50,11 @@ where
         // we have a tiny amount of dynamic behavior depending if we are resolved to be JSON
         // instead of JSONB
         buf.patch(|buf, ty: &PgTypeInfo| {
+            if buf.is_empty(){
+                return;
+            }
             if *ty == PgTypeInfo::JSON || *ty == PgTypeInfo::JSON_ARRAY {
-                buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? = &b' ';
+                buf[0] = b' ';
             }
         });
 
@@ -75,9 +78,9 @@ where
 
         if value.format() == PgValueFormat::Binary && value.type_info == PgTypeInfo::JSONB {
             assert_eq!(
-                buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?, 1,
+                *buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?, 1,
                 "unsupported JSONB format version {}; please open an issue",
-                buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?
+                *buf.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?
             );
 
             buf = &buf[1..];

--- a/sqlx-core/src/postgres/types/range.rs
+++ b/sqlx-core/src/postgres/types/range.rs
@@ -425,7 +425,7 @@ where
 
                 // remember the bounds
                 let sb = s.as_bytes();
-                let lower = sb.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? as char;
+                let lower = *sb.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? as char;
                 let upper = sb[sb.len() - 1] as char;
 
                 // trim the wrapping braces/brackets

--- a/sqlx-core/src/postgres/types/range.rs
+++ b/sqlx-core/src/postgres/types/range.rs
@@ -6,7 +6,7 @@ use bytes::Buf;
 
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
-use crate::error::BoxDynError;
+use crate::error::{BoxDynError, Error};
 use crate::postgres::type_info::PgTypeKind;
 use crate::postgres::{PgArgumentBuffer, PgTypeInfo, PgValueFormat, PgValueRef, Postgres};
 use crate::types::Type;
@@ -425,7 +425,7 @@ where
 
                 // remember the bounds
                 let sb = s.as_bytes();
-                let lower = sb[0] as char;
+                let lower = sb.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? as char;
                 let upper = sb[sb.len() - 1] as char;
 
                 // trim the wrapping braces/brackets

--- a/sqlx-core/src/postgres/types/range.rs
+++ b/sqlx-core/src/postgres/types/range.rs
@@ -425,7 +425,10 @@ where
 
                 // remember the bounds
                 let sb = s.as_bytes();
-                let lower = *sb.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))? as char;
+                let lower = *sb
+                    .get(0)
+                    .ok_or_else(|| Error::Protocol("unexpected packet index:0".to_string()))?
+                    as char;
                 let upper = sb[sb.len() - 1] as char;
 
                 // trim the wrapping braces/brackets


### PR DESCRIPTION
Replace unsafe take packet or buffer,prevent panic  on under 'mysql:8'!

for example:
```rust
packet[0]  
```
to:
```rust
packet.get(0).ok_or_else(||Error::Protocol("unexpected packet index:0".to_string()))?
```