### PR TITLE
SQLx-cli Readme: Move `Usage` to same level as `Install`

### DIFF
--- a/sqlx-cli/README.md
+++ b/sqlx-cli/README.md
@@ -21,7 +21,7 @@ $ cargo install sqlx-cli --features openssl-vendored
 $ cargo install sqlx-cli --no-default-features --features rustls
 ```
 
-### Usage
+## Usage
 
 All commands require that a database url is provided. This can be done either with the `--database-url` command line option or by setting `DATABASE_URL`, either in the environment or in a `.env` file
 in the current working directory.
@@ -33,7 +33,7 @@ For more details, run `sqlx <command> --help`.
 DATABASE_URL=postgres://postgres@localhost/my_database
 ```
 
-#### Create/drop the database at `DATABASE_URL`
+### Create/drop the database at `DATABASE_URL`
 
 ```bash
 sqlx database create
@@ -42,7 +42,7 @@ sqlx database drop
 
 ---
 
-#### Create and run migrations
+### Create and run migrations
 
 ```bash
 sqlx migrate add <name>
@@ -70,7 +70,7 @@ sqlx migrate info --source ../relative/migrations
 
 ---
 
-#### Reverting Migrations
+### Reverting Migrations
 
 If you would like to create _reversible_ migrations with corresponding "up" and "down" scripts, you use the `-r` flag when creating new migrations:
 
@@ -104,7 +104,7 @@ $ sqlx migrate add -r <name2>
 error: cannot mix reversible migrations with simple migrations. All migrations should be reversible or simple migrations
 ```
 
-#### Enable building in "offline mode" with `query!()`
+### Enable building in "offline mode" with `query!()`
 
 Note: must be run as `cargo sqlx`.
 
@@ -133,7 +133,7 @@ cargo sqlx prepare --check
 Exits with a nonzero exit status if the data in `sqlx-data.json` is out of date with the current
 database schema and queries in the project. Intended for use in Continuous Integration.
 
-#### Force building in offline mode
+### Force building in offline mode
 
 To make sure an accidentally-present `DATABASE_URL` environment variable or `.env` file does not
 result in `cargo build` (trying to) access the database, you can set the `SQLX_OFFLINE` environment
@@ -142,7 +142,7 @@ variable to `true`.
 If you want to make this the default, just add it to your `.env` file. `cargo sqlx prepare` will
 still do the right thing and connect to the database.
 
-#### Include queries behind feature flags (such as queryies inside of tests)
+### Include queries behind feature flags (such as queryies inside of tests)
 
 In order for sqlx to be able to find queries behind certain feature flags you need to turn them
 on by passing arguments to rustc.


### PR DESCRIPTION
From a formatting perspective, `Usage` is currently nested under `Install`. I think these would appropriately be siblings. This has the side benefit of making the headings under `Usage` more visually distinct from the rest of the content which I think makes it easier to read.

## Before

![image](https://user-images.githubusercontent.com/3683198/163746688-6d05fba2-e416-42c2-8aab-e9267dbe7137.png)


## After

![image](https://user-images.githubusercontent.com/3683198/163746753-b64c95a7-7abb-452f-a159-a16d65067a5b.png)
