### PR TITLE
Shut down statement worker in Sqlite Connection::close

### DIFF
--- a/sqlx-core/src/sqlite/connection/mod.rs
+++ b/sqlx-core/src/sqlite/connection/mod.rs
@@ -62,9 +62,12 @@ impl Connection for SqliteConnection {
 
     type Options = SqliteConnectOptions;
 
-    fn close(self) -> BoxFuture<'static, Result<(), Error>> {
-        // nothing explicit to do; connection will close in drop
-        Box::pin(future::ok(()))
+    fn close(mut self) -> BoxFuture<'static, Result<(), Error>> {
+        Box::pin(async move {
+            self.statements.clear();
+            self.statement.take();
+            self.worker.shutdown().await
+        })
     }
 
     fn ping(&mut self) -> BoxFuture<'_, Result<(), Error>> {

--- a/sqlx-core/src/sqlite/statement/worker.rs
+++ b/sqlx-core/src/sqlite/statement/worker.rs
@@ -76,14 +76,17 @@ impl StatementWorker {
                         }
                     }
                     StatementWorkerCommand::Shutdown { tx } => {
-                        // SAFETY: we need to make sure a strong ref to `conn` always
-                        // outlives anything in `rx`
+                        // drop the connection reference before sending confirmation
+                        // and ending the command loop
                         drop(conn);
                         let _ = tx.send(());
-                        break;
+                        return;
                     }
                 }
             }
+
+            // SAFETY: we need to make sure a strong ref to `conn` always outlives anything in `rx`
+            drop(conn);
         });
 
         Self { tx }

--- a/tests/sqlite/sqlite.rs
+++ b/tests/sqlite/sqlite.rs
@@ -206,7 +206,8 @@ async fn it_executes_with_pool() -> anyhow::Result<()> {
 async fn it_opens_in_memory() -> anyhow::Result<()> {
     // If the filename is ":memory:", then a private, temporary in-memory database
     // is created for the connection.
-    let _ = SqliteConnection::connect(":memory:").await?;
+    let conn = SqliteConnection::connect(":memory:").await?;
+    conn.close().await?;
 
     Ok(())
 }
@@ -215,7 +216,8 @@ async fn it_opens_in_memory() -> anyhow::Result<()> {
 async fn it_opens_temp_on_disk() -> anyhow::Result<()> {
     // If the filename is an empty string, then a private, temporary on-disk database will
     // be created.
-    let _ = SqliteConnection::connect("").await?;
+    let conn = SqliteConnection::connect("").await?;
+    conn.close().await?;
 
     Ok(())
 }


### PR DESCRIPTION
In my testing at least, this fixes #1452

I would prefer for the `StatementWorker::shutdown` method to take `mut self`, but that would require additional changes.