### PR TITLE
Revert webpki version bump to keep compatability with tokio-rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ checksum = "9c86f33abd5a4f3e2d6d9251a9e0c6a7e52eb1113caf893dae8429bf4a53f378"
 dependencies = [
  "futures-lite",
  "rustls",
- "webpki 0.21.4",
+ "webpki",
 ]
 
 [[package]]
@@ -2007,7 +2007,7 @@ dependencies = [
  "log",
  "ring",
  "sct",
- "webpki 0.21.4",
+ "webpki",
 ]
 
 [[package]]
@@ -2367,7 +2367,7 @@ dependencies = [
  "tokio-stream",
  "url",
  "uuid",
- "webpki 0.22.0",
+ "webpki",
  "webpki-roots",
  "whoami",
 ]
@@ -2820,7 +2820,7 @@ checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
  "rustls",
  "tokio",
- "webpki 0.21.4",
+ "webpki",
 ]
 
 [[package]]
@@ -3079,22 +3079,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "webpki-roots"
-version = "0.22.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b533367e7546a31c15093b12a273004b79eb3b57b15359af710460f9aee94cf8"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
- "webpki 0.22.0",
+ "webpki",
 ]
 
 [[package]]

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -153,8 +153,8 @@ tokio-stream = { version = "0.1.2", features = ["fs"], optional = true }
 smallvec = "1.4.0"
 url = { version = "2.1.1", default-features = false }
 uuid = { version = "0.8.1", default-features = false, optional = true, features = ["std"] }
-webpki = { version = "0.22.0", optional = true }
-webpki-roots = { version = "0.22.0", optional = true }
+webpki = { version = "0.21.0", optional = true }
+webpki-roots = { version = "0.21.0", optional = true }
 whoami = "1.0.1"
 stringprep = "0.1.2"
 bstr = { version = "0.2.14", default-features = false, features = ["std"], optional = true }


### PR DESCRIPTION
The latest webpki version bump results in some compilation failures when compiling sqlx-core when compiling with tokio-rustls, which depends on 0.21.4. For example:

```
error[E0308]: mismatched types
  --> /home/etcaton/.cargo/registry/src/github.com-1ecc6299db9ec823/sqlx-core-0.5.3/src/net/tls/rustls.rs:73:39
   |
72 |         match verifier.verify_server_cert(roots, presented_certs, dns_name, ocsp_response) {
   |               ---------------------------------------------------------------------------- this expression has type `std::result::Result<ServerCertVerified,
TLSError>`
73 |             Err(TLSError::WebPKIError(webpki::Error::CertNotValidForName)) => {
   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected enum `webpki::error::Error`, found enum `webpki::Error`
   |
   = note: perhaps two different versions of crate `webpki` are being used?
```

https://github.com/tokio-rs/tls/blob/794659740dcc399f79058c4eba325ffd97474c7b/tokio-rustls/Cargo.toml#L17

```
webpki v0.21.4
├── rustls v0.19.1
│   ├── sqlx-core v0.5.3 (https://github.com/ETCaton/sqlx#15c15019)
│   │   ├── sqlx v0.5.3 (https://github.com/ETCaton/sqlx#15c15019)
│   │   │   └── <my crate>
│   │   └── sqlx-macros v0.5.3 (proc-macro) (https://github.com/ETCaton/sqlx#15c15019)
│   │       └── sqlx v0.5.3 (https://github.com/ETCaton/sqlx#15c15019) (*)
│   └── tokio-rustls v0.22.0
│       └── sqlx-rt v0.5.3 (https://github.com/ETCaton/sqlx#15c15019)
│           ├── sqlx-core v0.5.3 (https://github.com/ETCaton/sqlx#15c15019) (*)
│           └── sqlx-macros v0.5.3 (proc-macro) (https://github.com/ETCaton/sqlx#15c15019) (*)
├── sqlx-core v0.5.3 (https://github.com/ETCaton/sqlx#15c15019) (*)
├── tokio-rustls v0.22.0 (*)
└── webpki-roots v0.21.1
    └── sqlx-core v0.5.3 (https://github.com/ETCaton/sqlx#15c15019) (*)
```