### PR TITLE
Remove crate restrictions on Postgres Types

### DIFF
--- a/sqlx-core/src/postgres/column.rs
+++ b/sqlx-core/src/postgres/column.rs
@@ -5,13 +5,13 @@ use crate::postgres::{PgTypeInfo, Postgres};
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "offline", derive(serde::Serialize, serde::Deserialize))]
 pub struct PgColumn {
-    pub(crate) ordinal: usize,
-    pub(crate) name: UStr,
-    pub(crate) type_info: PgTypeInfo,
+    pub ordinal: usize,
+    pub name: UStr,
+    pub type_info: PgTypeInfo,
     #[cfg_attr(feature = "offline", serde(skip))]
-    pub(crate) relation_id: Option<i32>,
+    pub relation_id: Option<i32>,
     #[cfg_attr(feature = "offline", serde(skip))]
-    pub(crate) relation_attribute_no: Option<i16>,
+    pub relation_attribute_no: Option<i16>,
 }
 
 impl crate::column::private_column::Sealed for PgColumn {}

--- a/sqlx-core/src/postgres/type_info.rs
+++ b/sqlx-core/src/postgres/type_info.rs
@@ -8,8 +8,7 @@ use crate::ext::ustr::UStr;
 use crate::type_info::TypeInfo;
 
 /// Type information for a PostgreSQL type.
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "offline", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct PgTypeInfo(pub(crate) PgType);
 
 impl Deref for PgTypeInfo {
@@ -20,8 +19,7 @@ impl Deref for PgTypeInfo {
     }
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "offline", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[repr(u32)]
 pub enum PgType {
     Bool,
@@ -131,17 +129,14 @@ pub enum PgType {
     DeclareWithOid(u32),
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "offline", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PgCustomType {
-    #[cfg_attr(feature = "offline", serde(skip))]
-    pub(crate) oid: u32,
-    pub(crate) name: UStr,
-    pub(crate) kind: PgTypeKind,
+    pub oid: u32,
+    pub name: UStr,
+    pub kind: PgTypeKind,
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "offline", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum PgTypeKind {
     Simple,
     Pseudo,
@@ -154,7 +149,7 @@ pub enum PgTypeKind {
 
 impl PgTypeInfo {
     /// Returns the corresponding `PgTypeInfo` if the OID is a built-in type and recognized by SQLx.
-    pub(crate) fn try_from_oid(oid: u32) -> Option<Self> {
+    pub fn try_from_oid(oid: u32) -> Option<Self> {
         PgType::try_from_oid(oid).map(Self)
     }
 
@@ -233,7 +228,7 @@ impl PgTypeInfo {
 
 impl PgType {
     /// Returns the corresponding `PgType` if the OID is a built-in type and recognized by SQLx.
-    pub(crate) fn try_from_oid(oid: u32) -> Option<Self> {
+    pub fn try_from_oid(oid: u32) -> Option<Self> {
         Some(match oid {
             16 => PgType::Bool,
             17 => PgType::Bytea,
@@ -334,14 +329,14 @@ impl PgType {
         })
     }
 
-    pub(crate) fn oid(&self) -> u32 {
+    pub fn oid(&self) -> u32 {
         match self.try_oid() {
             Some(oid) => oid,
             None => unreachable!("(bug) use of unresolved type declaration [oid]"),
         }
     }
 
-    pub(crate) fn try_oid(&self) -> Option<u32> {
+    pub fn try_oid(&self) -> Option<u32> {
         Some(match self {
             PgType::Bool => 16,
             PgType::Bytea => 17,
@@ -444,7 +439,7 @@ impl PgType {
         })
     }
 
-    pub(crate) fn display_name(&self) -> &str {
+    pub fn display_name(&self) -> &str {
         match self {
             PgType::Bool => "BOOL",
             PgType::Bytea => "BYTEA",
@@ -544,7 +539,7 @@ impl PgType {
         }
     }
 
-    pub(crate) fn name(&self) -> &str {
+    pub fn name(&self) -> &str {
         match self {
             PgType::Bool => "bool",
             PgType::Bytea => "bytea",
@@ -644,7 +639,7 @@ impl PgType {
         }
     }
 
-    pub(crate) fn kind(&self) -> &PgTypeKind {
+    pub fn kind(&self) -> &PgTypeKind {
         match self {
             PgType::Bool => &PgTypeKind::Simple,
             PgType::Bytea => &PgTypeKind::Simple,

--- a/sqlx-core/src/postgres/value.rs
+++ b/sqlx-core/src/postgres/value.rs
@@ -15,22 +15,22 @@ pub enum PgValueFormat {
 /// Implementation of [`ValueRef`] for PostgreSQL.
 #[derive(Clone)]
 pub struct PgValueRef<'r> {
-    pub(crate) value: Option<&'r [u8]>,
-    pub(crate) row: Option<&'r Bytes>,
-    pub(crate) type_info: PgTypeInfo,
-    pub(crate) format: PgValueFormat,
+    pub value: Option<&'r [u8]>,
+    pub row: Option<&'r Bytes>,
+    pub type_info: PgTypeInfo,
+    pub format: PgValueFormat,
 }
 
 /// Implementation of [`Value`] for PostgreSQL.
 #[derive(Clone)]
 pub struct PgValue {
-    pub(crate) value: Option<Bytes>,
-    pub(crate) type_info: PgTypeInfo,
-    pub(crate) format: PgValueFormat,
+    pub value: Option<Bytes>,
+    pub type_info: PgTypeInfo,
+    pub format: PgValueFormat,
 }
 
 impl<'r> PgValueRef<'r> {
-    pub(crate) fn get(buf: &mut &'r [u8], format: PgValueFormat, ty: PgTypeInfo) -> Self {
+    pub fn get(buf: &mut &'r [u8], format: PgValueFormat, ty: PgTypeInfo) -> Self {
         let mut element_len = buf.get_i32();
 
         let element_val = if element_len == -1 {
@@ -50,18 +50,18 @@ impl<'r> PgValueRef<'r> {
         }
     }
 
-    pub(crate) fn format(&self) -> PgValueFormat {
+    pub fn format(&self) -> PgValueFormat {
         self.format
     }
 
-    pub(crate) fn as_bytes(&self) -> Result<&'r [u8], BoxDynError> {
+    pub fn as_bytes(&self) -> Result<&'r [u8], BoxDynError> {
         match &self.value {
             Some(v) => Ok(v),
             None => Err(UnexpectedNullError.into()),
         }
     }
 
-    pub(crate) fn as_str(&self) -> Result<&'r str, BoxDynError> {
+    pub fn as_str(&self) -> Result<&'r str, BoxDynError> {
         Ok(from_utf8(self.as_bytes()?)?)
     }
 }


### PR DESCRIPTION
Why do these need to be public only to the crate? 
These are extremely valuable properties to have access to, and is restricting the use cases of this library.

My use case is a cross platform database viewer, with a shared library written in rust. It is powered by react native, so I want to pass all of the raw bytes from Postgres up to the JS layer, where I turn it into JS Types, or make it manipulatable with a UI Component.

An example of my use case implemented with this change:

```rs
  async fn query(
    &self,
    id: &u32,
    sql: &str,
  ) -> Result<DatabaseQueryResult, DatabaseError> {
    let instances = _INSTANCES.lock().await;
    if !instances.contains_key(&id) {
      return Result::Err(Box::new(NoConnectionError { id: id.clone() }));
    }
    let connection = &instances[id];
    drop(&instances);

    let query = sqlx::query(sql);
    let result = query.fetch_all(connection).await;
    if result.is_err() {
      return Result::Err(Box::new(result.err().unwrap()));
    }

    let mut columns: Vec<DatabaseColumnInfo> = Vec::new();
    let mut rows: Vec<Vec<Option<Vec<u8>>>> = Vec::new();

    let result_data = result.unwrap();
    if result_data.len() > 0 {
      let column_info = result_data[0].columns();

      for column in column_info {
        let type_info = column.type_info();

        columns.push(DatabaseColumnInfo {
          name: column.name().to_string(),
          data_type: type_info.oid().to_string(),
        });
      }

      for row in &result_data {
        let mut data: Vec<Option<Vec<u8>>> = Vec::new();
        for ordinal in 0..column_info.len() {
          let value_ref = row.try_get_raw(ordinal).unwrap();

          let mut value: Option<Vec<u8>> = None;
          if value_ref.value.is_some() {
            let value_bytes = value_ref.value.unwrap();
            value = Some(value_bytes.to_vec());
          }
          data.push(value);
        }
        rows.push(data);
      }
    }

    let payload = DatabaseQueryResult { columns, rows };
    return Result::Ok(payload);
  }
```