### PR TITLE
Support mssql's DateTime2 type via chrono

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2354,6 +2354,7 @@ version = "0.5.11"
 dependencies = [
  "anyhow",
  "async-std",
+ "chrono",
  "dotenv",
  "env_logger 0.8.4",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ all-types = [
     "decimal",
     "json",
     "time",
-    "chrono",
+    "with_chrono",
     "ipnetwork",
     "mac_address",
     "uuid",
@@ -121,7 +121,7 @@ mssql = ["sqlx-core/mssql", "sqlx-macros/mssql"]
 # types
 bigdecimal = ["sqlx-core/bigdecimal", "sqlx-macros/bigdecimal"]
 decimal = ["sqlx-core/decimal", "sqlx-macros/decimal"]
-chrono = ["sqlx-core/chrono", "sqlx-macros/chrono"]
+with_chrono = ["sqlx-core/chrono", "sqlx-macros/chrono"]
 ipnetwork = ["sqlx-core/ipnetwork", "sqlx-macros/ipnetwork"]
 mac_address = ["sqlx-core/mac_address", "sqlx-macros/mac_address"]
 uuid = ["sqlx-core/uuid", "sqlx-macros/uuid"]
@@ -153,6 +153,7 @@ url = "2.2.2"
 rand = "0.8.4"
 rand_xoshiro = "0.6.0"
 hex = "0.4.3"
+chrono = "0.4.19"
 #
 # Any
 #

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ sqlx = { version = "0.5", features = [ "runtime-async-std-native-tls" ] }
 
 -   `uuid`: Add support for UUID (in Postgres).
 
--   `chrono`: Add support for date and time types from `chrono`.
+-   `with_chrono`: Add support for date and time types from `chrono`.
 
 -   `time`: Add support for date and time types from `time` crate (alternative to `chrono`, which is preferred by `query!` macro, if both enabled)
 

--- a/sqlx-core/src/mssql/protocol/type_info.rs
+++ b/sqlx-core/src/mssql/protocol/type_info.rs
@@ -515,6 +515,9 @@ impl TypeInfo {
             DataType::BigChar => "BIGCHAR",
             DataType::NChar => "NCHAR",
 
+            DataType::DateTime2N => "DATETIME2",
+            DataType::DateTimeOffsetN => "DATETIMEOFFSET",
+
             _ => unimplemented!("name: unsupported data type {:?}", self.ty),
         }
     }
@@ -576,6 +579,18 @@ impl TypeInfo {
 
             DataType::BitN => {
                 s.push_str("bit");
+            }
+
+            DataType::DateTime2N => {
+                s.push_str("datetime2(");
+                s.push_str(itoa::Buffer::new().format(self.scale));
+                s.push_str(")");
+            }
+
+            DataType::DateTimeOffsetN => {
+                s.push_str("datetimeoffset(");
+                s.push_str(itoa::Buffer::new().format(self.scale));
+                s.push_str(")");
             }
 
             _ => unimplemented!("fmt: unsupported data type {:?}", self.ty),

--- a/sqlx-core/src/mssql/types/chrono.rs
+++ b/sqlx-core/src/mssql/types/chrono.rs
@@ -1,0 +1,152 @@
+use byteorder::{ByteOrder, LittleEndian};
+use chrono::{DateTime, Datelike, FixedOffset, NaiveDateTime, Offset, Timelike};
+
+use crate::decode::Decode;
+use crate::encode::{Encode, IsNull};
+use crate::error::BoxDynError;
+use crate::mssql::protocol::type_info::{DataType, TypeInfo};
+use crate::mssql::{Mssql, MssqlTypeInfo, MssqlValueRef};
+use crate::types::Type;
+
+/// Provides conversion of chrono::DateTime (UTC) to MS SQL DateTime2N
+///
+/// Note that MS SQL has a number of DateTime-related types and conversion
+/// might not work.
+/// During encoding, values are always encoded with the best possible
+/// precision, which uses 7 digits for nanoseconds.
+impl Type<Mssql> for NaiveDateTime {
+    fn type_info() -> MssqlTypeInfo {
+        MssqlTypeInfo(TypeInfo {
+            scale: 7,
+            ty: DataType::DateTime2N,
+            size: 8,
+            collation: None,
+            precision: 0,
+        })
+    }
+
+    fn compatible(ty: &MssqlTypeInfo) -> bool {
+        matches!(ty.0.ty, DataType::DateTime2N)
+    }
+}
+
+impl<T> Type<Mssql> for DateTime<T>
+where
+    T: chrono::TimeZone,
+{
+    fn type_info() -> MssqlTypeInfo {
+        MssqlTypeInfo(TypeInfo {
+            scale: 7,
+            ty: DataType::DateTimeOffsetN,
+            size: 8,
+            collation: None,
+            precision: 34,
+        })
+    }
+
+    fn compatible(ty: &MssqlTypeInfo) -> bool {
+        matches!(ty.0.ty, DataType::DateTimeOffsetN)
+    }
+}
+
+/// Split the time into days from Gregorian calendar, seconds and nanoseconds
+/// as required for DateTime2
+fn split_time(date_time: &NaiveDateTime) -> (i32, u32, u32) {
+    let mut days = date_time.num_days_from_ce() - 1;
+    let mut seconds = date_time.num_seconds_from_midnight();
+    let mut ns = date_time.nanosecond();
+
+    // this date format cannot encode anything outside of 0000-01-01 to 9999-12-31
+    // so it's best to do some bounds-checking
+    if days < 0 {
+        days = 0;
+        seconds = 0;
+        ns = 0;
+    } else if days > 3652058 {
+        // corresponds to 9999-12-31, the highest plausible value for YYYY-MM-DD
+        days = 3652058;
+        seconds = 59 + 59 * 60 + 23 * 3600;
+        ns = 999999900
+    }
+    (days, seconds, ns)
+}
+
+fn encode_date_time2(datetime: &NaiveDateTime) -> [u8; 8] {
+    let (days, seconds, ns) = split_time(datetime);
+
+    // always use full scale, 7 digits for nanoseconds,
+    // requiring 5 bytes for seconds + nanoseconds combined
+    let mut date = [0u8; 8];
+    let ns_total = (seconds as i64) * 1_000_000_000 + ns as i64;
+    let t = ns_total / 100;
+    for i in 0..5 {
+        date[i] = (t >> i * 8) as u8;
+    }
+    LittleEndian::write_i24(&mut date[5..8], days);
+    date
+}
+
+/// Encodes DateTime objects for transfer over the wire
+impl Encode<'_, Mssql> for NaiveDateTime {
+    fn encode_by_ref(&self, buf: &mut Vec<u8>) -> IsNull {
+        let encoded = encode_date_time2(self);
+        buf.extend_from_slice(&encoded);
+        IsNull::No
+    }
+}
+
+impl<T> Encode<'_, Mssql> for DateTime<T>
+where
+    T: chrono::TimeZone,
+{
+    fn encode_by_ref(&self, buf: &mut Vec<u8>) -> IsNull {
+        buf.extend_from_slice(&encode_date_time2(&self.naive_utc()));
+        let from_utc = self.offset().fix().local_minus_utc();
+        let mut encoded_offset: [u8; 2] = [0, 0];
+        LittleEndian::write_i16(&mut encoded_offset, (from_utc / 60) as i16);
+        buf.extend_from_slice(&encoded_offset);
+        IsNull::No
+    }
+}
+
+/// Determines seconds since midnight and nanoseconds since the last second
+fn decode_time(scale: u8, data: &[u8]) -> (u32, u32) {
+    let mut acc = 0u64;
+    for i in (0..data.len()).rev() {
+        acc <<= 8;
+        acc |= data[i] as u64;
+    }
+    acc *= 10u64.pow(9u32 - scale as u32);
+    let seconds = acc / 1_000_000_000;
+    let ns = acc % 1_000_000_000;
+    (seconds as u32, ns as u32)
+}
+
+fn decode_datetime2(scale: u8, bytes: &[u8]) -> NaiveDateTime {
+    let timesize = bytes.len() - 3;
+
+    let days_from_ce = LittleEndian::read_i24(&bytes[timesize..]);
+    let day = chrono::NaiveDate::from_num_days_from_ce(days_from_ce + 1);
+
+    let (seconds, nanoseconds) = decode_time(scale, &bytes[0..timesize]);
+    let time = chrono::NaiveTime::from_num_seconds_from_midnight(seconds, nanoseconds);
+
+    day.and_time(time)
+}
+
+/// Decodes DateTime2N values received from the server
+impl Decode<'_, Mssql> for NaiveDateTime {
+    fn decode(value: MssqlValueRef<'_>) -> Result<Self, BoxDynError> {
+        let bytes = value.as_bytes()?;
+        Ok(decode_datetime2(value.type_info.0.scale, bytes))
+    }
+}
+
+impl Decode<'_, Mssql> for DateTime<FixedOffset> {
+    fn decode(value: MssqlValueRef<'_>) -> Result<Self, BoxDynError> {
+        let bytes = value.as_bytes()?;
+        let naive = decode_datetime2(value.type_info.0.scale, &bytes[..bytes.len() - 2]);
+        let offset = LittleEndian::read_i16(&bytes[bytes.len() - 2..]);
+        Ok(DateTime::from_utc(naive, FixedOffset::east(offset as i32)))
+    }
+}

