### PR TITLE
docs(macros): remove sentences banning usage of `as _`

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -149,8 +149,7 @@
 ///
 /// In Rust 1.45 we can eliminate this redundancy by allowing casts using `as _` or type ascription
 /// syntax, i.e. `my_int: _` (which is unstable but can be stripped), but this requires modifying
-/// the expression which is not possible as the macros are currently implemented. Casts to `_` are
-/// forbidden for now as they produce rather nasty type errors.
+/// the expression which is not possible as the macros are currently implemented.
 ///
 /// ## Type Overrides: Output Columns
 /// Type overrides are also available for output columns, utilizing the SQL standard's support

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -147,8 +147,8 @@
 /// sqlx::query!("select $1::int4 as id", my_int as MyInt4)
 /// ```
 ///
-/// Using `expr as _` or `expr : _` simply signals to the macro to not type-check that bind expression, 
-/// and then that syntax is stripped from the expression so as to not trigger type errors 
+/// Using `expr as _` or `expr : _` simply signals to the macro to not type-check that bind expression,
+/// and then that syntax is stripped from the expression so as to not trigger type errors
 /// (or an unstable syntax feature in the case of the latter, which is called type ascription).
 ///
 /// ## Type Overrides: Output Columns

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -147,7 +147,7 @@
 /// sqlx::query!("select $1::int4 as id", my_int as MyInt4)
 /// ```
 ///
-/// Using as _ or : _ simply signals to the macro to not type-check that bind expression, 
+/// Using `expr as _` or `expr : _` simply signals to the macro to not type-check that bind expression, 
 /// and then that syntax is stripped from the expression so as to not trigger type errors 
 /// (or an unstable syntax feature in the case of the latter, which is called type ascription).
 ///

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -147,9 +147,9 @@
 /// sqlx::query!("select $1::int4 as id", my_int as MyInt4)
 /// ```
 ///
-/// In Rust 1.45 we can eliminate this redundancy by allowing casts using `as _` or type ascription
-/// syntax, i.e. `my_int: _` (which is unstable but can be stripped), but this requires modifying
-/// the expression which is not possible as the macros are currently implemented.
+/// Using as _ or : _ simply signals to the macro to not type-check that bind expression, 
+/// and then that syntax is stripped from the expression so as to not trigger type errors 
+/// (or an unstable syntax feature in the case of the latter, which is called type ascription).
 ///
 /// ## Type Overrides: Output Columns
 /// Type overrides are also available for output columns, utilizing the SQL standard's support


### PR DESCRIPTION
removing the sentences `the expression which is not possible as the macros are currently implemented.` 'cause it's confusing, which is referred in #1133.