### PR TITLE
postgres: atomic read message

### DIFF
--- a/sqlx-core/src/io/buf_stream.rs
+++ b/sqlx-core/src/io/buf_stream.rs
@@ -102,9 +102,9 @@ where
         Ok(self.rbuf.split_to(len).freeze())
     }
 
-    pub async fn consume(&mut self, len: usize) -> Result<(), Error> {
+    pub fn consume(&mut self, len: usize) -> Result<(), Error> {
         if self.rbuf.len() < len {
-            self.get_raw(len - self.rbuf.len()).await?;
+            return Err(Error::Protocol("buffer length shorter than requested size".into()));
         }
         let _rem = self.take(len);
         Ok(())

--- a/sqlx-core/src/io/buf_stream.rs
+++ b/sqlx-core/src/io/buf_stream.rs
@@ -97,7 +97,8 @@ where
 
     pub async fn get(&mut self, offset: usize, len: usize) -> Result<&[u8], Error> {
         if self.rbuf.len() < (offset + len) {
-            self.read_into_rbuf((offset + len) - self.rbuf.len()).await?;
+            self.read_into_rbuf((offset + len) - self.rbuf.len())
+                .await?;
         }
         Ok(&(self.rbuf.as_ref())[offset..(offset + len)])
     }

--- a/sqlx-core/src/postgres/connection/stream.rs
+++ b/sqlx-core/src/postgres/connection/stream.rs
@@ -85,7 +85,7 @@ impl PgStream {
         ) - 4) as usize;
 
         // remove the whole messaage from the inner stream
-        self.inner.consume(5).await?;
+        self.inner.consume(5)?;
         let contents = self.inner.read(size).await?;
 
         Ok(Message { format, contents })

--- a/sqlx-core/src/postgres/connection/stream.rs
+++ b/sqlx-core/src/postgres/connection/stream.rs
@@ -77,16 +77,16 @@ impl PgStream {
 
         // peek at the messaage type and payload size
         let header = self.inner.get(0, 5).await?;
-        let format = MessageFormat::try_from_u8(header[0])
-            .map_err(|err| err_protocol!("{}", err))?;
+        let format =
+            MessageFormat::try_from_u8(header[0]).map_err(|err| err_protocol!("{}", err))?;
         let size = (u32::from_be_bytes(
             header[1..5]
                 .try_into()
-                .map_err(|err| err_protocol!("{}", err))?
+                .map_err(|err| err_protocol!("{}", err))?,
         ) + 1) as usize;
 
         let mut contents: Bytes = self.inner.read_from_beginning(size).await?;
-        let _  = contents.split_to(5);
+        let _ = contents.split_to(5);
 
         Ok(Message { format, contents })
     }

--- a/sqlx-core/src/postgres/connection/stream.rs
+++ b/sqlx-core/src/postgres/connection/stream.rs
@@ -75,14 +75,13 @@ impl PgStream {
         // this header contains the message type and the total length of the message
 
         // peek at the messaage type and payload size
-        let format = MessageFormat::try_from_u8(self.inner.get(0, 1).await?[0])
+        let header = self.inner.get(0, 5).await?;
+        let format = MessageFormat::try_from_u8(header[0])
             .map_err(|err| err_protocol!("{}", err))?;
         let size = (u32::from_be_bytes(
-            self.inner
-                .get(1, 4)
-                .await?
+            header[1..5]
                 .try_into()
-                .map_err(|err| err_protocol!("{}", err))?,
+                .map_err(|err| err_protocol!("{}", err))?
         ) - 4) as usize;
 
         // remove the whole messaage from the inner stream


### PR DESCRIPTION
Here is an attempt to address  #886.  It peeks at the message header, then consumes the message, all or none.

This looks very awkward compared to the way it's done in the 'next' branch.  As a result, I'm not entirely sure whether it may have a performance impact.

This is just an idea for the sake of discussion, so feel free to close this if it's not a preferred way of approaching the issue.