### PR TITLE
Don't require `Cargo.toml` for all subcommands

### DIFF
--- a/sqlx-cli/src/lib.rs
+++ b/sqlx-cli/src/lib.rs
@@ -1,8 +1,7 @@
 use crate::opt::{Command, DatabaseCommand, MigrateCommand};
-use anyhow::{anyhow, bail};
+use anyhow::anyhow;
 use dotenv::dotenv;
 use std::env;
-use std::path::Path;
 
 mod database;
 // mod migration;
@@ -14,13 +13,6 @@ mod prepare;
 pub use crate::opt::Opt;
 
 pub async fn run(opt: Opt) -> anyhow::Result<()> {
-    if !Path::new("Cargo.toml").exists() {
-        bail!(
-            r#"Failed to read `Cargo.toml`.
-hint: This command only works in the manifest directory of a Cargo package."#
-        );
-    }
-
     dotenv().ok();
 
     let database_url = match opt.database_url {

--- a/sqlx-cli/src/prepare.rs
+++ b/sqlx-cli/src/prepare.rs
@@ -6,7 +6,7 @@ use sqlx::any::{AnyConnectOptions, AnyKind};
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str::FromStr;
 use std::time::SystemTime;
@@ -22,6 +22,12 @@ pub fn run(url: &str, merge: bool, cargo_args: Vec<String>) -> anyhow::Result<()
         #[serde(flatten)]
         data: QueryData,
     }
+
+    anyhow::ensure!(
+        Path::new("Cargo.toml").exists(),
+        r#"Failed to read `Cargo.toml`.
+hint: This command only works in the manifest directory of a Cargo package."#
+    );
 
     let db_kind = get_db_kind(url)?;
     let data = run_prepare_step(merge, cargo_args)?;

--- a/sqlx-cli/src/prepare.rs
+++ b/sqlx-cli/src/prepare.rs
@@ -23,12 +23,6 @@ pub fn run(url: &str, merge: bool, cargo_args: Vec<String>) -> anyhow::Result<()
         data: QueryData,
     }
 
-    anyhow::ensure!(
-        Path::new("Cargo.toml").exists(),
-        r#"Failed to read `Cargo.toml`.
-hint: This command only works in the manifest directory of a Cargo package."#
-    );
-
     let db_kind = get_db_kind(url)?;
     let data = run_prepare_step(merge, cargo_args)?;
 
@@ -89,6 +83,12 @@ pub fn check(url: &str, merge: bool, cargo_args: Vec<String>) -> anyhow::Result<
 }
 
 fn run_prepare_step(merge: bool, cargo_args: Vec<String>) -> anyhow::Result<QueryData> {
+    anyhow::ensure!(
+        Path::new("Cargo.toml").exists(),
+        r#"Failed to read `Cargo.toml`.
+hint: This command only works in the manifest directory of a Cargo package."#
+    );
+
     // path to the Cargo executable
     let cargo = env::var("CARGO")
         .context("`prepare` subcommand may only be invoked as `cargo sqlx prepare`")?;


### PR DESCRIPTION
Moves the check for the existence of `Cargo.toml` to the prepare module. Also uses `anyhow::ensure` instead of `anyhow::bail`.

Closes #1017.
