### PR TITLE
[CLI] Adds feature enabling Rustls usage rather than OpenSSL

### DIFF
--- a/sqlx-cli/Cargo.toml
+++ b/sqlx-cli/Cargo.toml
@@ -28,7 +28,6 @@ path = "src/bin/cargo-sqlx.rs"
 dotenv = "0.15"
 tokio = { version = "1.0.1", features = ["macros", "rt", "rt-multi-thread"] }
 sqlx = { version = "0.5.9", path = "..", default-features = false, features = [
-    "runtime-async-std-native-tls",
     "migrate",
     "any",
     "offline",
@@ -53,7 +52,9 @@ openssl = { version = "0.10.30", optional = true }
 remove_dir_all = "0.7.0"
 
 [features]
-default = ["postgres", "sqlite", "mysql"]
+default = ["postgres", "sqlite", "mysql", "native-tls"]
+rustls = ["sqlx/runtime-async-std-rustls"]
+native-tls = ["sqlx/runtime-async-std-native-tls", "openssl"]
 
 # databases
 mysql = ["sqlx/mysql"]

--- a/sqlx-cli/Cargo.toml
+++ b/sqlx-cli/Cargo.toml
@@ -54,7 +54,7 @@ remove_dir_all = "0.7.0"
 [features]
 default = ["postgres", "sqlite", "mysql", "native-tls"]
 rustls = ["sqlx/runtime-async-std-rustls"]
-native-tls = ["sqlx/runtime-async-std-native-tls", "openssl"]
+native-tls = ["sqlx/runtime-async-std-native-tls"]
 
 # databases
 mysql = ["sqlx/mysql"]

--- a/sqlx-cli/README.md
+++ b/sqlx-cli/README.md
@@ -16,6 +16,9 @@ $ cargo install sqlx-cli --no-default-features --features postgres
 
 # use vendored OpenSSL (build from source)
 $ cargo install sqlx-cli --features openssl-vendored
+
+# use Rustls rather than OpenSSL
+$ cargo install sqlx-cli --no-default-features --features rustls
 ```
 
 ### Usage


### PR DESCRIPTION
Pretty simple Cargo change to allow the CLI to use Rustls instead.  It still defaults to native-tls, so should be transparent to users!