### PR TITLE
postgres: peek at header then take whole message

### DIFF
--- a/sqlx-postgres/src/connection/stream.rs
+++ b/sqlx-postgres/src/connection/stream.rs
@@ -54,13 +54,13 @@ macro_rules! read_packet {
             read_packet!($(@$blocking)? @stream $self, 0, 5);
 
             // peek at the messaage type and payload size
-            let r#type = MessageType::try_from(*$self.stream.get(0,1))?;
-            let size = (u32::from_le_bytes($self.stream.get(1,4)) - 4) as usize;
+            let r#type = MessageType::try_from((*$self.stream.get(0,1)s@))?;
+            let size = (u32::from_be_bytes($self.stream.get(1,4)) - 4) as usize;
 
             read_packet!($(@$blocking)? @stream $self, 5, size);
 
             // take the whole packet
-            let header   = $self.stream.take(5);
+            $self.stream.consume(5);
             let contents = $self.stream.take(size);
 
             let message = Message { r#type, contents };

--- a/sqlx-postgres/src/connection/stream.rs
+++ b/sqlx-postgres/src/connection/stream.rs
@@ -54,8 +54,8 @@ macro_rules! read_packet {
             read_packet!($(@$blocking)? @stream $self, 0, 5);
 
             // peek at the messaage type and payload size
-            let r#type = MessageType::try_from((*$self.stream.get(0,1)s@))?;
-            let size = (u32::from_be_bytes($self.stream.get(1,4)) - 4) as usize;
+            let r#type = MessageType::try_from(*$self.stream.get(0, 1)s@)?;
+            let size = (u32::from_be_bytes($self.stream.get(1, 4)) - 4) as usize;
 
             read_packet!($(@$blocking)? @stream $self, 5, size);
 

--- a/sqlx-postgres/src/connection/stream.rs
+++ b/sqlx-postgres/src/connection/stream.rs
@@ -53,13 +53,14 @@ macro_rules! read_packet {
         loop {
             read_packet!($(@$blocking)? @stream $self, 0, 5);
 
-            let mut header: Bytes = $self.stream.take(5);
+            // peek at the messaage type and payload size
+            let r#type = MessageType::try_from(*$self.stream.get(0,1))?;
+            let size = (u32::from_le_bytes($self.stream.get(1,4)) - 4) as usize;
 
-            let r#type = MessageType::try_from(header.get_u8())?;
-            let size = (header.get_u32() - 4) as usize;
+            read_packet!($(@$blocking)? @stream $self, 5, size);
 
-            read_packet!($(@$blocking)? @stream $self, 4, size);
-
+            // take the whole packet
+            let header   = $self.stream.take(5);
             let contents = $self.stream.take(size);
 
             let message = Message { r#type, contents };

--- a/sqlx-postgres/src/connection/stream.rs
+++ b/sqlx-postgres/src/connection/stream.rs
@@ -54,7 +54,7 @@ macro_rules! read_packet {
             read_packet!($(@$blocking)? @stream $self, 0, 5);
 
             // peek at the messaage type and payload size
-            let r#type = MessageType::try_from(*$self.stream.get(0, 1)s@)?;
+            let r#type = MessageType::try_from(*$self.stream.get(0, 1))?;
             let size = (u32::from_be_bytes($self.stream.get(1, 4)) - 4) as usize;
 
             read_packet!($(@$blocking)? @stream $self, 5, size);


### PR DESCRIPTION
This peaks at the message type and payload size of a postgres message.
It delays removing the header from the buffer until the payload is removed as well.

The intent here is to make recovery after a dropped stream easier, by leaving the header in the stream such that the next reader sees a full message.