### PR TITLE
Remove redundant default hint in help

### DIFF
--- a/sqlx-cli/src/opt.rs
+++ b/sqlx-cli/src/opt.rs
@@ -69,14 +69,14 @@ pub enum DatabaseCommand {
         #[clap(short)]
         yes: bool,
 
-        /// Path to folder containing migrations. Defaults to 'migrations'
+        /// Path to folder containing migrations.
         #[clap(long, default_value = "migrations")]
         source: String,
     },
 
     /// Creates the database specified in your DATABASE_URL and runs any pending migrations.
     Setup {
-        /// Path to folder containing migrations. Defaults to 'migrations'
+        /// Path to folder containing migrations.
         #[clap(long, default_value = "migrations")]
         source: String,
     },
@@ -85,7 +85,7 @@ pub enum DatabaseCommand {
 /// Group of commands for creating and running migrations.
 #[derive(Clap, Debug)]
 pub struct MigrateOpt {
-    /// Path to folder containing migrations. Defaults to 'migrations'
+    /// Path to folder containing migrations.
     #[clap(long, default_value = "migrations")]
     pub source: String,
 


### PR DESCRIPTION
Executing `cargo sqlx database setup --help` produces the following output for me:

```
cargo-sqlx-database-setup 
Creates the database specified in your DATABASE_URL and runs any pending migrations

USAGE:
    cargo sqlx database setup [OPTIONS]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --source <source>    Path to folder containing migrations. Defaults to 'migrations'
                             [default: migrations]
```

In particular, two last lines have duplicated information about the default value. This PR removes the redundancy.