### PR TITLE
Simplify cargo-sqlx cmdline definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.0-rc.9"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7843ae7a539bef687e018bf9edf7e87728024b29d02b0f8409726be8880ae1a"
+checksum = "12e8611f9ae4e068fa3e56931fded356ff745e70987ff76924a6e0ab1c8ef2e3"
 dependencies = [
  "atty",
  "bitflags",
@@ -442,11 +442,11 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0-rc.9"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae3cc2f259ea636871f5da15b0ac033f1821d7a5506c3d1bfbdde201f14c803"
+checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1073,6 +1073,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -2386,7 +2392,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "clap 3.0.0-rc.9",
+ "clap 3.0.7",
  "console",
  "dotenv",
  "futures",
@@ -2543,7 +2549,7 @@ version = "0.5.10"
 dependencies = [
  "dotenv",
  "either",
- "heck",
+ "heck 0.3.3",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -2682,7 +2688,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",

--- a/sqlx-cli/Cargo.toml
+++ b/sqlx-cli/Cargo.toml
@@ -33,7 +33,7 @@ sqlx = { version = "0.5.10", path = "..", default-features = false, features = [
     "offline",
 ] }
 futures = "0.3.19"
-clap = { version = "3.0.0-rc.9", features = ["derive", "env", "cargo"] }
+clap = { version = "3.0", features = ["derive", "env"] }
 chrono = "0.4.19"
 anyhow = "1.0.52"
 url = { version = "2.2.2", default-features = false }

--- a/sqlx-cli/src/bin/cargo-sqlx.rs
+++ b/sqlx-cli/src/bin/cargo-sqlx.rs
@@ -9,7 +9,7 @@ use std::process;
 #[derive(Parser, Debug)]
 #[clap(bin_name = "cargo")]
 enum Cli {
-    Sqlx(Opt)
+    Sqlx(Opt),
 }
 
 #[tokio::main]

--- a/sqlx-cli/src/bin/cargo-sqlx.rs
+++ b/sqlx-cli/src/bin/cargo-sqlx.rs
@@ -4,6 +4,8 @@ use dotenv::dotenv;
 use sqlx_cli::Opt;
 use std::process;
 
+// cargo invokes this binary as `cargo-sqlx sqlx <args>`
+// so the parser below is defined with that in mind
 #[derive(Parser, Debug)]
 #[clap(bin_name = "cargo")]
 enum Cli {

--- a/sqlx-cli/src/bin/cargo-sqlx.rs
+++ b/sqlx-cli/src/bin/cargo-sqlx.rs
@@ -1,22 +1,19 @@
-use clap::{crate_version, AppSettings, FromArgMatches, IntoApp};
+use clap::Parser;
 use console::style;
 use dotenv::dotenv;
 use sqlx_cli::Opt;
-use std::{env, process};
+use std::process;
+
+#[derive(Parser, Debug)]
+#[clap(bin_name = "cargo")]
+enum Cli {
+    Sqlx(Opt)
+}
 
 #[tokio::main]
 async fn main() {
-    // when invoked as `cargo sqlx [...]` the args we see are `[...]/sqlx-cli sqlx prepare`
-    // so we want to notch out that superfluous "sqlx"
-    let args = env::args_os().skip(2);
-
     dotenv().ok();
-    let matches = Opt::into_app()
-        .bin_name("cargo sqlx")
-        .setting(AppSettings::NoBinaryName)
-        .get_matches_from(args);
-
-    let opt = Opt::from_arg_matches(&matches).unwrap_or_else(|e| e.exit());
+    let Cli::Sqlx(opt) = Cli::parse();
 
     if let Err(error) = sqlx_cli::run(opt).await {
         println!("{} {}", style("error:").bold().red(), error);


### PR DESCRIPTION
Updates clap to the official 3.0 release and removes workarounds for the cargo subcommand in favor of a simple enum Parser with the added `bin_name = "cargo"` setting.

This makes clap **think** the binary is called `cargo` and has only the `sqlx` subcommand, so the help output is unchanged.