### PR TITLE
don't assert #[repr(...)] on `#[derive(sqlx::Type)]` unless needed

### DIFF
--- a/sqlx-macros/src/derives/attributes.rs
+++ b/sqlx-macros/src/derives/attributes.rs
@@ -216,8 +216,6 @@ pub fn check_transparent_attributes(
         field
     );
 
-    assert_attribute!(attributes.repr.is_none(), "unexpected #[repr(..)]", input);
-
     let ch_attributes = parse_child_attributes(&field.attrs)?;
 
     assert_attribute!(


### PR DESCRIPTION
This allows users to do

```rust
#[derive(sqlx::Type)]
#[repr(transparent)]
pub struct MyType(String);
```

p.s The error this throwed was very unfriendly.

`error: unexpected #[repr(..)]`

with no hint as to why that's not allowed or why its enforced.