### PR TITLE
GUID(Uuid) support for MSSQL

### DIFF
--- a/sqlx-core/src/mssql/protocol/type_info.rs
+++ b/sqlx-core/src/mssql/protocol/type_info.rs
@@ -577,7 +577,7 @@ impl TypeInfo {
             }
 
             DataType::Guid => {
-                s.push_str("guid");
+                s.push_str("uniqueidentifier");
             }
 
             DataType::BitN => {

--- a/sqlx-core/src/mssql/protocol/type_info.rs
+++ b/sqlx-core/src/mssql/protocol/type_info.rs
@@ -515,6 +515,8 @@ impl TypeInfo {
             DataType::BigChar => "BIGCHAR",
             DataType::NChar => "NCHAR",
 
+            DataType::Guid => "GUID",
+
             _ => unimplemented!("name: unsupported data type {:?}", self.ty),
         }
     }
@@ -572,6 +574,10 @@ impl TypeInfo {
                 } else {
                     s.push_str("(max)");
                 }
+            }
+
+            DataType::Guid => {
+                s.push_str("guid");
             }
 
             DataType::BitN => {

--- a/sqlx-core/src/mssql/types/guid.rs
+++ b/sqlx-core/src/mssql/types/guid.rs
@@ -1,0 +1,31 @@
+use uuid::Uuid;
+use crate::decode::Decode;
+use crate::encode::{Encode, IsNull};
+use crate::error::BoxDynError;
+use crate::mssql::protocol::type_info::{DataType, TypeInfo};
+use crate::mssql::{Mssql, MssqlTypeInfo, MssqlValueRef};
+use crate::types::Type;
+
+impl Type<Mssql> for Uuid {
+    fn type_info() -> MssqlTypeInfo {
+        MssqlTypeInfo(TypeInfo::new(DataType::Guid, 16))
+    }
+
+    fn compatible(ty: &MssqlTypeInfo) -> bool {
+        matches!(ty.0.ty, DataType::Guid)
+    }
+}
+
+impl Encode<'_, Mssql> for Uuid {
+    fn encode_by_ref(&self, buf: &mut Vec<u8>) -> IsNull {
+        buf.extend(self.as_bytes());
+
+        IsNull::No
+    }
+}
+
+impl Decode<'_, Mssql> for Uuid {
+    fn decode(value: MssqlValueRef<'_>) -> Result<Self, BoxDynError> {
+        Uuid::from_slice(value.as_bytes()?).map_err(Into::into)
+    }
+}

--- a/sqlx-core/src/mssql/types/guid.rs
+++ b/sqlx-core/src/mssql/types/guid.rs
@@ -1,10 +1,10 @@
-use uuid::Uuid;
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
 use crate::error::BoxDynError;
 use crate::mssql::protocol::type_info::{DataType, TypeInfo};
 use crate::mssql::{Mssql, MssqlTypeInfo, MssqlValueRef};
 use crate::types::Type;
+use uuid::Uuid;
 
 impl Type<Mssql> for Uuid {
     fn type_info() -> MssqlTypeInfo {

--- a/sqlx-core/src/mssql/types/mod.rs
+++ b/sqlx-core/src/mssql/types/mod.rs
@@ -4,6 +4,7 @@ use crate::mssql::{Mssql, MssqlTypeInfo};
 
 mod bool;
 mod float;
+mod guid;
 mod int;
 mod str;
 

--- a/sqlx-macros/src/database/mssql.rs
+++ b/sqlx-macros/src/database/mssql.rs
@@ -1,3 +1,4 @@
+use sqlx::types::Uuid;
 use sqlx_core as sqlx;
 
 impl_database_ext! {
@@ -10,6 +11,7 @@ impl_database_ext! {
         f32,
         f64,
         String,
+        Uuid,
     },
     ParamChecking::Weak,
     feature-types: _info => None,

--- a/tests/mssql/types.rs
+++ b/tests/mssql/types.rs
@@ -42,7 +42,7 @@ test_type!(bool(
     "CAST(0 as BIT)" == false
 ));
 
-test_type!(uuid<sqlx::types::Uuid>(Postgres,
+test_type!(uuid<sqlx::types::Uuid>(Mssql,
     "'b731678f-636f-4135-bc6f-19440c13bd19'::uuid"
         == sqlx::types::Uuid::parse_str("b731678f-636f-4135-bc6f-19440c13bd19").unwrap(),
     "'00000000-0000-0000-0000-000000000000'::uuid"

--- a/tests/mssql/types.rs
+++ b/tests/mssql/types.rs
@@ -41,3 +41,10 @@ test_type!(bool(
     "CAST(1 as BIT)" == true,
     "CAST(0 as BIT)" == false
 ));
+
+test_type!(uuid<sqlx::types::Uuid>(Postgres,
+    "'b731678f-636f-4135-bc6f-19440c13bd19'::uuid"
+        == sqlx::types::Uuid::parse_str("b731678f-636f-4135-bc6f-19440c13bd19").unwrap(),
+    "'00000000-0000-0000-0000-000000000000'::uuid"
+        == sqlx::types::Uuid::parse_str("00000000-0000-0000-0000-000000000000").unwrap()
+));

--- a/tests/mssql/types.rs
+++ b/tests/mssql/types.rs
@@ -43,8 +43,8 @@ test_type!(bool(
 ));
 
 test_type!(uuid<sqlx::types::Uuid>(Mssql,
-    "'b731678f-636f-4135-bc6f-19440c13bd19'::uuid"
+    "CAST('b731678f-636f-4135-bc6f-19440c13bd19' AS uniqueidentifier)"
         == sqlx::types::Uuid::parse_str("b731678f-636f-4135-bc6f-19440c13bd19").unwrap(),
-    "'00000000-0000-0000-0000-000000000000'::uuid"
+    "CAST('00000000-0000-0000-0000-000000000000' AS uniqueidentifier)"
         == sqlx::types::Uuid::parse_str("00000000-0000-0000-0000-000000000000").unwrap()
 ));


### PR DESCRIPTION
First time attempting this, so hopefully I'm not too far out in the sticks.
Heavily based on implementations from other databases.

As I understand it the uniqueidentifier type should be RFC4122 compliant, at least when generated from NEWID() or NEWSEQUENTIALID().