### PR TITLE
sqlite: export SqliteLockingMode

### DIFF
--- a/sqlx-core/src/sqlite/mod.rs
+++ b/sqlx-core/src/sqlite/mod.rs
@@ -27,7 +27,7 @@ pub use column::SqliteColumn;
 pub use connection::SqliteConnection;
 pub use database::Sqlite;
 pub use error::SqliteError;
-pub use options::{SqliteConnectOptions, SqliteJournalMode, SqliteSynchronous};
+pub use options::{SqliteConnectOptions, SqliteJournalMode, SqliteLockingMode, SqliteSynchronous};
 pub use query_result::SqliteQueryResult;
 pub use row::SqliteRow;
 pub use statement::SqliteStatement;


### PR DESCRIPTION
This makes it possible to `use sqlx::sqlite::SqliteLockingMode`.