### PR TITLE
Remove "runtime-async-std-native-tls (on by default)"-hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ sqlx = { version = "0.5", features = [ "runtime-async-std-native-tls" ] }
 
 #### Cargo Feature Flags
 
--   `runtime-async-std-native-tls` (on by default): Use the `async-std` runtime and `native-tls` TLS backend.
+-   `runtime-async-std-native-tls`: Use the `async-std` runtime and `native-tls` TLS backend.
 
 -   `runtime-async-std-rustls`: Use the `async-std` runtime and `rustls` TLS backend.
 


### PR DESCRIPTION
It seems, the 'runtime-async-std-native-tls' feature isn't active by default (as mentioned in the README), so this PR removes the hint. Currently, users that don't use `async-std` might think they have to disable the default features to not pull-in `async-std` needlessly. But that doesn't seem to be required, because 'runtime-async-std-native-tls' isn't active by default.