### PR TITLE
Add support for serialized threading mode to sqlite

### DIFF
--- a/sqlx-core/src/sqlite/connection/establish.rs
+++ b/sqlx-core/src/sqlite/connection/establish.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 use libsqlite3_sys::{
     sqlite3_busy_timeout, sqlite3_extended_result_codes, sqlite3_open_v2, SQLITE_OK,
-    SQLITE_OPEN_CREATE, SQLITE_OPEN_MEMORY, SQLITE_OPEN_NOMUTEX, SQLITE_OPEN_PRIVATECACHE,
-    SQLITE_OPEN_READONLY, SQLITE_OPEN_READWRITE, SQLITE_OPEN_SHAREDCACHE,
+    SQLITE_OPEN_CREATE, SQLITE_OPEN_FULLMUTEX, SQLITE_OPEN_MEMORY, SQLITE_OPEN_NOMUTEX,
+    SQLITE_OPEN_PRIVATECACHE, SQLITE_OPEN_READONLY, SQLITE_OPEN_READWRITE, SQLITE_OPEN_SHAREDCACHE,
 };
 use sqlx_rt::blocking;
 use std::io;
@@ -33,7 +33,11 @@ pub(crate) async fn establish(options: &SqliteConnectOptions) -> Result<SqliteCo
     // [SQLITE_OPEN_NOMUTEX] will instruct [sqlite3_open_v2] to return an error if it
     // cannot satisfy our wish for a thread-safe, lock-free connection object
 
-    let mut flags = SQLITE_OPEN_NOMUTEX;
+    let mut flags = if options.serialized {
+        SQLITE_OPEN_FULLMUTEX
+    } else {
+        SQLITE_OPEN_NOMUTEX
+    };
 
     flags |= if options.read_only {
         SQLITE_OPEN_READONLY

--- a/sqlx-core/src/sqlite/options/mod.rs
+++ b/sqlx-core/src/sqlite/options/mod.rs
@@ -239,7 +239,7 @@ impl SqliteConnectOptions {
 
     /// Sets the [threading mode](https://www.sqlite.org/threadsafe.html) for the database connection.
     ///
-    /// The default setting if `false`, corersponding to using `OPEN_NOMUTEX`, if `true` then `OPEN_FULLMUTEX`.
+    /// The default setting is `false` corersponding to using `OPEN_NOMUTEX`, if `true` then `OPEN_FULLMUTEX`.
     ///
     /// See [open](https://www.sqlite.org/c3ref/open.html) for more details.
     pub fn serialized(mut self, serialized: bool) -> Self {

--- a/sqlx-core/src/sqlite/options/mod.rs
+++ b/sqlx-core/src/sqlite/options/mod.rs
@@ -61,6 +61,7 @@ pub struct SqliteConnectOptions {
     pub(crate) log_settings: LogSettings,
     pub(crate) immutable: bool,
     pub(crate) pragmas: IndexMap<Cow<'static, str>, Cow<'static, str>>,
+    pub(crate) serialized: bool,
 }
 
 impl Default for SqliteConnectOptions {
@@ -109,6 +110,7 @@ impl SqliteConnectOptions {
             log_settings: Default::default(),
             immutable: false,
             pragmas,
+            serialized: false,
         }
     }
 
@@ -233,5 +235,15 @@ impl SqliteConnectOptions {
     pub fn immutable(mut self, immutable: bool) -> Self {
         self.immutable = immutable;
         self
+    }
+
+    /// Sets the [threading mode](https://www.sqlite.org/threadsafe.html) for the database connection.
+    ///
+    /// The default setting if `false`, corersponding to using `OPEN_NOMUTEX`, if `true` then `OPEN_FULLMUTEX`.
+    ///
+    /// See [open](https://www.sqlite.org/c3ref/open.html) for more details.
+    pub fn serialized(mut self, serialized: bool) -> Self {
+        self.serialized = serialized;
+        serialized
     }
 }

--- a/sqlx-core/src/sqlite/options/mod.rs
+++ b/sqlx-core/src/sqlite/options/mod.rs
@@ -244,6 +244,6 @@ impl SqliteConnectOptions {
     /// See [open](https://www.sqlite.org/c3ref/open.html) for more details.
     pub fn serialized(mut self, serialized: bool) -> Self {
         self.serialized = serialized;
-        serialized
+        self
     }
 }


### PR DESCRIPTION
Currently, sqlx starts up in multi-threaded threading mode by default for sqlite, and attempts to maintain the invariants required for this (not using the same connection on multiple threads). We have encountered a situation where this was causing errors (on iOS, specifically, we are still unsure why only this platform seems effected), and verified this was resolved by switching to the serialized threading mode. This change weakens invariants at the cost of performance, and is something that could be configurable through the connection options (with the default still being to use multi threaded mode rather than serialized).

From what we can tell, diesel will use the default connection mode (serialized), thus this error started presenting itself when we migrated from diesel to sqlx.