### PR TITLE
Reduce indexmap version requirement to 1.6.2

### DIFF
--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -163,4 +163,4 @@ stringprep = "0.1.2"
 bstr = { version = "0.2.14", default-features = false, features = ["std"], optional = true }
 git2 = { version = "0.13.20", default-features = false, optional = true }
 hashlink = "0.7.0"
-indexmap = "1.7.0"
+indexmap = "1.6.2"


### PR DESCRIPTION
Ok, this is a very niche problem, but important in my particular case, and I think the change shouldn't have any impact to anyone else. I'm just submitting a PR with no prior discussion since it's just a one-line change, but I'm happy to discuss further if you have concerns.

### Problem

My project depends on both `deno_core` and `sqlx`, and [Deno requires `=1.6.2` of `indexmap`](https://github.com/denoland/deno/blob/004d07dccd69c9fae8370665632d90401f770938/core/Cargo.toml#L18) to work around some circular dependency problem in dependencies.

With the recent addition of `indexmap = "1.7.0"` to sqlx, I can no longer include both crates at the same time since Cargo refuses to resolve two different versions of a crate if those versions are semver-major-compatible. 

I initially intended to just stay on 0.5.7 for a while, but I also just started using a `PgListener` in my project, so the recent panic fix (https://github.com/launchbadge/sqlx/commit/135d16a34f2a05b075a7939d129d9076f4356c06) is important to me as well.

### Solution

This PR reduces the required version of `indexmap` to `1.6.2` so that Cargo will allow both `deno_core` and `sqlx` to coexist.  The changes between 1.6.2 and 1.7.0 are minor, and anyone without my unusual version requirements should get the latest `1.x` version anyway, so this shouldn't actually affect anyone else. Any thoughts?