--- a/sqlx-core/src/mssql/types/mod.rs
+++ b/sqlx-core/src/mssql/types/mod.rs
@@ -3,6 +3,8 @@ use crate::mssql::protocol::type_info::{DataType, TypeInfo};
 use crate::mssql::{Mssql, MssqlTypeInfo};
 
 mod bool;
+#[cfg(feature = "chrono")]
+mod chrono;
 mod float;
 mod int;
 mod str;

--- a/tests/mssql/types.rs
+++ b/tests/mssql/types.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, NaiveDateTime};
 use sqlx::mssql::Mssql;
 use sqlx_test::test_type;
 
@@ -40,4 +41,15 @@ test_type!(bool(
     Mssql,
     "CAST(1 as BIT)" == true,
     "CAST(0 as BIT)" == false
+));
+
+test_type!(NaiveDateTime(
+    Mssql,
+    "CAST('2016-10-23 12:45:37.1234567' as DateTime2)"
+        == NaiveDateTime::from_timestamp(1477226737, 123456700)
+));
+
+test_type!(DateTime<_>(
+    Mssql,
+    "CAST('2016-10-23 12:45:37.1234567 +02:00' as datetimeoffset(7))" == DateTime::parse_from_rfc3339("2016-10-23T12:45:37.1234567+02:00").unwrap()
 ));

--- a/tests/x.py
+++ b/tests/x.py
@@ -178,7 +178,7 @@ for runtime in ["async-std", "tokio", "actix"]:
 
         for version in ["2019", "2017"]:
             run(
-                f"cargo test --no-default-features --features macros,offline,any,all-types,mssql,runtime-{runtime}-{tls}",
+                f"cargo test --no-default-features --features macros,offline,any,all-types,with_chrono,mssql,runtime-{runtime}-{tls}",
                 comment=f"test mssql {version}",
                 service=f"mssql_{version}",
                 tag=f"mssql_{version}" if runtime == "async-std" else f"mssql_{version}_{runtime}",


### PR DESCRIPTION
There was some previous conversation about it in #1251 but I didn't find any code in the current version of the repository to get it working. So I wrote my own version, based on the [implementation from the `go-mssqldb` library](https://github.com/denisenkom/go-mssqldb/blob/master/types.go).

Unfortunately, In order to add it to have a full integration test for type casting, I had to add `chrono` to the `dev-dependencies` in `Cargo.toml`. And since one cannot have features with the same name as a dependency, I had to rename the feature from `chrono` to `with_chrono`.

Any suggestions for improvement welcome.