### PR TITLE
[SQLite] encoding & decoding `NaiveTime` with correct format

### DIFF
--- a/sqlx-core/src/sqlite/types/chrono.rs
+++ b/sqlx-core/src/sqlite/types/chrono.rs
@@ -181,6 +181,7 @@ impl<'r> Decode<'r, Sqlite> for NaiveTime {
         // https://github.com/diesel-rs/diesel/blob/93ab183bcb06c69c0aee4a7557b6798fd52dd0d8/diesel/src/sqlite/types/date_and_time/chrono.rs#L29-L47
         let sqlite_time_formats = &[
             // Most likely format
+            #[rustfmt::skip]
             "%T.f", "%T%.f",
             // Other formats in order of appearance in docs
             "%R", "%RZ", "%T%.fZ", "%R%:z", "%T%.f%:z",

--- a/sqlx-core/src/sqlite/types/chrono.rs
+++ b/sqlx-core/src/sqlite/types/chrono.rs
@@ -181,7 +181,8 @@ impl<'r> Decode<'r, Sqlite> for NaiveTime {
         // https://github.com/diesel-rs/diesel/blob/93ab183bcb06c69c0aee4a7557b6798fd52dd0d8/diesel/src/sqlite/types/date_and_time/chrono.rs#L29-L47
         let sqlite_time_formats = &[
             // Most likely format
-            "%T.f", // Other formats in order of appearance in docs
+            "%T.f", "%T%.f",
+            // Other formats in order of appearance in docs
             "%R", "%RZ", "%T%.fZ", "%R%:z", "%T%.f%:z",
         ];
 

--- a/sqlx-core/src/sqlite/types/chrono.rs
+++ b/sqlx-core/src/sqlite/types/chrono.rs
@@ -76,7 +76,7 @@ impl Encode<'_, Sqlite> for NaiveDate {
 
 impl Encode<'_, Sqlite> for NaiveTime {
     fn encode_by_ref(&self, buf: &mut Vec<SqliteArgumentValue<'_>>) -> IsNull {
-        Encode::<Sqlite>::encode(self.format("%T%.f%").to_string(), buf)
+        Encode::<Sqlite>::encode(self.format("%T%.f").to_string(), buf)
     }
 }
 

--- a/sqlx-core/src/sqlite/types/chrono.rs
+++ b/sqlx-core/src/sqlite/types/chrono.rs
@@ -179,9 +179,9 @@ impl<'r> Decode<'r, Sqlite> for NaiveTime {
 
         // Loop over common time patterns, inspired by Diesel
         // https://github.com/diesel-rs/diesel/blob/93ab183bcb06c69c0aee4a7557b6798fd52dd0d8/diesel/src/sqlite/types/date_and_time/chrono.rs#L29-L47
+        #[rustfmt::skip] // don't like how rustfmt mangles the comments
         let sqlite_time_formats = &[
             // Most likely format
-            #[rustfmt::skip]
             "%T.f", "%T%.f",
             // Other formats in order of appearance in docs
             "%R", "%RZ", "%T%.fZ", "%R%:z", "%T%.f%:z",


### PR DESCRIPTION
Hi, I encountered this problem while using `sqlx ^0.5`.

> hread 'main' panicked at 'a Display implementation returned an error unexpectedly: Error', /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/alloc/src/string.rs:2380:14

https://github.com/SeaQL/sea-orm/pull/207/checks?check_run_id=3728117667#step:5:212

After digging into the source code...
- I think there is a typo, `%T%.f%` should be `%T%.f`
    https://github.com/launchbadge/sqlx/blob/6e1c7a999a514be2df809f36f26bd5758b96c448/sqlx-core/src/sqlite/types/chrono.rs#L77-L81
- And, considering `NaiveTime` is encoded into a string with format `%T%.f`. Decoding it from string should also parse from the same format, i.e. `%T%.f`. However, it's not.
    https://github.com/launchbadge/sqlx/blob/6e1c7a999a514be2df809f36f26bd5758b96c448/sqlx-core/src/sqlite/types/chrono.rs#L176-L196