### PR TITLE
fix(pool): always test connection on release to see if it's still viable

### DIFF
--- a/tests/any/pool.rs
+++ b/tests/any/pool.rs
@@ -29,7 +29,9 @@ async fn pool_should_invoke_after_connect() -> anyhow::Result<()> {
     let _ = pool.acquire().await?;
     let _ = pool.acquire().await?;
 
-    assert_eq!(counter.load(Ordering::SeqCst), 1);
+    // since connections are released asynchronously,
+    // `.after_connect()` may be called more than once
+    assert!(counter.load(Ordering::SeqCst) >= 1);
 
     Ok(())
 }


### PR DESCRIPTION
This should alleviate some issues WRT cancellation (cc #563) as connections in an inconsistent state should not be recycled by `Pool`.

SQLx-next (0.6) will address the cancellation issue by ensuring connections remember all relevant state in order to resume where they left off.

