### PR TITLE
Mark the original DatabaseError as source.

### DIFF
--- a/sqlx-core/src/error.rs
+++ b/sqlx-core/src/error.rs
@@ -36,7 +36,7 @@ pub enum Error {
 
     /// Error returned from the database.
     #[error("error returned from database: {0}")]
-    Database(Box<dyn DatabaseError>),
+    Database(#[source] Box<dyn DatabaseError>),
 
     /// Error communicating with the database backend.
     #[error("error communicating with the server: {0}")]
@@ -104,6 +104,8 @@ pub enum Error {
     #[error("{0}")]
     Migrate(#[source] Box<crate::migrate::MigrateError>),
 }
+
+impl StdError for Box<dyn DatabaseError> {}
 
 impl Error {
     pub fn into_database_error(self) -> Option<Box<dyn DatabaseError + 'static>> {


### PR DESCRIPTION
I bumped into this limitation by chance and it seemed easy enough to fix.
Curious to know if there was a reason behind the omission or if it simply wasn't noticed.