### PR TITLE
Support setting sqlite page_size

### DIFF
--- a/sqlx-core/src/sqlite/options/connect.rs
+++ b/sqlx-core/src/sqlite/options/connect.rs
@@ -19,10 +19,13 @@ impl ConnectOptions for SqliteConnectOptions {
 
             // send an initial sql statement comprised of options
             //
+            // page_size must be set before any other action on the database.
+            //
             // Note that locking_mode should be set before journal_mode; see
             // https://www.sqlite.org/wal.html#use_of_wal_without_shared_memory .
             let init = format!(
-                "PRAGMA locking_mode = {}; PRAGMA journal_mode = {}; PRAGMA foreign_keys = {}; PRAGMA synchronous = {}; PRAGMA auto_vacuum = {}",
+                "PRAGMA page_size = {}; PRAGMA locking_mode = {}; PRAGMA journal_mode = {}; PRAGMA foreign_keys = {}; PRAGMA synchronous = {}; PRAGMA auto_vacuum = {}",
+                self.page_size,
                 self.locking_mode.as_str(),
                 self.journal_mode.as_str(),
                 if self.foreign_keys { "ON" } else { "OFF" },

--- a/sqlx-core/src/sqlite/options/mod.rs
+++ b/sqlx-core/src/sqlite/options/mod.rs
@@ -62,6 +62,7 @@ pub struct SqliteConnectOptions {
     pub(crate) log_settings: LogSettings,
     pub(crate) synchronous: SqliteSynchronous,
     pub(crate) auto_vacuum: SqliteAutoVacuum,
+    pub(crate) page_size: u32,
 }
 
 impl Default for SqliteConnectOptions {
@@ -86,6 +87,7 @@ impl SqliteConnectOptions {
             log_settings: Default::default(),
             synchronous: SqliteSynchronous::Full,
             auto_vacuum: Default::default(),
+            page_size: 4096,
         }
     }
 
@@ -170,6 +172,14 @@ impl SqliteConnectOptions {
     /// The default auto_vacuum setting is NONE.
     pub fn auto_vacuum(mut self, auto_vacuum: SqliteAutoVacuum) -> Self {
         self.auto_vacuum = auto_vacuum;
+        self
+    }
+
+    /// Sets the [page_size](https://www.sqlite.org/pragma.html#pragma_page_size) setting for the database connection.
+    ///
+    /// The default page_size setting is 4096.
+    pub fn page_size(mut self, page_size: u32) -> Self {
+        self.page_size = page_size;
         self
     }
 }


### PR DESCRIPTION
The page size setting only takes effect if set before doing anything
else to the database.