### PR TITLE
Update RustCrypto crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,9 +308,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
 dependencies = [
  "generic-array",
 ]
@@ -631,13 +631,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.11.1"
+name = "crypto-common"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+checksum = "683d6b536309245c849479fba3da410962a43ed8e51c26b729208ec0ac2798d0"
 dependencies = [
  "generic-array",
- "subtle",
 ]
 
 [[package]]
@@ -695,6 +694,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -1091,12 +1102,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+checksum = "ddca131f3e7f2ce2df364b57949a9d47915cfbd35e46cfee355ccebbf794d6a2"
 dependencies = [
- "crypto-mac",
- "digest",
+ "digest 0.10.1",
 ]
 
 [[package]]
@@ -1306,13 +1316,11 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "md-5"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+checksum = "e6a38fc55c8bbc10058782919516f88826e70320db6d206aebc49611d24216ae"
 dependencies = [
- "block-buffer",
- "digest",
- "opaque-debug",
+ "digest 0.10.1",
 ]
 
 [[package]]
@@ -1535,12 +1543,6 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -2034,7 +2036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c2603e2823634ab331437001b411b9ed11660fbc4066f3908c84a9439260d"
 dependencies = [
  "byteorder",
- "digest",
+ "digest 0.9.0",
  "lazy_static",
  "num-bigint-dig",
  "num-integer",
@@ -2237,15 +2239,13 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.8"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
- "block-buffer",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest",
- "opaque-debug",
+ "digest 0.10.1",
 ]
 
 [[package]]
@@ -2256,15 +2256,13 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
-version = "0.9.8"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
+checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
 dependencies = [
- "block-buffer",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest",
- "opaque-debug",
+ "digest 0.10.1",
 ]
 
 [[package]]
