### PR TITLE
Make whoami optional, and only pull it in for postgres

### DIFF
--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -32,6 +32,7 @@ postgres = [
     "futures-util/sink",
     "json",
     "dirs",
+    "whoami",
 ]
 mysql = [
     "sha-1",
@@ -158,7 +159,7 @@ url = { version = "2.1.1", default-features = false }
 uuid = { version = "0.8.1", default-features = false, optional = true, features = ["std"] }
 webpki = { version = "0.21.0", optional = true }
 webpki-roots = { version = "0.21.0", optional = true }
-whoami = "1.0.1"
+whoami = { version = "1.0.1", optional = true }
 stringprep = "0.1.2"
 bstr = { version = "0.2.14", default-features = false, features = ["std"], optional = true }
 git2 = { version = "0.13.20", default-features = false, optional = true }


### PR DESCRIPTION
sqlx-core uses whoami to provide the fallback for postgres username. If
not building postgres support, omit the dependency on whoami.
