### PR TITLE
fix(mysql): handle multiple waiting results correctly

### DIFF
--- a/sqlx-core/src/mysql/connection/executor.rs
+++ b/sqlx-core/src/mysql/connection/executor.rs
@@ -4,7 +4,7 @@ use crate::error::Error;
 use crate::executor::{Execute, Executor};
 use crate::ext::ustr::UStr;
 use crate::logger::QueryLogger;
-use crate::mysql::connection::stream::Busy;
+use crate::mysql::connection::stream::Waiting;
 use crate::mysql::io::MySqlBufExt;
 use crate::mysql::protocol::response::Status;
 use crate::mysql::protocol::statement::{
@@ -93,7 +93,7 @@ impl MySqlConnection {
         let mut logger = QueryLogger::new(sql, self.log_settings.clone());
 
         self.stream.wait_until_ready().await?;
-        self.stream.busy = Busy::Result;
+        self.stream.waiting.push_back(Waiting::Result);
 
         Ok(Box::pin(try_stream! {
             // make a slot for the shared column data
@@ -146,12 +146,12 @@ impl MySqlConnection {
                         continue;
                     }
 
-                    self.stream.busy = Busy::NotBusy;
+                    self.stream.waiting.pop_front();
                     return Ok(());
                 }
 
                 // otherwise, this first packet is the start of the result-set metadata,
-                self.stream.busy = Busy::Row;
+                *self.stream.waiting.front_mut().unwrap() = Waiting::Row;
 
                 let num_columns = packet.get_uint_lenenc() as usize; // column count
 
@@ -179,11 +179,11 @@ impl MySqlConnection {
 
                         if eof.status.contains(Status::SERVER_MORE_RESULTS_EXISTS) {
                             // more result sets exist, continue to the next one
-                            self.stream.busy = Busy::Result;
+                            *self.stream.waiting.front_mut().unwrap() = Waiting::Result;
                             break;
                         }
 
-                        self.stream.busy = Busy::NotBusy;
+                        self.stream.waiting.pop_front();
                         return Ok(());
                     }
 

--- a/sqlx-core/src/mysql/connection/mod.rs
+++ b/sqlx-core/src/mysql/connection/mod.rs
@@ -16,7 +16,7 @@ mod executor;
 mod stream;
 mod tls;
 
-pub(crate) use stream::{Busy, MySqlStream};
+pub(crate) use stream::{MySqlStream, Waiting};
 
 const MAX_PACKET_SIZE: u32 = 1024;
 

--- a/sqlx-core/src/mysql/transaction.rs
+++ b/sqlx-core/src/mysql/transaction.rs
@@ -2,7 +2,7 @@ use futures_core::future::BoxFuture;
 
 use crate::error::Error;
 use crate::executor::Executor;
-use crate::mysql::connection::Busy;
+use crate::mysql::connection::Waiting;
 use crate::mysql::protocol::text::Query;
 use crate::mysql::{MySql, MySqlConnection};
 use crate::transaction::{
@@ -57,7 +57,7 @@ impl TransactionManager for MySqlTransactionManager {
         let depth = conn.transaction_depth;
 
         if depth > 0 {
-            conn.stream.busy = Busy::Result;
+            conn.stream.waiting.push_back(Waiting::Result);
             conn.stream.sequence_id = 0;
             conn.stream
                 .write_packet(Query(&*rollback_ansi_transaction_sql(depth)));


### PR DESCRIPTION
This PR changes the state of unread query results from single value to queue. It's similar to pending_ready_for_query_count in PgConnection.
This should fix the panic described in #1078 and #1358.

The reason of panic is MySqlStream cannot handle multiple pending queries. In #1358 situation, there's two unread results:

1. The result of `SELECT 1` isn't fully read because fetch_one() only reads until the first row
2. `ROLLBACK` is pushed to wbuf when transaction is dropped
3. wbuf is sent to MySQL in the next wait_until_ready() phase
4. Here, there's two unread results: `SELECT 1` and `ROLLBACK`. wait_until_ready() didn't handle this situation correctly.

So I changed `busy` state to a queue. In my environment, #1358 example runs without panic.