### PR TITLE
(sqlx-macros) Ignore deps when getting metadata for workspace root

### DIFF
--- a/sqlx-macros/src/query/mod.rs
+++ b/sqlx-macros/src/query/mod.rs
@@ -46,7 +46,7 @@ impl Metadata {
             let cargo = env("CARGO").expect("`CARGO` must be set");
 
             let output = Command::new(&cargo)
-                .args(&["metadata", "--format-version=1"])
+                .args(&["metadata", "--format-version=1", "--no-deps"])
                 .current_dir(&self.manifest_dir)
                 .env_remove("__CARGO_FIX_PLZ")
                 .output()


### PR DESCRIPTION
When using compile-time queries in a workspace with a single `sqlx-data.json` file in the workspace root the  following code is run to get the path to the workspace root. Because we only need the workspace root we can ignore dep information which ends up being a small, but significant change

I setup a minimal test environment with a single crate in a workspace. Here are the timings of an incremental unchanged `cargo check`

| `master` (ec15f6b30c3eba483a1aff508d3f46fbbb7b7134) | PR (a4536c829c64d2636451a2f6e5bf2ce3c311e00d) | Diff |
| :---: | :---: | :---: |
| 228.4 ms ± 1.8 ms | 187.2 ms ± 1.5 ms | -42.2 ms |

I also tested with a workspace that had two crates compiled linearly, and the difference there came out to be roughly 40 ms per crate too