### PR TITLE
Try to make 'no queries found' message more clear

### DIFF
--- a/sqlx-cli/src/prepare.rs
+++ b/sqlx-cli/src/prepare.rs
@@ -28,7 +28,7 @@ pub fn run(url: &str, merge: bool, cargo_args: Vec<String>) -> anyhow::Result<()
 
     if data.is_empty() {
         println!(
-            "{} no queries found; do you have the `offline` feature enabled in sqlx?",
+            "{} no queries found; ensure that the `offline` feature is enabled in sqlx",
             style("warning:").yellow()
         );
     }

--- a/sqlx-cli/src/prepare.rs
+++ b/sqlx-cli/src/prepare.rs
@@ -28,7 +28,7 @@ pub fn run(url: &str, merge: bool, cargo_args: Vec<String>) -> anyhow::Result<()
 
     if data.is_empty() {
         println!(
-            "{} no queries found; ensure that the `offline` feature is enabled in sqlx",
+            "{} no queries found; please ensure that the `offline` feature is enabled in sqlx",
             style("warning:").yellow()
         );
     }


### PR DESCRIPTION
Hi and thanks for sqlx!

While trying to generate a metadata file for a CI build via `cargo sqlx prepare`, I found the help message slightly confusing. I didn't have the offline feature enabled of course which was the problem, and my initial thought when I saw the message "no queries found; do you have the 'offline' feature enabled in sqlx?" was "I don't think so, I never even heard of that feature... There must be another problem..." at which point I started googling.

Eventually I realised I had understood the message the wrong way round and that I _needed_ the offline feature to make the metadata generation work :) This message change may (or may not!) help people to avoid the same confusion as me.

Thanks again