### PR TITLE
Fix cargo fix bug with sqlx offline mode

### DIFF
--- a/sqlx-macros/src/query/mod.rs
+++ b/sqlx-macros/src/query/mod.rs
@@ -81,6 +81,7 @@ static METADATA: Lazy<Metadata> = Lazy::new(|| {
         let output = Command::new(&cargo)
             .args(&["metadata", "--format-version=1"])
             .current_dir(&manifest_dir)
+            .env_remove("__CARGO_FIX_PLZ")
             .output()
             .expect("Could not fetch metadata");
 


### PR DESCRIPTION
Workaround for https://github.com/launchbadge/sqlx/issues/1229, in which running `cargo fix` when using sqlx in offline mode breaks because `cargo` acts differently when being called under `cargo fix`.

The workaround is to unset the `__CARGO_FIX_PLZ` environment variable that is set by `cargo fix`. This should make `cargo metadata` work as normal.