### PR TITLE
feat(postgres): add an option to specify extra options

### DIFF
--- a/sqlx-core/src/postgres/connection/establish.rs
+++ b/sqlx-core/src/postgres/connection/establish.rs
@@ -40,6 +40,10 @@ impl PgConnection {
             params.push(("application_name", application_name));
         }
 
+        if let Some(ref options) = options.options {
+            params.push(("options", options));
+        }
+
         stream
             .send(Startup {
                 username: Some(&options.username),

--- a/sqlx-core/src/postgres/connection/establish.rs
+++ b/sqlx-core/src/postgres/connection/establish.rs
@@ -40,8 +40,8 @@ impl PgConnection {
             params.push(("application_name", application_name));
         }
 
-        if let Some(ref options) = options.options {
-            params.push(("options", options));
+        for (k, v) in options.options.iter() {
+            params.push((k, v));
         }
 
         stream

--- a/sqlx-core/src/postgres/connection/establish.rs
+++ b/sqlx-core/src/postgres/connection/establish.rs
@@ -40,8 +40,8 @@ impl PgConnection {
             params.push(("application_name", application_name));
         }
 
-        for (k, v) in options.options.iter() {
-            params.push((k, v));
+        if let Some(ref options) = options.options {
+            params.push(("options", options));
         }
 
         stream

--- a/sqlx-core/src/postgres/mod.rs
+++ b/sqlx-core/src/postgres/mod.rs
@@ -32,7 +32,6 @@ pub use error::{PgDatabaseError, PgErrorPosition};
 pub use listener::{PgListener, PgNotification};
 pub use message::PgSeverity;
 pub use options::{PgConnectOptions, PgSslMode};
-pub(crate) use options::parse_options;
 pub use query_result::PgQueryResult;
 pub use row::PgRow;
 pub use statement::PgStatement;

--- a/sqlx-core/src/postgres/mod.rs
+++ b/sqlx-core/src/postgres/mod.rs
@@ -32,6 +32,7 @@ pub use error::{PgDatabaseError, PgErrorPosition};
 pub use listener::{PgListener, PgNotification};
 pub use message::PgSeverity;
 pub use options::{PgConnectOptions, PgSslMode};
+pub(crate) use options::parse_options;
 pub use query_result::PgQueryResult;
 pub use row::PgRow;
 pub use statement::PgStatement;

--- a/sqlx-core/src/postgres/options/mod.rs
+++ b/sqlx-core/src/postgres/options/mod.rs
@@ -33,6 +33,7 @@ pub use ssl_mode::PgSslMode;
 /// | `password` | `None` | Password to be used if the server demands password authentication. |
 /// | `port` | `5432` | Port number to connect to at the server host, or socket file name extension for Unix-domain connections. |
 /// | `dbname` | `None` | The database name. |
+/// | `options` | `None` | The command-line options to send to the server at connection start. |
 ///
 /// The URI scheme designator can be either `postgresql://` or `postgres://`.
 /// Each of the URI parts is optional.
@@ -85,6 +86,7 @@ pub struct PgConnectOptions {
     pub(crate) statement_cache_capacity: usize,
     pub(crate) application_name: Option<String>,
     pub(crate) log_settings: LogSettings,
+    pub(crate) options: Option<String>,
 }
 
 impl Default for PgConnectOptions {
@@ -145,6 +147,7 @@ impl PgConnectOptions {
             statement_cache_capacity: 100,
             application_name: var("PGAPPNAME").ok(),
             log_settings: Default::default(),
+            options: var("PGOPTIONS").ok(),
         }
     }
 
@@ -316,6 +319,20 @@ impl PgConnectOptions {
     /// ```
     pub fn application_name(mut self, application_name: &str) -> Self {
         self.application_name = Some(application_name.to_owned());
+        self
+    }
+
+    /// Sets the extra options. Defaults to None
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use sqlx_core::postgres::PgConnectOptions;
+    /// let options = PgConnectOptions::new()
+    ///     .options("-c geqo=off -c statement_timeout=5min");
+    /// ```
+    pub fn options(mut self, options: &str) -> Self {
+        self.options = Some(options.to_owned());
         self
     }
 

--- a/sqlx-core/src/postgres/options/mod.rs
+++ b/sqlx-core/src/postgres/options/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::env::var;
 use std::path::{Path, PathBuf};
 
@@ -33,7 +34,7 @@ pub use ssl_mode::PgSslMode;
 /// | `password` | `None` | Password to be used if the server demands password authentication. |
 /// | `port` | `5432` | Port number to connect to at the server host, or socket file name extension for Unix-domain connections. |
 /// | `dbname` | `None` | The database name. |
-/// | `options` | `None` | The command-line options to send to the server at connection start. |
+/// | `options` | `None` | The runtime parameters to send to the server at connection start. |
 ///
 /// The URI scheme designator can be either `postgresql://` or `postgres://`.
 /// Each of the URI parts is optional.
@@ -86,7 +87,7 @@ pub struct PgConnectOptions {
     pub(crate) statement_cache_capacity: usize,
     pub(crate) application_name: Option<String>,
     pub(crate) log_settings: LogSettings,
-    pub(crate) options: Option<String>,
+    pub(crate) options: HashMap<String, String>,
 }
 
 impl Default for PgConnectOptions {
@@ -147,7 +148,9 @@ impl PgConnectOptions {
             statement_cache_capacity: 100,
             application_name: var("PGAPPNAME").ok(),
             log_settings: Default::default(),
-            options: var("PGOPTIONS").ok(),
+            options: var("PGOPTIONS")
+                .and_then(|v| Ok(parse_options(&v).unwrap_or_default().into_iter().collect()))
+                .unwrap_or_default(),
         }
     }
 
@@ -329,10 +332,17 @@ impl PgConnectOptions {
     /// ```rust
     /// # use sqlx_core::postgres::PgConnectOptions;
     /// let options = PgConnectOptions::new()
-    ///     .options("-c geqo=off -c statement_timeout=5min");
+    ///     .options(&[("geqo", "off"), ("statement_timeout", "5min")]);
     /// ```
-    pub fn options(mut self, options: &str) -> Self {
-        self.options = Some(options.to_owned());
+    pub fn options<K, V, I>(mut self, options: I) -> Self
+    where
+        K: ToString,
+        V: ToString,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        for (k, v) in options {
+            self.options.insert(k.to_string(), v.to_string());
+        }
         self
     }
 
@@ -351,6 +361,24 @@ impl PgConnectOptions {
             _ => None,
         }
     }
+}
+
+/// Parse a libpq style options string
+pub(crate) fn parse_options(input: &str) -> Option<Vec<(String, String)>> {
+    let mut options = Vec::new();
+    for part in input.split(' ') {
+        let part = part.trim();
+        if part.is_empty() || part == "-c" {
+            continue;
+        }
+        let pair = part.splitn(2, '=').collect::<Vec<_>>();
+        if pair.len() != 2 {
+            return None;
+        }
+        options.push((pair[0].to_string(), pair[1].to_string()));
+    }
+
+    Some(options)
 }
 
 fn default_host(port: u16) -> String {

--- a/sqlx-core/src/postgres/options/mod.rs
+++ b/sqlx-core/src/postgres/options/mod.rs
@@ -1,4 +1,5 @@
 use std::env::var;
+use std::fmt::Display;
 use std::path::{Path, PathBuf};
 
 mod connect;
@@ -322,7 +323,7 @@ impl PgConnectOptions {
         self
     }
 
-    /// Sets the extra options. Defaults to None
+    /// Set additional startup options for the connection as a list of key-value pairs.
     ///
     /// # Example
     ///
@@ -333,13 +334,13 @@ impl PgConnectOptions {
     /// ```
     pub fn options<K, V, I>(mut self, options: I) -> Self
     where
-        K: ToString,
-        V: ToString,
+        K: Display,
+        V: Display,
         I: IntoIterator<Item = (K, V)>,
     {
         let mut options_str = String::new();
         for (k, v) in options {
-            options_str += &format!("-c {}={}", k.to_string(), v.to_string());
+            options_str += &format!("-c {}={}", k, v);
         }
         if let Some(ref mut v) = self.options {
             v.push(' ');

--- a/sqlx-core/src/postgres/options/parse.rs
+++ b/sqlx-core/src/postgres/options/parse.rs
@@ -85,6 +85,8 @@ impl FromStr for PgConnectOptions {
 
                 "application_name" => options = options.application_name(&*value),
 
+                "options" => options = options.options(&*value),
+
                 _ => log::warn!("ignoring unrecognized connect parameter: {}={}", key, value),
             }
         }
@@ -194,4 +196,11 @@ fn it_parses_socket_correctly_with_username_percent_encoded() {
     assert_eq!("some_user", opts.username);
     assert_eq!(Some("/var/lib/postgres/".into()), opts.socket);
     assert_eq!(Some("database"), opts.database.as_deref());
+}
+#[test]
+fn it_parses_options() {
+    let uri = "postgres:///?options=-c%20synchronous_commit%3Doff%20--search_path%3Dpostgres";
+    let opts = PgConnectOptions::from_str(uri).unwrap();
+
+    assert_eq!(Some("-c synchronous_commit=off --search_path=postgres"), opts.options.as_deref());
 }


### PR DESCRIPTION
This Pull Request allows you to specify extra command options to the PostgreSQL server through connection options like search path and statement timeouts etc.

This could fix #1290.