### PR TITLE
feat: Adds `Debug, Clone` auto-derive to `SqliteArguments`

### DIFF
--- a/sqlx-core/src/sqlite/arguments.rs
+++ b/sqlx-core/src/sqlite/arguments.rs
@@ -17,7 +17,7 @@ pub enum SqliteArgumentValue<'q> {
     Int64(i64),
 }
 
-#[derive(Default)]
+#[derive(Default, Debug, Clone)]
 pub struct SqliteArguments<'q> {
     pub(crate) values: Vec<SqliteArgumentValue<'q>>,
 }


### PR DESCRIPTION
`MySqlArguments` implements `Debug + Default` but `SqliteArguments` only implements `Default`.

I wonder if I should add `Clone` especially for backward compatibility in the future. I'm willing to remove `Clone` if I should.