### PR TITLE
Fix issue #1431

### DIFF
--- a/sqlx-cli/src/bin/cargo-sqlx.rs
+++ b/sqlx-cli/src/bin/cargo-sqlx.rs
@@ -1,5 +1,6 @@
 use clap::{crate_version, AppSettings, FromArgMatches, IntoApp};
 use console::style;
+use dotenv::dotenv;
 use sqlx_cli::Opt;
 use std::{env, process};
 
@@ -9,6 +10,7 @@ async fn main() {
     // so we want to notch out that superfluous "sqlx"
     let args = env::args_os().skip(2);
 
+    dotenv().ok();
     let matches = Opt::into_app()
         .version(crate_version!())
         .bin_name("cargo sqlx")

--- a/sqlx-cli/src/bin/sqlx.rs
+++ b/sqlx-cli/src/bin/sqlx.rs
@@ -1,9 +1,11 @@
 use clap::{crate_version, FromArgMatches, IntoApp};
 use console::style;
+use dotenv::dotenv;
 use sqlx_cli::Opt;
 
 #[tokio::main]
 async fn main() {
+    dotenv().ok();
     let matches = Opt::into_app().version(crate_version!()).get_matches();
 
     // no special handling here

--- a/sqlx-cli/src/lib.rs
+++ b/sqlx-cli/src/lib.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use dotenv::dotenv;
 
 use crate::opt::{Command, DatabaseCommand, MigrateCommand};
 
@@ -13,8 +12,6 @@ mod prepare;
 pub use crate::opt::Opt;
 
 pub async fn run(opt: Opt) -> Result<()> {
-    dotenv().ok();
-
     match opt.command {
         Command::Migrate(migrate) => match migrate.command {
             MigrateCommand::Add {


### PR DESCRIPTION
This PR fixes the problem identified in #1431: currently, environmental variables set in `.env` are not detected in `sqlx database ...` commands.

This problem is a regression caused by commit 0e51272 which was part of issue #1391.

## Root Cause

`dotenv()` must execute before clap's `get_matches()`