### PR TITLE
Fix CIDR[] not being compatible with Vec<IpNetwork>

### DIFF
--- a/sqlx-core/src/postgres/types/ipnetwork.rs
+++ b/sqlx-core/src/postgres/types/ipnetwork.rs
@@ -38,6 +38,10 @@ impl Type<Postgres> for [IpNetwork] {
     fn type_info() -> PgTypeInfo {
         PgTypeInfo::INET_ARRAY
     }
+
+    fn compatible(ty: &PgTypeInfo) -> bool {
+        *ty == PgTypeInfo::CIDR_ARRAY || *ty == PgTypeInfo::INET_ARRAY
+    }
 }
 
 impl Type<Postgres> for Vec<IpNetwork> {


### PR DESCRIPTION
Fixes querying postgres columns of `CIDR[]` into a `Vec<IpNetwork>`. Inspired by the [bit_vec integration](https://github.com/launchbadge/sqlx/blob/b6e127561797fe9aababa24ec640275ecb9b42af/sqlx-core/src/postgres/types/bit_vec.rs#L28)