### PR TITLE
Support the immutable option on SQLite connections

### DIFF
--- a/sqlx-core/src/sqlite/connection/establish.rs
+++ b/sqlx-core/src/sqlite/connection/establish.rs
@@ -29,8 +29,6 @@ pub(crate) async fn establish(options: &SqliteConnectOptions) -> Result<SqliteCo
         })?
         .to_owned();
 
-    filename.push('\0');
-
     // By default, we connect to an in-memory database.
     // [SQLITE_OPEN_NOMUTEX] will instruct [sqlite3_open_v2] to return an error if it
     // cannot satisfy our wish for a thread-safe, lock-free connection object
@@ -54,6 +52,13 @@ pub(crate) async fn establish(options: &SqliteConnectOptions) -> Result<SqliteCo
     } else {
         SQLITE_OPEN_PRIVATECACHE
     };
+
+    if options.immutable {
+        filename = format!("file:{}?immutable=true", filename);
+        flags |= libsqlite3_sys::SQLITE_OPEN_URI;
+    }
+
+    filename.push('\0');
 
     let busy_timeout = options.busy_timeout;
 

--- a/sqlx-core/src/sqlite/options/mod.rs
+++ b/sqlx-core/src/sqlite/options/mod.rs
@@ -63,6 +63,7 @@ pub struct SqliteConnectOptions {
     pub(crate) synchronous: SqliteSynchronous,
     pub(crate) auto_vacuum: SqliteAutoVacuum,
     pub(crate) page_size: u32,
+    pub(crate) immutable: bool,
 }
 
 impl Default for SqliteConnectOptions {
@@ -88,6 +89,7 @@ impl SqliteConnectOptions {
             synchronous: SqliteSynchronous::Full,
             auto_vacuum: Default::default(),
             page_size: 4096,
+            immutable: false,
         }
     }
 
@@ -188,6 +190,11 @@ impl SqliteConnectOptions {
     /// The default page_size setting is 4096.
     pub fn page_size(mut self, page_size: u32) -> Self {
         self.page_size = page_size;
+        self
+    }
+
+    pub fn immutable(mut self, immutable: bool) -> Self {
+        self.immutable = immutable;
         self
     }
 }

--- a/sqlx-core/src/sqlite/options/parse.rs
+++ b/sqlx-core/src/sqlite/options/parse.rs
@@ -94,6 +94,20 @@ impl FromStr for SqliteConnectOptions {
                         }
                     },
 
+                    "immutable" => match &*value {
+                        "true" | "1" => {
+                            options.immutable = true;
+                        }
+                        "false" | "0" => {
+                            options.immutable = false;
+                        }
+                        _ => {
+                            return Err(Error::Configuration(
+                                format!("unknown value {:?} for `immutable`", value).into(),
+                            ));
+                        }
+                    },
+
                     _ => {
                         return Err(Error::Configuration(
                             format!(


### PR DESCRIPTION
This fixes https://github.com/launchbadge/sqlx/issues/987

This is working for us, but I admit I have not thought carefully about how it interacts with other options. Open to feedback on the PR.