### PR TITLE
Added any types for binary blobs and chrono NaiveDateTime

### DIFF
--- a/sqlx-core/src/any/types.rs
+++ b/sqlx-core/src/any/types.rs
@@ -56,6 +56,43 @@ impl_any_decode!(f64);
 impl_any_decode!(&'r str);
 impl_any_decode!(String);
 
+// Conversions for Blob SQL types
+// Type
+#[cfg(all(
+    any(feature = "mysql", feature = "sqlite", feature = "postgres"),
+    not(feature = "mssql")
+))]
+impl_any_type!([u8]);
+#[cfg(all(
+    any(feature = "mysql", feature = "sqlite", feature = "postgres"),
+    not(feature = "mssql")
+))]
+impl_any_type!(Vec<u8>);
+
+// Encode
+#[cfg(all(
+    any(feature = "mysql", feature = "sqlite", feature = "postgres"),
+    not(feature = "mssql")
+))]
+impl_any_encode!(&'q [u8]);
+#[cfg(all(
+    any(feature = "mysql", feature = "sqlite", feature = "postgres"),
+    not(feature = "mssql")
+))]
+impl_any_encode!(Vec<u8>);
+
+// Decode
+#[cfg(all(
+    any(feature = "mysql", feature = "sqlite", feature = "postgres"),
+    not(feature = "mssql")
+))]
+impl_any_decode!(&'r [u8]);
+#[cfg(all(
+    any(feature = "mysql", feature = "sqlite", feature = "postgres"),
+    not(feature = "mssql")
+))]
+impl_any_decode!(Vec<u8>);
+
 // Conversions for Time SQL types
 // Type
 #[cfg(all(
@@ -70,7 +107,12 @@ impl_any_type!(chrono::NaiveDate);
     not(feature = "mssql")
 ))]
 impl_any_type!(chrono::NaiveTime);
-
+#[cfg(all(
+    feature = "chrono",
+    any(feature = "mysql", feature = "sqlite", feature = "postgres"),
+    not(feature = "mssql")
+))]
+impl_any_type!(chrono::NaiveDateTime);
 #[cfg(all(
     feature = "chrono",
     any(feature = "mysql", feature = "sqlite", feature = "postgres"),
@@ -102,6 +144,12 @@ impl_any_encode!(chrono::NaiveTime);
     any(feature = "mysql", feature = "sqlite", feature = "postgres"),
     not(feature = "mssql")
 ))]
+impl_any_encode!(chrono::NaiveDateTime);
+#[cfg(all(
+    feature = "chrono",
+    any(feature = "mysql", feature = "sqlite", feature = "postgres"),
+    not(feature = "mssql")
+))]
 impl_any_encode!(chrono::DateTime<chrono::offset::Utc>);
 #[cfg(all(
     feature = "chrono",
@@ -123,6 +171,12 @@ impl_any_decode!(chrono::NaiveDate);
     not(feature = "mssql")
 ))]
 impl_any_decode!(chrono::NaiveTime);
+#[cfg(all(
+    feature = "chrono",
+    any(feature = "mysql", feature = "sqlite", feature = "postgres"),
+    not(feature = "mssql")
+))]
+impl_any_decode!(chrono::NaiveDateTime);
 #[cfg(all(
     feature = "chrono",
     any(feature = "mysql", feature = "sqlite", feature = "postgres"),


### PR DESCRIPTION
Added support of decoding/encoding of bytes and `chrono::NaiveDateTime` in `any`.
Both are supported for `sqlite`, `postgres`, `mysql`, but not for `mssql`.