### PR TITLE
Use postgres as maintenance db unless maintaining postgres itself

### DIFF
--- a/sqlx-core/src/postgres/migrate.rs
+++ b/sqlx-core/src/postgres/migrate.rs
@@ -24,9 +24,9 @@ fn parse_for_maintenance(uri: &str) -> Result<(PgConnectOptions, String), Error>
         .to_owned();
 
     // switch us to the maintenance database
-    // use `postgres` _unless_ the current user is postgres, in which case, use `template1`
+    // use `postgres` _unless_ the database is postgres, in which case, use `template1`
     // this matches the behavior of the `createdb` util
-    options.database = if options.username == "postgres" {
+    options.database = if database == "postgres" {
         Some("template1".into())
     } else {
         Some("postgres".into())


### PR DESCRIPTION
As described in #1283, currently when trying to create multiple databases in parallel, `sqlx::Postgres::create_database` will fail with the error message `source database "template1" is being accessed by other users`.

@li-kai did already find the cause of this. The function `parse_for_maintenance` is meant to emulate the behavior of the `createdb` util, but uses the username instead of the database. This PR fixes that.

I did not run extensive tests, but it works without issues on my project.