### PR TITLE
(mysql) Silence warnings for unused fields

### DIFF
--- a/sqlx-core/src/mysql/protocol/connect/handshake.rs
+++ b/sqlx-core/src/mysql/protocol/connect/handshake.rs
@@ -12,11 +12,15 @@ use crate::mysql::protocol::Capabilities;
 
 #[derive(Debug)]
 pub(crate) struct Handshake {
+    #[allow(unused)]
     pub(crate) protocol_version: u8,
     pub(crate) server_version: String,
+    #[allow(unused)]
     pub(crate) connection_id: u32,
     pub(crate) server_capabilities: Capabilities,
+    #[allow(unused)]
     pub(crate) server_default_collation: u8,
+    #[allow(unused)]
     pub(crate) status: Status,
     pub(crate) auth_plugin: Option<AuthPlugin>,
     pub(crate) auth_plugin_data: Chain<Bytes, Bytes>,

--- a/sqlx-core/src/mysql/protocol/statement/prepare_ok.rs
+++ b/sqlx-core/src/mysql/protocol/statement/prepare_ok.rs
@@ -11,6 +11,7 @@ pub(crate) struct PrepareOk {
     pub(crate) statement_id: u32,
     pub(crate) columns: u16,
     pub(crate) params: u16,
+    #[allow(unused)]
     pub(crate) warnings: u16,
 }
 

--- a/sqlx-core/src/mysql/protocol/text/column.rs
+++ b/sqlx-core/src/mysql/protocol/text/column.rs
@@ -101,9 +101,13 @@ pub enum ColumnType {
 
 #[derive(Debug)]
 pub(crate) struct ColumnDefinition {
+    #[allow(unused)]
     catalog: Bytes,
+    #[allow(unused)]
     schema: Bytes,
+    #[allow(unused)]
     table_alias: Bytes,
+    #[allow(unused)]
     table: Bytes,
     alias: Bytes,
     name: Bytes,
@@ -111,6 +115,7 @@ pub(crate) struct ColumnDefinition {
     pub(crate) max_size: u32,
     pub(crate) r#type: ColumnType,
     pub(crate) flags: ColumnFlags,
+    #[allow(unused)]
     decimals: u8,
 }
 


### PR DESCRIPTION
Not sure if there is a better way to go about this, but the sheer number of warnings generated on the CI makes it difficult to spot any new ones that show up.