### PR TITLE
SQLite unlock notification

### DIFF
--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -134,6 +134,7 @@ libsqlite3-sys = { version = "0.23.2", optional = true, default-features = false
     "pkg-config",
     "vcpkg",
     "bundled",
+    "unlock_notify"
 ] }
 log = { version = "0.4.14", default-features = false }
 md-5 = { version = "0.9.1", default-features = false, optional = true }

--- a/tests/sqlite/sqlite.rs
+++ b/tests/sqlite/sqlite.rs
@@ -664,7 +664,6 @@ async fn issue_1467() -> anyhow::Result<()> {
 }
 
 #[sqlx_macros::test]
-#[ignore] // FIXME
 async fn concurrent_read_and_write() {
     let pool: SqlitePool = SqlitePoolOptions::new()
         .min_connections(2)

--- a/tests/sqlite/sqlite.rs
+++ b/tests/sqlite/sqlite.rs
@@ -662,3 +662,61 @@ async fn issue_1467() -> anyhow::Result<()> {
     }
     Ok(())
 }
+
+#[sqlx_macros::test]
+#[ignore] // FIXME
+async fn concurrent_read_and_write() {
+    let pool: SqlitePool = SqlitePoolOptions::new()
+        .min_connections(2)
+        .connect(":memory:")
+        .await
+        .unwrap();
+
+    sqlx::query("CREATE TABLE kv (k PRIMARY KEY, v)")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let n = 100;
+
+    let read = sqlx_rt::spawn({
+        let mut conn = pool.acquire().await.unwrap();
+
+        async move {
+            for i in 0u32..n {
+                sqlx::query("SELECT v FROM kv")
+                    .bind(i)
+                    .fetch_all(&mut conn)
+                    .await
+                    .unwrap();
+            }
+        }
+    });
+
+    let write = sqlx_rt::spawn({
+        let mut conn = pool.acquire().await.unwrap();
+
+        async move {
+            for i in 0u32..n {
+                sqlx::query("INSERT INTO kv (k, v) VALUES (?, ?)")
+                    .bind(i)
+                    .bind(i * i)
+                    .execute(&mut conn)
+                    .await
+                    .unwrap();
+            }
+        }
+    });
+
+    #[cfg(any(feature = "_rt-tokio", feature = "_rt-actix"))]
+    {
+        read.await.unwrap();
+        write.await.unwrap();
+    }
+
+    #[cfg(feature = "_rt-async-std")]
+    {
+        read.await;
+        write.await;
+    }
+}


### PR DESCRIPTION
This PR implement unlock notification to avoid `SQLITE_LOCKED` ("database table is locked") errors when running concurrent queries. The implementation is basically rustified version of the example from the official sqlite docs on https://www.sqlite.org/unlock_notify.html.

Closes #1649 
