### PR TITLE
Update `regex`

### DIFF
--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -144,7 +144,7 @@ num-bigint = { version = "0.3.3", default-features = false, optional = true, fea
 once_cell = "1.9.0"
 percent-encoding = "2.1.0"
 rand = { version = "0.8.4", default-features = false, optional = true, features = ["std", "std_rng"] }
-regex = { version = "1.5.4", optional = true }
+regex = { version = "1.5.5", optional = true }
 rsa = { version = "0.5.0", optional = true }
 rustls = { version = "0.19.1", features = ["dangerous_configuration"], optional = true }
 serde = { version = "1.0.132", features = ["derive", "rc"], optional = true }


### PR DESCRIPTION
Update regex to 1.5.5 as per the [security advisory](https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html)