### PR TITLE
Use `chrono::NaiveDateTime` on MySQL timestamp columns

### DIFF
--- a/sqlx-core/src/mysql/types/chrono.rs
+++ b/sqlx-core/src/mysql/types/chrono.rs
@@ -169,6 +169,10 @@ impl Type<MySql> for NaiveDateTime {
     fn type_info() -> MySqlTypeInfo {
         MySqlTypeInfo::binary(ColumnType::Datetime)
     }
+
+    fn compatible(ty: &MySqlTypeInfo) -> bool {
+        matches!(ty.r#type, ColumnType::Datetime | ColumnType::Timestamp)
+    }
 }
 
 impl Encode<'_, MySql> for NaiveDateTime {


### PR DESCRIPTION
Hi there, I wonder why we couldn't use `chrono::NaiveDateTime` on a MySQL timestamp column? It should be compatible. Is there any reason behind it? Thanks!!