### PR TITLE
Fix Rust type for SQLite REAL

### DIFF
--- a/sqlx-macros/src/database/sqlite.rs
+++ b/sqlx-macros/src/database/sqlite.rs
@@ -1,11 +1,13 @@
 use sqlx_core as sqlx;
 
+// f32 is not included below as REAL represents a floating point value
+// stored as an 8-byte IEEE floating point number
+// For more info see: https://www.sqlite.org/datatype3.html#storage_classes_and_datatypes
 impl_database_ext! {
     sqlx::sqlite::Sqlite {
         bool,
         i32,
         i64,
-        f32,
         f64,
         String,
         Vec<u8>,


### PR DESCRIPTION
REAL is stored as as 8-byte IEEE floating point number
See https://www.sqlite.org/datatype3.html#storage_classes_and_datatypes

NB: As discussed, this is a breaking change