### PR TITLE
add `rt::set_runtime` for tokio runtime features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ authors = [
 ]
 
 [package.metadata.docs.rs]
-features = ["all", "runtime-async-std-native-tls"]
+features = ["all", "runtime-async-std-native-tls", "sqlx-core/rt-docs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 
 [package.metadata.docs.rs]
-features = ["all-databases", "all-types", "offline", "runtime-async-std-native-tls"]
+features = ["all-databases", "all-types", "offline", "runtime-async-std-native-tls", "rt-docs"]
 
 [features]
 default = ["migrate"]
@@ -78,6 +78,9 @@ runtime-tokio-native-tls = [
     "sqlx-rt/runtime-tokio-native-tls",
     "_tls-native-tls",
     "_rt-tokio",
+]
+"rt-docs" = [
+    "sqlx-rt/rt-docs"
 ]
 
 runtime-actix-rustls = ["sqlx-rt/runtime-actix-rustls", "_tls-rustls", "_rt-actix"]

--- a/sqlx-core/src/lib.rs
+++ b/sqlx-core/src/lib.rs
@@ -68,6 +68,7 @@ mod net;
 pub mod query_as;
 pub mod query_scalar;
 pub mod row;
+pub mod rt;
 pub mod type_info;
 pub mod value;
 

--- a/sqlx-core/src/rt.rs
+++ b/sqlx-core/src/rt.rs
@@ -1,0 +1,19 @@
+//! This module contains feature specific to only certain runtimes
+
+#[cfg(any(
+    feature = "runtime-actix-native-tls",
+    feature = "runtime-tokio-native-tls",
+    feature = "runtime-actix-rustls",
+    feature = "runtime-tokio-rustls",
+    feature = "rt-docs",
+))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(
+        feature = "runtime-actix-native-tls",
+        feature = "runtime-tokio-native-tls",
+        feature = "runtime-actix-rustls",
+        feature = "runtime-tokio-rustls",
+    )))
+)]
+pub use sqlx_rt::set_runtime;

--- a/sqlx-rt/Cargo.toml
+++ b/sqlx-rt/Cargo.toml
@@ -30,6 +30,8 @@ _rt-tokio = ["tokio", "once_cell"]
 _tls-native-tls = ["native-tls"]
 _tls-rustls = []
 
+rt-docs = ["tokio"]
+
 [dependencies]
 async-native-tls = { version = "0.3.3", optional = true }
 async-rustls = { version = "0.2.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,22 @@ pub use sqlx_core::query::{query, query_with};
 pub use sqlx_core::query_as::{query_as, query_as_with};
 pub use sqlx_core::query_scalar::{query_scalar, query_scalar_with};
 pub use sqlx_core::row::Row;
+pub mod rt {
+    //! This module contains feature specific to only certain runtimes
+
+    // rustdoc doesn't appear to transfer these doc() attributes across 
+    // crates, so we have to replicated it here
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "runtime-actix-native-tls",
+            feature = "runtime-tokio-native-tls",
+            feature = "runtime-actix-rustls",
+            feature = "runtime-tokio-rustls",
+        )))
+    )]
+    pub use sqlx_core::rt::set_runtime;
+}
 pub use sqlx_core::statement::Statement;
 pub use sqlx_core::transaction::{Transaction, TransactionManager};
 pub use sqlx_core::type_info::TypeInfo;


### PR DESCRIPTION
Currently `sqlx-rt` unconditionally creates a new `tokio` runtime when asked. If someone erroneously uses `sqlx_rt::block_on` or others, it will create a new runtime, with a new block pool, reactor, and thread-per-core, _even if the user already has a running tokio runtime_. I have seen that typically people setup one multi-threaded runtime early in `main`, and the use that for everything. This can be more efficient than having multiple large thread pools running around

This PR adds a `rt` module to `sqlx-core` and `sqlx` that offer a `set_runtime` fn to let a user use a handle to an existing `tokio` runtime. This feature is only enabled for `tokio` (and therefore also `actix`) runtime features. An example of using this new feature is in https://github.com/guswynn/test-sqlx/blob/main/src/main.rs


```
    let runtime = tokio::runtime::Builder::new_multi_thread()
        .enable_all()
        .max_blocking_threads(10) // my special configuration
        .build()?;

    sqlx::rt::set_runtime(runtime.handle().clone())
        .map_err(|_| anyhow::anyhow!("something else initialized the runtime first"))?;
```


# Note on documentation

I used this command to test the doc changes:
`RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --features runtime-async-std-native-tls,sqlx-core/rt-docs --open`

I think this feature should always show up in docs. Currently, I use a bit of `features` soup to accomplish this. However, some of the repetition of the `doc_attr` attributes could be cleanup up with we add `rustc-args = ["--cfg=docsrs"]` to the `[package.metadata.docs.rs]`. This is because when building docs, rust/cargo only uses `cfg(doc)/RUSTDOCARGS` for the immediate crate, and not the deps. See this zulip convo for more details: https://rust-lang.zulipchat.com/#narrow/stream/266220-rustdoc/topic/rustdoc.20uses.20.60debug.60.20deps/near/251641055, and let me know if you want me to switch to a pure `--cfg=docsrs` configuration.
