### PR TITLE
Support the sqlite locking_mode and auto_vacuum pragmas

### DIFF
--- a/sqlx-core/src/sqlite/options/auto_vacuum.rs
+++ b/sqlx-core/src/sqlite/options/auto_vacuum.rs
@@ -1,0 +1,25 @@
+use crate::error::Error;
+use std::str::FromStr;
+
+#[derive(Debug, Clone)]
+pub enum SqliteAutoVacuum {
+    None,
+    Full,
+    Incremental,
+}
+
+impl SqliteAutoVacuum {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            SqliteAutoVacuum::None => "NONE",
+            SqliteAutoVacuum::Full => "FULL",
+            SqliteAutoVacuum::Incremental => "INCREMENTAL",
+        }
+    }
+}
+
+impl Default for SqliteAutoVacuum {
+    fn default() -> Self {
+        SqliteAutoVacuum::None
+    }
+}

--- a/sqlx-core/src/sqlite/options/connect.rs
+++ b/sqlx-core/src/sqlite/options/connect.rs
@@ -18,8 +18,12 @@ impl ConnectOptions for SqliteConnectOptions {
             let mut conn = establish(self).await?;
 
             // send an initial sql statement comprised of options
+            //
+            // Note that locking_mode should be set before journal_mode; see
+            // https://www.sqlite.org/wal.html#use_of_wal_without_shared_memory .
             let init = format!(
-                "PRAGMA journal_mode = {}; PRAGMA foreign_keys = {}; PRAGMA synchronous = {}",
+                "PRAGMA locking_mode = {}; PRAGMA journal_mode = {}; PRAGMA foreign_keys = {}; PRAGMA synchronous = {}",
+                self.locking_mode.as_str(),
                 self.journal_mode.as_str(),
                 if self.foreign_keys { "ON" } else { "OFF" },
                 self.synchronous.as_str(),

--- a/sqlx-core/src/sqlite/options/connect.rs
+++ b/sqlx-core/src/sqlite/options/connect.rs
@@ -22,11 +22,12 @@ impl ConnectOptions for SqliteConnectOptions {
             // Note that locking_mode should be set before journal_mode; see
             // https://www.sqlite.org/wal.html#use_of_wal_without_shared_memory .
             let init = format!(
-                "PRAGMA locking_mode = {}; PRAGMA journal_mode = {}; PRAGMA foreign_keys = {}; PRAGMA synchronous = {}",
+                "PRAGMA locking_mode = {}; PRAGMA journal_mode = {}; PRAGMA foreign_keys = {}; PRAGMA synchronous = {}; PRAGMA auto_vacuum = {}",
                 self.locking_mode.as_str(),
                 self.journal_mode.as_str(),
                 if self.foreign_keys { "ON" } else { "OFF" },
                 self.synchronous.as_str(),
+                self.auto_vacuum.as_str(),
             );
 
             conn.execute(&*init).await?;

--- a/sqlx-core/src/sqlite/options/locking_mode.rs
+++ b/sqlx-core/src/sqlite/options/locking_mode.rs
@@ -1,0 +1,23 @@
+use crate::error::Error;
+use std::str::FromStr;
+
+#[derive(Debug, Clone)]
+pub enum SqliteLockingMode {
+    Normal,
+    Exclusive,
+}
+
+impl SqliteLockingMode {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            SqliteLockingMode::Normal => "NORMAL",
+            SqliteLockingMode::Exclusive => "EXCLUSIVE",
+        }
+    }
+}
+
+impl Default for SqliteLockingMode {
+    fn default() -> Self {
+        SqliteLockingMode::Normal
+    }
+}

--- a/sqlx-core/src/sqlite/options/mod.rs
+++ b/sqlx-core/src/sqlite/options/mod.rs
@@ -2,11 +2,13 @@ use std::path::Path;
 
 mod connect;
 mod journal_mode;
+mod locking_mode;
 mod parse;
 mod synchronous;
 
 use crate::connection::LogSettings;
 pub use journal_mode::SqliteJournalMode;
+pub use locking_mode::SqliteLockingMode;
 use std::{borrow::Cow, time::Duration};
 pub use synchronous::SqliteSynchronous;
 
@@ -50,6 +52,7 @@ pub struct SqliteConnectOptions {
     pub(crate) read_only: bool,
     pub(crate) create_if_missing: bool,
     pub(crate) journal_mode: SqliteJournalMode,
+    pub(crate) locking_mode: SqliteLockingMode,
     pub(crate) foreign_keys: bool,
     pub(crate) shared_cache: bool,
     pub(crate) statement_cache_capacity: usize,
@@ -75,6 +78,7 @@ impl SqliteConnectOptions {
             shared_cache: false,
             statement_cache_capacity: 100,
             journal_mode: SqliteJournalMode::Wal,
+            locking_mode: Default::default(),
             busy_timeout: Duration::from_secs(5),
             log_settings: Default::default(),
             synchronous: SqliteSynchronous::Full,
@@ -101,6 +105,14 @@ impl SqliteConnectOptions {
     /// there are [disadvantages](https://www.sqlite.org/wal.html).
     pub fn journal_mode(mut self, mode: SqliteJournalMode) -> Self {
         self.journal_mode = mode;
+        self
+    }
+
+    /// Sets the [locking mode](https://www.sqlite.org/pragma.html#pragma_locking_mode) for the database connection.
+    ///
+    /// The default locking mode is NORMAL.
+    pub fn locking_mode(mut self, mode: SqliteLockingMode) -> Self {
+        self.locking_mode = mode;
         self
     }
 

--- a/sqlx-core/src/sqlite/options/mod.rs
+++ b/sqlx-core/src/sqlite/options/mod.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+mod auto_vacuum;
 mod connect;
 mod journal_mode;
 mod locking_mode;
@@ -7,6 +8,7 @@ mod parse;
 mod synchronous;
 
 use crate::connection::LogSettings;
+pub use auto_vacuum::SqliteAutoVacuum;
 pub use journal_mode::SqliteJournalMode;
 pub use locking_mode::SqliteLockingMode;
 use std::{borrow::Cow, time::Duration};
@@ -59,6 +61,7 @@ pub struct SqliteConnectOptions {
     pub(crate) busy_timeout: Duration,
     pub(crate) log_settings: LogSettings,
     pub(crate) synchronous: SqliteSynchronous,
+    pub(crate) auto_vacuum: SqliteAutoVacuum,
 }
 
 impl Default for SqliteConnectOptions {
@@ -82,6 +85,7 @@ impl SqliteConnectOptions {
             busy_timeout: Duration::from_secs(5),
             log_settings: Default::default(),
             synchronous: SqliteSynchronous::Full,
+            auto_vacuum: Default::default(),
         }
     }
 
@@ -158,6 +162,14 @@ impl SqliteConnectOptions {
     /// then NORMAL is normally all one needs in WAL mode.
     pub fn synchronous(mut self, synchronous: SqliteSynchronous) -> Self {
         self.synchronous = synchronous;
+        self
+    }
+
+    /// Sets the [auto_vacuum](https://www.sqlite.org/pragma.html#pragma_auto_vacuum) setting for the database connection.
+    ///
+    /// The default auto_vacuum setting is NONE.
+    pub fn auto_vacuum(mut self, auto_vacuum: SqliteAutoVacuum) -> Self {
+        self.auto_vacuum = auto_vacuum;
         self
     }
 }


### PR DESCRIPTION
This adds enums for the possible values of those two pragmas, and sets
them at connection time.

My primary motivation for this is that to get the full benefits of
locking_mode, it needs to be set *before* setting journal_mode.