### PR TITLE
Drop worker shared state in shutdown (Sqlite)

### DIFF
--- a/sqlx-core/src/sqlite/connection/worker.rs
+++ b/sqlx-core/src/sqlite/connection/worker.rs
@@ -215,9 +215,10 @@ impl ConnectionWorker {
                             tx.send(()).ok();
                         }
                         Command::Shutdown { tx } => {
-                            // drop the connection reference before sending confirmation
+                            // drop the connection references before sending confirmation
                             // and ending the command loop
                             drop(conn);
+                            drop(shared);
                             let _ = tx.send(());
                             return;
                         }


### PR DESCRIPTION
Related to previous issue #1452 