### PR TITLE
Add reverting instructions to README

### DIFF
--- a/sqlx-cli/README.md
+++ b/sqlx-cli/README.md
@@ -49,6 +49,40 @@ $ sqlx migrate run
 Compares the migration history of the running database against the `migrations/` folder and runs
 any scripts that are still pending.
 
+#### Reverting Migrations
+
+If you would like to create _reversible_ migrations with corresponding "up" and "down" scripts, you use the `-r` flag when creating new migrations:
+
+```bash
+$ sqlx migrate add -r <name>
+Creating migrations/20211001154420_<name>.up.sql
+Creating migrations/20211001154420_<name>.down.sql
+```
+
+After that, you can run these as above:
+
+```bash
+$ sqlx migrate run
+Applied migrations/20211001154420 <name> (32.517835ms)
+```
+
+And reverts work as well:
+
+```bash
+$ sqlx migrate revert
+Applied 20211001154420/revert <name>
+```
+
+**Note**: attempting to mix "simple" migrations with reversible migrations with result in an error.
+
+```bash
+$ sqlx migrate add <name1>
+Creating migrations/20211001154420_<name>.sql
+
+$ sqlx migrate add -r <name2>
+error: cannot mix reversible migrations with simple migrations. All migrations should be reversible or simple migrations
+```
+
 #### Enable building in "offline mode" with `query!()`
 
 Note: must be run as `cargo sqlx`.


### PR DESCRIPTION
Hello! Thanks for working on SQLX: it's been a great library to include in our own projects. 

Today, while I was adding migrations to a new project for the first time (previously we were using another solution), I found that it took some digging to understand how to _revert_ migrations. I thought that I might try to save other people from having to investigate this themselves by adding a note to the README on reverting migrations. No worries about rejecting this if this doesn't fit with your plans for the project: I just thought it might be helpful for others.