### PR TITLE
Any connection kind public

### DIFF
--- a/sqlx-core/src/any/connection/mod.rs
+++ b/sqlx-core/src/any/connection/mod.rs
@@ -30,7 +30,7 @@ mod executor;
 /// sqlite://a.sqlite
 /// ```
 #[derive(Debug)]
-pub struct AnyConnection(pub(super) AnyConnectionKind);
+pub struct AnyConnection(pub AnyConnectionKind);
 
 #[derive(Debug)]
 pub enum AnyConnectionKind {

--- a/sqlx-core/src/any/connection/mod.rs
+++ b/sqlx-core/src/any/connection/mod.rs
@@ -33,7 +33,7 @@ mod executor;
 pub struct AnyConnection(pub(super) AnyConnectionKind);
 
 #[derive(Debug)]
-pub(crate) enum AnyConnectionKind {
+pub enum AnyConnectionKind {
     #[cfg(feature = "postgres")]
     Postgres(postgres::PgConnection),
 

--- a/sqlx-core/src/any/mod.rs
+++ b/sqlx-core/src/any/mod.rs
@@ -30,7 +30,7 @@ mod migrate;
 
 pub use arguments::{AnyArgumentBuffer, AnyArguments};
 pub use column::{AnyColumn, AnyColumnIndex};
-pub use connection::AnyConnection;
+pub use connection::{AnyConnection, AnyConnectionKind};
 pub use database::Any;
 pub use decode::AnyDecode;
 pub use encode::AnyEncode;


### PR DESCRIPTION
I have made a few changes to AnyConnection and AnyConnectionKind which would allow me to directly Use it to insert my own Connections into it to support consolidated database needs.  Please let me know if you have any issues with this OR if you would like to add a Means to Convert Connections into a AnyConnection via into?