### PR TITLE
fix(postgres): allow rust_decimal::Decimal in PgRange

### DIFF
--- a/sqlx-core/src/postgres/types/range.rs
+++ b/sqlx-core/src/postgres/types/range.rs
@@ -142,6 +142,17 @@ impl Type<Postgres> for PgRange<bigdecimal::BigDecimal> {
     }
 }
 
+#[cfg(feature = "decimal")]
+impl Type<Postgres> for PgRange<rust_decimal::Decimal> {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::NUM_RANGE
+    }
+
+    fn compatible(ty: &PgTypeInfo) -> bool {
+        range_compatible::<rust_decimal::Decimal>(ty)
+    }
+}
+
 #[cfg(feature = "chrono")]
 impl Type<Postgres> for PgRange<chrono::NaiveDate> {
     fn type_info() -> PgTypeInfo {
@@ -227,6 +238,13 @@ impl Type<Postgres> for [PgRange<bigdecimal::BigDecimal>] {
     }
 }
 
+#[cfg(feature = "decimal")]
+impl Type<Postgres> for [PgRange<rust_decimal::Decimal>] {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::NUM_RANGE_ARRAY
+    }
+}
+
 #[cfg(feature = "chrono")]
 impl Type<Postgres> for [PgRange<chrono::NaiveDate>] {
     fn type_info() -> PgTypeInfo {
@@ -283,6 +301,13 @@ impl Type<Postgres> for Vec<PgRange<i64>> {
 
 #[cfg(feature = "bigdecimal")]
 impl Type<Postgres> for Vec<PgRange<bigdecimal::BigDecimal>> {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::NUM_RANGE_ARRAY
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl Type<Postgres> for Vec<PgRange<rust_decimal::Decimal>> {
     fn type_info() -> PgTypeInfo {
         PgTypeInfo::NUM_RANGE_ARRAY
     }

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -425,6 +425,13 @@ test_type!(bigdecimal<sqlx::types::BigDecimal>(Postgres,
     "12345.6789::numeric" == "12345.6789".parse::<sqlx::types::BigDecimal>().unwrap(),
 ));
 
+#[cfg(feature = "bigdecimal")]
+test_type!(numrange_bigdecimal<PgRange<sqlx::types::BigDecimal>>(Postgres,
+    "'(1.3,2.4)'::numrange" == PgRange::from(
+        (Bound::Excluded("1.3".parse::<sqlx::types::BigDecimal>().unwrap()),
+         Bound::Excluded("2.4".parse::<sqlx::types::BigDecimal>().unwrap())))
+));
+
 #[cfg(feature = "decimal")]
 test_type!(decimal<sqlx::types::Decimal>(Postgres,
     "0::numeric" == sqlx::types::Decimal::from_str("0").unwrap(),
@@ -434,6 +441,13 @@ test_type!(decimal<sqlx::types::Decimal>(Postgres,
     "0.01234::numeric" == sqlx::types::Decimal::from_str("0.01234").unwrap(),
     "12.34::numeric" == sqlx::types::Decimal::from_str("12.34").unwrap(),
     "12345.6789::numeric" == sqlx::types::Decimal::from_str("12345.6789").unwrap(),
+));
+
+#[cfg(feature = "decimal")]
+test_type!(numrange_decimal<PgRange<sqlx::types::Decimal>>(Postgres,
+    "'(1.3,2.4)'::numrange" == PgRange::from(
+        (Bound::Excluded(sqlx::types::Decimal::from_str("1.3").unwrap()),
+         Bound::Excluded(sqlx::types::Decimal::from_str("2.4").unwrap()))),
 ));
 
 const EXC2: Bound<i32> = Bound::Excluded(2);


### PR DESCRIPTION
I'm about to test if this works, but it should be fine, I believe, who knows!

I wish there weren't two decimal crates.