### PR TITLE
Revert "feat: allow log level customization (#1371)"

### DIFF
--- a/sqlx-core/src/connection.rs
+++ b/sqlx-core/src/connection.rs
@@ -2,7 +2,7 @@ use crate::database::{Database, HasStatementCache};
 use crate::error::Error;
 use crate::transaction::Transaction;
 use futures_core::future::BoxFuture;
-pub use log::LevelFilter;
+use log::LevelFilter;
 use std::fmt::Debug;
 use std::str::FromStr;
 use std::time::Duration;
@@ -126,16 +126,16 @@ pub trait Connection: Send {
 }
 
 #[derive(Clone, Debug)]
-pub struct LogSettings {
-    pub statements_level: LevelFilter,
-    pub slow_statements_level: LevelFilter,
-    pub slow_statements_duration: Duration,
+pub(crate) struct LogSettings {
+    pub(crate) statements_level: LevelFilter,
+    pub(crate) slow_statements_level: LevelFilter,
+    pub(crate) slow_statements_duration: Duration,
 }
 
 impl Default for LogSettings {
     fn default() -> Self {
         LogSettings {
-            statements_level: LevelFilter::Debug,
+            statements_level: LevelFilter::Info,
             slow_statements_level: LevelFilter::Warn,
             slow_statements_duration: Duration::from_secs(1),
         }
@@ -143,10 +143,10 @@ impl Default for LogSettings {
 }
 
 impl LogSettings {
-    pub fn log_statements(&mut self, level: LevelFilter) {
+    pub(crate) fn log_statements(&mut self, level: LevelFilter) {
         self.statements_level = level;
     }
-    pub fn log_slow_statements(&mut self, level: LevelFilter, duration: Duration) {
+    pub(crate) fn log_slow_statements(&mut self, level: LevelFilter, duration: Duration) {
         self.slow_statements_level = level;
         self.slow_statements_duration = duration;
     }

--- a/sqlx-core/src/mysql/options/mod.rs
+++ b/sqlx-core/src/mysql/options/mod.rs
@@ -212,21 +212,4 @@ impl MySqlConnectOptions {
         self.collation = Some(collation.to_owned());
         self
     }
-
-    /// Sets the log settings.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use sqlx_core::mysql::MySqlConnectOptions;
-    /// let options = MySqlConnectOptions::new()
-    ///     .log_settings(sqlx_core::connection::LogSettings {
-    ///     statements_level: sqlx_core::connection::LevelFilter::Info,
-    ///     ..Default::default()
-    /// });
-    /// ```
-    pub fn log_settings(mut self, log_settings: LogSettings) -> Self {
-        self.log_settings = log_settings;
-        self
-    }
 }

--- a/sqlx-core/src/postgres/options/mod.rs
+++ b/sqlx-core/src/postgres/options/mod.rs
@@ -319,23 +319,6 @@ impl PgConnectOptions {
         self
     }
 
-    /// Sets the log settings.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use sqlx_core::postgres::PgConnectOptions;
-    /// let options = PgConnectOptions::new()
-    ///     .log_settings(sqlx_core::connection::LogSettings {
-    ///     statements_level: sqlx_core::connection::LevelFilter::Info,
-    ///     ..Default::default()
-    /// });
-    /// ```
-    pub fn log_settings(mut self, log_settings: LogSettings) -> Self {
-        self.log_settings = log_settings;
-        self
-    }
-
     /// We try using a socket if hostname starts with `/` or if socket parameter
     /// is specified.
     pub(crate) fn fetch_socket(&self) -> Option<String> {

--- a/sqlx-core/src/sqlite/options/mod.rs
+++ b/sqlx-core/src/sqlite/options/mod.rs
@@ -234,21 +234,4 @@ impl SqliteConnectOptions {
         self.immutable = immutable;
         self
     }
-
-    /// Sets the log settings.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use sqlx_core::sqlite::SqliteConnectOptions;
-    /// let options = SqliteConnectOptions::new()
-    ///     .log_settings(sqlx_core::connection::LogSettings {
-    ///     statements_level: sqlx_core::connection::LevelFilter::Info,
-    ///     ..Default::default()
-    /// });
-    /// ```
-    pub fn log_settings(mut self, log_settings: LogSettings) -> Self {
-        self.log_settings = log_settings;
-        self
-    }
 }


### PR DESCRIPTION
This reverts commit 719d80038b2f685ab52ce15bb15e953f1f162b42.

@EliseZeroTwo we already support setting these options if you import the `ConnectOptions` trait: https://docs.rs/sqlx/0.5.7/sqlx/trait.ConnectOptions.html

I should have taken a closer look at your PR, sorry. It ended up being redundant.