### PR TITLE
Append to existing RUSTFLAGS, instead of overwriting.

### DIFF
--- a/sqlx-cli/src/prepare.rs
+++ b/sqlx-cli/src/prepare.rs
@@ -115,16 +115,15 @@ hint: This command only works in the manifest directory of a Cargo package."#
             bail!("`cargo clean` failed with status: {}", check_status);
         }
 
+        let rustflags = env::var("RUSTFLAGS").unwrap_or_default().push_str(&format!(
+            " --cfg __sqlx_recompile_trigger=\"{}\"",
+            SystemTime::UNIX_EPOCH.elapsed()?.as_millis()
+        ));
+
         Command::new(&cargo)
             .arg("check")
             .args(cargo_args)
-            .env(
-                "RUSTFLAGS",
-                format!(
-                    "--cfg __sqlx_recompile_trigger=\"{}\"",
-                    SystemTime::UNIX_EPOCH.elapsed()?.as_millis()
-                ),
-            )
+            .env("RUSTFLAGS", rustflags)
             .env("SQLX_OFFLINE", "false")
             .status()?
     } else {

--- a/sqlx-cli/src/prepare.rs
+++ b/sqlx-cli/src/prepare.rs
@@ -115,7 +115,8 @@ hint: This command only works in the manifest directory of a Cargo package."#
             bail!("`cargo clean` failed with status: {}", check_status);
         }
 
-        let rustflags = env::var("RUSTFLAGS").unwrap_or_default().push_str(&format!(
+        let mut rustflags = env::var("RUSTFLAGS").unwrap_or_default();
+        rustflags.push_str(&format!(
             " --cfg __sqlx_recompile_trigger=\"{}\"",
             SystemTime::UNIX_EPOCH.elapsed()?.as_millis()
         ));


### PR DESCRIPTION
This fixes #1579 .

Running `sqlx prepare --merged` should respect existing `RUSTFLAGS` set in the environment.

This change will append to the variable instead of overwriting it.