### PR TITLE
Mark derived impl blocks #[automatically_derived]

### DIFF
--- a/sqlx-macros/src/derives/decode.rs
+++ b/sqlx-macros/src/derives/decode.rs
@@ -73,6 +73,7 @@ fn expand_derive_decode_transparent(
     let (impl_generics, _, where_clause) = generics.split_for_impl();
 
     let tts = quote!(
+        #[automatically_derived]
         impl #impl_generics ::sqlx::decode::Decode<'r, DB> for #ident #ty_generics #where_clause {
             fn decode(
                 value: <DB as ::sqlx::database::HasValueRef<'r>>::ValueRef,
@@ -111,6 +112,7 @@ fn expand_derive_decode_weak_enum(
         .collect::<Vec<Arm>>();
 
     Ok(quote!(
+        #[automatically_derived]
         impl<'r, DB: ::sqlx::Database> ::sqlx::decode::Decode<'r, DB> for #ident
         where
             #repr: ::sqlx::decode::Decode<'r, DB>,
@@ -173,6 +175,7 @@ fn expand_derive_decode_strong_enum(
 
     if cfg!(feature = "mysql") {
         tts.extend(quote!(
+            #[automatically_derived]
             impl<'r> ::sqlx::decode::Decode<'r, ::sqlx::mysql::MySql> for #ident {
                 fn decode(
                     value: ::sqlx::mysql::MySqlValueRef<'r>,
@@ -198,6 +201,7 @@ fn expand_derive_decode_strong_enum(
 
     if cfg!(feature = "postgres") {
         tts.extend(quote!(
+            #[automatically_derived]
             impl<'r> ::sqlx::decode::Decode<'r, ::sqlx::postgres::Postgres> for #ident {
                 fn decode(
                     value: ::sqlx::postgres::PgValueRef<'r>,
@@ -223,6 +227,7 @@ fn expand_derive_decode_strong_enum(
 
     if cfg!(feature = "sqlite") {
         tts.extend(quote!(
+            #[automatically_derived]
             impl<'r> ::sqlx::decode::Decode<'r, ::sqlx::sqlite::Sqlite> for #ident {
                 fn decode(
                     value: ::sqlx::sqlite::SqliteValueRef<'r>,
@@ -291,6 +296,7 @@ fn expand_derive_decode_struct(
         let names = fields.iter().map(|field| &field.ident);
 
         tts.extend(quote!(
+            #[automatically_derived]
             impl #impl_generics ::sqlx::decode::Decode<'r, ::sqlx::Postgres> for #ident #ty_generics
             #where_clause
             {

--- a/sqlx-macros/src/derives/encode.rs
+++ b/sqlx-macros/src/derives/encode.rs
@@ -78,6 +78,7 @@ fn expand_derive_encode_transparent(
     let (impl_generics, _, where_clause) = generics.split_for_impl();
 
     Ok(quote!(
+        #[automatically_derived]
         impl #impl_generics ::sqlx::encode::Encode<#lifetime, DB> for #ident #ty_generics
         #where_clause
         {
@@ -115,6 +116,7 @@ fn expand_derive_encode_weak_enum(
     }
 
     Ok(quote!(
+        #[automatically_derived]
         impl<'q, DB: ::sqlx::Database> ::sqlx::encode::Encode<'q, DB> for #ident
         where
             #repr: ::sqlx::encode::Encode<'q, DB>,
@@ -164,6 +166,7 @@ fn expand_derive_encode_strong_enum(
     }
 
     Ok(quote!(
+        #[automatically_derived]
         impl<'q, DB: ::sqlx::Database> ::sqlx::encode::Encode<'q, DB> for #ident
         where
             &'q ::std::primitive::str: ::sqlx::encode::Encode<'q, DB>,
@@ -239,6 +242,7 @@ fn expand_derive_encode_struct(
         });
 
         tts.extend(quote!(
+            #[automatically_derived]
             impl #impl_generics ::sqlx::encode::Encode<'_, ::sqlx::Postgres> for #ident #ty_generics
             #where_clause
             {

--- a/sqlx-macros/src/derives/row.rs
+++ b/sqlx-macros/src/derives/row.rs
@@ -107,6 +107,7 @@ fn expand_derive_from_row_struct(
     let names = fields.iter().map(|field| &field.ident);
 
     Ok(quote!(
+        #[automatically_derived]
         impl #impl_generics ::sqlx::FromRow<#lifetime, R> for #ident #ty_generics #where_clause {
             fn from_row(row: &#lifetime R) -> ::sqlx::Result<Self> {
                 #(#reads)*
@@ -163,6 +164,7 @@ fn expand_derive_from_row_struct_unnamed(
         .map(|(idx, _)| quote!(row.try_get(#idx)?));
 
     Ok(quote!(
+        #[automatically_derived]
         impl #impl_generics ::sqlx::FromRow<#lifetime, R> for #ident #ty_generics #where_clause {
             fn from_row(row: &#lifetime R) -> ::sqlx::Result<Self> {
                 ::std::result::Result::Ok(#ident (

--- a/sqlx-macros/src/derives/type.rs
+++ b/sqlx-macros/src/derives/type.rs
@@ -71,6 +71,7 @@ fn expand_derive_has_sql_type_transparent(
         let (impl_generics, _, where_clause) = generics.split_for_impl();
 
         return Ok(quote!(
+            #[automatically_derived]
             impl #impl_generics ::sqlx::Type< DB > for #ident #ty_generics #where_clause {
                 fn type_info() -> DB::TypeInfo {
                     <#ty as ::sqlx::Type<DB>>::type_info()
@@ -89,6 +90,7 @@ fn expand_derive_has_sql_type_transparent(
         let ty_name = type_name(ident, attr.type_name.as_ref());
 
         tts.extend(quote!(
+            #[automatically_derived]
             impl ::sqlx::Type<::sqlx::postgres::Postgres> for #ident #ty_generics {
                 fn type_info() -> ::sqlx::postgres::PgTypeInfo {
                     ::sqlx::postgres::PgTypeInfo::with_name(#ty_name)
@@ -108,6 +110,7 @@ fn expand_derive_has_sql_type_weak_enum(
     let repr = attr.repr.unwrap();
     let ident = &input.ident;
     let ts = quote!(
+        #[automatically_derived]
         impl<DB: ::sqlx::Database> ::sqlx::Type<DB> for #ident
         where
             #repr: ::sqlx::Type<DB>,
@@ -132,6 +135,7 @@ fn expand_derive_has_sql_type_strong_enum(
 
     if cfg!(feature = "mysql") {
         tts.extend(quote!(
+            #[automatically_derived]
             impl ::sqlx::Type<::sqlx::MySql> for #ident {
                 fn type_info() -> ::sqlx::mysql::MySqlTypeInfo {
                     ::sqlx::mysql::MySqlTypeInfo::__enum()
@@ -148,6 +152,7 @@ fn expand_derive_has_sql_type_strong_enum(
         let ty_name = type_name(ident, attributes.type_name.as_ref());
 
         tts.extend(quote!(
+            #[automatically_derived]
             impl ::sqlx::Type<::sqlx::Postgres> for #ident {
                 fn type_info() -> ::sqlx::postgres::PgTypeInfo {
                     ::sqlx::postgres::PgTypeInfo::with_name(#ty_name)
@@ -158,6 +163,7 @@ fn expand_derive_has_sql_type_strong_enum(
 
     if cfg!(feature = "sqlite") {
         tts.extend(quote!(
+            #[automatically_derived]
             impl sqlx::Type<::sqlx::Sqlite> for #ident {
                 fn type_info() -> ::sqlx::sqlite::SqliteTypeInfo {
                     <::std::primitive::str as ::sqlx::Type<sqlx::Sqlite>>::type_info()
@@ -186,6 +192,7 @@ fn expand_derive_has_sql_type_struct(
         let ty_name = type_name(ident, attributes.type_name.as_ref());
 
         tts.extend(quote!(
+            #[automatically_derived]
             impl ::sqlx::Type<::sqlx::Postgres> for #ident {
                 fn type_info() -> ::sqlx::postgres::PgTypeInfo {
                     ::sqlx::postgres::PgTypeInfo::with_name(#ty_name)


### PR DESCRIPTION
There's a lesser-known attribute called [#[automatically_derived]](https://doc.rust-lang.org/reference/attributes/derive.html#the-automatically_derived-attribute) that marks an `impl` block as "derived". Docs state it does nothing, but it actually [disables at least one lint](https://github.com/rust-lang/rust/commit/24d410abd6924c175ee776ed84be851b615a555b) to improve perf (can't find who wrote this where, but also seems not super important).