### PR TITLE
Allow tuples in query_as! macro

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -552,6 +552,12 @@ macro_rules! query_as (
     });
     ($out_struct:path, $query:expr, $($args:tt)*) => ( {
         $crate::sqlx_macros::expand_query!(record = $out_struct, source = $query, args = [$($args)*])
+    });
+    ($out_struct:ty, $query:expr) => ( {
+        $crate::sqlx_macros::expand_query!(record = $out_struct, source = $query)
+    });
+    ($out_struct:ty, $query:expr, $($args:tt)*) => ( {
+        $crate::sqlx_macros::expand_query!(record = $out_struct, source = $query, args = [$($args)*])
     })
 );
 


### PR DESCRIPTION
allow tuples to be used in `query_as!` macro by adding macro_rules cases for for `ty` captures. e.g:
```
let most_downloaded: Vec<_> =
    sqlx::query_as!((String, i64), "SELECT name, downloads FROM crates ORDER BY downloads DESC LIMIT 10")
        .fetch_all(pool)
        .await?;
```