### PR TITLE
Fix #1249 Left joins in SQLite can break the query macros

### DIFF
--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -242,5 +242,17 @@ async fn it_describes_left_join() -> anyhow::Result<()> {
     assert_eq!(d.column(1).type_info().name(), "INTEGER");
     assert_eq!(d.nullable(1), Some(false));
 
+    let d = conn
+        .describe(
+            "select tweet.id, accounts.id from accounts left join tweet on tweet.id = accounts.id",
+        )
+        .await?;
+
+    assert_eq!(d.column(0).type_info().name(), "INTEGER");
+    assert_eq!(d.nullable(0), Some(true));
+
+    assert_eq!(d.column(1).type_info().name(), "INTEGER");
+    assert_eq!(d.nullable(1), Some(false));
+
     Ok(())
 }


### PR DESCRIPTION
Populate column datatypes for a cursor reading from table/index blocks in the main database by parsing sqlite table/index pragmas.  Having that data available allows the Column opcode to map r_cursor correctly, which in turn allows NullRow opcode to clear the correct registers.