### PR TITLE
Basic MySql dialog authentication support

### DIFF
--- a/sqlx-core/src/mysql/connection/auth.rs
+++ b/sqlx-core/src/mysql/connection/auth.rs
@@ -27,6 +27,9 @@ impl AuthPlugin {
 
             // https://mariadb.com/kb/en/sha256_password-plugin/
             AuthPlugin::Sha256Password => encrypt_rsa(stream, 0x01, password, nonce).await,
+
+            // https://mariadb.com/kb/en/authentication-plugin-pam/#dialog
+            AuthPlugin::Dialog => Ok(password.as_bytes().to_vec()),
         }
     }
 

--- a/sqlx-core/src/mysql/protocol/auth.rs
+++ b/sqlx-core/src/mysql/protocol/auth.rs
@@ -7,6 +7,7 @@ pub enum AuthPlugin {
     MySqlNativePassword,
     CachingSha2Password,
     Sha256Password,
+    Dialog,
 }
 
 impl AuthPlugin {
@@ -15,6 +16,16 @@ impl AuthPlugin {
             AuthPlugin::MySqlNativePassword => "mysql_native_password",
             AuthPlugin::CachingSha2Password => "caching_sha2_password",
             AuthPlugin::Sha256Password => "sha256_password",
+            AuthPlugin::Dialog => "dialog",
+        }
+    }
+
+    // See: https://github.com/mysql/mysql-server/blob/ea7d2e2d16ac03afdd9cb72a972a95981107bf51/sql/auth/sha2_password.cc#L942
+    pub(crate) fn auth_switch_request_data_length(self) -> usize {
+        use AuthPlugin::*;
+        match self {
+            MySqlNativePassword | CachingSha2Password | Sha256Password => 21,
+            Dialog => 0,
         }
     }
 }
@@ -27,6 +38,7 @@ impl FromStr for AuthPlugin {
             "mysql_native_password" => Ok(AuthPlugin::MySqlNativePassword),
             "caching_sha2_password" => Ok(AuthPlugin::CachingSha2Password),
             "sha256_password" => Ok(AuthPlugin::Sha256Password),
+            "dialog" => Ok(AuthPlugin::Dialog),
 
             _ => Err(err_protocol!("unknown authentication plugin: {}", s)),
         }


### PR DESCRIPTION
Encountered a mariadb server that only accepted [dialog](https://mariadb.com/kb/en/authentication-plugin-pam/#dialog) authentication (which seems typical if using mariadb's pam integration). This PR adds support for dialog authentication if the server is only asking for a password.

On my system I set up a mariadb server with basic pam authentication. When providing the correct password I am able to connect to the database and execute queries.

If the password is wrong I get the following error:
```
Error: Database(MySqlDatabaseError { code: Some("28000"), number: 1045, message: "Access denied for user \'ahouts\'@\'localhost\' (using password: NO)" })
```

If I do not provide a password I get the following:
```
Error: Protocol("interactive dialog authentication is currently not supported")
```