### PR TITLE
Improve Sqlite support for sub-queries and CTE's

### DIFF
--- a/sqlx-core/src/logger.rs
+++ b/sqlx-core/src/logger.rs
@@ -1,6 +1,9 @@
 use crate::connection::LogSettings;
+#[cfg(feature = "sqlite")]
 use std::collections::HashSet;
+#[cfg(feature = "sqlite")]
 use std::fmt::Debug;
+#[cfg(feature = "sqlite")]
 use std::hash::Hash;
 use std::time::Instant;
 
@@ -81,6 +84,7 @@ impl<'q> Drop for QueryLogger<'q> {
     }
 }
 
+#[cfg(feature = "sqlite")]
 pub(crate) struct QueryPlanLogger<'q, O: Debug + Hash + Eq, R: Debug + Hash + Eq, P: Debug> {
     sql: &'q str,
     unknown_operations: HashSet<O>,
@@ -89,6 +93,7 @@ pub(crate) struct QueryPlanLogger<'q, O: Debug + Hash + Eq, R: Debug + Hash + Eq
     settings: LogSettings,
 }
 
+#[cfg(feature = "sqlite")]
 impl<'q, O: Debug + Hash + Eq, R: Debug + Hash + Eq, P: Debug> QueryPlanLogger<'q, O, R, P> {
     pub(crate) fn new(sql: &'q str, settings: LogSettings) -> Self {
         Self {
@@ -150,6 +155,7 @@ impl<'q, O: Debug + Hash + Eq, R: Debug + Hash + Eq, P: Debug> QueryPlanLogger<'
     }
 }
 
+#[cfg(feature = "sqlite")]
 impl<'q, O: Debug + Hash + Eq, R: Debug + Hash + Eq, P: Debug> Drop
     for QueryPlanLogger<'q, O, R, P>
 {

--- a/sqlx-core/src/logger.rs
+++ b/sqlx-core/src/logger.rs
@@ -1,4 +1,7 @@
 use crate::connection::LogSettings;
+use std::collections::HashSet;
+use std::fmt::Debug;
+use std::hash::Hash;
 use std::time::Instant;
 
 pub(crate) struct QueryLogger<'q> {
@@ -73,6 +76,75 @@ impl<'q> QueryLogger<'q> {
 }
 
 impl<'q> Drop for QueryLogger<'q> {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+pub(crate) struct QueryPlanLogger<'q, O: Debug + Hash + Eq, P: Debug + Hash + Eq> {
+    sql: &'q str,
+    unknown_operations: HashSet<O>,
+    results: HashSet<P>,
+    settings: LogSettings,
+}
+
+impl<'q, O: Debug + Hash + Eq, P: Debug + Hash + Eq> QueryPlanLogger<'q, O, P> {
+    pub(crate) fn new(sql: &'q str, settings: LogSettings) -> Self {
+        Self {
+            sql,
+            unknown_operations: HashSet::new(),
+            results: HashSet::new(),
+            settings,
+        }
+    }
+
+    pub(crate) fn add_result(&mut self, result: P) {
+        self.results.insert(result);
+    }
+
+    pub(crate) fn add_unknown_operation(&mut self, operation: O) {
+        self.unknown_operations.insert(operation);
+    }
+
+    pub(crate) fn finish(&self) {
+        let lvl = self.settings.statements_level;
+
+        if let Some(lvl) = lvl
+            .to_level()
+            .filter(|lvl| log::log_enabled!(target: "sqlx::explain", *lvl))
+        {
+            let mut summary = parse_query_summary(&self.sql);
+
+            let sql = if summary != self.sql {
+                summary.push_str(" …");
+                format!(
+                    "\n\n{}\n",
+                    sqlformat::format(
+                        &self.sql,
+                        &sqlformat::QueryParams::None,
+                        sqlformat::FormatOptions::default()
+                    )
+                )
+            } else {
+                String::new()
+            };
+
+            log::logger().log(
+                &log::Record::builder()
+                    .args(format_args!(
+                        "{}; unknown_operations:{:?}, results: {:?}",
+                        summary, self.unknown_operations, self.results
+                    ))
+                    .level(lvl)
+                    .module_path_static(Some("sqlx::explain"))
+                    .target("sqlx::explain")
+                    .build(),
+            );
+        }
+    }
+}
+
+impl<'q, O: Debug + Hash + Eq, P: Debug + Hash + Eq> Drop for QueryPlanLogger<'q, O, P> {
     fn drop(&mut self) {
         self.finish();
     }

--- a/sqlx-core/src/logger.rs
+++ b/sqlx-core/src/logger.rs
@@ -138,8 +138,8 @@ impl<'q, O: Debug + Hash + Eq, R: Debug + Hash + Eq, P: Debug> QueryPlanLogger<'
             log::logger().log(
                 &log::Record::builder()
                     .args(format_args!(
-                        "{}; program:{:?}, unknown_operations:{:?}, results: {:?}",
-                        summary, self.program, self.unknown_operations, self.results
+                        "{}; program:{:?}, unknown_operations:{:?}, results: {:?}{}",
+                        summary, self.program, self.unknown_operations, self.results, sql
                     ))
                     .level(lvl)
                     .module_path_static(Some("sqlx::explain"))

--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -507,7 +507,7 @@ pub(super) fn explain(
                 }
 
                 OP_ROW_DATA => {
-                    //Get the row stored at p1, or NULL; get the column stored at p2, or NULL
+                    //Get entire row from cursor p1, store it into register p2
                     if let Some(record) = state.p.get(&p1) {
                         let rowdata = record.map_to_dense_record(&state.r);
                         state.r.insert(p2, RegDataType::Record(rowdata));

--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -117,9 +117,6 @@ const OP_CONCAT: &str = "Concat";
 const OP_RESULT_ROW: &str = "ResultRow";
 const OP_HALT: &str = "Halt";
 
-use crate::connection::LogSettings;
-use std::time::Instant;
-
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 struct ColumnType {
     pub datatype: DataType,

--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -169,7 +169,7 @@ impl RegDataType {
                 nullable: None,
             }, //If we're trying to coerce to a regular Datatype, we can assume a Record is invalid for the context
             RegDataType::Int(_) => ColumnType {
-                datatype: DataType::Int64,
+                datatype: DataType::Int,
                 nullable: Some(false),
             },
         }
@@ -611,21 +611,7 @@ pub(super) fn explain(
                     let idx_range = if p2 < p3 { p2..=p3 } else { p2..=p2 };
 
                     for idx in idx_range {
-                        match state.r.get(&idx).cloned() {
-                            Some(a) => {
-                                state.r.insert(
-                                    idx,
-                                    RegDataType::Single(ColumnType {
-                                        datatype: a.map_to_datatype(),
-                                        nullable: Some(true),
-                                    }),
-                                );
-                            }
-
-                            None => {
-                                state.r.insert(idx, RegDataType::Single(ColumnType::null()));
-                            }
-                        }
+                        state.r.insert(idx, RegDataType::Single(ColumnType::null()));
                     }
                 }
 
@@ -723,12 +709,9 @@ pub(super) fn explain(
                 if output.len() == idx {
                     output.push(this_type);
                 } else if output[idx].is_none()
-                //|| matches!(output[idx], Some(SqliteTypeInfo(DataType::Null)))
+                    || matches!(output[idx], Some(SqliteTypeInfo(DataType::Null)))
                 {
                     output[idx] = this_type;
-                } else if output[idx] != this_type {
-                    //found inconsistent result types, so we can't claim which type it will be
-                    output[idx] = Some(SqliteTypeInfo(DataType::Null))
                 }
 
                 if nullable.len() == idx {

--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -57,6 +57,7 @@ const OP_PREV: &str = "Prev";
 const OP_PROGRAM: &str = "Program";
 const OP_RETURN: &str = "Return";
 const OP_REWIND: &str = "Rewind";
+const OP_ROW_DATA: &str = "RowData";
 const OP_ROW_SET_READ: &str = "RowSetRead";
 const OP_ROW_SET_TEST: &str = "RowSetTest";
 const OP_SEEK_GE: &str = "SeekGE";
@@ -450,6 +451,21 @@ pub(super) fn explain(
                         state
                             .r
                             .insert(p3, RegDataType::Single(ColumnType::default()));
+                    }
+                }
+
+                OP_ROW_DATA => {
+                    //Get the row stored at p1, or NULL; get the column stored at p2, or NULL
+                    if let Some(record) = state.p.get(&p1) {
+                        let mut rowdata = vec![ColumnType::default(); record.len()];
+
+                        for (idx, col) in record.iter() {
+                            rowdata[*idx as usize] = col.clone();
+                        }
+
+                        state.r.insert(p2, RegDataType::Record(rowdata));
+                    } else {
+                        state.r.insert(p2, RegDataType::Record(Vec::new()));
                     }
                 }
 

--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -234,7 +234,7 @@ pub(super) fn explain(
                 //Noop if the register p2 isn't a record, or if pointer p1 does not exist
             }
 
-            OP_OPEN_READ | OP_OPEN_WRITE | OP_OPEN_EPHEMERAL | OP_OPEN_AUTOINDEX => {
+            OP_OPEN_READ | OP_OPEN_WRITE => {
                 //Create a new pointer which is referenced by p1
 
                 //Create a new pointer which is referenced by p1, take column metadata from db schema if found
@@ -253,6 +253,10 @@ pub(super) fn explain(
                 } else {
                     p.insert(p1, HashMap::with_capacity(6));
                 }
+            }
+
+            OP_OPEN_EPHEMERAL | OP_OPEN_AUTOINDEX => {
+                p.insert(p1, HashMap::with_capacity(6));
             }
 
             OP_VARIABLE => {

--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -56,6 +56,7 @@ const OP_DIVIDE: &str = "Divide";
 const OP_REMAINDER: &str = "Remainder";
 const OP_CONCAT: &str = "Concat";
 const OP_RESULT_ROW: &str = "ResultRow";
+const OP_HALT: &str = "Halt";
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 enum RegDataType {
@@ -188,7 +189,8 @@ pub(super) fn explain(
     while state.program_i < program_size {
         if state.visited[state.program_i] {
             state.program_i += 1;
-            continue;
+            //avoid (infinite) loops by breaking if we ever hit the same instruction twice
+            break;
         }
         let (_, ref opcode, p1, p2, p3, ref p4) = program[state.program_i];
 
@@ -402,6 +404,10 @@ pub(super) fn explain(
 
                 // output = r[p1 .. p1 + p2]
                 state.result = Some(p1..p1 + p2);
+            }
+
+            OP_HALT => {
+                break;
             }
 
             _ => {

--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -268,7 +268,6 @@ struct QueryState {
     pub program_i: usize,
     // Results published by the execution
     pub result: Option<Vec<(Option<SqliteTypeInfo>, Option<bool>)>>,
-    pub history: Vec<(i64, String, i64, i64, i64, Vec<u8>)>,
 }
 
 // Opcode Reference: https://sqlite.org/opcode.html
@@ -291,7 +290,6 @@ pub(super) fn explain(
         p: HashMap::with_capacity(6),
         program_i: 0,
         result: None,
-        history: Vec::new(),
     }];
 
     let mut result_states = Vec::new();
@@ -304,8 +302,6 @@ pub(super) fn explain(
                 break;
             }
             let (_, ref opcode, p1, p2, p3, ref p4) = program[state.program_i];
-
-            state.history.push(program[state.program_i].clone());
 
             match &**opcode {
                 OP_INIT => {

--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -773,7 +773,7 @@ fn test_root_block_columns_has_types() {
     .is_some());
     assert!(execute::iter(
         &mut conn,
-        r"CREATE TABLE t2(a INTEGER, b_null NUMERIC NULL, b NUMERIC NOT NULL);",
+        r"CREATE TABLE t2(a INTEGER NOT NULL, b_null NUMERIC NULL, b NUMERIC NOT NULL);",
         None,
         false
     )
@@ -826,7 +826,7 @@ fn test_root_block_columns_has_types() {
         assert_eq!(
             ColumnType {
                 datatype: DataType::Int64,
-                nullable: Some(false)
+                nullable: Some(true) //sqlite primary key columns are nullable unless declared not null
             },
             root_block_cols[&blocknum][&0]
         );
@@ -851,7 +851,7 @@ fn test_root_block_columns_has_types() {
         assert_eq!(
             ColumnType {
                 datatype: DataType::Int64,
-                nullable: Some(false)
+                nullable: Some(true) //sqlite primary key columns are nullable unless declared not null
             },
             root_block_cols[&blocknum][&0]
         );
@@ -869,7 +869,7 @@ fn test_root_block_columns_has_types() {
         assert_eq!(
             ColumnType {
                 datatype: DataType::Int64,
-                nullable: Some(false)
+                nullable: Some(true) //sqlite primary key columns are nullable unless declared not null
             },
             root_block_cols[&blocknum][&0]
         );
@@ -937,7 +937,7 @@ fn test_root_block_columns_has_types() {
         assert_eq!(
             ColumnType {
                 datatype: DataType::Null,
-                nullable: Some(true)
+                nullable: Some(false)
             },
             root_block_cols[&blocknum][&1]
         );

--- a/sqlx-core/src/sqlite/type_info.rs
+++ b/sqlx-core/src/sqlite/type_info.rs
@@ -7,7 +7,7 @@ use libsqlite3_sys::{SQLITE_BLOB, SQLITE_FLOAT, SQLITE_INTEGER, SQLITE_NULL, SQL
 use crate::error::BoxDynError;
 use crate::type_info::TypeInfo;
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "offline", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) enum DataType {
     Null,
@@ -29,7 +29,7 @@ pub(crate) enum DataType {
 }
 
 /// Type information for a SQLite type.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "offline", derive(serde::Serialize, serde::Deserialize))]
 pub struct SqliteTypeInfo(pub(crate) DataType);
 

--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -290,6 +290,11 @@ async fn it_describes_literal_subquery() -> anyhow::Result<()> {
         "WITH cte AS MATERIALIZED (SELECT 'a', NULL) SELECT * FROM cte",
     )
     .await?;
+    assert_literal_described(
+        &mut conn,
+        "WITH RECURSIVE cte(a,b) AS (SELECT 'a', NULL UNION ALL SELECT a||a, NULL FROM cte WHERE length(a)<3) SELECT * FROM cte",
+    )
+    .await?;
 
     Ok(())
 }

--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -44,13 +44,13 @@ async fn it_describes_variables() -> anyhow::Result<()> {
     let info = conn.describe("SELECT ?1").await?;
 
     assert_eq!(info.columns()[0].type_info().name(), "NULL");
-    assert_eq!(info.nullable(0), None); // unknown
+    assert_eq!(info.nullable(0), Some(true)); // nothing prevents the value from being bound to null
 
     // context can be provided by using CAST(_ as _)
     let info = conn.describe("SELECT CAST(?1 AS REAL)").await?;
 
     assert_eq!(info.columns()[0].type_info().name(), "REAL");
-    assert_eq!(info.nullable(0), None); // unknown
+    assert_eq!(info.nullable(0), Some(true)); // nothing prevents the value from being bound to null
 
     Ok(())
 }


### PR DESCRIPTION
Improves the datatype and null tracking for sub-queries and common table expressions through a series of independent changes:
* separating the  'OpenEphemeral' and 'OpenAutoindex' operations from the regular/normal cursor read operations
* unify tracking nullability, inline with the datatype for registers AND cursors, instead of a separate hashtable only tracking cursors, so that nullability will be retained when going through the register.  Retrieve not-null column metadata at the same time, and include temp-tables schema too.
* track all branches of OpCode execution, including following both sides of branch instructions, then merging the possible result rows.
