### PR TITLE
Fix a panic in the worker thread when dropping the connection while `SqliteRow`s still exist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,12 +1031,6 @@ checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-
-[[package]]
-name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
@@ -1050,7 +1044,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
 dependencies = [
- "hashbrown 0.11.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1115,12 +1109,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg 1.0.1",
- "hashbrown 0.9.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2424,6 +2418,7 @@ dependencies = [
  "hashlink",
  "hex",
  "hmac",
+ "indexmap",
  "ipnetwork",
  "itoa",
  "libc",

--- a/sqlx-core/src/sqlite/connection/executor.rs
+++ b/sqlx-core/src/sqlite/connection/executor.rs
@@ -152,7 +152,7 @@ impl<'c> Executor<'c> for &'c mut SqliteConnection {
 
                         Either::Right(()) => {
                             let (row, weak_values_ref) = SqliteRow::current(
-                                &stmt,
+                                stmt.to_ref(conn.to_ref()),
                                 columns,
                                 column_names
                             );
@@ -216,8 +216,11 @@ impl<'c> Executor<'c> for &'c mut SqliteConnection {
                     Either::Left(_) => (),
 
                     Either::Right(()) => {
-                        let (row, weak_values_ref) =
-                            SqliteRow::current(stmt, columns, column_names);
+                        let (row, weak_values_ref) = SqliteRow::current(
+                            stmt.to_ref(self.handle.to_ref()),
+                            columns,
+                            column_names,
+                        );
 
                         *last_row_values = Some(weak_values_ref);
 

--- a/sqlx-core/src/sqlite/connection/handle.rs
+++ b/sqlx-core/src/sqlite/connection/handle.rs
@@ -15,6 +15,7 @@ pub(crate) struct ConnectionHandle(Arc<HandleInner>);
 /// or `sqlite3_reset()`.
 ///
 /// Note that this does *not* actually give access to the database handle!
+#[derive(Clone, Debug)]
 pub(crate) struct ConnectionHandleRef(Arc<HandleInner>);
 
 // Wrapper for `*mut sqlite3` which finalizes the handle on-drop.

--- a/sqlx-core/src/sqlite/connection/mod.rs
+++ b/sqlx-core/src/sqlite/connection/mod.rs
@@ -104,8 +104,7 @@ impl Connection for SqliteConnection {
 
 impl Drop for SqliteConnection {
     fn drop(&mut self) {
-        // before the connection handle is dropped,
-        // we must explicitly drop the statements as the drop-order in a struct is undefined
+        // explicitly drop statements before the connection handle is dropped
         self.statements.clear();
         self.statement.take();
     }

--- a/sqlx-core/src/sqlite/row.rs
+++ b/sqlx-core/src/sqlite/row.rs
@@ -11,7 +11,7 @@ use crate::column::ColumnIndex;
 use crate::error::Error;
 use crate::ext::ustr::UStr;
 use crate::row::Row;
-use crate::sqlite::statement::StatementHandle;
+use crate::sqlite::statement::{StatementHandle, StatementHandleRef};
 use crate::sqlite::{Sqlite, SqliteColumn, SqliteValue, SqliteValueRef};
 
 /// Implementation of [`Row`] for SQLite.
@@ -23,7 +23,7 @@ pub struct SqliteRow {
     // IF the user drops the Row before iterating the stream (so
     // nearly all of our internal stream iterators), the executor moves on; otherwise,
     // it actually inflates this row with a list of owned sqlite3 values.
-    pub(crate) statement: Arc<StatementHandle>,
+    pub(crate) statement: StatementHandleRef,
 
     pub(crate) values: Arc<AtomicPtr<SqliteValue>>,
     pub(crate) num_values: usize,
@@ -48,7 +48,7 @@ impl SqliteRow {
     // returns a weak reference to an atomic list where the executor should inflate if its going
     // to increment the statement with [step]
     pub(crate) fn current(
-        statement: &Arc<StatementHandle>,
+        statement: StatementHandleRef,
         columns: &Arc<Vec<SqliteColumn>>,
         column_names: &Arc<HashMap<UStr, usize>>,
     ) -> (Self, Weak<AtomicPtr<SqliteValue>>) {
@@ -57,7 +57,7 @@ impl SqliteRow {
         let size = statement.column_count();
 
         let row = Self {
-            statement: Arc::clone(statement),
+            statement,
             values,
             num_values: size,
             columns: Arc::clone(columns),

--- a/sqlx-core/src/sqlite/statement/mod.rs
+++ b/sqlx-core/src/sqlite/statement/mod.rs
@@ -12,7 +12,7 @@ mod handle;
 mod r#virtual;
 mod worker;
 
-pub(crate) use handle::StatementHandle;
+pub(crate) use handle::{StatementHandle, StatementHandleRef};
 pub(crate) use r#virtual::VirtualStatement;
 pub(crate) use worker::StatementWorker;
 


### PR DESCRIPTION
Was able to cut the example given in #1419 down to a nice minimal repro.

Closes #1419