### PR TITLE
Switch builder methods in ConnectOptions to take ownership

### DIFF
--- a/sqlx-core/src/any/options.rs
+++ b/sqlx-core/src/any/options.rs
@@ -123,53 +123,55 @@ impl ConnectOptions for AnyConnectOptions {
         Box::pin(AnyConnection::establish(self))
     }
 
-    fn log_statements(&mut self, level: LevelFilter) -> &mut Self {
-        match &mut self.0 {
+    fn log_statements(self, level: LevelFilter) -> Self {
+        let kind = match self.0 {
             #[cfg(feature = "postgres")]
             AnyConnectOptionsKind::Postgres(o) => {
-                o.log_statements(level);
+                AnyConnectOptionsKind::Postgres(o.log_statements(level))
             }
 
             #[cfg(feature = "mysql")]
             AnyConnectOptionsKind::MySql(o) => {
-                o.log_statements(level);
+                AnyConnectOptionsKind::MySql(o.log_statements(level))
             }
 
             #[cfg(feature = "sqlite")]
             AnyConnectOptionsKind::Sqlite(o) => {
-                o.log_statements(level);
+                AnyConnectOptionsKind::Sqlite(o.log_statements(level))
             }
 
             #[cfg(feature = "mssql")]
             AnyConnectOptionsKind::Mssql(o) => {
-                o.log_statements(level);
+                AnyConnectOptionsKind::Mssql(o.log_statements(level))
             }
         };
-        self
+
+        Self(kind)
     }
 
-    fn log_slow_statements(&mut self, level: LevelFilter, duration: Duration) -> &mut Self {
-        match &mut self.0 {
+    fn log_slow_statements(self, level: LevelFilter, duration: Duration) -> Self {
+        let kind = match self.0 {
             #[cfg(feature = "postgres")]
             AnyConnectOptionsKind::Postgres(o) => {
-                o.log_slow_statements(level, duration);
+                AnyConnectOptionsKind::Postgres(o.log_slow_statements(level, duration))
             }
 
             #[cfg(feature = "mysql")]
             AnyConnectOptionsKind::MySql(o) => {
-                o.log_slow_statements(level, duration);
+                AnyConnectOptionsKind::MySql(o.log_slow_statements(level, duration))
             }
 
             #[cfg(feature = "sqlite")]
             AnyConnectOptionsKind::Sqlite(o) => {
-                o.log_slow_statements(level, duration);
+                AnyConnectOptionsKind::Sqlite(o.log_slow_statements(level, duration))
             }
 
             #[cfg(feature = "mssql")]
             AnyConnectOptionsKind::Mssql(o) => {
-                o.log_slow_statements(level, duration);
+                AnyConnectOptionsKind::Mssql(o.log_slow_statements(level, duration))
             }
         };
-        self
+
+        Self(kind)
     }
 }

--- a/sqlx-core/src/connection.rs
+++ b/sqlx-core/src/connection.rs
@@ -161,14 +161,14 @@ pub trait ConnectOptions: 'static + Send + Sync + FromStr<Err = Error> + Debug {
         Self::Connection: Sized;
 
     /// Log executed statements with the specified `level`
-    fn log_statements(&mut self, level: LevelFilter) -> &mut Self;
+    fn log_statements(self, level: LevelFilter) -> Self;
 
     /// Log executed statements with a duration above the specified `duration`
     /// at the specified `level`.
-    fn log_slow_statements(&mut self, level: LevelFilter, duration: Duration) -> &mut Self;
+    fn log_slow_statements(self, level: LevelFilter, duration: Duration) -> Self;
 
     /// Entirely disables statement logging (both slow and regular).
-    fn disable_statement_logging(&mut self) -> &mut Self {
+    fn disable_statement_logging(self) -> Self {
         self.log_statements(LevelFilter::Off)
             .log_slow_statements(LevelFilter::Off, Duration::default())
     }

--- a/sqlx-core/src/mssql/options/connect.rs
+++ b/sqlx-core/src/mssql/options/connect.rs
@@ -15,12 +15,12 @@ impl ConnectOptions for MssqlConnectOptions {
         Box::pin(MssqlConnection::establish(self))
     }
 
-    fn log_statements(&mut self, level: LevelFilter) -> &mut Self {
+    fn log_statements(mut self, level: LevelFilter) -> Self {
         self.log_settings.log_statements(level);
         self
     }
 
-    fn log_slow_statements(&mut self, level: LevelFilter, duration: Duration) -> &mut Self {
+    fn log_slow_statements(mut self, level: LevelFilter, duration: Duration) -> Self {
         self.log_settings.log_slow_statements(level, duration);
         self
     }

--- a/sqlx-core/src/mysql/options/connect.rs
+++ b/sqlx-core/src/mysql/options/connect.rs
@@ -56,12 +56,12 @@ impl ConnectOptions for MySqlConnectOptions {
         })
     }
 
-    fn log_statements(&mut self, level: LevelFilter) -> &mut Self {
+    fn log_statements(mut self, level: LevelFilter) -> Self {
         self.log_settings.log_statements(level);
         self
     }
 
-    fn log_slow_statements(&mut self, level: LevelFilter, duration: Duration) -> &mut Self {
+    fn log_slow_statements(mut self, level: LevelFilter, duration: Duration) -> Self {
         self.log_settings.log_slow_statements(level, duration);
         self
     }

--- a/sqlx-core/src/postgres/options/connect.rs
+++ b/sqlx-core/src/postgres/options/connect.rs
@@ -15,12 +15,12 @@ impl ConnectOptions for PgConnectOptions {
         Box::pin(PgConnection::establish(self))
     }
 
-    fn log_statements(&mut self, level: LevelFilter) -> &mut Self {
+    fn log_statements(mut self, level: LevelFilter) -> Self {
         self.log_settings.log_statements(level);
         self
     }
 
-    fn log_slow_statements(&mut self, level: LevelFilter, duration: Duration) -> &mut Self {
+    fn log_slow_statements(mut self, level: LevelFilter, duration: Duration) -> Self {
         self.log_settings.log_slow_statements(level, duration);
         self
     }

--- a/sqlx-core/src/sqlite/options/connect.rs
+++ b/sqlx-core/src/sqlite/options/connect.rs
@@ -31,12 +31,12 @@ impl ConnectOptions for SqliteConnectOptions {
         })
     }
 
-    fn log_statements(&mut self, level: LevelFilter) -> &mut Self {
+    fn log_statements(mut self, level: LevelFilter) -> Self {
         self.log_settings.log_statements(level);
         self
     }
 
-    fn log_slow_statements(&mut self, level: LevelFilter, duration: Duration) -> &mut Self {
+    fn log_slow_statements(mut self, level: LevelFilter, duration: Duration) -> Self {
         self.log_settings.log_slow_statements(level, duration);
         self
     }


### PR DESCRIPTION
This makes them consistent with the inherent builder methods on the various ConnectOptions implementors.