### PR TITLE
sqlx-core: impl Type for Cow<str> on Mssql, MySql, and Sqlite

### DIFF
--- a/sqlx-core/src/mssql/types/str.rs
+++ b/sqlx-core/src/mssql/types/str.rs
@@ -83,6 +83,16 @@ impl Decode<'_, Mssql> for String {
     }
 }
 
+impl Type<Mssql> for Cow<'_, str> {
+    fn type_info() -> MssqlTypeInfo {
+        <&str as Type<Mssql>>::type_info()
+    }
+
+    fn compatible(ty: &MssqlTypeInfo) -> bool {
+        <&str as Type<Mssql>>::compatible(ty)
+    }
+}
+
 impl Encode<'_, Mssql> for Cow<'_, str> {
     fn produces(&self) -> Option<MssqlTypeInfo> {
         match self {

--- a/sqlx-core/src/mysql/types/str.rs
+++ b/sqlx-core/src/mysql/types/str.rs
@@ -82,6 +82,16 @@ impl Decode<'_, MySql> for String {
     }
 }
 
+impl Type<MySql> for Cow<'_, str> {
+    fn type_info() -> MySqlTypeInfo {
+        <&str as Type<MySql>>::type_info()
+    }
+
+    fn compatible(ty: &MySqlTypeInfo) -> bool {
+        <&str as Type<MySql>>::compatible(ty)
+    }
+}
+
 impl Encode<'_, MySql> for Cow<'_, str> {
     fn encode_by_ref(&self, buf: &mut Vec<u8>) -> IsNull {
         match self {

--- a/sqlx-core/src/sqlite/types/str.rs
+++ b/sqlx-core/src/sqlite/types/str.rs
@@ -53,6 +53,16 @@ impl<'r> Decode<'r, Sqlite> for String {
     }
 }
 
+impl Type<Sqlite> for Cow<'_, str> {
+    fn type_info() -> SqliteTypeInfo {
+        <&str as Type<Sqlite>>::type_info()
+    }
+
+    fn compatible(ty: &SqliteTypeInfo) -> bool {
+        <&str as Type<Sqlite>>::compatible(ty)
+    }
+}
+
 impl<'q> Encode<'q, Sqlite> for Cow<'q, str> {
     fn encode(self, args: &mut Vec<SqliteArgumentValue<'q>>) -> IsNull {
         args.push(SqliteArgumentValue::Text(self));


### PR DESCRIPTION
I saw that #1343 added Encode/Decode impls for `Cow<str>` for all databases, but `Type` was only implemented on Postgres.

This change adds the missing `Type` impls for the remaining databases (which forward calls to the `&str` implementations).