### PR TITLE
sqlx-cli database reset fix confirmation flag

### DIFF
--- a/sqlx-cli/src/lib.rs
+++ b/sqlx-cli/src/lib.rs
@@ -40,7 +40,7 @@ pub async fn run(opt: Opt) -> anyhow::Result<()> {
             DatabaseCommand::Create => database::create(&database_url).await?,
             DatabaseCommand::Drop { yes } => database::drop(&database_url, !yes).await?,
             DatabaseCommand::Reset { yes, source } => {
-                database::reset(&source, &database_url, yes).await?
+                database::reset(&source, &database_url, !yes).await?
             }
             DatabaseCommand::Setup { source } => database::setup(&source, &database_url).await?,
         },


### PR DESCRIPTION
sqlx database reset currenctly requires no confirmation and a
confirmation when -y flag is set. Should be the other way around
as it is for sqlx database drop. This commit fixes this.