### PR TITLE
Add support for named query inside query_file! macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2535,6 +2535,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
+ "regex",
  "serde",
  "serde_json",
  "sha2",

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -79,16 +79,17 @@ json = ["sqlx-core/json", "serde_json"]
 
 [dependencies]
 dotenv = { version = "0.15.0", default-features = false }
-hex = { version = "0.4.2", optional = true }
-heck = "0.3.1"
 either = "1.5.3"
+heck = "0.3.1"
+hex = { version = "0.4.2", optional = true }
 once_cell = "1.5.2"
 proc-macro2 = { version = "1.0.9", default-features = false }
-sqlx-core = { version = "0.5.9", default-features = false, path = "../sqlx-core" }
-sqlx-rt = { version = "0.5.9", default-features = false, path = "../sqlx-rt" }
+quote = { version = "1.0.6", default-features = false }
+regex = "1.5.4"
 serde = { version = "1.0.111", features = ["derive"], optional = true }
 serde_json = { version = "1.0.30", features = ["preserve_order"], optional = true }
 sha2 = { version = "0.9.1", optional = true }
+sqlx-core = { version = "0.5.9", default-features = false, path = "../sqlx-core" }
+sqlx-rt = { version = "0.5.9", default-features = false, path = "../sqlx-rt" }
 syn = { version = "1.0.30", default-features = false, features = ["full"] }
-quote = { version = "1.0.6", default-features = false }
 url = { version = "2.1.1", default-features = false }


### PR DESCRIPTION
### Summary

This adds support for named queries inside a single query file identified by a comment.

### Motivation

We are considering moving a large amount of queries out of Rust code into an external sql file, which improves rust and sql code readibility to a great extent. However, putting each query inside their own file is a maintanance burden and doesn't scale well. We can workaround that issue by grouping named queries inside a single file. This has an additional benefit where sql code formatting can be run/automated more easily, which again improves sql code readablilty.   

### Example 

```sql
--- name: get_all_users

SELECT * FROM "user";

--- name: hello

SELECT name FROM "table";

```

```rust
sqlx::named_query_from_file_as!(get_all_users, "query.sql")
```

### Notes

Unfortunately, the name for `named_query_from_file_as` is quite long, but I am open to other suggestions :)
