### PR TITLE
Update BigDecimal dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,9 +262,9 @@ checksum = "e6b4d9b1225d28d360ec6a231d65af1fd99a2a095154c8040689617290569c5c"
 
 [[package]]
 name = "bigdecimal"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e50562e37200edf7c6c43e54a08e64a5553bfb59d9c297d5572512aa517256"
+checksum = "6aaf33151a6429fe9211d1b276eafdf70cdff28b071e76c0b0e1503221ea3744"
 dependencies = [
  "num-bigint",
  "num-integer",
@@ -1448,17 +1448,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint-dig"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2235,6 +2224,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc31e6cf34ad4321d3a2b8f934949b429e314519f753a77962f16c664dca8e13"
+dependencies = [
+ "chrono",
+ "num-bigint",
+ "num-traits",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.25"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
+checksum = "3826a6e0e2215d7a41c2bfc7c9244123969273f3476b939a226aac0ab56e9e3c"
 dependencies = [
  "bitflags",
  "libc",
@@ -1225,9 +1225,9 @@ checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.26+1.3.0"
+version = "0.13.2+1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
+checksum = "3a42de9a51a5c12e00fc0e4ca6bc2ea43582fc6418488e8f615e905d886f258b"
 dependencies = [
  "cc",
  "libc",
@@ -1445,6 +1445,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -2224,18 +2235,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "simple_asn1"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc31e6cf34ad4321d3a2b8f934949b429e314519f753a77962f16c664dca8e13"
-dependencies = [
- "chrono",
- "num-bigint",
- "num-traits",
- "thiserror",
 ]
 
 [[package]]

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -105,7 +105,7 @@ ahash = "0.7.6"
 atoi = "0.4.0"
 sqlx-rt = { path = "../sqlx-rt", version = "0.5.12"}
 base64 = { version = "0.13.0", default-features = false, optional = true, features = ["std"] }
-bigdecimal_ = { version = "0.2.2", optional = true, package = "bigdecimal" }
+bigdecimal_ = { version = "0.3.2", optional = true, package = "bigdecimal" }
 rust_decimal = { version = "1.19.0", optional = true }
 bit-vec = { version = "0.6.3", optional = true }
 bitflags = { version = "1.3.2", default-features = false }
@@ -141,7 +141,7 @@ libsqlite3-sys = { version = "0.24.1", optional = true, default-features = false
 log = { version = "0.4.14", default-features = false }
 md-5 = { version = "0.10.0", default-features = false, optional = true }
 memchr = { version = "2.4.1", default-features = false }
-num-bigint = { version = "0.3.3", default-features = false, optional = true, features = ["std"] }
+num-bigint = { version = "0.4.0", default-features = false, optional = true, features = ["std"] }
 once_cell = "1.9.0"
 percent-encoding = "2.1.0"
 rand = { version = "0.8.4", default-features = false, optional = true, features = ["std", "std_rng"] }

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -105,7 +105,7 @@ ahash = "0.7.6"
 atoi = "0.4.0"
 sqlx-rt = { path = "../sqlx-rt", version = "0.5.12"}
 base64 = { version = "0.13.0", default-features = false, optional = true, features = ["std"] }
-bigdecimal_ = { version = "0.3.2", optional = true, package = "bigdecimal" }
+bigdecimal_ = { version = "0.3.0", optional = true, package = "bigdecimal" }
 rust_decimal = { version = "1.19.0", optional = true }
 bit-vec = { version = "0.6.3", optional = true }
 bitflags = { version = "1.3.2", default-features = false }


### PR DESCRIPTION
The current release of num is 0.4. Without this change to use BigDecimal with sqlx you need to intentionally use an older version of num and BigDecmial.