### PR TITLE
Add a `get_kind` method to Pool

### DIFF
--- a/sqlx-core/src/any/kind.rs
+++ b/sqlx-core/src/any/kind.rs
@@ -1,7 +1,7 @@
 use crate::error::Error;
 use std::str::FromStr;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum AnyKind {
     #[cfg(feature = "postgres")]
     Postgres,

--- a/sqlx-core/src/pool/mod.rs
+++ b/sqlx-core/src/pool/mod.rs
@@ -55,6 +55,8 @@
 //! [`Pool::begin`].
 
 use self::inner::SharedPool;
+#[cfg(feature = "any")]
+use crate::any::{Any, AnyKind};
 use crate::connection::Connection;
 use crate::database::Database;
 use crate::error::Error;
@@ -290,7 +292,7 @@ impl<DB: Database> Pool<DB> {
         }
     }
 
-    /// Shut down the connection pool, waiting for all connections to be gracefully closed.    
+    /// Shut down the connection pool, waiting for all connections to be gracefully closed.
     ///
     /// Upon `.await`ing this call, any currently waiting or subsequent calls to [Pool::acquire] and
     /// the like will immediately return [Error::PoolClosed] and no new connections will be opened.
@@ -334,6 +336,17 @@ impl<DB: Database> Pool<DB> {
     /// changing rapidly, this may run indefinitely.
     pub fn num_idle(&self) -> usize {
         self.0.num_idle()
+    }
+}
+
+#[cfg(feature = "any")]
+impl Pool<Any> {
+    /// Returns the database driver currently in-use by this `Pool`.
+    ///
+    /// Determined by the connection URI.
+    #[cfg(feature = "any")]
+    pub fn any_kind(&self) -> AnyKind {
+        self.0.connect_options.kind()
     }
 }
 


### PR DESCRIPTION
This PR addresses https://github.com/launchbadge/sqlx/issues/1225

It adds a `get_kind` method to `Pool`, going through `SharedPool` and `ConnectionOptions` to get the (dynamic for `Any`) type of the connection.

This will allow query builders to build the query based on which driver (and so which dialect) is used.

Note: The `sqlx-core/src/any/kind.rs` was moved to `sqlx-core/src/any_kind.rs` because it's now needed for every DB, so it shouldn't be guarded by the `any` feature.

I didn't add any tests, because I'm not entirely sure where to add them, and there is not really any logic to test. The test (if any) should probably only check the interface, maybe in a test where we have a `&any_pool` and we check its `.get_kind()`?