### PR TITLE
Only migrate Simple and ReversibleUp in Migrator.run()

### DIFF
--- a/sqlx-core/src/migrate/migration_type.rs
+++ b/sqlx-core/src/migrate/migration_type.rs
@@ -1,5 +1,5 @@
 /// Migration Type represents the type of migration
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum MigrationType {
     /// Simple migration are single file migrations with no up / down queries
     Simple,

--- a/sqlx-core/src/migrate/migrator.rs
+++ b/sqlx-core/src/migrate/migrator.rs
@@ -1,5 +1,5 @@
 use crate::acquire::Acquire;
-use crate::migrate::{Migrate, MigrateError, Migration, MigrationSource};
+use crate::migrate::{Migrate, MigrateError, Migration, MigrationSource, MigrationType};
 use std::borrow::Cow;
 use std::ops::Deref;
 use std::slice;
@@ -79,6 +79,9 @@ impl Migrator {
         }
 
         for migration in self.iter() {
+            if migration.migration_type == MigrationType::ReversibleDown {
+                continue;
+            }
             if migration.version > version {
                 conn.apply(migration).await?;
             } else {


### PR DESCRIPTION
I was just bit by the issue in #863 when using both up and down migrations, and this seemed like an easy fix. I'm not 100% sold on this initial way of solving it, so I'm _very_ open for suggestions.