### PR TITLE
XXX: Hack statement ID to be random instead of sequential

### DIFF
--- a/sqlx-core/src/postgres/connection/establish.rs
+++ b/sqlx-core/src/postgres/connection/establish.rs
@@ -8,6 +8,8 @@ use crate::postgres::message::{
     Authentication, BackendKeyData, MessageFormat, Password, ReadyForQuery, Startup,
 };
 use crate::postgres::{PgConnectOptions, PgConnection};
+use rand::thread_rng;
+use rand::Rng;
 
 // https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.5.7.3
 // https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.5.7.11
@@ -142,7 +144,7 @@ impl PgConnection {
             transaction_status,
             transaction_depth: 0,
             pending_ready_for_query_count: 0,
-            next_statement_id: 1,
+            next_statement_id: thread_rng().gen(),
             cache_statement: StatementCache::new(options.statement_cache_capacity),
             cache_type_oid: HashMap::new(),
             cache_type_info: HashMap::new(),

--- a/sqlx-core/src/postgres/connection/executor.rs
+++ b/sqlx-core/src/postgres/connection/executor.rs
@@ -17,6 +17,8 @@ use futures_core::future::BoxFuture;
 use futures_core::stream::BoxStream;
 use futures_core::Stream;
 use futures_util::{pin_mut, TryStreamExt};
+use rand::thread_rng;
+use rand::Rng;
 use std::{borrow::Cow, sync::Arc};
 
 async fn prepare(
@@ -26,7 +28,13 @@ async fn prepare(
     metadata: Option<Arc<PgStatementMetadata>>,
 ) -> Result<(u32, Arc<PgStatementMetadata>), Error> {
     let id = conn.next_statement_id;
-    conn.next_statement_id = conn.next_statement_id.wrapping_add(1);
+
+    // XXX(mq): Use random statement IDs instead of sequence to avoid conflicts (almost
+    //          100% of the time). This obviously is not the solution to the problem.
+    //          It is only the proof of concept to verify that this is the root cause
+    //          of the problem.
+    //conn.next_statement_id = conn.next_statement_id.wrapping_add(1);
+    conn.next_statement_id = thread_rng().gen();
 
     // build a list of type OIDs to send to the database in the PARSE command
     // we have not yet started the query sequence, so we are *safe* to cleanly make


### PR DESCRIPTION
Hi, we are trying to use [PgBouncer](https://www.pgbouncer.org/), but there is (a known? related issue: https://github.com/launchbadge/sqlx/issues/67#issuecomment-916272246) problem with the duplicate IDs of prepared statements used by distinct instances sharing the database connections.

One nasty hacky way to get around the problem (statistically working most of the time) is using random statement IDs instead of the sequence. This obviously is not the real solution. It is only the proof of concept to verify that this is the root cause.

So, I am not really looking to merge this PR. Instead, I wanted to ask you guys what are your thoughts on this. What would you see as the best approach to resolve the problem?