### PR TITLE
Make a note about sqlx macros opt level

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ modifications (to the database-accessing parts of the code) are done, you can en
 to cache the results of the SQL query analysis using the `sqlx` command-line tool. See
 [sqlx-cli/README.md](./sqlx-cli/README.md#enable-building-in-offline-mode-with-query).
 
-Compile time verified queries does quite a bit of work at compile time. Incremental actions like
+Compile time verified queries do quite a bit of work at compile time. Incremental actions like
 `cargo check` and `cargo build` can be significantly faster when using an optimized build by
 putting the following in your `Cargo.toml` (More information in the
 [Profiles section](https://doc.rust-lang.org/cargo/reference/profiles.html) of The Cargo Book)

--- a/README.md
+++ b/README.md
@@ -413,6 +413,16 @@ modifications (to the database-accessing parts of the code) are done, you can en
 to cache the results of the SQL query analysis using the `sqlx` command-line tool. See
 [sqlx-cli/README.md](./sqlx-cli/README.md#enable-building-in-offline-mode-with-query).
 
+Compile time verified queries does quite a bit of work at compile time. Incremental actions like
+`cargo check` and `cargo build` can be significantly faster when using an optimized build by
+putting the following in your `Cargo.toml` (More information in the
+[Profiles section](https://doc.rust-lang.org/cargo/reference/profiles.html) of The Cargo Book)
+
+```toml
+[profile.dev.package.sqlx-macros]
+opt-level = 3
+```
+
 ## Safety
 
 This crate uses `#![forbid(unsafe_code)]` to ensure everything is implemented in 100% Safe Rust.


### PR DESCRIPTION
Changing this build setting made `cargo check` over twice as fast on a project I work on. I didn't see this mentioned anywhere in the documentation for this project, so I figured it was worth adding a note