### PR TITLE
fix(postgres): Match `~/.pgpass` password after URL parsing and fix user and database ordering

### DIFF
--- a/sqlx-core/src/postgres/options/mod.rs
+++ b/sqlx-core/src/postgres/options/mod.rs
@@ -89,6 +89,36 @@ pub struct PgConnectOptions {
 
 impl Default for PgConnectOptions {
     fn default() -> Self {
+        Self::new_without_pgpass().apply_pgpass()
+    }
+}
+
+impl PgConnectOptions {
+    /// Creates a new, default set of options ready for configuration.
+    ///
+    /// By default, this reads the following environment variables and sets their
+    /// equivalent options.
+    ///
+    ///  * `PGHOST`
+    ///  * `PGPORT`
+    ///  * `PGUSER`
+    ///  * `PGPASSWORD`
+    ///  * `PGDATABASE`
+    ///  * `PGSSLROOTCERT`
+    ///  * `PGSSLMODE`
+    ///  * `PGAPPNAME`
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use sqlx_core::postgres::PgConnectOptions;
+    /// let options = PgConnectOptions::new();
+    /// ```
+    pub fn new() -> Self {
+        Self::new_without_pgpass().apply_pgpass()
+    }
+
+    pub fn new_without_pgpass() -> Self {
         let port = var("PGPORT")
             .ok()
             .and_then(|v| v.parse().ok())
@@ -116,32 +146,6 @@ impl Default for PgConnectOptions {
             application_name: var("PGAPPNAME").ok(),
             log_settings: Default::default(),
         }
-    }
-}
-
-impl PgConnectOptions {
-    /// Creates a new, default set of options ready for configuration.
-    ///
-    /// By default, this reads the following environment variables and sets their
-    /// equivalent options.
-    ///
-    ///  * `PGHOST`
-    ///  * `PGPORT`
-    ///  * `PGUSER`
-    ///  * `PGPASSWORD`
-    ///  * `PGDATABASE`
-    ///  * `PGSSLROOTCERT`
-    ///  * `PGSSLMODE`
-    ///  * `PGAPPNAME`
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use sqlx_core::postgres::PgConnectOptions;
-    /// let options = PgConnectOptions::new();
-    /// ```
-    pub fn new() -> Self {
-        Self::default().apply_pgpass()
     }
 
     pub(crate) fn apply_pgpass(mut self) -> Self {

--- a/sqlx-core/src/postgres/options/mod.rs
+++ b/sqlx-core/src/postgres/options/mod.rs
@@ -150,7 +150,12 @@ impl PgConnectOptions {
 
     pub(crate) fn apply_pgpass(mut self) -> Self {
         if self.password.is_none() {
-            self.password = pgpass::load_password(&self.host, self.port, &self.username, self.database.as_deref());
+            self.password = pgpass::load_password(
+                &self.host,
+                self.port,
+                &self.username,
+                self.database.as_deref(),
+            );
         }
 
         self

--- a/sqlx-core/src/postgres/options/parse.rs
+++ b/sqlx-core/src/postgres/options/parse.rs
@@ -89,6 +89,8 @@ impl FromStr for PgConnectOptions {
             }
         }
 
+        let options = options.apply_pgpass();
+
         Ok(options)
     }
 }

--- a/sqlx-core/src/postgres/options/parse.rs
+++ b/sqlx-core/src/postgres/options/parse.rs
@@ -11,7 +11,7 @@ impl FromStr for PgConnectOptions {
     fn from_str(s: &str) -> Result<Self, Error> {
         let url: Url = s.parse().map_err(Error::config)?;
 
-        let mut options = Self::default();
+        let mut options = Self::new_without_pgpass();
 
         if let Some(host) = url.host_str() {
             let host_decoded = percent_decode_str(host);

--- a/sqlx-core/src/postgres/options/pgpass.rs
+++ b/sqlx-core/src/postgres/options/pgpass.rs
@@ -90,13 +90,15 @@ fn load_password_from_line(
 ) -> Option<String> {
     let whole_line = line;
 
+    // Pgpass line ordering: hostname, port, database, username, password
+    // See: https://www.postgresql.org/docs/9.3/libpq-pgpass.html
     match line.trim_start().chars().next() {
         None | Some('#') => None,
         _ => {
             matches_next_field(whole_line, &mut line, host)?;
             matches_next_field(whole_line, &mut line, &port.to_string())?;
-            matches_next_field(whole_line, &mut line, username)?;
             matches_next_field(whole_line, &mut line, database.unwrap_or_default())?;
+            matches_next_field(whole_line, &mut line, username)?;
             Some(line.to_owned())
         }
     }

--- a/sqlx-core/src/postgres/options/pgpass.rs
+++ b/sqlx-core/src/postgres/options/pgpass.rs
@@ -221,7 +221,7 @@ mod tests {
         // normal
         assert_eq!(
             load_password_from_line(
-                "localhost:5432:foo:bar:baz",
+                "localhost:5432:bar:foo:baz",
                 "localhost",
                 5432,
                 "foo",
@@ -231,19 +231,19 @@ mod tests {
         );
         // wildcard
         assert_eq!(
-            load_password_from_line("*:5432:foo:bar:baz", "localhost", 5432, "foo", Some("bar")),
+            load_password_from_line("*:5432:bar:foo:baz", "localhost", 5432, "foo", Some("bar")),
             Some("baz".to_owned())
         );
         // accept wildcard with missing db
         assert_eq!(
-            load_password_from_line("localhost:5432:foo:*:baz", "localhost", 5432, "foo", None),
+            load_password_from_line("localhost:5432:*:foo:baz", "localhost", 5432, "foo", None),
             Some("baz".to_owned())
         );
 
         // doesn't match
         assert_eq!(
             load_password_from_line(
-                "thishost:5432:foo:bar:baz",
+                "thishost:5432:bar:foo:baz",
                 "thathost",
                 5432,
                 "foo",
@@ -254,7 +254,7 @@ mod tests {
         // malformed entry
         assert_eq!(
             load_password_from_line(
-                "localhost:5432:foo:bar",
+                "localhost:5432:bar:foo",
                 "localhost",
                 5432,
                 "foo",


### PR DESCRIPTION
This fixes two bugs in loading postgres passwords from `~/.pgpass` files:

- pgpass was applied before parsing the database URLs so it wasn't matching against  the host/port/user/database from the URL provided
- pgpass was matching user and database in the wrong order