### PR TITLE
Reimport Either used in Executor

### DIFF
--- a/sqlx-core/src/lib.rs
+++ b/sqlx-core/src/lib.rs
@@ -58,6 +58,7 @@ pub mod column;
 pub mod statement;
 
 mod common;
+pub use either::Either;
 pub mod database;
 pub mod describe;
 pub mod executor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ compile_error!(
      and 'tls' is one of 'native-tls' and 'rustls'."
 );
 
+pub use sqlx_core as core;
 pub use sqlx_core::Either;
 pub use sqlx_core::acquire::Acquire;
 pub use sqlx_core::arguments::{Arguments, IntoArguments};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@ compile_error!(
      and 'tls' is one of 'native-tls' and 'rustls'."
 );
 
-pub use sqlx_core as core;
 pub use sqlx_core::Either;
 pub use sqlx_core::acquire::Acquire;
 pub use sqlx_core::arguments::{Arguments, IntoArguments};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ compile_error!(
      and 'tls' is one of 'native-tls' and 'rustls'."
 );
 
+pub use sqlx_core::Either;
 pub use sqlx_core::acquire::Acquire;
 pub use sqlx_core::arguments::{Arguments, IntoArguments};
 pub use sqlx_core::column::Column;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@ compile_error!(
      and 'tls' is one of 'native-tls' and 'rustls'."
 );
 
-pub use sqlx_core::Either;
 pub use sqlx_core::acquire::Acquire;
 pub use sqlx_core::arguments::{Arguments, IntoArguments};
 pub use sqlx_core::column::Column;
@@ -31,6 +30,7 @@ pub use sqlx_core::transaction::{Transaction, TransactionManager};
 pub use sqlx_core::type_info::TypeInfo;
 pub use sqlx_core::types::Type;
 pub use sqlx_core::value::{Value, ValueRef};
+pub use sqlx_core::Either;
 
 #[doc(inline)]
 pub use sqlx_core::error::{self, Error, Result};


### PR DESCRIPTION
Subj
It is convenient when you need to implement own Executor

`sqlx-core` is also would be nice to have available for `describe::Describe`