### PR TITLE
Adding Any support for Local chrono datetime for MySQL

### DIFF
--- a/sqlx-core/src/any/types.rs
+++ b/sqlx-core/src/any/types.rs
@@ -79,8 +79,8 @@ impl_any_type!(chrono::NaiveTime);
 impl_any_type!(chrono::DateTime<chrono::offset::Utc>);
 #[cfg(all(
     feature = "chrono",
-    any(feature = "sqlite", feature = "postgres"),
-    not(any(feature = "mysql", feature = "mssql"))
+    any(feature = "sqlite", feature = "postgres", feature = "mysql"),
+    not(feature = "mssql")
 ))]
 impl_any_type!(chrono::DateTime<chrono::offset::Local>);
 
@@ -105,8 +105,8 @@ impl_any_encode!(chrono::NaiveTime);
 impl_any_encode!(chrono::DateTime<chrono::offset::Utc>);
 #[cfg(all(
     feature = "chrono",
-    any(feature = "sqlite", feature = "postgres"),
-    not(any(feature = "mysql", feature = "mssql"))
+    any(feature = "sqlite", feature = "postgres", feature = "mysql"),
+    not(feature = "mssql")
 ))]
 impl_any_encode!(chrono::DateTime<chrono::offset::Local>);
 
@@ -131,7 +131,7 @@ impl_any_decode!(chrono::NaiveTime);
 impl_any_decode!(chrono::DateTime<chrono::offset::Utc>);
 #[cfg(all(
     feature = "chrono",
-    any(feature = "sqlite", feature = "postgres"),
-    not(any(feature = "mysql", feature = "mssql"))
+    any(feature = "sqlite", feature = "postgres", feature = "mysql"),
+    not(feature = "mssql")
 ))]
 impl_any_decode!(chrono::DateTime<chrono::offset::Local>);


### PR DESCRIPTION
Hello, a while back I put in a PR adding `Any` type support for `chrono` types. It seems I somehow missed that the `mysql` implementation supports `chrono::DateTime<chrono::types::Local>`. So this PR should add that support. 