### PR TITLE
Remove `Self: Type` bounds in Encode / Decode implementations

### DIFF
--- a/sqlx-core/src/net/tls/mod.rs
+++ b/sqlx-core/src/net/tls/mod.rs
@@ -230,7 +230,9 @@ where
             #[cfg(all(not(feature = "_rt-async-std"), feature = "_tls-native-tls"))]
             MaybeTlsStream::Tls(s) => s.get_ref().get_ref().get_ref(),
 
-            MaybeTlsStream::Upgrading => panic!(io::Error::from(io::ErrorKind::ConnectionAborted)),
+            MaybeTlsStream::Upgrading => {
+                panic!("{}", io::Error::from(io::ErrorKind::ConnectionAborted))
+            }
         }
     }
 }
@@ -252,7 +254,9 @@ where
             #[cfg(all(not(feature = "_rt-async-std"), feature = "_tls-native-tls"))]
             MaybeTlsStream::Tls(s) => s.get_mut().get_mut().get_mut(),
 
-            MaybeTlsStream::Upgrading => panic!(io::Error::from(io::ErrorKind::ConnectionAborted)),
+            MaybeTlsStream::Upgrading => {
+                panic!("{}", io::Error::from(io::ErrorKind::ConnectionAborted))
+            }
         }
     }
 }

--- a/sqlx-core/src/postgres/types/array.rs
+++ b/sqlx-core/src/postgres/types/array.rs
@@ -37,7 +37,6 @@ impl<'q, T> Encode<'q, Postgres> for Vec<T>
 where
     for<'a> &'a [T]: Encode<'q, Postgres>,
     T: Encode<'q, Postgres>,
-    Self: Type<Postgres>,
 {
     #[inline]
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> IsNull {
@@ -48,7 +47,6 @@ where
 impl<'q, T> Encode<'q, Postgres> for &'_ [T]
 where
     T: Encode<'q, Postgres> + Type<Postgres>,
-    Self: Type<Postgres>,
 {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> IsNull {
         buf.extend(&1_i32.to_be_bytes()); // number of dimensions
@@ -77,7 +75,6 @@ where
 impl<'r, T> Decode<'r, Postgres> for Vec<T>
 where
     T: for<'a> Decode<'a, Postgres> + Type<Postgres>,
-    Self: Type<Postgres>,
 {
     fn decode(value: PgValueRef<'r>) -> Result<Self, BoxDynError> {
         let element_type_info;

--- a/sqlx-core/src/sqlite/options/auto_vacuum.rs
+++ b/sqlx-core/src/sqlite/options/auto_vacuum.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 #[derive(Debug, Clone)]
 pub enum SqliteAutoVacuum {
     None,

--- a/sqlx-core/src/sqlite/options/locking_mode.rs
+++ b/sqlx-core/src/sqlite/options/locking_mode.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 #[derive(Debug, Clone)]
 pub enum SqliteLockingMode {
     Normal,

--- a/sqlx-core/src/types/json.rs
+++ b/sqlx-core/src/types/json.rs
@@ -86,7 +86,6 @@ where
 
 impl<'q, DB> Encode<'q, DB> for JsonValue
 where
-    Self: Type<DB>,
     for<'a> Json<&'a Self>: Encode<'q, DB>,
     DB: Database,
 {
@@ -97,7 +96,6 @@ where
 
 impl<'r, DB> Decode<'r, DB> for JsonValue
 where
-    Self: Type<DB>,
     Json<Self>: Decode<'r, DB>,
     DB: Database,
 {
@@ -124,7 +122,6 @@ where
 // implementation for Encode
 impl<'r, DB> Decode<'r, DB> for &'r JsonRawValue
 where
-    Self: Type<DB>,
     Json<Self>: Decode<'r, DB>,
     DB: Database,
 {

--- a/sqlx-rt/src/lib.rs
+++ b/sqlx-rt/src/lib.rs
@@ -75,7 +75,7 @@ mod tokio_runtime {
     where
         F: FnOnce() -> R,
     {
-        RUNTIME.enter();
+        let _rt = RUNTIME.enter();
         f()
     }
 }


### PR DESCRIPTION
Notes on the first commit:

* This changes a few `panic!`s behaviors. I'm assuming not using a format string there was an oversight, rather than those panics really being meant to be catch-able as `std::io::Error`s.
* It looks like `enter_runtime` for tokio was actually wrong before, due to the runtime guard being dropped before calling the function argument.

About the second ("main") commit: I've only tested that the change of the slice implementation doesn't result in compilation errors, nothing more.