@@ -2417,7 +2415,7 @@ dependencies = [
  "chrono",
  "crc",
  "crossbeam-queue",
- "digest",
+ "digest 0.10.1",
  "dirs",
  "either",
  "encoding_rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,15 +689,6 @@ checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
@@ -1106,7 +1097,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddca131f3e7f2ce2df364b57949a9d47915cfbd35e46cfee355ccebbf794d6a2"
 dependencies = [
- "digest 0.10.1",
+ "digest",
 ]
 
 [[package]]
@@ -1320,7 +1311,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6a38fc55c8bbc10058782919516f88826e70320db6d206aebc49611d24216ae"
 dependencies = [
- "digest 0.10.1",
+ "digest",
 ]
 
 [[package]]
@@ -2032,12 +2023,10 @@ dependencies = [
 [[package]]
 name = "rsa"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c2603e2823634ab331437001b411b9ed11660fbc4066f3908c84a9439260d"
+source = "git+https://github.com/RustCrypto/RSA.git?rev=2d68db2#2d68db2e0fddbccb23a9fdcec26f4a23f6d844e4"
 dependencies = [
  "byteorder",
- "digest 0.9.0",
- "lazy_static",
+ "digest",
  "num-bigint-dig",
  "num-integer",
  "num-iter",
@@ -2245,7 +2234,7 @@ checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.1",
+ "digest",
 ]
 
 [[package]]
@@ -2262,7 +2251,7 @@ checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.1",
+ "digest",
 ]
 
 [[package]]
@@ -2415,7 +2404,7 @@ dependencies = [
  "chrono",
  "crc",
  "crossbeam-queue",
- "digest 0.10.1",
+ "digest",
  "dirs",
  "either",
  "encoding_rs",

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -112,7 +112,7 @@ byteorder = { version = "1.4.3", default-features = false, features = ["std"] }
 chrono = { version = "0.4.19", default-features = false, features = ["clock"], optional = true }
 crc = { version = "2.1.0", optional = true }
 crossbeam-queue = "0.3.2"
-digest = { version = "0.9.0", default-features = false, optional = true, features = ["std"] }
+digest = { version = "0.10.0", default-features = false, optional = true, features = ["std"] }
 dirs = { version = "4.0.0", optional = true }
 encoding_rs = { version = "0.8.30", optional = true }
 either = "1.6.1"
@@ -125,7 +125,7 @@ futures-executor = { version = "0.3.19", optional = true }
 flume = { version = "0.10.9", optional = true, default-features = false, features = ["async"] }
 generic-array = { version = "0.14.4", default-features = false, optional = true }
 hex = "0.4.3"
-hmac = { version = "0.11.0", default-features = false, optional = true }
+hmac = { version = "0.12.0", default-features = false, optional = true }
 itoa = "1.0.1"
 ipnetwork = { version = "0.17.0", default-features = false, optional = true }
 mac_address = { version = "1.1.2", default-features = false, optional = true }
@@ -136,7 +136,7 @@ libsqlite3-sys = { version = "0.23.2", optional = true, default-features = false
     "bundled",
 ] }
 log = { version = "0.4.14", default-features = false }
-md-5 = { version = "0.9.1", default-features = false, optional = true }
+md-5 = { version = "0.10.0", default-features = false, optional = true }
 memchr = { version = "2.4.1", default-features = false }
 num-bigint = { version = "0.3.3", default-features = false, optional = true, features = ["std"] }
 once_cell = "1.9.0"
@@ -147,8 +147,8 @@ rsa = { version = "0.5.0", optional = true }
 rustls = { version = "0.19.1", features = ["dangerous_configuration"], optional = true }
 serde = { version = "1.0.132", features = ["derive", "rc"], optional = true }
 serde_json = { version = "1.0.73", features = ["raw_value"], optional = true }
-sha-1 = { version = "0.9.8", default-features = false, optional = true }
-sha2 = { version = "0.9.8", default-features = false, optional = true }
+sha-1 = { version = "0.10.0", default-features = false, optional = true }
+sha2 = { version = "0.10.0", default-features = false, optional = true }
 sqlformat = "0.1.8"
 thiserror = "1.0.30"
 time = { version = "0.2.27", optional = true }

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -143,7 +143,7 @@ once_cell = "1.9.0"
 percent-encoding = "2.1.0"
 rand = { version = "0.8.4", default-features = false, optional = true, features = ["std", "std_rng"] }
 regex = { version = "1.5.4", optional = true }
-rsa = { version = "0.5.0", optional = true }
+rsa = { git = "https://github.com/RustCrypto/RSA.git", rev = "2d68db2", optional = true }
 rustls = { version = "0.19.1", features = ["dangerous_configuration"], optional = true }
 serde = { version = "1.0.132", features = ["derive", "rc"], optional = true }
 serde_json = { version = "1.0.73", features = ["raw_value"], optional = true }

--- a/sqlx-core/src/mysql/connection/auth.rs
+++ b/sqlx-core/src/mysql/connection/auth.rs
@@ -1,6 +1,6 @@
 use bytes::buf::Chain;
 use bytes::Bytes;
-use digest::{Digest, FixedOutput};
+use digest::{Digest, OutputSizeUser};
 use generic_array::GenericArray;
 use rand::thread_rng;
 use rsa::{pkcs8::FromPublicKey, PaddingScheme, PublicKey, RsaPublicKey};
@@ -71,7 +71,7 @@ impl AuthPlugin {
 fn scramble_sha1(
     password: &str,
     nonce: &Chain<Bytes, Bytes>,
-) -> GenericArray<u8, <Sha1 as FixedOutput>::OutputSize> {
+) -> GenericArray<u8, <Sha1 as OutputSizeUser>::OutputSize> {
     // SHA1( password ) ^ SHA1( seed + SHA1( SHA1( password ) ) )
     // https://mariadb.com/kb/en/connection/#mysql_native_password-plugin
 
@@ -99,7 +99,7 @@ fn scramble_sha1(
 fn scramble_sha256(
     password: &str,
     nonce: &Chain<Bytes, Bytes>,
-) -> GenericArray<u8, <Sha256 as FixedOutput>::OutputSize> {
+) -> GenericArray<u8, <Sha256 as OutputSizeUser>::OutputSize> {
     // XOR(SHA256(password), SHA256(seed, SHA256(SHA256(password))))
     // https://mariadb.com/kb/en/caching_sha2_password-authentication-plugin/#sha-2-encrypted-password
     let mut ctx = Sha256::new();

--- a/sqlx-core/src/postgres/connection/sasl.rs
+++ b/sqlx-core/src/postgres/connection/sasl.rs
@@ -4,10 +4,9 @@ use crate::postgres::message::{
     Authentication, AuthenticationSasl, MessageFormat, SaslInitialResponse, SaslResponse,
 };
 use crate::postgres::PgConnectOptions;
-use hmac::{Hmac, Mac, NewMac};
+use hmac::{Hmac, Mac};
 use rand::Rng;
-use sha2::digest::Digest;
-use sha2::Sha256;
+use sha2::{Digest, Sha256};
 use stringprep::saslprep;
 
 const GS2_HEADER: &str = "n,,";
@@ -163,7 +162,7 @@ pub(crate) async fn authenticate(
     };
 
     // authentication is only considered valid if this verification passes
-    mac.verify(&data.verifier).map_err(Error::protocol)?;
+    mac.verify_slice(&data.verifier).map_err(Error::protocol)?;
 
     Ok(())
 }

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -88,7 +88,7 @@ sqlx-core = { version = "0.5.10", default-features = false, path = "../sqlx-core
 sqlx-rt = { version = "0.5.10", default-features = false, path = "../sqlx-rt" }
 serde = { version = "1.0.132", features = ["derive"], optional = true }
 serde_json = { version = "1.0.73", features = ["preserve_order"], optional = true }
-sha2 = { version = "0.9.8", optional = true }
+sha2 = { version = "0.10.0", optional = true }
 syn = { version = "1.0.84", default-features = false, features = ["full"] }
 quote = { version = "1.0.14", default-features = false }
 url = { version = "2.2.2", default-features = false }


### PR DESCRIPTION
Updates all RustCrypto dependencies depending on digest 0.9 to the latest versions depending on digest 0.10

Opening as draft, waiting for RSA 0.6.0 to be released.