### PR TITLE
Reduce futures-util features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2535,7 +2535,6 @@ version = "0.5.7"
 dependencies = [
  "dotenv",
  "either",
- "futures",
  "heck",
  "hex",
  "once_cell",

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -121,7 +121,7 @@ either = "1.5.3"
 futures-channel = { version = "0.3.5", default-features = false, features = ["sink", "alloc", "std"] }
 futures-core = { version = "0.3.5", default-features = false }
 futures-intrusive = "0.4.0"
-futures-util = { version = "0.3.5", features = ["sink"] }
+futures-util = { version = "0.3.5", default-features = false, features = ["alloc", "sink"] }
 generic-array = { version = "0.14.4", default-features = false, optional = true }
 hex = "0.4.2"
 hmac = { version = "0.10.1", default-features = false, optional = true }

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -79,7 +79,6 @@ json = ["sqlx-core/json", "serde_json"]
 
 [dependencies]
 dotenv = { version = "0.15.0", default-features = false }
-futures = { version = "0.3.4", default-features = false, features = ["executor"] }
 hex = { version = "0.4.2", optional = true }
 heck = "0.3.1"
 either = "1.5.3"


### PR DESCRIPTION
`futures-util` enables the `async-await-macro` feature by default, which imports `futures-macro`, `proc-macro-hack` and `proc-macro-nested`. Those features are unnecessary and slow to compile.