### PR TITLE
refactor: alias actix-* features to their equivalent tokio-* features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,6 @@
 version = 3
 
 [[package]]
-name = "actix-rt"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea16c295198e958ef31930a6ef37d0fb64e9ca3b6116e6b93a8bdae96ee1000"
-dependencies = [
- "futures-core",
- "tokio",
-]
-
-[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2673,7 +2663,6 @@ dependencies = [
 name = "sqlx-rt"
 version = "0.6.0"
 dependencies = [
- "actix-rt",
  "async-native-tls",
  "async-std",
  "futures-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,11 +75,7 @@ runtime-async-std = []
 runtime-tokio = []
 
 # actual runtimes
-runtime-actix-native-tls = [
-    "sqlx-core/runtime-actix-native-tls",
-    "sqlx-macros/runtime-actix-native-tls",
-    "_rt-actix",
-]
+runtime-actix-native-tls = ["runtime-tokio-native-tls"]
 runtime-async-std-native-tls = [
     "sqlx-core/runtime-async-std-native-tls",
     "sqlx-macros/runtime-async-std-native-tls",
@@ -91,11 +87,7 @@ runtime-tokio-native-tls = [
     "_rt-tokio",
 ]
 
-runtime-actix-rustls = [
-    "sqlx-core/runtime-actix-rustls",
-    "sqlx-macros/runtime-actix-rustls",
-    "_rt-actix",
-]
+runtime-actix-rustls = ["runtime-tokio-rustls"]
 runtime-async-std-rustls = [
     "sqlx-core/runtime-async-std-rustls",
     "sqlx-macros/runtime-async-std-rustls",
@@ -108,7 +100,6 @@ runtime-tokio-rustls = [
 ]
 
 # for conditional compilation
-_rt-actix = []
 _rt-async-std = []
 _rt-tokio = []
 

--- a/README.md
+++ b/README.md
@@ -218,10 +218,6 @@ async-std = { version = "1", features = [ "attributes" ] }
 # Tokio:
 sqlx = { version = "0.5", features = [ "runtime-tokio-native-tls" , "postgres" ] }
 tokio = { version = "1", features = ["full"] }
-
-# Actix-web:
-sqlx = { version = "0.5", features = [ "runtime-actix-native-tls" , "postgres" ] }
-actix-web = "3"
 ```
 
 ```rust

--- a/sqlx-bench/Cargo.toml
+++ b/sqlx-bench/Cargo.toml
@@ -6,10 +6,7 @@ edition = "2021"
 publish = false
 
 [features]
-runtime-actix-native-tls = [
-    "sqlx/runtime-actix-native-tls",
-    "sqlx-rt/runtime-actix-native-tls",
-]
+runtime-actix-native-tls = ["runtime-tokio-native-tls"]
 runtime-async-std-native-tls = [
     "sqlx/runtime-async-std-native-tls",
     "sqlx-rt/runtime-async-std-native-tls",
@@ -19,10 +16,7 @@ runtime-tokio-native-tls = [
     "sqlx-rt/runtime-tokio-native-tls",
 ]
 
-runtime-actix-rustls = [
-    "sqlx/runtime-actix-rustls",
-    "sqlx-rt/runtime-actix-rustls",
-]
+runtime-actix-rustls = ["runtime-tokio-rustls"]
 runtime-async-std-rustls = [
     "sqlx/runtime-async-std-rustls",
     "sqlx-rt/runtime-async-std-rustls",

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -65,12 +65,7 @@ decimal = ["rust_decimal", "num-bigint"]
 json = ["serde", "serde_json"]
 
 # runtimes
-runtime-actix-native-tls = [
-    "sqlx-rt/runtime-actix-native-tls",
-    "sqlx/runtime-actix-native-tls",
-    "_tls-native-tls",
-    "_rt-actix",
-]
+runtime-actix-native-tls = ["runtime-tokio-native-tls"]
 runtime-async-std-native-tls = [
     "sqlx-rt/runtime-async-std-native-tls",
     "sqlx/runtime-async-std-native-tls",
@@ -84,12 +79,7 @@ runtime-tokio-native-tls = [
     "_rt-tokio",
 ]
 
-runtime-actix-rustls = [
-    "sqlx-rt/runtime-actix-rustls",
-    "sqlx/runtime-actix-rustls",
-    "_tls-rustls",
-    "_rt-actix"
-]
+runtime-actix-rustls = ['runtime-tokio-rustls']
 runtime-async-std-rustls = [
     "sqlx-rt/runtime-async-std-rustls",
     "sqlx/runtime-async-std-rustls",
@@ -104,7 +94,6 @@ runtime-tokio-rustls = [
 ]
 
 # for conditional compilation
-_rt-actix = ["tokio-stream"]
 _rt-async-std = []
 _rt-tokio = ["tokio-stream"]
 _tls-native-tls = []

--- a/sqlx-core/src/migrate/source.rs
+++ b/sqlx-core/src/migrate/source.rs
@@ -24,7 +24,7 @@ impl<'s> MigrationSource<'s> for &'s Path {
             let mut s = fs::read_dir(self.canonicalize()?).await?;
             let mut migrations = Vec::new();
 
-            #[cfg(any(feature = "_rt-actix", feature = "_rt-tokio"))]
+            #[cfg(feature = "_rt-tokio")]
             let mut s = tokio_stream::wrappers::ReadDirStream::new(s);
 
             while let Some(entry) = s.try_next().await? {

--- a/sqlx-core/src/mssql/connection/mod.rs
+++ b/sqlx-core/src/mssql/connection/mod.rs
@@ -45,7 +45,7 @@ impl Connection for MssqlConnection {
             ready(self.stream.shutdown(Shutdown::Both).map_err(Into::into)).boxed()
         }
 
-        #[cfg(any(feature = "_rt-actix", feature = "_rt-tokio"))]
+        #[cfg(feature = "_rt-tokio")]
         {
             use sqlx_rt::AsyncWriteExt;
 

--- a/sqlx-core/src/net/mod.rs
+++ b/sqlx-core/src/net/mod.rs
@@ -7,11 +7,11 @@ pub use tls::{CertificateInput, MaybeTlsStream};
 #[cfg(feature = "_rt-async-std")]
 type PollReadBuf<'a> = [u8];
 
-#[cfg(any(feature = "_rt-actix", feature = "_rt-tokio"))]
+#[cfg(feature = "_rt-tokio")]
 type PollReadBuf<'a> = sqlx_rt::ReadBuf<'a>;
 
 #[cfg(feature = "_rt-async-std")]
 type PollReadOut = usize;
 
-#[cfg(any(feature = "_rt-actix", feature = "_rt-tokio"))]
+#[cfg(feature = "_rt-tokio")]
 type PollReadOut = ();

--- a/sqlx-core/src/net/socket.rs
+++ b/sqlx-core/src/net/socket.rs
@@ -51,7 +51,7 @@ impl Socket {
             }
         }
 
-        #[cfg(any(feature = "_rt-actix", feature = "_rt-tokio"))]
+        #[cfg(feature = "_rt-tokio")]
         {
             use sqlx_rt::AsyncWriteExt;
 
@@ -103,7 +103,7 @@ impl AsyncWrite for Socket {
         }
     }
 
-    #[cfg(any(feature = "_rt-actix", feature = "_rt-tokio"))]
+    #[cfg(feature = "_rt-tokio")]
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         match &mut *self {
             Socket::Tcp(s) => Pin::new(s).poll_shutdown(cx),

--- a/sqlx-core/src/net/tls/mod.rs
+++ b/sqlx-core/src/net/tls/mod.rs
@@ -190,7 +190,7 @@ where
         }
     }
 
-    #[cfg(any(feature = "_rt-actix", feature = "_rt-tokio"))]
+    #[cfg(feature = "_rt-tokio")]
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         match &mut *self {
             MaybeTlsStream::Raw(s) => Pin::new(s).poll_shutdown(cx),

--- a/sqlx-core/src/postgres/copy.rs
+++ b/sqlx-core/src/postgres/copy.rs
@@ -203,7 +203,7 @@ impl<C: DerefMut<Target = PgConnection>> PgCopyIn<C> {
             loop {
                 let read = match () {
                     // Tokio lets us read into the buffer without zeroing first
-                    #[cfg(any(feature = "runtime-tokio", feature = "runtime-actix"))]
+                    #[cfg(feature = "runtime-tokio")]
                     _ if buf.len() != buf.capacity() => {
                         // in case we have some data in the buffer, which can occur
                         // if the previous write did not fill the buffer

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -20,11 +20,7 @@ default = ["runtime-async-std-native-tls", "migrate"]
 migrate = ["sha2", "sqlx-core/migrate"]
 
 # runtimes
-runtime-actix-native-tls = [
-    "sqlx-core/runtime-actix-native-tls",
-    "sqlx-rt/runtime-actix-native-tls",
-    "_rt-actix",
-]
+runtime-actix-native-tls = ["runtime-tokio-native-tls"]
 runtime-async-std-native-tls = [
     "sqlx-core/runtime-async-std-native-tls",
     "sqlx-rt/runtime-async-std-native-tls",
@@ -36,11 +32,7 @@ runtime-tokio-native-tls = [
     "_rt-tokio",
 ]
 
-runtime-actix-rustls = [
-    "sqlx-core/runtime-actix-rustls",
-    "sqlx-rt/runtime-actix-rustls",
-    "_rt-actix",
-]
+runtime-actix-rustls = ["runtime-tokio-rustls"]
 runtime-async-std-rustls = [
     "sqlx-core/runtime-async-std-rustls",
     "sqlx-rt/runtime-async-std-rustls",
@@ -53,7 +45,6 @@ runtime-tokio-rustls = [
 ]
 
 # for conditional compilation
-_rt-actix = []
 _rt-async-std = []
 _rt-tokio = []
 

--- a/sqlx-macros/src/lib.rs
+++ b/sqlx-macros/src/lib.rs
@@ -128,15 +128,6 @@ pub fn test(_attr: TokenStream, input: TokenStream) -> TokenStream {
                 ::sqlx_rt::async_std::task::block_on(async { #body })
             }
         }
-    } else if cfg!(feature = "_rt-actix") {
-        quote! {
-            #[test]
-            #(#attrs)*
-            fn #name() #ret {
-                ::sqlx_rt::actix_rt::System::new()
-                    .block_on(async { #body })
-            }
-        }
     } else {
         panic!("one of 'runtime-actix', 'runtime-async-std' or 'runtime-tokio' features must be enabled");
     };

--- a/sqlx-rt/Cargo.toml
+++ b/sqlx-rt/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 
 [features]
-runtime-actix-native-tls = ["_rt-actix", "_tls-native-tls", "tokio-native-tls"]
+runtime-actix-native-tls = ["runtime-tokio-native-tls"]
 runtime-async-std-native-tls = [
     "_rt-async-std",
     "_tls-native-tls",
@@ -19,12 +19,11 @@ runtime-async-std-native-tls = [
 ]
 runtime-tokio-native-tls = ["_rt-tokio", "_tls-native-tls", "tokio-native-tls"]
 
-runtime-actix-rustls = ["_rt-actix", "_tls-rustls", "tokio-rustls"]
+runtime-actix-rustls = ["runtime-tokio-rustls"]
 runtime-async-std-rustls = ["_rt-async-std", "_tls-rustls", "futures-rustls"]
 runtime-tokio-rustls = ["_rt-tokio", "_tls-rustls", "tokio-rustls"]
 
 # Not used directly and not re-exported from sqlx
-_rt-actix = ["actix-rt", "tokio", "once_cell"]
 _rt-async-std = ["async-std"]
 _rt-tokio = ["tokio", "once_cell"]
 _tls-native-tls = ["native-tls"]
@@ -33,7 +32,6 @@ _tls-rustls = []
 [dependencies]
 async-native-tls = { version = "0.4.0", optional = true }
 futures-rustls = { version = "0.22.0", optional = true }
-actix-rt = { version = "2.0.0", default-features = false, optional = true }
 async-std = { version = "1.7.0", features = ["unstable"], optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
 tokio-rustls = { version = "0.23.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-#[cfg(any(
-    feature = "runtime-actix",
-    feature = "runtime-async-std",
-    feature = "runtime-tokio"
-))]
+#[cfg(any(feature = "runtime-async-std", feature = "runtime-tokio"))]
 compile_error!(
     "the features 'runtime-actix', 'runtime-async-std' and 'runtime-tokio' have been removed in
      favor of new features 'runtime-{rt}-{tls}' where rt is one of 'actix', 'async-std' and 'tokio'

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -938,7 +938,7 @@ from (values (null)) vals(val)
 
 #[sqlx_macros::test]
 async fn test_listener_cleanup() -> anyhow::Result<()> {
-    #[cfg(any(feature = "_rt-tokio", feature = "_rt-actix"))]
+    #[cfg(feature = "_rt-tokio")]
     use tokio::time::timeout;
 
     #[cfg(feature = "_rt-async-std")]


### PR DESCRIPTION
Actix Web v4 is stable and finally works under `#[tokio::main]` / `#[tokio::test]`. Therefore, I think it's safe to "remove" these feature flags now. They haven't actually been doing anything more than tokio- flags for a while.

I thought that removing the private flags and aliasing the public ones to their tokio- equivalent would be the best migration path. That way this could go out in a non-breaking release.

Inspired by #1669.