### PR TITLE
replace deprecated compare_and_swap() with compare_exchange()

### DIFF
--- a/sqlx-core/src/pool/inner.rs
+++ b/sqlx-core/src/pool/inner.rs
@@ -113,13 +113,12 @@ impl<DB: Database> SharedPool<DB> {
         let mut size = self.size();
 
         while size < self.options.max_connections {
-            let new_size = self.size.compare_and_swap(size, size + 1, Ordering::AcqRel);
-
-            if new_size == size {
-                return Some(DecrementSizeGuard::new(self));
+            if let Ok(new_size) = self.size.compare_exchange(size, size + 1, Ordering::AcqRel, Ordering::Acquire) {
+                if new_size == size {
+                    return Some(DecrementSizeGuard::new(self));
+                }
+                size = new_size;
             }
-
-            size = new_size;
         }
 
         None

--- a/sqlx-core/src/pool/inner.rs
+++ b/sqlx-core/src/pool/inner.rs
@@ -113,7 +113,10 @@ impl<DB: Database> SharedPool<DB> {
         let mut size = self.size();
 
         while size < self.options.max_connections {
-            if let Ok(new_size) = self.size.compare_exchange(size, size + 1, Ordering::AcqRel, Ordering::Acquire) {
+            if let Ok(new_size) =
+                self.size
+                    .compare_exchange(size, size + 1, Ordering::AcqRel, Ordering::Acquire)
+            {
                 if new_size == size {
                     return Some(DecrementSizeGuard::new(self));
                 }


### PR DESCRIPTION
AtomicU32::compare_and_swap() is marked deprecated, in favor of compare_exchange().
compare_exchange() is fallible, so we continue to loop if it fails.
According to the docs, for the original AcqRel ordering, the equivalent failure ordering is Acquire.
https://doc.rust-lang.org/std/sync/atomic/struct.AtomicU32.html#method.compare_exchange_weak