### PR TITLE
Fix macro error with CockroachDB

### DIFF
--- a/sqlx-core/src/postgres/connection/describe.rs
+++ b/sqlx-core/src/postgres/connection/describe.rs
@@ -399,13 +399,16 @@ SELECT oid FROM pg_catalog.pg_type WHERE typname ILIKE $1
             .fetch_all(&mut *self)
             .await?;
 
-        // patch up our null inference with data from EXPLAIN
-        let nullable_patch = self
-            .nullables_from_explain(stmt_id, meta.parameters.len())
-            .await?;
+        // if it's cockroachdb skip this step #1248
+        if !self.stream.parameter_statuses.contains_key("crdb_version") {
+            // patch up our null inference with data from EXPLAIN
+            let nullable_patch = self
+                .nullables_from_explain(stmt_id, meta.parameters.len())
+                .await?;
 
-        for (nullable, patch) in nullables.iter_mut().zip(nullable_patch) {
-            *nullable = patch.or(*nullable);
+            for (nullable, patch) in nullables.iter_mut().zip(nullable_patch) {
+                *nullable = patch.or(*nullable);
+            }
         }
 
         Ok(nullables)

--- a/sqlx-core/src/postgres/message/parameter_status.rs
+++ b/sqlx-core/src/postgres/message/parameter_status.rs
@@ -47,3 +47,16 @@ fn bench_decode_parameter_status(b: &mut test::Bencher) {
         ParameterStatus::decode(test::black_box(Bytes::from_static(DATA))).unwrap();
     });
 }
+
+#[test]
+fn test_decode_parameter_status_response() {
+    const PARAMETER_STATUS_RESPONSE: &[u8] = b"crdb_version\0CockroachDB CCL v21.1.0 (x86_64-unknown-linux-gnu, built 2021/05/17 13:49:40, go1.15.11)\0";
+
+    let message = ParameterStatus::decode(Bytes::from(PARAMETER_STATUS_RESPONSE)).unwrap();
+
+    assert_eq!(message.name, "crdb_version");
+    assert_eq!(
+        message.value,
+        "CockroachDB CCL v21.1.0 (x86_64-unknown-linux-gnu, built 2021/05/17 13:49:40, go1.15.11)"
+    );
+}


### PR DESCRIPTION
CockroachDB currently can't handle explain with verbose and json params, so query! wasn't working .
If crdb_version exists in parameter_statuses  it doesn't use nullables_from_explain function.