### PR TITLE
Make PgLTree::push infallible and take PgLTreeLabel directly.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.25"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
+checksum = "3826a6e0e2215d7a41c2bfc7c9244123969273f3476b939a226aac0ab56e9e3c"
 dependencies = [
  "bitflags",
  "libc",
@@ -1225,9 +1225,9 @@ checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.26+1.3.0"
+version = "0.13.2+1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
+checksum = "3a42de9a51a5c12e00fc0e4ca6bc2ea43582fc6418488e8f615e905d886f258b"
 dependencies = [
  "cc",
  "libc",

--- a/sqlx-core/src/postgres/types/ltree.rs
+++ b/sqlx-core/src/postgres/types/ltree.rs
@@ -29,7 +29,7 @@ pub struct PgLTreeLabel(String);
 impl PgLTreeLabel {
     pub fn new<S>(label: S) -> Result<Self, PgLTreeParseError>
     where
-        S: Into<String>,
+        String: From<S>,
     {
         let label = String::from(label);
         if label.len() <= 256

--- a/sqlx-core/src/postgres/types/ltree.rs
+++ b/sqlx-core/src/postgres/types/ltree.rs
@@ -101,20 +101,19 @@ impl PgLTree {
     /// creates ltree from an iterator with checking labels
     pub fn from_iter<I, S>(labels: I) -> Result<Self, PgLTreeParseError>
     where
-        S: Into<String>,
+        String: From<S>,
         I: IntoIterator<Item = S>,
     {
         let mut ltree = Self::default();
         for label in labels {
-            ltree.push(&label.into())?;
+            ltree.push(String::from(label).parse()?);
         }
         Ok(ltree)
     }
 
     /// push a label to ltree
-    pub fn push(&mut self, label: &str) -> Result<(), PgLTreeParseError> {
-        self.labels.push(PgLTreeLabel::new(label)?);
-        Ok(())
+    pub fn push(&mut self, label: PgLTreeLabel) {
+        self.labels.push(label);
     }
 
     /// pop a label from ltree

--- a/sqlx-core/src/postgres/types/ltree.rs
+++ b/sqlx-core/src/postgres/types/ltree.rs
@@ -27,13 +27,17 @@ pub enum PgLTreeParseError {
 pub struct PgLTreeLabel(String);
 
 impl PgLTreeLabel {
-    pub fn new(label: &str) -> Result<Self, PgLTreeParseError> {
+    pub fn new<S>(label: S) -> Result<Self, PgLTreeParseError>
+    where
+        S: Into<String>,
+    {
+        let label = String::from(label);
         if label.len() <= 256
             && label
                 .bytes()
                 .all(|c| c.is_ascii_alphabetic() || c.is_ascii_digit() || c == b'_')
         {
-            Ok(Self(label.to_owned()))
+            Ok(Self(label))
         } else {
             Err(PgLTreeParseError::InvalidLtreeLabel)
         }
@@ -106,7 +110,7 @@ impl PgLTree {
     {
         let mut ltree = Self::default();
         for label in labels {
-            ltree.push(String::from(label).parse()?);
+            ltree.push(PgLTreeLabel::new(label)?);
         }
         Ok(ltree)
     }


### PR DESCRIPTION
Previously the function took strings and parsed them into PgLTreeLabel internally, now it's possible to directlry push PgLTreeLabels onto a PgLTree.

It was a bit awkward that pop and push returned different types