### PR TITLE
Add `try_from` attribute for `FromRow` derive

### DIFF
--- a/sqlx-core/src/from_row.rs
+++ b/sqlx-core/src/from_row.rs
@@ -149,6 +149,32 @@ use crate::row::Row;
 ///     }
 /// }
 /// ```
+///
+/// #### `try_from`
+///
+/// When your struct contains a field whose type is not matched with the database type,
+/// if the field type has an implementation [`TryFrom`] for the database type,
+/// you can use the `try_from` attribute to convert the database type to the field type.
+/// For example:
+///
+/// ```rust,ignore
+/// #[derive(sqlx::FromRow)]
+/// struct User {
+///     id: i32,
+///     name: String,
+///     #[sqlx(try_from = "i64")]
+///     bigIntInMySql: u64
+/// }
+/// ```
+///
+/// Given a query such as:
+///
+/// ```sql
+/// SELECT id, name, bigIntInMySql FROM users;
+/// ```
+///
+/// In MySql, `BigInt` type matches `i64`, but you can convert it to `u64` by `try_from`.
+///
 pub trait FromRow<'r, R: Row>: Sized {
     fn from_row(row: &'r R) -> Result<Self, Error>;
 }

--- a/sqlx-macros/src/derives/attributes.rs
+++ b/sqlx-macros/src/derives/attributes.rs
@@ -71,6 +71,7 @@ pub struct SqlxChildAttributes {
     pub rename: Option<String>,
     pub default: bool,
     pub flatten: bool,
+    pub try_from: Option<Ident>,
 }
 
 pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContainerAttributes> {
@@ -178,6 +179,7 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
 pub fn parse_child_attributes(input: &[Attribute]) -> syn::Result<SqlxChildAttributes> {
     let mut rename = None;
     let mut default = false;
+    let mut try_from = None;
     let mut flatten = false;
 
     for attr in input.iter().filter(|a| a.path.is_ident("sqlx")) {
@@ -194,6 +196,11 @@ pub fn parse_child_attributes(input: &[Attribute]) -> syn::Result<SqlxChildAttri
                             lit: Lit::Str(val),
                             ..
                         }) if path.is_ident("rename") => try_set!(rename, val.value(), value),
+                        Meta::NameValue(MetaNameValue {
+                            path,
+                            lit: Lit::Str(val),
+                            ..
+                        }) if path.is_ident("try_from") => try_set!(try_from, val.parse()?, value),
                         Meta::Path(path) if path.is_ident("default") => default = true,
                         Meta::Path(path) if path.is_ident("flatten") => flatten = true,
                         u => fail!(u, "unexpected attribute"),
@@ -208,6 +215,7 @@ pub fn parse_child_attributes(input: &[Attribute]) -> syn::Result<SqlxChildAttri
         rename,
         default,
         flatten,
+        try_from,
     })
 }
 


### PR DESCRIPTION
  This is used for converting type in FromRow.And I am not sure whether it is worth and just for discussing.
## Example
```rust
#[derive(sqlx::FromRow)]
struct Record {
    #[sqlx(try_from = "i64")]  
    id: u64,
}

// for custom type
 #[derive(sqlx::FromRow)]
struct Record {
    #[sqlx(try_from = "i64")]
    id: Id,
}

#[derive(Debug, PartialEq)]
struct Id(i64);
impl std::convert::TryFrom<i64> for Id{
    type Error = Error;
    fn try_from(v:i64) -> Result<Id,Self::Error>{
         Ok(Id(v))
    }
}
```
## issues
* In fact,I open this pr mainly for decoding Bigint to u64,which will be supported in sqlx 6.0+.It makes me confused whether this pr is worth.

There is another attribute `with` for type converting.Maybe I will open another issue for discussing.
## Example for with
```rust
 #[derive(sqlx::FromRow)]
struct Record {
    #[sqlx(with(mysql = "path"))]
    id: u64,
}
fn path(value:MySqlValueRef) -> Result<u64,Box<dyn Error + 'static + Send + Sync>>{
  Ok(Decode::<i64>::decode(value)?.try_info()?)
}
```