### PR TITLE
fix(cli) move database_url

### DIFF
--- a/sqlx-cli/src/lib.rs
+++ b/sqlx-cli/src/lib.rs
@@ -1,7 +1,7 @@
-use crate::opt::{Command, DatabaseCommand, MigrateCommand};
-use anyhow::anyhow;
+use anyhow::Result;
 use dotenv::dotenv;
-use std::env;
+
+use crate::opt::{Command, DatabaseCommand, MigrateCommand};
 
 mod database;
 // mod migration;
@@ -12,14 +12,8 @@ mod prepare;
 
 pub use crate::opt::Opt;
 
-pub async fn run(opt: Opt) -> anyhow::Result<()> {
+pub async fn run(opt: Opt) -> Result<()> {
     dotenv().ok();
-
-    let database_url = match opt.database_url {
-        Some(db_url) => db_url,
-        None => env::var("DATABASE_URL")
-            .map_err(|_| anyhow!("The DATABASE_URL environment variable must be set"))?,
-    };
 
     match opt.command {
         Command::Migrate(migrate) => match migrate.command {
@@ -30,34 +24,47 @@ pub async fn run(opt: Opt) -> anyhow::Result<()> {
             MigrateCommand::Run {
                 dry_run,
                 ignore_missing,
+                database_url,
             } => migrate::run(&migrate.source, &database_url, dry_run, ignore_missing).await?,
             MigrateCommand::Revert {
                 dry_run,
                 ignore_missing,
+                database_url,
             } => migrate::revert(&migrate.source, &database_url, dry_run, ignore_missing).await?,
-            MigrateCommand::Info => migrate::info(&migrate.source, &database_url).await?,
+            MigrateCommand::Info { database_url } => {
+                migrate::info(&migrate.source, &database_url).await?
+            }
             MigrateCommand::BuildScript { force } => migrate::build_script(&migrate.source, force)?,
         },
 
         Command::Database(database) => match database.command {
-            DatabaseCommand::Create => database::create(&database_url).await?,
-            DatabaseCommand::Drop { yes } => database::drop(&database_url, !yes).await?,
-            DatabaseCommand::Reset { yes, source } => {
-                database::reset(&source, &database_url, !yes).await?
+            DatabaseCommand::Create { database_url } => database::create(&database_url).await?,
+            DatabaseCommand::Drop { yes, database_url } => {
+                database::drop(&database_url, !yes).await?
             }
-            DatabaseCommand::Setup { source } => database::setup(&source, &database_url).await?,
+            DatabaseCommand::Reset {
+                yes,
+                source,
+                database_url,
+            } => database::reset(&source, &database_url, !yes).await?,
+            DatabaseCommand::Setup {
+                source,
+                database_url,
+            } => database::setup(&source, &database_url).await?,
         },
 
         Command::Prepare {
             check: false,
             merged,
             args,
+            database_url,
         } => prepare::run(&database_url, merged, args)?,
 
         Command::Prepare {
             check: true,
             merged,
             args,
+            database_url,
         } => prepare::check(&database_url, merged, args)?,
     };
 

--- a/sqlx-cli/src/opt.rs
+++ b/sqlx-cli/src/opt.rs
@@ -4,9 +4,6 @@ use clap::Clap;
 pub struct Opt {
     #[clap(subcommand)]
     pub command: Command,
-
-    #[clap(short = 'D', long)]
-    pub database_url: Option<String>,
 }
 
 #[derive(Clap, Debug)]
@@ -36,6 +33,10 @@ pub enum Command {
         /// Arguments to be passed to `cargo rustc ...`.
         #[clap(last = true)]
         args: Vec<String>,
+
+        /// Location of the DB, by default will be read from the DATABASE_URL env var
+        #[clap(long, short = 'D', env)]
+        database_url: String,
     },
 
     #[clap(alias = "mig")]
@@ -52,7 +53,11 @@ pub struct DatabaseOpt {
 #[derive(Clap, Debug)]
 pub enum DatabaseCommand {
     /// Creates the database specified in your DATABASE_URL.
-    Create,
+    Create {
+        /// Location of the DB, by default will be read from the DATABASE_URL env var
+        #[clap(long, short = 'D', env)]
+        database_url: String,
+    },
 
     /// Drops the database specified in your DATABASE_URL.
     Drop {
@@ -60,6 +65,10 @@ pub enum DatabaseCommand {
         /// your database.
         #[clap(short)]
         yes: bool,
+
+        /// Location of the DB, by default will be read from the DATABASE_URL env var
+        #[clap(long, short = 'D', env)]
+        database_url: String,
     },
 
     /// Drops the database specified in your DATABASE_URL, re-creates it, and runs any pending migrations.
@@ -72,6 +81,10 @@ pub enum DatabaseCommand {
         /// Path to folder containing migrations.
         #[clap(long, default_value = "migrations")]
         source: String,
+
+        /// Location of the DB, by default will be read from the DATABASE_URL env var
+        #[clap(long, short = 'D', env)]
+        database_url: String,
     },
 
     /// Creates the database specified in your DATABASE_URL and runs any pending migrations.
@@ -79,6 +92,10 @@ pub enum DatabaseCommand {
         /// Path to folder containing migrations.
         #[clap(long, default_value = "migrations")]
         source: String,
+
+        /// Location of the DB, by default will be read from the DATABASE_URL env var
+        #[clap(long, short = 'D', env)]
+        database_url: String,
     },
 }
 
@@ -115,6 +132,10 @@ pub enum MigrateCommand {
         /// Ignore applied migrations that missing in the resolved migrations
         #[clap(long)]
         ignore_missing: bool,
+
+        /// Location of the DB, by default will be read from the DATABASE_URL env var
+        #[clap(long, short = 'D', env)]
+        database_url: String,
     },
 
     /// Revert the latest migration with a down file.
@@ -126,10 +147,18 @@ pub enum MigrateCommand {
         /// Ignore applied migrations that missing in the resolved migrations
         #[clap(long)]
         ignore_missing: bool,
+
+        /// Location of the DB, by default will be read from the DATABASE_URL env var
+        #[clap(long, short = 'D', env)]
+        database_url: String,
     },
 
     /// List all available migrations.
-    Info,
+    Info {
+        /// Location of the DB, by default will be read from the DATABASE_URL env var
+        #[clap(long, env)]
+        database_url: String,
+    },
 
     /// Generate a `build.rs` to trigger recompilation when a new migration is added.
     ///


### PR DESCRIPTION
closes #1391 

bit of churn in the diff but it's just moving `database_url` to the subcommands which actually use it. 