### PR TITLE
Make all ConnectOptions clonable

### DIFF
--- a/sqlx-core/src/connection.rs
+++ b/sqlx-core/src/connection.rs
@@ -152,7 +152,7 @@ impl LogSettings {
     }
 }
 
-pub trait ConnectOptions: 'static + Send + Sync + FromStr<Err = Error> + Debug {
+pub trait ConnectOptions: 'static + Send + Sync + FromStr<Err = Error> + Debug + Clone {
     type Connection: Connection + ?Sized;
 
     /// Establish a new database connection with the options specified by `self`.


### PR DESCRIPTION
Currently all `ConnectOptions` implementation are `Clone`. I think this will continue to be true, and it might be useful to give this guarantee in general.