### PR TITLE
Impl PgHasArrayType for serde_json::{Value,RawValue}

### DIFF
--- a/sqlx-core/src/postgres/types/json.rs
+++ b/sqlx-core/src/postgres/types/json.rs
@@ -7,6 +7,8 @@ use crate::postgres::{
 };
 use crate::types::{Json, Type};
 use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue as JsonRawValue;
+use serde_json::Value as JsonValue;
 
 // <https://www.postgresql.org/docs/12/datatype-json.html>
 
@@ -31,6 +33,26 @@ impl<T> PgHasArrayType for Json<T> {
 
     fn array_compatible(ty: &PgTypeInfo) -> bool {
         array_compatible::<Json<T>>(ty)
+    }
+}
+
+impl PgHasArrayType for JsonValue {
+    fn array_type_info() -> PgTypeInfo {
+        PgTypeInfo::JSONB_ARRAY
+    }
+
+    fn array_compatible(ty: &PgTypeInfo) -> bool {
+        array_compatible::<JsonValue>(ty)
+    }
+}
+
+impl PgHasArrayType for JsonRawValue {
+    fn array_type_info() -> PgTypeInfo {
+        PgTypeInfo::JSONB_ARRAY
+    }
+
+    fn array_compatible(ty: &PgTypeInfo) -> bool {
+        array_compatible::<JsonRawValue>(ty)
     }
 }
 

--- a/sqlx-core/src/postgres/types/mod.rs
+++ b/sqlx-core/src/postgres/types/mod.rs
@@ -231,7 +231,7 @@ pub use time_tz::PgTimeTz;
 pub use record::{PgRecordDecoder, PgRecordEncoder};
 
 // Type::compatible impl appropriate for arrays
-fn array_compatible<E: Type<Postgres>>(ty: &PgTypeInfo) -> bool {
+fn array_compatible<E: Type<Postgres> + ?Sized>(ty: &PgTypeInfo) -> bool {
     // we require the declared type to be an _array_ with an
     // element type that is acceptable
     if let PgTypeKind::Array(element) = &ty.kind() {

--- a/sqlx-core/src/types/json.rs
+++ b/sqlx-core/src/types/json.rs
@@ -56,34 +56,6 @@ where
     }
 }
 
-impl<DB> Type<DB> for Vec<JsonValue>
-where
-    Vec<Json<JsonValue>>: Type<DB>,
-    DB: Database,
-{
-    fn type_info() -> DB::TypeInfo {
-        <Vec<Json<JsonValue>> as Type<DB>>::type_info()
-    }
-
-    fn compatible(ty: &DB::TypeInfo) -> bool {
-        <Vec<Json<JsonValue>> as Type<DB>>::compatible(ty)
-    }
-}
-
-impl<DB> Type<DB> for [JsonValue]
-where
-    [Json<JsonValue>]: Type<DB>,
-    DB: Database,
-{
-    fn type_info() -> DB::TypeInfo {
-        <[Json<JsonValue>] as Type<DB>>::type_info()
-    }
-
-    fn compatible(ty: &DB::TypeInfo) -> bool {
-        <[Json<JsonValue>] as Type<DB>>::compatible(ty)
-    }
-}
-
 impl<'q, DB> Encode<'q, DB> for JsonValue
 where
     for<'a> Json<&'a Self>: Encode<'q, DB>,


### PR DESCRIPTION
Fixes #1721. 

This adds `PgHasArrayType` for `serde_json::Value` and `serde_json::RawValue`, so that they can be bound to queries again.