### PR TITLE
trim [ and ] from host string before used to connect by TcpStream

### DIFF
--- a/sqlx-core/src/net/socket.rs
+++ b/sqlx-core/src/net/socket.rs
@@ -17,7 +17,10 @@ pub enum Socket {
 
 impl Socket {
     pub async fn connect_tcp(host: &str, port: u16) -> io::Result<Self> {
-        TcpStream::connect((host, port)).await.map(Socket::Tcp)
+        // Trim square brackets from host if it's an IPv6 address as the `url` crate doesn't do that.
+        TcpStream::connect((host.trim_matches(|c| c == '[' || c == ']'), port))
+            .await
+            .map(Socket::Tcp)
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
I follow suggestion of @abonander and trim `[` and `]` from host string before connect

Close #1739 