### PR TITLE
Fix `sqlx-cli` crate link

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -290,7 +290,7 @@
 /// project and your database schema itself, run
 /// `cargo install sqlx-cli && cargo sqlx prepare --check` in your Continuous Integration script.
 ///
-/// See [the README for `sqlx-cli`](https://crates.io/crate/sqlx-cli) for more information.
+/// See [the README for `sqlx-cli`](https://crates.io/crates/sqlx-cli) for more information.
 ///
 /// ## See Also
 /// * [query_as!] if you want to use a struct you can name,


### PR DESCRIPTION
The link was broken since it used a singular "crate" in the URL.
Fix it by using "crates".