### PR TITLE
fix: pool internals improvements

### DIFF
--- a/sqlx-core/src/pool/connection.rs
+++ b/sqlx-core/src/pool/connection.rs
@@ -69,7 +69,7 @@ impl<DB: Database> PoolConnection<DB> {
 /// Returns the connection to the [`Pool`][crate::pool::Pool] it was checked-out from.
 impl<DB: Database> Drop for PoolConnection<DB> {
     fn drop(&mut self) {
-        if let Some(mut live) = self.live.take() {
+        if let Some(live) = self.live.take() {
             let pool = self.pool.clone();
             spawn(async move {
                 let mut floating = live.float(&pool);


### PR DESCRIPTION
* fix `DecrementSizeGuard::drop()` only waking one `Waiter` regardless of whether that waiter was already woken
* fix connect-backoff loop giving up the size guard
* don't cut in line to open a new connection
* have tasks waiting on `acquire()` wake periodically to check if there's a connection in the queue

@dignifiedquire do you mind testing this?

Signed-off-by: Austin Bonander <austin@launchbadge.com>