### PR TITLE
Fix newline parsing in pgpass

### DIFF
--- a/sqlx-core/src/postgres/options/pgpass.rs
+++ b/sqlx-core/src/postgres/options/pgpass.rs
@@ -59,6 +59,16 @@ fn load_password_from_file(
     let mut reader = BufReader::new(file);
     let mut line = String::new();
 
+    // https://stackoverflow.com/a/55041833
+    fn trim_newline(s: &mut String) {
+        if s.ends_with('\n') {
+            s.pop();
+            if s.ends_with('\r') {
+                s.pop();
+            }
+        }
+    }
+
     while let Ok(n) = reader.read_line(&mut line) {
         if n == 0 {
             break;
@@ -68,8 +78,8 @@ fn load_password_from_file(
             // comment, do nothing
         } else {
             // try to load password from line
-            let line = &line[..line.len() - 1]; // trim newline
-            if let Some(password) = load_password_from_line(line, host, port, username, database) {
+            trim_newline(&mut line);
+            if let Some(password) = load_password_from_line(&line, host, port, username, database) {
                 return Some(password);
             }
         }


### PR DESCRIPTION
# Previous behavior

When parsing `pgpass` files, the BufReader's `read_line` function is used which does not strip \n or \r. To handle this, a substring was created that strips out the last character (`&line[..line.len() - 1]`)

# Why is this an issue

This behavior fails in two cases:
1. If the file uses \r\n instead of just \n
2. If the file has no trailing newline

Case (2) is subtle because it means if you modify your pgpass to add a new entry and forget to add a trailing newline to your file, `[..line.len() - 1]` will cut off the last letter of your password (ex: `hunter12` -> `hunter1`) giving you an authentication error.

# How can we fix it?

Two options:
1. Similar to my PR, we manually strip the newline characters from the end of the string
4. We switch from the `read_line` to the `lines` method which strips the newline characters for you (I don't think this is a performance concern because pgpass files are presumably not large files)

# Tests

I noticed there weren't any tests for `load_password_from_file`  -- only for `load_password_from_line`. I assume it's because setup for a test on file reading is tedious and any issue would get caught integration tests. However, this means I'm not sure what you suggest for a test for this specific case. Please let me know if you're okay without a test or if you have a specific way you'd like me to set it up (or push to my branch yourself)