### PR TITLE
Reuse a cached DB connection instead of always recreating for `sqlx-macros`

### DIFF
--- a/sqlx-core/src/any/connection/mod.rs
+++ b/sqlx-core/src/any/connection/mod.rs
@@ -33,7 +33,9 @@ mod executor;
 pub struct AnyConnection(pub(super) AnyConnectionKind);
 
 #[derive(Debug)]
-pub(crate) enum AnyConnectionKind {
+// Used internally in `sqlx-macros`
+#[doc(hidden)]
+pub enum AnyConnectionKind {
     #[cfg(feature = "postgres")]
     Postgres(postgres::PgConnection),
 
@@ -68,6 +70,12 @@ impl AnyConnectionKind {
 impl AnyConnection {
     pub fn kind(&self) -> AnyKind {
         self.0.kind()
+    }
+
+    // Used internally in `sqlx-macros`
+    #[doc(hidden)]
+    pub fn private_get_mut(&mut self) -> &mut AnyConnectionKind {
+        &mut self.0
     }
 }
 

--- a/sqlx-core/src/any/mod.rs
+++ b/sqlx-core/src/any/mod.rs
@@ -31,6 +31,9 @@ mod migrate;
 pub use arguments::{AnyArgumentBuffer, AnyArguments};
 pub use column::{AnyColumn, AnyColumnIndex};
 pub use connection::AnyConnection;
+// Used internally in `sqlx-macros`
+#[doc(hidden)]
+pub use connection::AnyConnectionKind;
 pub use database::Any;
 pub use decode::AnyDecode;
 pub use encode::AnyEncode;

--- a/sqlx-core/src/pool/mod.rs
+++ b/sqlx-core/src/pool/mod.rs
@@ -55,7 +55,15 @@
 //! [`Pool::begin`].
 
 use self::inner::SharedPool;
-#[cfg(feature = "any")]
+#[cfg(all(
+    any(
+        feature = "postgres",
+        feature = "mysql",
+        feature = "mssql",
+        feature = "sqlite"
+    ),
+    feature = "any"
+))]
 use crate::any::{Any, AnyKind};
 use crate::connection::Connection;
 use crate::database::Database;
@@ -339,12 +347,19 @@ impl<DB: Database> Pool<DB> {
     }
 }
 
-#[cfg(feature = "any")]
+#[cfg(all(
+    any(
+        feature = "postgres",
+        feature = "mysql",
+        feature = "mssql",
+        feature = "sqlite"
+    ),
+    feature = "any"
+))]
 impl Pool<Any> {
     /// Returns the database driver currently in-use by this `Pool`.
     ///
     /// Determined by the connection URI.
-    #[cfg(feature = "any")]
     pub fn any_kind(&self) -> AnyKind {
         self.0.connect_options.kind()
     }

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -84,7 +84,7 @@ heck = { version = "0.4", features = ["unicode"] }
 either = "1.6.1"
 once_cell = "1.9.0"
 proc-macro2 = { version = "1.0.36", default-features = false }
-sqlx-core = { version = "0.5.11", default-features = false, path = "../sqlx-core" }
+sqlx-core = { version = "0.5.11", default-features = false, features = ["any"], path = "../sqlx-core" }
 sqlx-rt = { version = "0.5.11", default-features = false, path = "../sqlx-rt" }
 serde = { version = "1.0.132", features = ["derive"], optional = true }
 serde_json = { version = "1.0.73", optional = true }

--- a/sqlx-macros/src/query/mod.rs
+++ b/sqlx-macros/src/query/mod.rs
@@ -179,7 +179,7 @@ fn expand_from_db(input: QueryMacroInput, db_url: &str) -> crate::Result<TokenSt
                 expand_with_data(input, data, false)
             }
             #[cfg(feature = "mssql")]
-            AnyConnectionKind::MsSql(conn) => {
+            AnyConnectionKind::Mssql(conn) => {
                 let data = QueryData::from_db(conn, &input.sql).await?;
                 expand_with_data(input, data, false)
             }

--- a/sqlx-macros/src/query/mod.rs
+++ b/sqlx-macros/src/query/mod.rs
@@ -181,7 +181,6 @@ fn expand_from_db(input: QueryMacroInput, db_url: &str) -> crate::Result<TokenSt
                         // Connections in `CONNECTION_CACHE` won't get dropped so disable journaling
                         // to avoid `.db-wal` and `.db-shm` files from lingering around
                         .journal_mode(SqliteJournalMode::Off)
-                        .read_only(true)
                         .connect()
                         .await?;
                     AnyConnection::from(sqlite_conn)

--- a/sqlx-rt/src/lib.rs
+++ b/sqlx-rt/src/lib.rs
@@ -37,7 +37,8 @@ pub use native_tls;
 ))]
 pub use tokio::{
     self, fs, io::AsyncRead, io::AsyncReadExt, io::AsyncWrite, io::AsyncWriteExt, io::ReadBuf,
-    net::TcpStream, runtime::Handle, task::spawn, task::yield_now, time::sleep, time::timeout,
+    net::TcpStream, runtime::Handle, sync::Mutex as AsyncMutex, task::spawn, task::yield_now,
+    time::sleep, time::timeout,
 };
 
 #[cfg(all(
@@ -142,7 +143,7 @@ macro_rules! blocking {
 pub use async_std::{
     self, fs, future::timeout, io::prelude::ReadExt as AsyncReadExt,
     io::prelude::WriteExt as AsyncWriteExt, io::Read as AsyncRead, io::Write as AsyncWrite,
-    net::TcpStream, task::sleep, task::spawn, task::yield_now,
+    net::TcpStream, sync::Mutex as AsyncMutex, task::sleep, task::spawn, task::yield_now,
 };
 
 #[cfg(all(


### PR DESCRIPTION
Similar spirit to #1684, but this focus in on speeding up `cargo sqlx prepare` with a remote database. This change reuses the same DB connection instead of recreating one for each `sqlx-macros` query macro.

## Comparison

Three setups tested here. Two MariaDB setups on my work computer, one local and one remote, and the SQLite setup from #1684 on my personal laptop

MariaDB query \#: 332
MariaDB `sqlx-data.json` size: 705 KiB

SQLite query \#: 200
SQLite `sqlx-data.json` size: 305 KiB

The runtimes for `cargo sqlx prepare` on the various setups

| Setup | `master` (f8581386d232aa1e7d4b76d2a7bb1009f8169bcc) | This PR | Reduction `(new - old) / old` |
| :---: | :---: | :---: | :---:
| MariaDB remote | 61.421 s ±  1.985 s | 12.694 s ±  0.153 s | -79% |
| MariaDb local | 5.291 s ±  0.086 s | 5.050 s ±  0.064 s |  -5% |
| SQLite local | 1.562 s ±  0.006 s | 1.425 s ±  0.004 s | -9% |

It looks like the change lowered `cargo sqlx prepare` times across the board with the most significant impact by far on remote DBs