### PR TITLE
Support `NUMERIC[]` using `decimal` feature

### DIFF
--- a/sqlx-macros/src/database/postgres.rs
+++ b/sqlx-macros/src/database/postgres.rs
@@ -117,6 +117,9 @@ impl_database_ext! {
         #[cfg(feature = "bigdecimal")]
         Vec<sqlx::types::BigDecimal> | &[sqlx::types::BigDecimal],
 
+        #[cfg(feature = "decimal")]
+        Vec<sqlx::types::Decimal> | &[sqlx::types::Decimal],
+
         #[cfg(feature = "ipnetwork")]
         Vec<sqlx::types::ipnetwork::IpNetwork> | &[sqlx::types::ipnetwork::IpNetwork],
 
@@ -133,6 +136,9 @@ impl_database_ext! {
 
         #[cfg(feature = "bigdecimal")]
         sqlx::postgres::types::PgRange<sqlx::types::BigDecimal>,
+
+        #[cfg(feature = "decimal")]
+        sqlx::postgres::types::PgRange<sqlx::types::Decimal>,
 
         #[cfg(feature = "chrono")]
         sqlx::postgres::types::PgRange<sqlx::types::chrono::NaiveDate>,
@@ -161,6 +167,10 @@ impl_database_ext! {
         #[cfg(feature = "bigdecimal")]
         Vec<sqlx::postgres::types::PgRange<sqlx::types::BigDecimal>> |
             &[sqlx::postgres::types::PgRange<sqlx::types::BigDecimal>],
+
+        #[cfg(feature = "decimal")]
+        Vec<sqlx::postgres::types::PgRange<sqlx::types::Decimal>> |
+            &[sqlx::postgres::types::PgRange<sqlx::types::Decimal>],
 
         #[cfg(feature = "chrono")]
         Vec<sqlx::postgres::types::PgRange<sqlx::types::chrono::NaiveDate>> |


### PR DESCRIPTION
Updates macros for postgres to support arrays and ranges for `numeric` type using `decimal` feature.
The implementation just follows `bigdecimal` feature and adds the missing parts.

Fixes #1778 