### PR TITLE
Add target context to Postgres notice logs

### DIFF
--- a/sqlx-core/src/postgres/connection/stream.rs
+++ b/sqlx-core/src/postgres/connection/stream.rs
@@ -146,12 +146,13 @@ impl PgStream {
                         PgSeverity::Log => Level::Trace,
                     };
 
-                    if lvl <= log::STATIC_MAX_LEVEL && lvl <= log::max_level() {
+                    if log::log_enabled!(target: "sqlx::postgres::notice", lvl) {
                         log::logger().log(
                             &log::Record::builder()
                                 .args(format_args!("{}", notice.message()))
                                 .level(lvl)
                                 .module_path_static(Some("sqlx::postgres::notice"))
+                                .target("sqlx::postgres::notice")
                                 .file_static(Some(file!()))
                                 .line(Some(line!()))
                                 .build(),


### PR DESCRIPTION
Adds a `target` field to the Postgres notice logs and filters based on that target. This makes it similar to how the query logs [have a `target` field](https://github.com/launchbadge/sqlx/blob/49928ddf81fe99137c565aa1ef43fd67282ee902/sqlx-core/src/logger.rs#L64) and [filter based on target](https://github.com/launchbadge/sqlx/blob/49928ddf81fe99137c565aa1ef43fd67282ee902/sqlx-core/src/logger.rs#L36).
