### PR TITLE
fix(sqlite): reset the statement when fetch_many() stream is dropped

### DIFF
--- a/sqlx-core/src/sqlite/statement/handle.rs
+++ b/sqlx-core/src/sqlite/statement/handle.rs
@@ -13,8 +13,9 @@ use libsqlite3_sys::{
     sqlite3_column_count, sqlite3_column_database_name, sqlite3_column_decltype,
     sqlite3_column_double, sqlite3_column_int, sqlite3_column_int64, sqlite3_column_name,
     sqlite3_column_origin_name, sqlite3_column_table_name, sqlite3_column_type,
-    sqlite3_column_value, sqlite3_db_handle, sqlite3_sql, sqlite3_stmt, sqlite3_stmt_readonly,
-    sqlite3_table_column_metadata, sqlite3_value, SQLITE_OK, SQLITE_TRANSIENT, SQLITE_UTF8,
+    sqlite3_column_value, sqlite3_db_handle, sqlite3_reset, sqlite3_sql, sqlite3_stmt,
+    sqlite3_stmt_readonly, sqlite3_table_column_metadata, sqlite3_value, SQLITE_OK,
+    SQLITE_TRANSIENT, SQLITE_UTF8,
 };
 
 use crate::error::{BoxDynError, Error};
@@ -277,5 +278,9 @@ impl StatementHandle {
 
     pub(crate) fn column_text(&self, index: usize) -> Result<&str, BoxDynError> {
         Ok(from_utf8(self.column_blob(index))?)
+    }
+
+    pub(crate) fn reset(&self) {
+        unsafe { sqlite3_reset(self.0.as_ptr()) };
     }
 }


### PR DESCRIPTION
Unlike `Executor.fetch_optional()`, `Executor.fetch_many()` does not
have a single exit.  The stream can be dropped at any time.  To catch
this event, we create a `StatementResetter` structure inside the stream
loop and reset the statement when it is dropped.

A test case `it_resets_prepared_statement_after_fetch_many` is
similar to `it_resets_prepared_statement_after_fetch_one` which tests
`Executor.fetch_optional()`.

Fixes #1147