### PR TITLE
bump libsqlite3-sys to 0.23.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,9 +1246,9 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.22.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
+checksum = "abd5850c449b40bacb498b2bbdfaff648b1b055630073ba8db499caf2d0ea9f2"
 dependencies = [
  "cc",
  "pkg-config",

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -129,7 +129,7 @@ itoa = "0.4.5"
 ipnetwork = { version = "0.17.0", default-features = false, optional = true }
 mac_address = { version = "1.1", default-features = false, optional = true }
 libc = "0.2.71"
-libsqlite3-sys = { version = "0.22.0", optional = true, default-features = false, features = [
+libsqlite3-sys = { version = "0.23.1", optional = true, default-features = false, features = [
     "pkg-config",
     "vcpkg",
     "bundled",


### PR DESCRIPTION
This PR bumps libsqlite3-sys to the latest version.