### PR TITLE
feat: From/Into for types::Json<T>

### DIFF
--- a/sqlx-core/src/types/json.rs
+++ b/sqlx-core/src/types/json.rs
@@ -42,6 +42,18 @@ impl<T> AsMut<T> for Json<T> {
     }
 }
 
+impl<T> Into<T> for Json<T> {
+    fn into(self) -> T {
+        self.0
+    }
+}
+
+impl<T> From<T> for Json<T> {
+    fn from(other: T) -> Self<T> {
+        Self(other)
+    }
+}
+
 impl<DB> Type<DB> for JsonValue
 where
     Json<Self>: Type<DB>,


### PR DESCRIPTION
This allows `types::Json<T>` to work seamlessly for thing which would take `impl Into<T>` and also other similar patterns.