### PR TITLE
move extra_float_digits parameter to PgConnectOptions

### DIFF
--- a/sqlx-core/src/postgres/connection/establish.rs
+++ b/sqlx-core/src/postgres/connection/establish.rs
@@ -32,9 +32,9 @@ impl PgConnection {
             // Sets the time zone for displaying and interpreting time stamps.
             ("TimeZone", "UTC"),
             // Adjust postgres to return precise values for floats
-            // NOTE: This is default in postgres 12+
-            ("extra_float_digits", "3"),
+            ("extra_float_digits", options.extra_float_digits.to_string().as_str()),
         ];
+
 
         if let Some(ref application_name) = options.application_name {
             params.push(("application_name", application_name));

--- a/sqlx-core/src/postgres/connection/establish.rs
+++ b/sqlx-core/src/postgres/connection/establish.rs
@@ -32,10 +32,7 @@ impl PgConnection {
             // Sets the time zone for displaying and interpreting time stamps.
             ("TimeZone", "UTC"),
             // Adjust postgres to return precise values for floats
-            (
-                "extra_float_digits",
-                options.extra_float_digits.as_str(),
-            ),
+            ("extra_float_digits", options.extra_float_digits.as_str()),
         ];
 
         if let Some(ref application_name) = options.application_name {

--- a/sqlx-core/src/postgres/connection/establish.rs
+++ b/sqlx-core/src/postgres/connection/establish.rs
@@ -32,9 +32,11 @@ impl PgConnection {
             // Sets the time zone for displaying and interpreting time stamps.
             ("TimeZone", "UTC"),
             // Adjust postgres to return precise values for floats
-            ("extra_float_digits", options.extra_float_digits.to_string().as_str()),
+            (
+                "extra_float_digits",
+                options.extra_float_digits.as_str(),
+            ),
         ];
-
 
         if let Some(ref application_name) = options.application_name {
             params.push(("application_name", application_name));

--- a/sqlx-core/src/postgres/options/mod.rs
+++ b/sqlx-core/src/postgres/options/mod.rs
@@ -88,7 +88,7 @@ pub struct PgConnectOptions {
     pub(crate) application_name: Option<String>,
     pub(crate) log_settings: LogSettings,
     pub(crate) options: Option<String>,
-    pub(crate) extra_float_digits: i32,
+    pub(crate) extra_float_digits: String,
 }
 
 impl Default for PgConnectOptions {
@@ -151,7 +151,7 @@ impl PgConnectOptions {
             log_settings: Default::default(),
             options: var("PGOPTIONS").ok(),
             // NOTE: This is default in postgres 12+
-            extra_float_digits: 3
+            extra_float_digits: "3".to_owned(),
         }
     }
 
@@ -380,6 +380,20 @@ impl PgConnectOptions {
             }
             _ => None,
         }
+    }
+
+    /// Sets the extra float digits. Defaults to 3
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use sqlx_core::postgres::PgConnectOptions;
+    /// let options = PgConnectOptions::new()
+    ///     .extra_float_digits("2");
+    /// ```
+    pub fn extra_float_digits(mut self, extra_float_digits: &str) -> Self {
+        self.extra_float_digits = extra_float_digits.to_owned();
+        self
     }
 }
 

--- a/sqlx-core/src/postgres/options/mod.rs
+++ b/sqlx-core/src/postgres/options/mod.rs
@@ -88,6 +88,7 @@ pub struct PgConnectOptions {
     pub(crate) application_name: Option<String>,
     pub(crate) log_settings: LogSettings,
     pub(crate) options: Option<String>,
+    pub(crate) extra_float_digits: i32,
 }
 
 impl Default for PgConnectOptions {
@@ -149,6 +150,8 @@ impl PgConnectOptions {
             application_name: var("PGAPPNAME").ok(),
             log_settings: Default::default(),
             options: var("PGOPTIONS").ok(),
+            // NOTE: This is default in postgres 12+
+            extra_float_digits: 3
         }
     }
 


### PR DESCRIPTION
Moves `extra_float_digits` to `PgConnectOptions` to allow overriding the parameter.

This solves one of the issues mentioned in [#801](https://github.com/launchbadge/sqlx/issues/801)