### PR TITLE
use absolute paths in macros

### DIFF
--- a/sqlx-macros/src/derives/attributes.rs
+++ b/sqlx-macros/src/derives/attributes.rs
@@ -40,7 +40,7 @@ impl TypeName {
         let val = &self.val;
         if self.deprecated_rename {
             quote_spanned!(self.span=> {
-                sqlx::_rename();
+                ::sqlx::_rename();
                 #val
             })
         } else {

--- a/sqlx-macros/src/derives/decode.rs
+++ b/sqlx-macros/src/derives/decode.rs
@@ -61,7 +61,9 @@ fn expand_derive_decode_transparent(
 
     // add db type for impl generics & where clause
     let mut generics = generics.clone();
-    generics.params.insert(0, parse_quote!(DB: ::sqlx::Database));
+    generics
+        .params
+        .insert(0, parse_quote!(DB: ::sqlx::Database));
     generics.params.insert(0, parse_quote!('r));
     generics
         .make_where_clause()

--- a/sqlx-macros/src/derives/encode.rs
+++ b/sqlx-macros/src/derives/encode.rs
@@ -68,7 +68,9 @@ fn expand_derive_encode_transparent(
         .params
         .insert(0, LifetimeDef::new(lifetime.clone()).into());
 
-    generics.params.insert(0, parse_quote!(DB: ::sqlx::Database));
+    generics
+        .params
+        .insert(0, parse_quote!(DB: ::sqlx::Database));
     generics
         .make_where_clause()
         .predicates
@@ -195,7 +197,8 @@ fn expand_derive_encode_struct(
         for field in fields {
             let ty = &field.ty;
 
-            predicates.push(parse_quote!(#ty: for<'q> ::sqlx::encode::Encode<'q, ::sqlx::Postgres>));
+            predicates
+                .push(parse_quote!(#ty: for<'q> ::sqlx::encode::Encode<'q, ::sqlx::Postgres>));
             predicates.push(parse_quote!(#ty: ::sqlx::types::Type<::sqlx::Postgres>));
         }
 

--- a/sqlx-macros/src/derives/row.rs
+++ b/sqlx-macros/src/derives/row.rs
@@ -144,7 +144,9 @@ fn expand_derive_from_row_struct_unnamed(
 
     let predicates = &mut generics.make_where_clause().predicates;
 
-    predicates.push(parse_quote!(::std::primitive::usize: ::sqlx::ColumnIndex<R>));
+    predicates.push(parse_quote!(
+        ::std::primitive::usize: ::sqlx::ColumnIndex<R>
+    ));
 
     for field in fields {
         let ty = &field.ty;

--- a/sqlx-macros/src/derives/row.rs
+++ b/sqlx-macros/src/derives/row.rs
@@ -53,7 +53,7 @@ fn expand_derive_from_row_struct(
     let (_, ty_generics, _) = generics.split_for_impl();
 
     let mut generics = generics.clone();
-    generics.params.insert(0, parse_quote!(R: sqlx::Row));
+    generics.params.insert(0, parse_quote!(R: ::sqlx::Row));
 
     if provided {
         generics.params.insert(0, parse_quote!(#lifetime));
@@ -61,13 +61,13 @@ fn expand_derive_from_row_struct(
 
     let predicates = &mut generics.make_where_clause().predicates;
 
-    predicates.push(parse_quote!(&#lifetime str: sqlx::ColumnIndex<R>));
+    predicates.push(parse_quote!(&#lifetime ::std::primitive::str: ::sqlx::ColumnIndex<R>));
 
     for field in fields {
         let ty = &field.ty;
 
-        predicates.push(parse_quote!(#ty: sqlx::decode::Decode<#lifetime, R::Database>));
-        predicates.push(parse_quote!(#ty: sqlx::types::Type<R::Database>));
+        predicates.push(parse_quote!(#ty: ::sqlx::decode::Decode<#lifetime, R::Database>));
+        predicates.push(parse_quote!(#ty: ::sqlx::types::Type<R::Database>));
     }
 
     let (impl_generics, _, where_clause) = generics.split_for_impl();
@@ -91,10 +91,10 @@ fn expand_derive_from_row_struct(
         if attributes.default {
             Some(
                 parse_quote!(let #id: #ty = row.try_get(#id_s).or_else(|e| match e {
-                sqlx::Error::ColumnNotFound(_) => {
-                    Ok(Default::default())
+                ::sqlx::Error::ColumnNotFound(_) => {
+                    ::std::result::Result::Ok(Default::default())
                 },
-                e => Err(e)
+                e => ::std::result::Result::Err(e)
             })?;),
             )
         } else {
@@ -107,11 +107,11 @@ fn expand_derive_from_row_struct(
     let names = fields.iter().map(|field| &field.ident);
 
     Ok(quote!(
-        impl #impl_generics sqlx::FromRow<#lifetime, R> for #ident #ty_generics #where_clause {
-            fn from_row(row: &#lifetime R) -> sqlx::Result<Self> {
+        impl #impl_generics ::sqlx::FromRow<#lifetime, R> for #ident #ty_generics #where_clause {
+            fn from_row(row: &#lifetime R) -> ::sqlx::Result<Self> {
                 #(#reads)*
 
-                Ok(#ident {
+                ::std::result::Result::Ok(#ident {
                     #(#names),*
                 })
             }
@@ -136,7 +136,7 @@ fn expand_derive_from_row_struct_unnamed(
     let (_, ty_generics, _) = generics.split_for_impl();
 
     let mut generics = generics.clone();
-    generics.params.insert(0, parse_quote!(R: sqlx::Row));
+    generics.params.insert(0, parse_quote!(R: ::sqlx::Row));
 
     if provided {
         generics.params.insert(0, parse_quote!(#lifetime));
@@ -144,13 +144,13 @@ fn expand_derive_from_row_struct_unnamed(
 
     let predicates = &mut generics.make_where_clause().predicates;
 
-    predicates.push(parse_quote!(usize: sqlx::ColumnIndex<R>));
+    predicates.push(parse_quote!(::std::primitive::usize: ::sqlx::ColumnIndex<R>));
 
     for field in fields {
         let ty = &field.ty;
 
-        predicates.push(parse_quote!(#ty: sqlx::decode::Decode<#lifetime, R::Database>));
-        predicates.push(parse_quote!(#ty: sqlx::types::Type<R::Database>));
+        predicates.push(parse_quote!(#ty: ::sqlx::decode::Decode<#lifetime, R::Database>));
+        predicates.push(parse_quote!(#ty: ::sqlx::types::Type<R::Database>));
     }
 
     let (impl_generics, _, where_clause) = generics.split_for_impl();
@@ -161,9 +161,9 @@ fn expand_derive_from_row_struct_unnamed(
         .map(|(idx, _)| quote!(row.try_get(#idx)?));
 
     Ok(quote!(
-        impl #impl_generics sqlx::FromRow<#lifetime, R> for #ident #ty_generics #where_clause {
-            fn from_row(row: &#lifetime R) -> sqlx::Result<Self> {
-                Ok(#ident (
+        impl #impl_generics ::sqlx::FromRow<#lifetime, R> for #ident #ty_generics #where_clause {
+            fn from_row(row: &#lifetime R) -> ::sqlx::Result<Self> {
+                ::std::result::Result::Ok(#ident (
                     #(#gets),*
                 ))
             }

--- a/sqlx-macros/src/derives/type.rs
+++ b/sqlx-macros/src/derives/type.rs
@@ -59,7 +59,9 @@ fn expand_derive_has_sql_type_transparent(
 
     if attr.transparent {
         let mut generics = generics.clone();
-        generics.params.insert(0, parse_quote!(DB: ::sqlx::Database));
+        generics
+            .params
+            .insert(0, parse_quote!(DB: ::sqlx::Database));
         generics
             .make_where_clause()
             .predicates

--- a/sqlx-macros/src/derives/type.rs
+++ b/sqlx-macros/src/derives/type.rs
@@ -75,7 +75,7 @@ fn expand_derive_has_sql_type_transparent(
                     <#ty as ::sqlx::Type<DB>>::type_info()
                 }
 
-                fn compatible(ty: &DB::TypeInfo) -> ::std::bool {
+                fn compatible(ty: &DB::TypeInfo) -> ::std::primitive::bool {
                     <#ty as ::sqlx::Type<DB>>::compatible(ty)
                 }
             }
@@ -139,7 +139,7 @@ fn expand_derive_has_sql_type_strong_enum(
                     ::sqlx::mysql::MySqlTypeInfo::__enum()
                 }
 
-                fn compatible(ty: &::sqlx::mysql::MySqlTypeInfo) -> ::std::bool {
+                fn compatible(ty: &::sqlx::mysql::MySqlTypeInfo) -> ::std::primitive::bool {
                     *ty == ::sqlx::mysql::MySqlTypeInfo::__enum()
                 }
             }
@@ -168,8 +168,8 @@ fn expand_derive_has_sql_type_strong_enum(
                     <::std::primitive::str as ::sqlx::Type<sqlx::Sqlite>>::type_info()
                 }
 
-                fn compatible(ty: &::sqlx::sqlite::SqliteTypeInfo) -> ::std::bool {
-                    <&::str::str as ::sqlx::types::Type<sqlx::sqlite::Sqlite>>::compatible(ty)
+                fn compatible(ty: &::sqlx::sqlite::SqliteTypeInfo) -> ::std::primitive::bool {
+                    <&::std::primitive::str as ::sqlx::types::Type<sqlx::sqlite::Sqlite>>::compatible(ty)
                 }
             }
         ));

--- a/sqlx-macros/src/derives/type.rs
+++ b/sqlx-macros/src/derives/type.rs
@@ -59,22 +59,22 @@ fn expand_derive_has_sql_type_transparent(
 
     if attr.transparent {
         let mut generics = generics.clone();
-        generics.params.insert(0, parse_quote!(DB: sqlx::Database));
+        generics.params.insert(0, parse_quote!(DB: ::sqlx::Database));
         generics
             .make_where_clause()
             .predicates
-            .push(parse_quote!(#ty: sqlx::Type<DB>));
+            .push(parse_quote!(#ty: ::sqlx::Type<DB>));
 
         let (impl_generics, _, where_clause) = generics.split_for_impl();
 
         return Ok(quote!(
-            impl #impl_generics sqlx::Type< DB > for #ident #ty_generics #where_clause {
+            impl #impl_generics ::sqlx::Type< DB > for #ident #ty_generics #where_clause {
                 fn type_info() -> DB::TypeInfo {
-                    <#ty as sqlx::Type<DB>>::type_info()
+                    <#ty as ::sqlx::Type<DB>>::type_info()
                 }
 
-                fn compatible(ty: &DB::TypeInfo) -> bool {
-                    <#ty as sqlx::Type<DB>>::compatible(ty)
+                fn compatible(ty: &DB::TypeInfo) -> ::std::bool {
+                    <#ty as ::sqlx::Type<DB>>::compatible(ty)
                 }
             }
         ));
@@ -89,9 +89,9 @@ fn expand_derive_has_sql_type_transparent(
             .unwrap_or_else(|| quote! { #ident });
 
         tts.extend(quote!(
-            impl sqlx::Type< sqlx::postgres::Postgres > for #ident #ty_generics {
-                fn type_info() -> sqlx::postgres::PgTypeInfo {
-                    sqlx::postgres::PgTypeInfo::with_name(#ty_name)
+            impl ::sqlx::Type<::sqlx::postgres::Postgres> for #ident #ty_generics {
+                fn type_info() -> ::sqlx::postgres::PgTypeInfo {
+                    ::sqlx::postgres::PgTypeInfo::with_name(#ty_name)
                 }
             }
         ));
@@ -108,12 +108,12 @@ fn expand_derive_has_sql_type_weak_enum(
     let repr = attr.repr.unwrap();
     let ident = &input.ident;
     let ts = quote!(
-        impl<DB: sqlx::Database> sqlx::Type<DB> for #ident
+        impl<DB: ::sqlx::Database> ::sqlx::Type<DB> for #ident
         where
-            #repr: sqlx::Type<DB>,
+            #repr: ::sqlx::Type<DB>,
         {
             fn type_info() -> DB::TypeInfo {
-                <#repr as sqlx::Type<DB>>::type_info()
+                <#repr as ::sqlx::Type<DB>>::type_info()
             }
         }
     );
@@ -132,13 +132,13 @@ fn expand_derive_has_sql_type_strong_enum(
 
     if cfg!(feature = "mysql") {
         tts.extend(quote!(
-            impl sqlx::Type< sqlx::MySql > for #ident {
-                fn type_info() -> sqlx::mysql::MySqlTypeInfo {
-                    sqlx::mysql::MySqlTypeInfo::__enum()
+            impl ::sqlx::Type<::sqlx::MySql> for #ident {
+                fn type_info() -> ::sqlx::mysql::MySqlTypeInfo {
+                    ::sqlx::mysql::MySqlTypeInfo::__enum()
                 }
 
-                fn compatible(ty: &sqlx::mysql::MySqlTypeInfo) -> bool {
-                    *ty == sqlx::mysql::MySqlTypeInfo::__enum()
+                fn compatible(ty: &::sqlx::mysql::MySqlTypeInfo) -> ::std::bool {
+                    *ty == ::sqlx::mysql::MySqlTypeInfo::__enum()
                 }
             }
         ));
@@ -151,9 +151,9 @@ fn expand_derive_has_sql_type_strong_enum(
             .unwrap_or_else(|| quote! { #ident });
 
         tts.extend(quote!(
-            impl sqlx::Type< sqlx::Postgres > for #ident {
-                fn type_info() -> sqlx::postgres::PgTypeInfo {
-                    sqlx::postgres::PgTypeInfo::with_name(#ty_name)
+            impl ::sqlx::Type<::sqlx::Postgres> for #ident {
+                fn type_info() -> ::sqlx::postgres::PgTypeInfo {
+                    ::sqlx::postgres::PgTypeInfo::with_name(#ty_name)
                 }
             }
         ));
@@ -161,13 +161,13 @@ fn expand_derive_has_sql_type_strong_enum(
 
     if cfg!(feature = "sqlite") {
         tts.extend(quote!(
-            impl sqlx::Type< sqlx::Sqlite > for #ident {
-                fn type_info() -> sqlx::sqlite::SqliteTypeInfo {
-                    <str as sqlx::Type<sqlx::Sqlite>>::type_info()
+            impl sqlx::Type<::sqlx::Sqlite> for #ident {
+                fn type_info() -> ::sqlx::sqlite::SqliteTypeInfo {
+                    <::std::primitive::str as ::sqlx::Type<sqlx::Sqlite>>::type_info()
                 }
 
-                fn compatible(ty: &sqlx::sqlite::SqliteTypeInfo) -> bool {
-                    <&str as sqlx::types::Type<sqlx::sqlite::Sqlite>>::compatible(ty)
+                fn compatible(ty: &::sqlx::sqlite::SqliteTypeInfo) -> ::std::bool {
+                    <&::str::str as ::sqlx::types::Type<sqlx::sqlite::Sqlite>>::compatible(ty)
                 }
             }
         ));
@@ -192,9 +192,9 @@ fn expand_derive_has_sql_type_struct(
             .unwrap_or_else(|| quote! { #ident });
 
         tts.extend(quote!(
-            impl sqlx::Type< sqlx::Postgres > for #ident {
-                fn type_info() -> sqlx::postgres::PgTypeInfo {
-                    sqlx::postgres::PgTypeInfo::with_name(#ty_name)
+            impl ::sqlx::Type<::sqlx::Postgres> for #ident {
+                fn type_info() -> ::sqlx::postgres::PgTypeInfo {
+                    ::sqlx::postgres::PgTypeInfo::with_name(#ty_name)
                 }
             }
         ));

--- a/sqlx-macros/src/lib.rs
+++ b/sqlx-macros/src/lib.rs
@@ -31,7 +31,7 @@ pub fn expand_query(input: TokenStream) -> TokenStream {
                 parse_err.to_compile_error().into()
             } else {
                 let msg = e.to_string();
-                quote!(compile_error!(#msg)).into()
+                quote!(::std::compile_error!(#msg)).into()
             }
         }
     }
@@ -87,7 +87,7 @@ pub fn migrate(input: TokenStream) -> TokenStream {
                 parse_err.to_compile_error().into()
             } else {
                 let msg = e.to_string();
-                quote!(compile_error!(#msg)).into()
+                quote!(::std::compile_error!(#msg)).into()
             }
         }
     }
@@ -108,7 +108,7 @@ pub fn test(_attr: TokenStream, input: TokenStream) -> TokenStream {
             #[test]
             #(#attrs)*
             fn #name() #ret {
-                sqlx_rt::tokio::runtime::Builder::new_multi_thread()
+                ::sqlx_rt::tokio::runtime::Builder::new_multi_thread()
                     .enable_io()
                     .enable_time()
                     .build()
@@ -121,7 +121,7 @@ pub fn test(_attr: TokenStream, input: TokenStream) -> TokenStream {
             #[test]
             #(#attrs)*
             fn #name() #ret {
-                sqlx_rt::async_std::task::block_on(async { #body })
+                ::sqlx_rt::async_std::task::block_on(async { #body })
             }
         }
     } else if cfg!(feature = "_rt-actix") {
@@ -129,7 +129,7 @@ pub fn test(_attr: TokenStream, input: TokenStream) -> TokenStream {
             #[test]
             #(#attrs)*
             fn #name() #ret {
-                sqlx_rt::actix_rt::System::new("sqlx-test")
+                ::sqlx_rt::actix_rt::System::new("sqlx-test")
                     .block_on(async { #body })
             }
         }

--- a/sqlx-macros/src/migrate.rs
+++ b/sqlx-macros/src/migrate.rs
@@ -43,8 +43,8 @@ impl ToTokens for QuotedMigration {
                 version: #version,
                 description: ::std::borrow::Cow::Borrowed(#description),
                 migration_type:  #migration_type,
-                sql: :std::borrow::Cow::Borrowed(#sql),
-                checksum: :std::borrow::Cow::Borrowed(&[
+                sql: ::std::borrow::Cow::Borrowed(#sql),
+                checksum: ::std::borrow::Cow::Borrowed(&[
                     #(#checksum),*
                 ]),
             }

--- a/sqlx-macros/src/migrate.rs
+++ b/sqlx-macros/src/migrate.rs
@@ -10,10 +10,10 @@ pub struct QuotedMigrationType(MigrationType);
 impl ToTokens for QuotedMigrationType {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let ts = match self.0 {
-            MigrationType::Simple => quote! { sqlx::migrate::MigrationType::Simple },
-            MigrationType::ReversibleUp => quote! { sqlx::migrate::MigrationType::ReversibleUp },
+            MigrationType::Simple => quote! { ::sqlx::migrate::MigrationType::Simple },
+            MigrationType::ReversibleUp => quote! { ::sqlx::migrate::MigrationType::ReversibleUp },
             MigrationType::ReversibleDown => {
-                quote! { sqlx::migrate::MigrationType::ReversibleDown }
+                quote! { ::sqlx::migrate::MigrationType::ReversibleDown }
             }
         };
         tokens.append_all(ts.into_iter());
@@ -39,12 +39,12 @@ impl ToTokens for QuotedMigration {
         } = &self;
 
         let ts = quote! {
-            sqlx::migrate::Migration {
+            ::sqlx::migrate::Migration {
                 version: #version,
-                description: std::borrow::Cow::Borrowed(#description),
+                description: ::std::borrow::Cow::Borrowed(#description),
                 migration_type:  #migration_type,
-                sql: std::borrow::Cow::Borrowed(#sql),
-                checksum: std::borrow::Cow::Borrowed(&[
+                sql: :std::borrow::Cow::Borrowed(#sql),
+                checksum: :std::borrow::Cow::Borrowed(&[
                     #(#checksum),*
                 ]),
             }
@@ -102,8 +102,8 @@ pub(crate) fn expand_migrator_from_dir(dir: LitStr) -> crate::Result<proc_macro2
     migrations.sort_by_key(|m| m.version);
 
     Ok(quote! {
-        sqlx::migrate::Migrator {
-            migrations: std::borrow::Cow::Borrowed(&[
+        ::sqlx::migrate::Migrator {
+            migrations: ::std::borrow::Cow::Borrowed(&[
                 #(#migrations),*
             ])
         }

--- a/sqlx-macros/src/query/args.rs
+++ b/sqlx-macros/src/query/args.rs
@@ -17,7 +17,7 @@ pub fn quote_args<DB: DatabaseExt>(
 
     if input.arg_exprs.is_empty() {
         return Ok(quote! {
-            let query_args = <#db_path as sqlx::database::HasArguments>::Arguments::default();
+            let query_args = <#db_path as ::sqlx::database::HasArguments>::Arguments::default();
         });
     }
 
@@ -76,21 +76,21 @@ pub fn quote_args<DB: DatabaseExt>(
                     Ok(quote_spanned!(expr.span() =>
                         // this shouldn't actually run
                         if false {
-                            use sqlx::ty_match::{WrapSameExt as _, MatchBorrowExt as _};
+                            use ::sqlx::ty_match::{WrapSameExt as _, MatchBorrowExt as _};
 
                             // evaluate the expression only once in case it contains moves
-                            let _expr = sqlx::ty_match::dupe_value(#name);
+                            let _expr = ::sqlx::ty_match::dupe_value(#name);
 
                             // if `_expr` is `Option<T>`, get `Option<$ty>`, otherwise `$ty`
-                            let ty_check = sqlx::ty_match::WrapSame::<#param_ty, _>::new(&_expr).wrap_same();
+                            let ty_check = ::sqlx::ty_match::WrapSame::<#param_ty, _>::new(&_expr).wrap_same();
 
                             // if `_expr` is `&str`, convert `String` to `&str`
-                            let (mut _ty_check, match_borrow) = sqlx::ty_match::MatchBorrow::new(ty_check, &_expr);
+                            let (mut _ty_check, match_borrow) = ::sqlx::ty_match::MatchBorrow::new(ty_check, &_expr);
 
                             _ty_check = match_borrow.match_borrow();
 
                             // this causes move-analysis to effectively ignore this block
-                            panic!();
+                            ::std::panic!();
                         }
                     ))
                 })
@@ -105,10 +105,10 @@ pub fn quote_args<DB: DatabaseExt>(
 
         #args_check
 
-        let mut query_args = <#db_path as sqlx::database::HasArguments>::Arguments::default();
+        let mut query_args = <#db_path as ::sqlx::database::HasArguments>::Arguments::default();
         query_args.reserve(
             #args_count,
-            0 #(+ sqlx::encode::Encode::<#db_path>::size_hint(#arg_name))*
+            0 #(+ ::sqlx::encode::Encode::<#db_path>::size_hint(#arg_name))*
         );
         #(query_args.add(#arg_name);)*
     })

--- a/sqlx-macros/src/query/mod.rs
+++ b/sqlx-macros/src/query/mod.rs
@@ -253,7 +253,7 @@ where
         let sql = &input.src;
 
         quote! {
-            sqlx::query_with::<#db_path, _>(#sql, #query_args)
+            ::sqlx::query_with::<#db_path, _>(#sql, #query_args)
         }
     } else {
         match input.record_type {
@@ -309,7 +309,7 @@ where
         {
             #[allow(clippy::all)]
             {
-                use sqlx::Arguments as _;
+                use ::sqlx::Arguments as _;
 
                 #args_tokens
 

--- a/sqlx-macros/src/query/output.rs
+++ b/sqlx-macros/src/query/output.rs
@@ -96,7 +96,9 @@ fn column_to_rust<DB: DatabaseExt>(describe: &Describe<DB>, i: usize) -> crate::
     };
     let type_ = match (type_, nullable) {
         (ColumnTypeOverride::Exact(type_), false) => ColumnType::Exact(type_.to_token_stream()),
-        (ColumnTypeOverride::Exact(type_), true) => ColumnType::Exact(quote! { ::std::option::Option<#type_> }),
+        (ColumnTypeOverride::Exact(type_), true) => {
+            ColumnType::Exact(quote! { ::std::option::Option<#type_> })
+        }
 
         (ColumnTypeOverride::Wildcard, false) => ColumnType::Wildcard,
         (ColumnTypeOverride::Wildcard, true) => ColumnType::OptWildcard,


### PR DESCRIPTION
This pr makes all paths in macros absolute paths, so for example `sqlx::Database` becomes `::sqlx::Database`, `str` becomes `::std::primitive::str` and `format!(...)` becomes `::std::format!(...)`