### PR TITLE
build(deps): bump git2 from 0.13.19 to 0.13.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,9 +984,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.19"
+version = "0.13.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17929de7239dea9f68aa14f94b2ab4974e7b24c1314275ffcc12a7758172fa18"
+checksum = "d9831e983241f8c5591ed53f17d874833e2fa82cac2625f3888c50cbfe136cba"
 dependencies = [
  "bitflags",
  "libc",
@@ -1225,9 +1225,9 @@ checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.20+1.1.0"
+version = "0.12.21+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2f09917e00b9ad194ae72072bb5ada2cca16d8171a43e91ddba2afbb02664b"
+checksum = "86271bacd72b2b9e854c3dcfb82efd538f15f870e4c11af66900effb462f6825"
 dependencies = [
  "cc",
  "libc",

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -161,5 +161,5 @@ webpki-roots = { version = "0.21.0", optional = true }
 whoami = "1.0.1"
 stringprep = "0.1.2"
 bstr = { version = "0.2.14", default-features = false, features = ["std"], optional = true }
-git2 = { version = "0.13.12", default-features = false, optional = true }
+git2 = { version = "0.13.20", default-features = false, optional = true }
 hashlink = "0.7.0"


### PR DESCRIPTION
avoid regression rust-lang/rust#85574

this will fix build for PR #1351 #1352