### PR TITLE
fix(cli): pin `clap_derive` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1808,9 +1808,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -2329,6 +2329,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap 3.0.0-beta.2",
+ "clap_derive",
  "console",
  "dialoguer",
  "dotenv",
@@ -2637,9 +2638,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/sqlx-cli/Cargo.toml
+++ b/sqlx-cli/Cargo.toml
@@ -34,7 +34,11 @@ sqlx = { version = "0.5.5", path = "..", default-features = false, features = [
     "offline",
 ] }
 futures = "0.3"
+# FIXME: we need to fix both of these versions until Clap 3.0 proper is released, then we can drop `clap_derive`
+# https://github.com/launchbadge/sqlx/issues/1378
+# https://github.com/clap-rs/clap/issues/2705
 clap = "=3.0.0-beta.2"
+clap_derive = "=3.0.0-beta.2"
 chrono = "0.4"
 anyhow = "1.0"
 url = { version = "2.1.1", default-features = false }


### PR DESCRIPTION
When `clap_derive 3.0.0-beta.4` released, new invocations of `cargo install sqlx-cli` would try to compile that against `clap 3.0.0-beta.2` which caused some breakages.

Until `clap 3.0.0` proper is released, we need to pin both versions to insure against potential breakages from automatic upgrades.

closes #1378