### PR TITLE
Basic MySql dialog authentication support (attempt 2)

### DIFF
--- a/sqlx-mysql/src/protocol/auth_plugin.rs
+++ b/sqlx-mysql/src/protocol/auth_plugin.rs
@@ -8,11 +8,13 @@ use sqlx_core::{Error, Result};
 use crate::MySqlDatabaseError;
 
 mod caching_sha2;
+mod dialog;
 mod native;
 mod rsa;
 mod sha256;
 
 pub(crate) use self::caching_sha2::CachingSha2AuthPlugin;
+pub(crate) use self::dialog::DialogAuthPlugin;
 pub(crate) use self::native::NativeAuthPlugin;
 pub(crate) use self::sha256::Sha256AuthPlugin;
 
@@ -39,6 +41,7 @@ impl dyn AuthPlugin {
             _ if s == CachingSha2AuthPlugin.name() => Ok(Box::new(CachingSha2AuthPlugin)),
             _ if s == Sha256AuthPlugin.name() => Ok(Box::new(Sha256AuthPlugin)),
             _ if s == NativeAuthPlugin.name() => Ok(Box::new(NativeAuthPlugin)),
+            _ if s == DialogAuthPlugin.name() => Ok(Box::new(DialogAuthPlugin)),
 
             _ => Err(MySqlDatabaseError::new(
                 2059,
@@ -63,7 +66,8 @@ fn err_msg(plugin: &'static str, message: &str) -> Error {
     MySqlDatabaseError::new(
         2061,
         &format!("Authentication plugin '{}' reported error: {}", plugin, message),
-    ).into()
+    )
+    .into()
 }
 
 fn err<E>(plugin: &'static str, error: &E) -> Error

--- a/sqlx-mysql/src/protocol/auth_plugin/dialog.rs
+++ b/sqlx-mysql/src/protocol/auth_plugin/dialog.rs
@@ -1,0 +1,33 @@
+use bytes::buf::Chain;
+use bytes::Bytes;
+use sqlx_core::{Error, Result};
+use std::borrow::Cow;
+
+/// Dialog authentication implementation
+///
+/// https://mariadb.com/kb/en/authentication-plugin-pam/#dialog
+///
+#[derive(Debug)]
+pub(crate) struct DialogAuthPlugin;
+
+impl super::AuthPlugin for DialogAuthPlugin {
+    fn name(&self) -> &'static str {
+        "dialog"
+    }
+
+    fn invoke(&self, _nonce: &Chain<Bytes, Bytes>, password: &str) -> Vec<u8> {
+        password.as_bytes().to_vec()
+    }
+
+    fn handle(
+        &self,
+        _data: Bytes,
+        _nonce: &Chain<Bytes, Bytes>,
+        _password: &str,
+    ) -> Result<Option<Vec<u8>>> {
+        Err(Error::ConnectOptions {
+            message: Cow::Borrowed("interactive dialog authentication is currently not supported"),
+            source: None,
+        })
+    }
+}


### PR DESCRIPTION
Same thing as #1062 but targeting `next`.

Encountered a mariadb server that only accepted [dialog](https://mariadb.com/kb/en/authentication-plugin-pam/#dialog) authentication (which seems typical if using mariadb's pam integration). This PR adds support for dialog authentication if the server is only asking for a password.

On my system I set up a mariadb server with basic pam authentication. When providing the correct password I am able to connect to the database and execute queries.

If I provide the wrong password I get this error:
```
[2021-02-28T00:28:46Z TRACE sqlx_core::io::buf_stream] read  [   4] > b"X\0\0\0"
[2021-02-28T00:28:46Z TRACE sqlx_core::io::buf_stream] read  [  88] > b"\n5.5.5-10.5.9-MariaDB\0*\0\0\09JHj^xbb\0\xfe\xf7\xe0\x02\0\xff\x81\x15\0\0\0\0\0\0\x0f\0\0\0Dlrw!:B{hs,~\0mysql_native_password\0"
[2021-02-28T00:28:46Z TRACE sqlx_mysql::protocol::packet] read  > Handshake { protocol_version: 10, server_version: "5.5.5-10.5.9-MariaDB", connection_id: 42, capabilities: FOUND_ROWS | LONG_FLAG | CONNECT_WITH_DB | NO_SCHEMA | COMPRESS | ODBC | LOCAL_FILES | IGNORE_SPACE | PROTOCOL_41 | INTERACTIVE | TRANSACTIONS | SECURE_CONNECTION | MULTI_STATEMENTS | MULTI_RESULTS | PS_MULTI_RESULTS | PLUGIN_AUTH | CONNECT_ATTRS | PLUGIN_AUTH_LENENC_DATA | CAN_HANDLE_EXPIRED_PASSWORDS | SESSION_TRACK | DEPRECATE_EOF, status: AUTOCOMMIT, charset: Some(224), auth_plugin: NativeAuthPlugin, auth_plugin_data: Chain { a: b"9JHj^xbb", b: b"Dlrw!:B{hs,~" } }
[2021-02-28T00:28:46Z TRACE sqlx_mysql::stream] write > HandshakeResponse { capabilities: LONG_FLAG | CONNECT_WITH_DB | IGNORE_SPACE | PROTOCOL_41 | TRANSACTIONS | SECURE_CONNECTION | MULTI_STATEMENTS | MULTI_RESULTS | PS_MULTI_RESULTS | PLUGIN_AUTH | PLUGIN_AUTH_LENENC_DATA | CAN_HANDLE_EXPIRED_PASSWORDS | SESSION_TRACK | DEPRECATE_EOF, database: Some("testdb"), max_packet_size: 1024, charset: 45, username: Some("ahouts"), auth_plugin_name: "mysql_native_password", auth_response: [82, 87, 205, 8, 180, 12, 127, 53, 22, 72, 82, 120, 3, 157, 81, 154, 140, 28, 140, 209] }
[2021-02-28T00:28:46Z TRACE sqlx_core::io::buf_stream] write [  93] > b"Y\0\0\x01\x0c\xa3\xef\x01\0\x04\0\0-\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0ahouts\0\x14RW\xcd\x08\xb4\x0c\x7f5\x16HRx\x03\x9dQ\x9a\x8c\x1c\x8c\xd1testdb\0mysql_native_password\0"
[2021-02-28T00:28:46Z TRACE sqlx_core::io::buf_stream] read  [   4] > b"\x08\0\0\x02"
[2021-02-28T00:28:46Z TRACE sqlx_core::io::buf_stream] read  [   8] > b"\xfedialog\0"
[2021-02-28T00:28:46Z TRACE sqlx_mysql::protocol::packet] read  > Switch(AuthSwitch { plugin: DialogAuthPlugin, plugin_data: Chain { a: b"", b: b"" } })
[2021-02-28T00:28:46Z TRACE sqlx_mysql::stream] write > [97, 115, 100, 102]
[2021-02-28T00:28:46Z TRACE sqlx_core::io::buf_stream] write [   8] > b"\x04\0\0\x03asdf"
[2021-02-28T00:28:47Z TRACE sqlx_core::io::buf_stream] read  [   4] > b"I\0\0\x04"
[2021-02-28T00:28:47Z TRACE sqlx_core::io::buf_stream] read  [  73] > b"\xff\x15\x04#28000Access denied for user 'ahouts'@'localhost' (using password: NO)"
Error: Database(MySqlDatabaseError(ErrPacket { error_code: 2027, sql_state: Some("HY000"), error_message: "Malformed packet: Received 0xff but expected one of: 0x0 (OK), 0x1 (MORE DATA), or 0xfe (SWITCH) for auth response" }))
```
Seems like `next` doesn't have complete error handling yet.

If I provide no password I get the following:
```
[2021-02-28T00:54:25Z TRACE sqlx_core::io::buf_stream] read  [   4] > b"X\0\0\0"
[2021-02-28T00:54:25Z TRACE sqlx_core::io::buf_stream] read  [  88] > b"\n5.5.5-10.5.9-MariaDB\0+\0\0\07y\"7/$dN\0\xfe\xf7\xe0\x02\0\xff\x81\x15\0\0\0\0\0\0\x0f\0\0\0<~(Iv7Nc(9)`\0mysql_native_password\0"
[2021-02-28T00:54:25Z TRACE sqlx_mysql::protocol::packet] read  > Handshake { protocol_version: 10, server_version: "5.5.5-10.5.9-MariaDB", connection_id: 43, capabilities: FOUND_ROWS | LONG_FLAG | CONNECT_WITH_DB | NO_SCHEMA | COMPRESS | ODBC | LOCAL_FILES | IGNORE_SPACE | PROTOCOL_41 | INTERACTIVE | TRANSACTIONS | SECURE_CONNECTION | MULTI_STATEMENTS | MULTI_RESULTS | PS_MULTI_RESULTS | PLUGIN_AUTH | CONNECT_ATTRS | PLUGIN_AUTH_LENENC_DATA | CAN_HANDLE_EXPIRED_PASSWORDS | SESSION_TRACK | DEPRECATE_EOF, status: AUTOCOMMIT, charset: Some(224), auth_plugin: NativeAuthPlugin, auth_plugin_data: Chain { a: b"7y\"7/$dN", b: b"<~(Iv7Nc(9)`" } }
[2021-02-28T00:54:25Z TRACE sqlx_mysql::stream] write > HandshakeResponse { capabilities: LONG_FLAG | CONNECT_WITH_DB | IGNORE_SPACE | PROTOCOL_41 | TRANSACTIONS | SECURE_CONNECTION | MULTI_STATEMENTS | MULTI_RESULTS | PS_MULTI_RESULTS | PLUGIN_AUTH | PLUGIN_AUTH_LENENC_DATA | CAN_HANDLE_EXPIRED_PASSWORDS | SESSION_TRACK | DEPRECATE_EOF, database: Some("testdb"), max_packet_size: 1024, charset: 45, username: Some("ahouts"), auth_plugin_name: "mysql_native_password", auth_response: [] }
[2021-02-28T00:54:25Z TRACE sqlx_core::io::buf_stream] write [  73] > b"E\0\0\x01\x0c\xa3\xef\x01\0\x04\0\0-\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0ahouts\0\0testdb\0mysql_native_password\0"
[2021-02-28T00:54:25Z TRACE sqlx_core::io::buf_stream] read  [   4] > b"\x08\0\0\x02"
[2021-02-28T00:54:25Z TRACE sqlx_core::io::buf_stream] read  [   8] > b"\xfedialog\0"
[2021-02-28T00:54:25Z TRACE sqlx_mysql::protocol::packet] read  > Switch(AuthSwitch { plugin: DialogAuthPlugin, plugin_data: Chain { a: b"", b: b"" } })
[2021-02-28T00:54:25Z TRACE sqlx_mysql::stream] write > []
[2021-02-28T00:54:25Z TRACE sqlx_core::io::buf_stream] write [   4] > b"\0\0\0\x03"
[2021-02-28T00:54:25Z TRACE sqlx_core::io::buf_stream] read  [   4] > b"\x0b\0\0\x04"
[2021-02-28T00:54:25Z TRACE sqlx_core::io::buf_stream] read  [  11] > b"\x04Password: "
Error: Database(MySqlDatabaseError(ErrPacket { error_code: 2027, sql_state: Some("HY000"), error_message: "Malformed packet: Received 0x4 but expected one of: 0x0 (OK), 0x1 (MORE DATA), or 0xfe (SWITCH) for auth response" }))
```
The `dialog` plugin branches based on the value of the command byte (first byte of the response). The LSB indicates if further communication is required (0 = more packets), and if the command byte bit shifted once to the right == 2 the dialog is a password dialog. All of this logic is avoided by sending the password in the initial auth packet. To support a better error message here or interactive prompts, the packet parser would have to defer to `dialog` specific code instead of trying to interpret the command byte itself (although 0x0 and 0xfe retain their meaning in the context of the dialog plugin).