### PR TITLE
docs: added a note about MySQL syntax in the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ async fn main() -> Result<(), sqlx::Error> {
         .max_connections(5)
         .connect("postgres://postgres:password@localhost/test").await?;
 
-    // Make a simple query to return the given parameter
+    // Make a simple query to return the given parameter (use a question mark `?` instead of `$1` for MySQL)
     let row: (i64,) = sqlx::query_as("SELECT $1")
         .bind(150_i64)
         .fetch_one(&pool).await?;


### PR DESCRIPTION
I did manual checks for some of the other backends:

* PostgreSQL requires `$1`
* MySQL requires `?`
* SQLite is fine with either `$1` or `?`