### PR TITLE
Remove Arc around sqlite ValueHandle

### DIFF
--- a/sqlx-core/src/sqlite/value.rs
+++ b/sqlx-core/src/sqlite/value.rs
@@ -1,7 +1,6 @@
 use std::ptr::NonNull;
 use std::slice::from_raw_parts;
 use std::str::from_utf8;
-use std::sync::Arc;
 
 use libsqlite3_sys::{
     sqlite3_value, sqlite3_value_blob, sqlite3_value_bytes, sqlite3_value_double,
@@ -81,30 +80,20 @@ impl<'r> ValueRef<'r> for SqliteValueRef<'r> {
 
 #[derive(Clone)]
 pub struct SqliteValue {
-    pub(crate) handle: Arc<ValueHandle>,
+    pub(crate) handle: ValueHandle,
     pub(crate) type_info: SqliteTypeInfo,
 }
 
-pub(crate) struct ValueHandle(NonNull<sqlite3_value>);
-
-// SAFE: only protected value objects are stored in SqliteValue
-unsafe impl Send for ValueHandle {}
-unsafe impl Sync for ValueHandle {}
-
 impl SqliteValue {
     pub(crate) unsafe fn new(value: *mut sqlite3_value, type_info: SqliteTypeInfo) -> Self {
-        debug_assert!(!value.is_null());
-
         Self {
             type_info,
-            handle: Arc::new(ValueHandle(NonNull::new_unchecked(sqlite3_value_dup(
-                value,
-            )))),
+            handle: ValueHandle::dup(value),
         }
     }
 
     fn type_info_opt(&self) -> Option<SqliteTypeInfo> {
-        let dt = DataType::from_code(unsafe { sqlite3_value_type(self.handle.0.as_ptr()) });
+        let dt = DataType::from_code(unsafe { sqlite3_value_type(self.handle.as_ptr()) });
 
         if let DataType::Null = dt {
             None
@@ -114,26 +103,26 @@ impl SqliteValue {
     }
 
     fn int(&self) -> i32 {
-        unsafe { sqlite3_value_int(self.handle.0.as_ptr()) }
+        unsafe { sqlite3_value_int(self.handle.as_ptr()) }
     }
 
     fn int64(&self) -> i64 {
-        unsafe { sqlite3_value_int64(self.handle.0.as_ptr()) }
+        unsafe { sqlite3_value_int64(self.handle.as_ptr()) }
     }
 
     fn double(&self) -> f64 {
-        unsafe { sqlite3_value_double(self.handle.0.as_ptr()) }
+        unsafe { sqlite3_value_double(self.handle.as_ptr()) }
     }
 
     fn blob(&self) -> &[u8] {
-        let len = unsafe { sqlite3_value_bytes(self.handle.0.as_ptr()) } as usize;
+        let len = unsafe { sqlite3_value_bytes(self.handle.as_ptr()) } as usize;
 
         if len == 0 {
             // empty blobs are NULL so just return an empty slice
             return &[];
         }
 
-        let ptr = unsafe { sqlite3_value_blob(self.handle.0.as_ptr()) } as *const u8;
+        let ptr = unsafe { sqlite3_value_blob(self.handle.as_ptr()) } as *const u8;
         debug_assert!(!ptr.is_null());
 
         unsafe { from_raw_parts(ptr, len) }
@@ -158,15 +147,7 @@ impl Value for SqliteValue {
     }
 
     fn is_null(&self) -> bool {
-        unsafe { sqlite3_value_type(self.handle.0.as_ptr()) == SQLITE_NULL }
-    }
-}
-
-impl Drop for ValueHandle {
-    fn drop(&mut self) {
-        unsafe {
-            sqlite3_value_free(self.0.as_ptr());
-        }
+        unsafe { sqlite3_value_type(self.handle.as_ptr()) == SQLITE_NULL }
     }
 }
 
@@ -188,6 +169,45 @@ impl From<SqliteValue> for crate::any::AnyValue {
         crate::any::AnyValue {
             type_info: value.type_info().clone().into_owned().into(),
             kind: crate::any::value::AnyValueKind::Sqlite(value),
+        }
+    }
+}
+
+pub(crate) struct ValueHandle(NonNull<sqlite3_value>);
+
+// SAFE: only protected value objects are stored in SqliteValue
+unsafe impl Send for ValueHandle {}
+unsafe impl Sync for ValueHandle {}
+
+impl ValueHandle {
+    #[inline]
+    pub unsafe fn dup(value: *mut sqlite3_value) -> Self {
+        debug_assert!(!value.is_null());
+
+        let dup_value = sqlite3_value_dup(value);
+        if dup_value.is_null() {
+            panic!("Sqlite: memory allocation for value failed");
+        }
+
+        Self(NonNull::new_unchecked(dup_value))
+    }
+
+    #[inline]
+    pub fn as_ptr(&self) -> *mut sqlite3_value {
+        self.0.as_ptr()
+    }
+}
+
+impl Clone for ValueHandle {
+    fn clone(&self) -> Self {
+        unsafe { Self::dup(self.as_ptr()) }
+    }
+}
+
+impl Drop for ValueHandle {
+    fn drop(&mut self) {
+        unsafe {
+            sqlite3_value_free(self.as_ptr());
         }
     }
 }


### PR DESCRIPTION
This avoids an extra allocation per row value, although I don't believe there's any significant impact on performance.