### PR TITLE
Fix segfault in sqlite when a future is aborted

### DIFF
--- a/sqlx-core/src/sqlite/connection/describe.rs
+++ b/sqlx-core/src/sqlite/connection/describe.rs
@@ -64,7 +64,7 @@ pub(super) fn describe<'c: 'e, 'q: 'e, 'e>(
                     // fallback to [column_decltype]
                     if !stepped && stmt.read_only() {
                         stepped = true;
-                        let _ = conn.worker.step(*stmt).await;
+                        let _ = conn.worker.step(stmt).await;
                     }
 
                     let mut ty = stmt.column_type_info(col);

--- a/sqlx-core/src/sqlite/row.rs
+++ b/sqlx-core/src/sqlite/row.rs
@@ -23,7 +23,7 @@ pub struct SqliteRow {
     // IF the user drops the Row before iterating the stream (so
     // nearly all of our internal stream iterators), the executor moves on; otherwise,
     // it actually inflates this row with a list of owned sqlite3 values.
-    pub(crate) statement: StatementHandle,
+    pub(crate) statement: Arc<StatementHandle>,
 
     pub(crate) values: Arc<AtomicPtr<SqliteValue>>,
     pub(crate) num_values: usize,
@@ -48,7 +48,7 @@ impl SqliteRow {
     // returns a weak reference to an atomic list where the executor should inflate if its going
     // to increment the statement with [step]
     pub(crate) fn current(
-        statement: StatementHandle,
+        statement: &Arc<StatementHandle>,
         columns: &Arc<Vec<SqliteColumn>>,
         column_names: &Arc<HashMap<UStr, usize>>,
     ) -> (Self, Weak<AtomicPtr<SqliteValue>>) {
@@ -57,7 +57,7 @@ impl SqliteRow {
         let size = statement.column_count();
 
         let row = Self {
-            statement,
+            statement: Arc::clone(statement),
             values,
             num_values: size,
             columns: Arc::clone(columns),

--- a/sqlx-core/src/sqlite/statement/worker.rs
+++ b/sqlx-core/src/sqlite/statement/worker.rs
@@ -4,6 +4,7 @@ use crossbeam_channel::{unbounded, Sender};
 use either::Either;
 use futures_channel::oneshot;
 use libsqlite3_sys::{sqlite3_step, SQLITE_DONE, SQLITE_ROW};
+use std::sync::{Arc, Weak};
 use std::thread;
 
 // Each SQLite connection has a dedicated thread.
@@ -18,7 +19,7 @@ pub(crate) struct StatementWorker {
 
 enum StatementWorkerCommand {
     Step {
-        statement: StatementHandle,
+        statement: Weak<StatementHandle>,
         tx: oneshot::Sender<Result<Either<u64, ()>, Error>>,
     },
 }
@@ -31,14 +32,19 @@ impl StatementWorker {
             for cmd in rx {
                 match cmd {
                     StatementWorkerCommand::Step { statement, tx } => {
-                        let status = unsafe { sqlite3_step(statement.0.as_ptr()) };
+                        let resp = if let Some(statement) = statement.upgrade() {
+                            let status = unsafe { sqlite3_step(statement.0.as_ptr()) };
 
-                        let resp = match status {
-                            SQLITE_ROW => Ok(Either::Right(())),
-                            SQLITE_DONE => Ok(Either::Left(statement.changes())),
-                            _ => Err(statement.last_error().into()),
+                            let resp = match status {
+                                SQLITE_ROW => Ok(Either::Right(())),
+                                SQLITE_DONE => Ok(Either::Left(statement.changes())),
+                                _ => Err(statement.last_error().into()),
+                            };
+                            resp
+                        } else {
+                            // Statement is already finalized.
+                            Err(Error::WorkerCrashed)
                         };
-
                         let _ = tx.send(resp);
                     }
                 }
@@ -50,12 +56,15 @@ impl StatementWorker {
 
     pub(crate) async fn step(
         &mut self,
-        statement: StatementHandle,
+        statement: &Arc<StatementHandle>,
     ) -> Result<Either<u64, ()>, Error> {
         let (tx, rx) = oneshot::channel();
 
         self.tx
-            .send(StatementWorkerCommand::Step { statement, tx })
+            .send(StatementWorkerCommand::Step {
+                statement: Arc::downgrade(statement),
+                tx,
+            })
             .map_err(|_| Error::WorkerCrashed)?;
 
         rx.await.map_err(|_| Error::WorkerCrashed)?


### PR DESCRIPTION
This PR attempts to fix a memory corruption that happens when a future executing a db query is interrupted (more details in #1300). It is built on top of #1186, only the [last commit](https://github.com/launchbadge/sqlx/commit/bb62cf767e3e44896bf4607da8e18237241ed170) is new. Neither #1186, nor https://github.com/launchbadge/sqlx/commit/bb62cf767e3e44896bf4607da8e18237241ed170 are by themselves enough to fix this issue, but together they do seem to be.

Some notes:

The fix consist of making sure that calls to `sqlite3_reset` and `sqlite3_step` are never called concurrently without synchronization. The synchronization is implemented using an atomic bitflag in `StatementHandle`. This should be more efficient than using a mutex, however it makes the code a bit more difficult to reason about. Also the performance difference may or might not be significant. The solution only protects against concurrent use of `reset` and `step`, not any other functions. This should be fine as those seem to be the only two functions that might possibly be called concurrently from multiple threads. On the other hand this means that the `StatementHandle` API is strictly speaking not sound and should probably be marked as `unsafe`. I decided not to do it to keep the changes in this PR minimal. 

Closes #1300.

