### PR TITLE
fix panic when converting negative chrono::Duration into PgInterval

### DIFF
--- a/sqlx-core/src/postgres/types/interval.rs
+++ b/sqlx-core/src/postgres/types/interval.rs
@@ -148,7 +148,7 @@ impl TryFrom<chrono::Duration> for PgInterval {
     /// Convert a `chrono::Duration` to a `PgInterval`.
     ///
     /// This returns an error if there is a loss of precision using nanoseconds or if there is a
-    /// microsecond or nanosecond overflow.
+    /// nanosecond overflow.
     fn try_from(value: chrono::Duration) -> Result<Self, BoxDynError> {
         value
             .num_nanoseconds()
@@ -352,10 +352,6 @@ fn test_pginterval_chrono() {
     // Case when precision loss occurs
     assert!(PgInterval::try_from(chrono::Duration::nanoseconds(27_000_001)).is_err());
     assert!(PgInterval::try_from(chrono::Duration::nanoseconds(-27_000_001)).is_err());
-
-    // Case when microsecond overflow occurs
-    assert!(PgInterval::try_from(chrono::Duration::seconds(10_000_000_000_000)).is_err());
-    assert!(PgInterval::try_from(chrono::Duration::seconds(-10_000_000_000_000)).is_err());
 
     // Case when nanosecond overflow occurs
     assert!(PgInterval::try_from(chrono::Duration::seconds(10_000_000_000)).is_err());

--- a/sqlx-core/src/postgres/types/interval.rs
+++ b/sqlx-core/src/postgres/types/interval.rs
@@ -306,6 +306,7 @@ fn test_encode_interval() {
 
 #[test]
 fn test_pginterval_std() {
+    // Case for positive duration
     let interval = PgInterval {
         days: 0,
         months: 0,
@@ -315,11 +316,18 @@ fn test_pginterval_std() {
         &PgInterval::try_from(std::time::Duration::from_micros(27_000)).unwrap(),
         &interval
     );
+
+    // Case when precision loss occurs
+    assert!(PgInterval::try_from(std::time::Duration::from_nanos(27_000_001)).is_err());
+
+    // Case when microsecond overflow occurs
+    assert!(PgInterval::try_from(std::time::Duration::from_secs(20_000_000_000_000)).is_err());
 }
 
 #[test]
 #[cfg(feature = "chrono")]
 fn test_pginterval_chrono() {
+    // Case for positive duration
     let interval = PgInterval {
         days: 0,
         months: 0,
@@ -329,11 +337,35 @@ fn test_pginterval_chrono() {
         &PgInterval::try_from(chrono::Duration::microseconds(27_000)).unwrap(),
         &interval
     );
+
+    // Case for negative duration
+    let interval = PgInterval {
+        days: 0,
+        months: 0,
+        microseconds: -27_000,
+    };
+    assert_eq!(
+        &PgInterval::try_from(chrono::Duration::microseconds(-27_000)).unwrap(),
+        &interval
+    );
+
+    // Case when precision loss occurs
+    assert!(PgInterval::try_from(chrono::Duration::nanoseconds(27_000_001)).is_err());
+    assert!(PgInterval::try_from(chrono::Duration::nanoseconds(-27_000_001)).is_err());
+
+    // Case when microsecond overflow occurs
+    assert!(PgInterval::try_from(chrono::Duration::seconds(10_000_000_000_000)).is_err());
+    assert!(PgInterval::try_from(chrono::Duration::seconds(-10_000_000_000_000)).is_err());
+
+    // Case when nanosecond overflow occurs
+    assert!(PgInterval::try_from(chrono::Duration::seconds(10_000_000_000)).is_err());
+    assert!(PgInterval::try_from(chrono::Duration::seconds(-10_000_000_000)).is_err());
 }
 
 #[test]
 #[cfg(feature = "time")]
 fn test_pginterval_time() {
+    // Case for positive duration
     let interval = PgInterval {
         days: 0,
         months: 0,
@@ -343,4 +375,23 @@ fn test_pginterval_time() {
         &PgInterval::try_from(time::Duration::microseconds(27_000)).unwrap(),
         &interval
     );
+
+    // Case for negative duration
+    let interval = PgInterval {
+        days: 0,
+        months: 0,
+        microseconds: -27_000,
+    };
+    assert_eq!(
+        &PgInterval::try_from(time::Duration::microseconds(-27_000)).unwrap(),
+        &interval
+    );
+
+    // Case when precision loss occurs
+    assert!(PgInterval::try_from(time::Duration::nanoseconds(27_000_001)).is_err());
+    assert!(PgInterval::try_from(time::Duration::nanoseconds(-27_000_001)).is_err());
+
+    // Case when microsecond overflow occurs
+    assert!(PgInterval::try_from(time::Duration::seconds(10_000_000_000_000)).is_err());
+    assert!(PgInterval::try_from(time::Duration::seconds(-10_000_000_000_000)).is_err());
 }


### PR DESCRIPTION
## What I did

* resolves https://github.com/launchbadge/sqlx/issues/736
* adds related unit tests

## Remarks

How I dealt with corner cases follows existing comments (for [std::time](https://github.com/launchbadge/sqlx/blob/65222a62aaf7485a06c33c8ec71fe51b73a45a6a/sqlx-core/src/postgres/types/interval.rs#L103-L104), [chrono](https://github.com/launchbadge/sqlx/blob/65222a62aaf7485a06c33c8ec71fe51b73a45a6a/sqlx-core/src/postgres/types/interval.rs#L150-L151), [time](https://github.com/launchbadge/sqlx/blob/65222a62aaf7485a06c33c8ec71fe51b73a45a6a/sqlx-core/src/postgres/types/interval.rs#L189-L190)).

*I'm a newcomer to this repo. If I had anything inappropriate, it would be great if you point it out.*