### PR TITLE
ban `Ord::{min, max}` with Clippy as it's too easy to misread infix calls

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,5 @@
+disallowed-methods = [
+    # It is *much* too easy to misread `x.min(y)` as "x should be *at least* y" when in fact it
+    # means the *exact* opposite, and same with `x.max(y)`; use `cmp::{min, max}` instead.
+    "core::cmp::Ord::min", "core::cmp::Ord::max"
+]

--- a/sqlx-core/src/lib.rs
+++ b/sqlx-core/src/lib.rs
@@ -3,6 +3,8 @@
 #![recursion_limit = "512"]
 #![warn(future_incompatible, rust_2018_idioms)]
 #![allow(clippy::needless_doctest_main, clippy::type_complexity)]
+// See `clippy.toml` at the workspace root
+#![deny(clippy::disallowed_method)]
 //
 // Allows an API be documented as only available in some specific platforms.
 // <https://doc.rust-lang.org/unstable-book/language-features/doc-cfg.html>

--- a/sqlx-core/src/pool/options.rs
+++ b/sqlx-core/src/pool/options.rs
@@ -5,6 +5,7 @@ use crate::pool::inner::SharedPool;
 use crate::pool::Pool;
 use futures_core::future::BoxFuture;
 use sqlx_rt::spawn;
+use std::cmp;
 use std::fmt::{self, Debug, Formatter};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -228,7 +229,7 @@ impl<DB: Database> PoolOptions<DB> {
 }
 
 async fn init_min_connections<DB: Database>(pool: &SharedPool<DB>) -> Result<(), Error> {
-    for _ in 0..pool.options.min_connections.max(1) {
+    for _ in 0..cmp::max(pool.options.min_connections, 1) {
         let deadline = Instant::now() + pool.options.connect_timeout;
 
         // this guard will prevent us from exceeding `max_size`


### PR DESCRIPTION
It is *much* too easy to misread `x.min(y)` as "`x` should be *at least* `y`" when in fact it means the *exact* opposite, and same with `x.max(y)`. This has bitten us in the gluteus maximus a number of times both in SQLx and in private projects. For example: https://discordapp.com/channels/665528275556106240/729682286513225799/806793002340057098

We need a CI pass running Clippy to make this truly effective though, and it needs to hit all the optional features (at least the not-mutally-exclusive ones) to be sure.