### PR TITLE
fix explicit_outlives_requirements warnings

### DIFF
--- a/sqlx-core/src/query_builder.rs
+++ b/sqlx-core/src/query_builder.rs
@@ -310,7 +310,7 @@ where
 /// A wrapper around `QueryBuilder` for creating comma(or other token)-separated lists.
 ///
 /// See [`QueryBuilder::separated()`] for details.
-pub struct Separated<'qb, 'args: 'qb, DB, Sep>
+pub struct Separated<'qb, 'args, DB, Sep>
 where
     DB: Database,
 {


### PR DESCRIPTION
This fix following warnings

```
warning: outlives requirements can be inferred                                                  
     --> sqlx-core/src/query_builder.rs:313:32                                                       
       |                                                                                                 
313 | pub struct Separated<'qb, 'args: 'qb, DB, Sep>                                                      
       |                                ^^^^^ help: remove this bound                               
       |                                                                                                 
note: the lint level is defined here                                                                     
     --> sqlx-core/src/lib.rs:4:30                                                                
       |                                                                                                 
4     | #![warn(future_incompatible, rust_2018_idioms)]                                               
       |                              ^^^^^^^^^^^^^^^^                                                  
     = note: `#[warn(explicit_outlives_requirements)]` implied by `#[warn(rust_2018_idioms)]`                                                                                                                
```

https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
