### PR TITLE
feat: Add secrecy crate feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2080,6 +2080,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0673d6a6449f5e7d12a1caf424fd9363e2af3a4953023ed455e3c4beef4597c0"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,6 +2373,7 @@ dependencies = [
  "rsa",
  "rust_decimal",
  "rustls",
+ "secrecy",
  "serde",
  "serde_json",
  "sha-1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ all-types = [
     "bit-vec",
     "bstr",
     "git2",
+    "secrecy"
 ]
 
 # previous runtimes, available as features for error messages better than just
@@ -127,6 +128,7 @@ time = ["sqlx-core/time", "sqlx-macros/time"]
 bit-vec = ["sqlx-core/bit-vec", "sqlx-macros/bit-vec"]
 bstr = ["sqlx-core/bstr"]
 git2 = ["sqlx-core/git2"]
+secrecy = ["sqlx-core/secrecy"]
 
 [dependencies]
 sqlx-core = { version = "0.5.2", path = "sqlx-core", default-features = false }

--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ sqlx = { version = "0.5", features = [ "runtime-async-std-native-tls" ] }
 
 -   `tls`: Add support for TLS connections.
 
+-   `secrecy`: Add support for `secrecy::Secret<T>`.
+
 ## Usage
 
 ### Quickstart

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -57,6 +57,7 @@ all-types = [
     "json",
     "uuid",
     "bit-vec",
+    "secrecy"
 ]
 bigdecimal = ["bigdecimal_", "num-bigint"]
 decimal = ["rust_decimal", "num-bigint"]
@@ -160,3 +161,4 @@ stringprep = "0.1.2"
 bstr = { version = "0.2.14", default-features = false, features = ["std"], optional = true }
 git2 = { version = "0.13.12", default-features = false, optional = true }
 hashlink = "0.6.0"
+secrecy = { version = "0.7.0", optional = true }

--- a/sqlx-core/src/types/mod.rs
+++ b/sqlx-core/src/types/mod.rs
@@ -28,6 +28,10 @@ pub mod bstr;
 #[cfg_attr(docsrs, doc(cfg(feature = "git2")))]
 pub mod git2;
 
+#[cfg(feature = "secrecy")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secrecy")))]
+pub mod secrecy;
+
 #[cfg(feature = "json")]
 #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 mod json;

--- a/sqlx-core/src/types/secrecy.rs
+++ b/sqlx-core/src/types/secrecy.rs
@@ -1,0 +1,58 @@
+/// Conversions between `secrecy::Secret<T>` and SQL types.
+use crate::database::{Database, HasArguments, HasValueRef};
+use crate::decode::Decode;
+use crate::encode::{Encode, IsNull};
+use crate::error::BoxDynError;
+use crate::types::Type;
+
+pub use secrecy::{ExposeSecret, Secret, Zeroize};
+
+impl<DB, T> Type<DB> for Secret<T>
+where
+    DB: Database,
+    T: Type<DB> + Zeroize,
+{
+    fn type_info() -> DB::TypeInfo {
+        T::type_info()
+    }
+
+    fn compatible(ty: &DB::TypeInfo) -> bool {
+        T::compatible(ty)
+    }
+}
+
+impl<'r, DB, T> Decode<'r, DB> for Secret<T>
+where
+    DB: Database,
+    T: Decode<'r, DB> + Zeroize,
+{
+    fn decode(value: <DB as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+        T::decode(value).map(Secret::new)
+    }
+}
+
+impl<'q, DB, T> Encode<'q, DB> for Secret<T>
+where
+    DB: Database,
+    T: Encode<'q, DB> + Zeroize,
+{
+    #[inline]
+    fn encode(self, buf: &mut <DB as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
+        self.expose_secret().encode(buf)
+    }
+
+    #[inline]
+    fn encode_by_ref(&self, buf: &mut <DB as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
+        self.expose_secret().encode_by_ref(buf)
+    }
+
+    #[inline]
+    fn produces(&self) -> Option<DB::TypeInfo> {
+        self.expose_secret().produces()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> usize {
+        self.expose_secret().size_hint()
+    }
+}


### PR DESCRIPTION
Hey 👋 

This PR adds the ability to use `secrecy::Secret<T>` from the [`secrecy` crate](https://crates.io/crates/secrecy) as an `sqlx::Type`.

Example:

```rust
#[derive(Debug, FromRow)]
pub struct User {
    pub id: i32,
    pub email_address: String,
    pub password_hash: secrecy::Secret<String>,
}
```