### PR TITLE
Enable SqliteOptions.create_if_missing by default for Any options

### DIFF
--- a/sqlx-core/src/any/options.rs
+++ b/sqlx-core/src/any/options.rs
@@ -79,7 +79,7 @@ impl From<MySqlConnectOptions> for AnyConnectOptions {
 #[cfg(feature = "sqlite")]
 impl From<SqliteConnectOptions> for AnyConnectOptions {
     fn from(options: SqliteConnectOptions) -> Self {
-        Self(AnyConnectOptionsKind::Sqlite(options))
+        Self(AnyConnectOptionsKind::Sqlite(options.create_if_missing(true)))
     }
 }
 


### PR DESCRIPTION
(This is just a suggestion, not demand, please let me know if it makes no sense or breaks something).

When used from 'any' context, it seems that SQLite's 'create_if_missing' option would make sense to be enabled by default. The use case I had in mind is using `AnyPool` with Postgres for production and with SQLite for unit-/system-testing. Ideally just changing the connection string would do the trick (I am omitting possible Pg/Sqlite compatibility issues here). Currently AnyPoolOptions seem to not provide a way to enable 'create_if_missing' (please let me know if I'm mistaken and it does!) with 'sqlite://...' connection string, but even if it did I don't like this kind of test setup 'leaking' into production code. The workaround is to create and empty file 'manually' (e.g. for 'sqlite://target/test.db' the './target/test.db' empty file must exist), but it looks weird and unnecessary, as in such case I would expect the database to exist **or to be created**. This suggestion does not break `SqliteOptions` contract, where, I believe, the 'create_if_missing' must be set explicitly to avoid empty database creation by mistake.

