### PR TITLE
Pass the `DATABASE_URL` to command spawned for `sqlx-macros`

### DIFF
--- a/sqlx-cli/src/prepare.rs
+++ b/sqlx-cli/src/prepare.rs
@@ -24,7 +24,7 @@ struct DataFile {
 
 pub fn run(url: &str, merge: bool, cargo_args: Vec<String>) -> anyhow::Result<()> {
     let db_kind = get_db_kind(url)?;
-    let data = run_prepare_step(merge, cargo_args)?;
+    let data = run_prepare_step(url, merge, cargo_args)?;
 
     if data.is_empty() {
         println!(
@@ -54,7 +54,7 @@ pub fn run(url: &str, merge: bool, cargo_args: Vec<String>) -> anyhow::Result<()
 
 pub fn check(url: &str, merge: bool, cargo_args: Vec<String>) -> anyhow::Result<()> {
     let db_kind = get_db_kind(url)?;
-    let data = run_prepare_step(merge, cargo_args)?;
+    let data = run_prepare_step(url, merge, cargo_args)?;
 
     let data_file = File::open("sqlx-data.json").context(
         "failed to open `sqlx-data.json`; you may need to run `cargo sqlx prepare` first",
@@ -80,7 +80,7 @@ pub fn check(url: &str, merge: bool, cargo_args: Vec<String>) -> anyhow::Result<
     Ok(())
 }
 
-fn run_prepare_step(merge: bool, cargo_args: Vec<String>) -> anyhow::Result<QueryData> {
+fn run_prepare_step(url: &str, merge: bool, cargo_args: Vec<String>) -> anyhow::Result<QueryData> {
     anyhow::ensure!(
         Path::new("Cargo.toml").exists(),
         r#"Failed to read `Cargo.toml`.
@@ -126,6 +126,7 @@ hint: This command only works in the manifest directory of a Cargo package."#
             .args(cargo_args)
             .env("RUSTFLAGS", rustflags)
             .env("SQLX_OFFLINE", "false")
+            .env("DATABASE_URL", url)
             .status()?
     } else {
         Command::new(&cargo)
@@ -141,6 +142,7 @@ hint: This command only works in the manifest directory of a Cargo package."#
                 SystemTime::UNIX_EPOCH.elapsed()?.as_millis()
             ))
             .env("SQLX_OFFLINE", "false")
+            .env("DATABASE_URL", url)
             .status()?
     };
 


### PR DESCRIPTION
Currently `cargo sqlx prepare` doesn't pass the database url value to the child command spawned for `sqlx-macros`.

```cmd
$ DATABASE_URL="..." cargo sqlx prepare
```

works as expected because `sqlx-macros` will read the value from the env var which is inherited, but

```cmd
$ cargo sqlx prepare --database-url "..."
```

will fail in some way (An existing `sqlx-data.json` makes it not fail, but causes it to find no queries. No existing `sqlx-data.json` will lead to a `error: failed to find data for query`) because the database url isn't being passed to the child process.

It's also worth noting that these changes appear to obey precedence correctly too where

```cmd
$ DATABASE_URL="A" cargo sqlx prepare --database-url "B"
```

will lead to `"B"` being used which should be right. I wasn't certain that the old env var would be overridden until I tested it, but it follows what I would have assumed.