### PR TITLE
Add Arc implementation hint to docs of Pool

### DIFF
--- a/sqlx-core/src/pool/mod.rs
+++ b/sqlx-core/src/pool/mod.rs
@@ -97,9 +97,10 @@ pub use self::options::PoolOptions;
 ///
 /// Calls to `acquire()` are fair, i.e. fulfilled on a first-come, first-serve basis.
 ///
-/// `Pool` is `Send`, `Sync` and `Clone` (internally backed by `Arc`), so it should be created once at the start of your
-/// application/daemon/web server/etc. and then shared with all tasks throughout its lifetime. How
-/// best to accomplish this depends on your program architecture.
+/// `Pool` is `Send`, `Sync` and `Clone`, and can be cloned cheaply (similar to a structure
+/// backed by Arc), so it should be created once at the start of your application/daemon/web server/
+/// etc. and then shared with all tasks throughout its lifetime, either by cloning or by
+/// reference. How best to accomplish this depends on your program architecture.
 ///
 /// In Actix-Web, you can share a single pool with all request handlers using [web::Data].
 ///

--- a/sqlx-core/src/pool/mod.rs
+++ b/sqlx-core/src/pool/mod.rs
@@ -97,7 +97,7 @@ pub use self::options::PoolOptions;
 ///
 /// Calls to `acquire()` are fair, i.e. fulfilled on a first-come, first-serve basis.
 ///
-/// `Pool` is `Send`, `Sync` and `Clone`, so it should be created once at the start of your
+/// `Pool` is `Send`, `Sync` and `Clone` (internally backed by `Arc`), so it should be created once at the start of your
 /// application/daemon/web server/etc. and then shared with all tasks throughout its lifetime. How
 /// best to accomplish this depends on your program architecture.
 ///


### PR DESCRIPTION
I wasn't 100% sure what happens when I clone a `Pool` (I missed the docs of the `Clone` implementation / didn't look at it, because most of the time, it contains only the default text, I believe).

After some quick googling, I found [this](https://github.com/launchbadge/sqlx/discussions/917) thread, however.

I think, a small hint, as proposed in this PR, would make a bit more clear what's going on (to people like me, who are not 100% sure).

English isn't my native language, so please feel free to change this hint as you see fit.

