### PR TITLE
Add docs for rename_all attribute for Type derive macro

### DIFF
--- a/sqlx-core/src/types/mod.rs
+++ b/sqlx-core/src/types/mod.rs
@@ -117,6 +117,7 @@ pub use json::Json;
 ///   `<SQL type name>` instead. May trigger errors or unexpected behavior if the encoding of the
 ///   given type is different than that of the inferred type (e.g. if you rename the above to
 ///   `VARCHAR`). Affects Postgres only.
+/// * `#[sqlx(rename_all = "<strategy>")]` on struct definition: See [`derive docs in FromRow`](crate::from_row::FromRow#rename_all)
 ///
 /// ### Enumeration
 ///

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -245,7 +245,7 @@
 /// # async fn main() {
 /// # let mut conn = panic!();
 /// #[derive(sqlx::Type)]
-/// #[sqlx(transparent)
+/// #[sqlx(transparent)]
 /// struct MyInt4(i32);
 ///
 /// let my_int = MyInt4(1);


### PR DESCRIPTION
First time contributing, so please point out if I missed a guideline!

When looking for information on how to add an enum to my schema, I stumbled across the derive macro for the `Type` trait and had to search a bit before finding the supported values for the `rename_all` attribute. This PR adds a link for people in the same situation :)

Also, I've fixed a typo that made the build fail, I hope it's okay to include this here, wasn't sure if a second PR was warranted for that.