### PR TITLE
Add example for manual implemenation of the FromRow trait

### DIFF
--- a/sqlx-core/src/from_row.rs
+++ b/sqlx-core/src/from_row.rs
@@ -122,6 +122,33 @@ use crate::row::Row;
 /// ```
 ///
 /// This field is compatible with the `default` attribute.
+///
+/// ## Manual implementation
+///
+/// You can also implement the [`FromRow`] trait by hand. This can be useful, if you
+/// have a struct with a field that needs manuel decoding:
+///
+///
+/// ```rust,ignore
+/// use sqlx::{FromRow, Result, sqlite::SqliteRow, sqlx::Row};
+/// struct MyCustomType {
+///     custom: String,
+/// }
+///
+/// struct Foo {
+///     bar: MyCustomType,
+/// }
+///
+/// impl FromRow<'_, SqliteRow> for Foo {
+///     fn from_row(row: &SqliteRow) -> Result<Self> {
+///         Ok(Self {
+///             bar: MyCustomType {
+///                 custom: row.try_get("custom")?
+///             }
+///         })
+///     }
+/// }
+/// ```
 pub trait FromRow<'r, R: Row>: Sized {
     fn from_row(row: &'r R) -> Result<Self, Error>;
 }

--- a/sqlx-core/src/from_row.rs
+++ b/sqlx-core/src/from_row.rs
@@ -130,7 +130,7 @@ use crate::row::Row;
 ///
 ///
 /// ```rust,ignore
-/// use sqlx::{FromRow, Result, sqlite::SqliteRow, sqlx::Row};
+/// use sqlx::{FromRow, sqlite::SqliteRow, sqlx::Row};
 /// struct MyCustomType {
 ///     custom: String,
 /// }
@@ -140,7 +140,7 @@ use crate::row::Row;
 /// }
 ///
 /// impl FromRow<'_, SqliteRow> for Foo {
-///     fn from_row(row: &SqliteRow) -> Result<Self> {
+///     fn from_row(row: &SqliteRow) -> sqlx::Result<Self> {
 ///         Ok(Self {
 ///             bar: MyCustomType {
 ///                 custom: row.try_get("custom")?

--- a/sqlx-core/src/from_row.rs
+++ b/sqlx-core/src/from_row.rs
@@ -125,7 +125,7 @@ use crate::row::Row;
 ///
 /// ## Manual implementation
 ///
-/// You can also implement the [`FromRow`] trait by hand. This can be useful, if you
+/// You can also implement the [`FromRow`] trait by hand. This can be useful if you
 /// have a struct with a field that needs manuel decoding:
 ///
 ///


### PR DESCRIPTION
After a [discussion](https://discord.com/channels/665528275556106240/665528275556106243/898651938642591836) on the discord server, i decided to add an example for a manual implemenation of the FromRow trait. A manual implementation is useful if you can't use the derive macro (e.g. because of a external type from another crate)