### PR TITLE
Implement transaction options API

### DIFF
--- a/sqlx-core/src/any/connection/mod.rs
+++ b/sqlx-core/src/any/connection/mod.rs
@@ -132,11 +132,14 @@ impl Connection for AnyConnection {
         delegate_to_mut!(self.ping())
     }
 
-    fn begin(&mut self) -> BoxFuture<'_, Result<Transaction<'_, Self::Database>, Error>>
+    fn begin_with(
+        &mut self,
+        options: (),
+    ) -> BoxFuture<'_, Result<Transaction<'_, Self::Database>, Error>>
     where
         Self: Sized,
     {
-        Transaction::begin(self)
+        Transaction::begin_with(self, options)
     }
 
     fn cached_statements_size(&self) -> usize {

--- a/sqlx-core/src/any/transaction.rs
+++ b/sqlx-core/src/any/transaction.rs
@@ -10,27 +10,40 @@ pub struct AnyTransactionManager;
 
 impl TransactionManager for AnyTransactionManager {
     type Database = Any;
+    type Options = ();
 
-    fn begin(conn: &mut AnyConnection) -> BoxFuture<'_, Result<(), Error>> {
+    fn begin_with(conn: &mut AnyConnection, _options: ()) -> BoxFuture<'_, Result<(), Error>> {
         match &mut conn.0 {
             #[cfg(feature = "postgres")]
             AnyConnectionKind::Postgres(conn) => {
-                <crate::postgres::Postgres as Database>::TransactionManager::begin(conn)
+                <crate::postgres::Postgres as Database>::TransactionManager::begin_with(
+                    conn,
+                    Default::default(),
+                )
             }
 
             #[cfg(feature = "mysql")]
             AnyConnectionKind::MySql(conn) => {
-                <crate::mysql::MySql as Database>::TransactionManager::begin(conn)
+                <crate::mysql::MySql as Database>::TransactionManager::begin_with(
+                    conn,
+                    Default::default(),
+                )
             }
 
             #[cfg(feature = "sqlite")]
             AnyConnectionKind::Sqlite(conn) => {
-                <crate::sqlite::Sqlite as Database>::TransactionManager::begin(conn)
+                <crate::sqlite::Sqlite as Database>::TransactionManager::begin_with(
+                    conn,
+                    Default::default(),
+                )
             }
 
             #[cfg(feature = "mssql")]
             AnyConnectionKind::Mssql(conn) => {
-                <crate::mssql::Mssql as Database>::TransactionManager::begin(conn)
+                <crate::mssql::Mssql as Database>::TransactionManager::begin_with(
+                    conn,
+                    Default::default(),
+                )
             }
         }
     }

--- a/sqlx-core/src/connection.rs
+++ b/sqlx-core/src/connection.rs
@@ -1,6 +1,6 @@
 use crate::database::{Database, HasStatementCache};
 use crate::error::Error;
-use crate::transaction::Transaction;
+use crate::transaction::{Transaction, TransactionManager};
 use futures_core::future::BoxFuture;
 use log::LevelFilter;
 use std::fmt::Debug;
@@ -27,6 +27,19 @@ pub trait Connection: Send {
     ///
     /// Returns a [`Transaction`] for controlling and tracking the new transaction.
     fn begin(&mut self) -> BoxFuture<'_, Result<Transaction<'_, Self::Database>, Error>>
+    where
+        Self: Sized,
+    {
+        Self::begin_with(self, Default::default())
+    }
+
+    /// Begin a new transaction or establish a savepoint within the active transaction.
+    ///
+    /// Returns a [`Transaction`] for controlling and tracking the new transaction.
+    fn begin_with(
+        &mut self,
+        options: <<Self::Database as Database>::TransactionManager as TransactionManager>::Options,
+    ) -> BoxFuture<'_, Result<Transaction<'_, Self::Database>, Error>>
     where
         Self: Sized;
 

--- a/sqlx-core/src/mssql/connection/mod.rs
+++ b/sqlx-core/src/mssql/connection/mod.rs
@@ -60,7 +60,10 @@ impl Connection for MssqlConnection {
         self.execute("/* SQLx ping */").map_ok(|_| ()).boxed()
     }
 
-    fn begin_with(&mut self, options: ()) -> BoxFuture<'_, Result<Transaction<'_, Self::Database>, Error>>
+    fn begin_with(
+        &mut self,
+        options: (),
+    ) -> BoxFuture<'_, Result<Transaction<'_, Self::Database>, Error>>
     where
         Self: Sized,
     {

--- a/sqlx-core/src/mssql/connection/mod.rs
+++ b/sqlx-core/src/mssql/connection/mod.rs
@@ -60,11 +60,11 @@ impl Connection for MssqlConnection {
         self.execute("/* SQLx ping */").map_ok(|_| ()).boxed()
     }
 
-    fn begin(&mut self) -> BoxFuture<'_, Result<Transaction<'_, Self::Database>, Error>>
+    fn begin_with(&mut self, options: ()) -> BoxFuture<'_, Result<Transaction<'_, Self::Database>, Error>>
     where
         Self: Sized,
     {
-        Transaction::begin(self)
+        Transaction::begin_with(self, options)
     }
 
     #[doc(hidden)]

--- a/sqlx-core/src/mssql/transaction.rs
+++ b/sqlx-core/src/mssql/transaction.rs
@@ -14,8 +14,9 @@ pub struct MssqlTransactionManager;
 
 impl TransactionManager for MssqlTransactionManager {
     type Database = Mssql;
+    type Options = ();
 
-    fn begin(conn: &mut MssqlConnection) -> BoxFuture<'_, Result<(), Error>> {
+    fn begin_with(conn: &mut MssqlConnection, options: ()) -> BoxFuture<'_, Result<(), Error>> {
         Box::pin(async move {
             let depth = conn.stream.transaction_depth;
 

--- a/sqlx-core/src/mssql/transaction.rs
+++ b/sqlx-core/src/mssql/transaction.rs
@@ -16,7 +16,7 @@ impl TransactionManager for MssqlTransactionManager {
     type Database = Mssql;
     type Options = ();
 
-    fn begin_with(conn: &mut MssqlConnection, options: ()) -> BoxFuture<'_, Result<(), Error>> {
+    fn begin_with(conn: &mut MssqlConnection, _options: ()) -> BoxFuture<'_, Result<(), Error>> {
         Box::pin(async move {
             let depth = conn.stream.transaction_depth;
 

--- a/sqlx-core/src/mysql/connection/mod.rs
+++ b/sqlx-core/src/mysql/connection/mod.rs
@@ -4,6 +4,7 @@ use crate::error::Error;
 use crate::mysql::protocol::statement::StmtClose;
 use crate::mysql::protocol::text::{Ping, Quit};
 use crate::mysql::statement::MySqlStatementMetadata;
+use crate::mysql::transaction::MySqlTransactionOptions;
 use crate::mysql::{MySql, MySqlConnectOptions};
 use crate::transaction::Transaction;
 use futures_core::future::BoxFuture;
@@ -94,10 +95,13 @@ impl Connection for MySqlConnection {
         !self.stream.wbuf.is_empty()
     }
 
-    fn begin(&mut self) -> BoxFuture<'_, Result<Transaction<'_, Self::Database>, Error>>
+    fn begin_with(
+        &mut self,
+        options: MySqlTransactionOptions,
+    ) -> BoxFuture<'_, Result<Transaction<'_, Self::Database>, Error>>
     where
         Self: Sized,
     {
-        Transaction::begin(self)
+        Transaction::begin_with(self, options)
     }
 }

--- a/sqlx-core/src/mysql/mod.rs
+++ b/sqlx-core/src/mysql/mod.rs
@@ -31,7 +31,7 @@ pub use options::{MySqlConnectOptions, MySqlSslMode};
 pub use query_result::MySqlQueryResult;
 pub use row::MySqlRow;
 pub use statement::MySqlStatement;
-pub use transaction::MySqlTransactionManager;
+pub use transaction::{MySqlIsolationLevel, MySqlTransactionManager, MySqlTransactionOptions};
 pub use type_info::MySqlTypeInfo;
 pub use value::{MySqlValue, MySqlValueFormat, MySqlValueRef};
 

--- a/sqlx-core/src/mysql/transaction.rs
+++ b/sqlx-core/src/mysql/transaction.rs
@@ -6,8 +6,8 @@ use crate::mysql::connection::Waiting;
 use crate::mysql::protocol::text::Query;
 use crate::mysql::{MySql, MySqlConnection};
 use crate::transaction::{
-    begin_ansi_transaction_sql, commit_ansi_transaction_sql, rollback_ansi_transaction_sql,
-    TransactionManager,
+    begin_savepoint_sql, commit_savepoint_sql, rollback_savepoint_sql, TransactionManager,
+    COMMIT_ANSI_TRANSACTION, ROLLBACK_ANSI_TRANSACTION,
 };
 
 /// Implementation of [`TransactionManager`] for MySQL.
@@ -15,12 +15,20 @@ pub struct MySqlTransactionManager;
 
 impl TransactionManager for MySqlTransactionManager {
     type Database = MySql;
+    type Options = MySqlTransactionOptions;
 
-    fn begin(conn: &mut MySqlConnection) -> BoxFuture<'_, Result<(), Error>> {
+    fn begin_with(
+        conn: &mut MySqlConnection,
+        options: MySqlTransactionOptions,
+    ) -> BoxFuture<'_, Result<(), Error>> {
         Box::pin(async move {
             let depth = conn.transaction_depth;
-
-            conn.execute(&*begin_ansi_transaction_sql(depth)).await?;
+            let stmt = if depth == 0 {
+                options.sql()
+            } else {
+                begin_savepoint_sql(depth)
+            };
+            conn.execute(&*stmt).await?;
             conn.transaction_depth = depth + 1;
 
             Ok(())
@@ -30,10 +38,14 @@ impl TransactionManager for MySqlTransactionManager {
     fn commit(conn: &mut MySqlConnection) -> BoxFuture<'_, Result<(), Error>> {
         Box::pin(async move {
             let depth = conn.transaction_depth;
-
             if depth > 0 {
-                conn.execute(&*commit_ansi_transaction_sql(depth)).await?;
-                conn.transaction_depth = depth - 1;
+                let stmt = if depth == 1 {
+                    COMMIT_ANSI_TRANSACTION.to_string()
+                } else {
+                    commit_savepoint_sql(depth)
+                };
+                conn.execute(&*stmt).await?;
+                conn.transaction_depth -= 1;
             }
 
             Ok(())
@@ -43,10 +55,14 @@ impl TransactionManager for MySqlTransactionManager {
     fn rollback(conn: &mut MySqlConnection) -> BoxFuture<'_, Result<(), Error>> {
         Box::pin(async move {
             let depth = conn.transaction_depth;
-
             if depth > 0 {
-                conn.execute(&*rollback_ansi_transaction_sql(depth)).await?;
-                conn.transaction_depth = depth - 1;
+                let stmt = if depth == 1 {
+                    ROLLBACK_ANSI_TRANSACTION.to_string()
+                } else {
+                    rollback_savepoint_sql(depth)
+                };
+                conn.execute(&*stmt).await?;
+                conn.transaction_depth -= 1;
             }
 
             Ok(())
@@ -55,14 +71,93 @@ impl TransactionManager for MySqlTransactionManager {
 
     fn start_rollback(conn: &mut MySqlConnection) {
         let depth = conn.transaction_depth;
-
         if depth > 0 {
             conn.stream.waiting.push_back(Waiting::Result);
             conn.stream.sequence_id = 0;
-            conn.stream
-                .write_packet(Query(&*rollback_ansi_transaction_sql(depth)));
-
-            conn.transaction_depth = depth - 1;
+            if depth == 1 {
+                conn.stream.write_packet(Query(ROLLBACK_ANSI_TRANSACTION));
+            } else {
+                conn.stream
+                    .write_packet(Query(&rollback_savepoint_sql(depth)));
+            }
+            conn.transaction_depth -= 1;
         }
+    }
+}
+
+/// Transaction initiation options for MySQL.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MySqlTransactionOptions {
+    pub(crate) consistent_read: bool,
+    pub(crate) read_only: bool,
+    pub(crate) iso_level: Option<MySqlIsolationLevel>,
+}
+
+impl MySqlTransactionOptions {
+    pub fn consistent_read(mut self) -> Self {
+        self.consistent_read = true;
+        self
+    }
+
+    pub fn read_only(mut self) -> Self {
+        self.read_only = true;
+        self
+    }
+
+    pub fn isolation_level(mut self, level: MySqlIsolationLevel) -> Self {
+        self.iso_level.replace(level);
+        self
+    }
+
+    pub(crate) fn sql(&self) -> String {
+        let mut sql = String::with_capacity(64);
+        if let Some(level) = self.iso_level {
+            sql.push_str("SET TRANSACTION");
+            match level {
+                MySqlIsolationLevel::Serializable => sql.push_str(" ISOLATION LEVEL SERIALIZABLE"),
+                MySqlIsolationLevel::RepeatableRead => {
+                    sql.push_str(" ISOLATION LEVEL REPEATABLE READ")
+                }
+                MySqlIsolationLevel::ReadCommitted => {
+                    sql.push_str(" ISOLATION LEVEL READ COMMITTED")
+                }
+                MySqlIsolationLevel::ReadUncommitted => {
+                    sql.push_str(" ISOLATION LEVEL READ UNCOMMITTED")
+                }
+            }
+            sql.push_str("; ");
+        }
+        sql.push_str("START TRANSACTION");
+        if self.read_only {
+            sql.push_str(" READ ONLY");
+        }
+        if self.consistent_read {
+            sql.push_str(" WITH CONSISTENT SNAPSHOT");
+        }
+        sql
+    }
+}
+
+impl From<MySqlIsolationLevel> for MySqlTransactionOptions {
+    fn from(iso_level: MySqlIsolationLevel) -> Self {
+        Self {
+            iso_level: Some(iso_level),
+            ..Default::default()
+        }
+    }
+}
+
+/// Transaction isolation levels for MySQL.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MySqlIsolationLevel {
+    ReadUncommitted,
+    ReadCommitted,
+    RepeatableRead,
+    Serializable,
+}
+
+impl Default for MySqlIsolationLevel {
+    fn default() -> Self {
+        Self::RepeatableRead
     }
 }

--- a/sqlx-core/src/postgres/connection/mod.rs
+++ b/sqlx-core/src/postgres/connection/mod.rs
@@ -21,6 +21,8 @@ use crate::transaction::Transaction;
 
 pub use self::stream::PgStream;
 
+use super::transaction::PgTransactionOptions;
+
 pub(crate) mod describe;
 mod establish;
 mod executor;
@@ -148,11 +150,14 @@ impl Connection for PgConnection {
         self.execute("/* SQLx ping */").map_ok(|_| ()).boxed()
     }
 
-    fn begin(&mut self) -> BoxFuture<'_, Result<Transaction<'_, Self::Database>, Error>>
+    fn begin_with(
+        &mut self,
+        options: PgTransactionOptions,
+    ) -> BoxFuture<'_, Result<Transaction<'_, Self::Database>, Error>>
     where
         Self: Sized,
     {
-        Transaction::begin(self)
+        Transaction::begin_with(self, options)
     }
 
     fn cached_statements_size(&self) -> usize {

--- a/sqlx-core/src/postgres/mod.rs
+++ b/sqlx-core/src/postgres/mod.rs
@@ -37,7 +37,7 @@ pub use options::{PgConnectOptions, PgSslMode};
 pub use query_result::PgQueryResult;
 pub use row::PgRow;
 pub use statement::PgStatement;
-pub use transaction::PgTransactionManager;
+pub use transaction::{PgIsolationLevel, PgTransactionManager, PgTransactionOptions};
 pub use type_info::{PgTypeInfo, PgTypeKind};
 pub use types::PgHasArrayType;
 pub use value::{PgValue, PgValueFormat, PgValueRef};

--- a/sqlx-core/src/postgres/transaction.rs
+++ b/sqlx-core/src/postgres/transaction.rs
@@ -4,8 +4,8 @@ use crate::error::Error;
 use crate::executor::Executor;
 use crate::postgres::{PgConnection, Postgres};
 use crate::transaction::{
-    begin_ansi_transaction_sql, commit_ansi_transaction_sql, rollback_ansi_transaction_sql,
-    TransactionManager,
+    begin_savepoint_sql, commit_savepoint_sql, rollback_savepoint_sql, TransactionManager,
+    COMMIT_ANSI_TRANSACTION, ROLLBACK_ANSI_TRANSACTION,
 };
 
 /// Implementation of [`TransactionManager`] for PostgreSQL.
@@ -13,12 +13,20 @@ pub struct PgTransactionManager;
 
 impl TransactionManager for PgTransactionManager {
     type Database = Postgres;
+    type Options = PgTransactionOptions;
 
-    fn begin(conn: &mut PgConnection) -> BoxFuture<'_, Result<(), Error>> {
+    fn begin_with(
+        conn: &mut PgConnection,
+        options: PgTransactionOptions,
+    ) -> BoxFuture<'_, Result<(), Error>> {
         Box::pin(async move {
-            conn.execute(&*begin_ansi_transaction_sql(conn.transaction_depth))
-                .await?;
-
+            let depth = conn.transaction_depth;
+            let stmt = if depth == 0 {
+                options.sql()
+            } else {
+                begin_savepoint_sql(depth)
+            };
+            conn.execute(&*stmt).await?;
             conn.transaction_depth += 1;
 
             Ok(())
@@ -27,10 +35,14 @@ impl TransactionManager for PgTransactionManager {
 
     fn commit(conn: &mut PgConnection) -> BoxFuture<'_, Result<(), Error>> {
         Box::pin(async move {
-            if conn.transaction_depth > 0 {
-                conn.execute(&*commit_ansi_transaction_sql(conn.transaction_depth))
-                    .await?;
-
+            let depth = conn.transaction_depth;
+            if depth > 0 {
+                let stmt = if depth == 1 {
+                    COMMIT_ANSI_TRANSACTION.to_string()
+                } else {
+                    commit_savepoint_sql(depth)
+                };
+                conn.execute(&*stmt).await?;
                 conn.transaction_depth -= 1;
             }
 
@@ -40,10 +52,14 @@ impl TransactionManager for PgTransactionManager {
 
     fn rollback(conn: &mut PgConnection) -> BoxFuture<'_, Result<(), Error>> {
         Box::pin(async move {
-            if conn.transaction_depth > 0 {
-                conn.execute(&*rollback_ansi_transaction_sql(conn.transaction_depth))
-                    .await?;
-
+            let depth = conn.transaction_depth;
+            if depth > 0 {
+                let stmt = if depth == 1 {
+                    ROLLBACK_ANSI_TRANSACTION.to_string()
+                } else {
+                    rollback_savepoint_sql(depth)
+                };
+                conn.execute(&*stmt).await?;
                 conn.transaction_depth -= 1;
             }
 
@@ -52,10 +68,88 @@ impl TransactionManager for PgTransactionManager {
     }
 
     fn start_rollback(conn: &mut PgConnection) {
-        if conn.transaction_depth > 0 {
-            conn.queue_simple_query(&rollback_ansi_transaction_sql(conn.transaction_depth));
-
+        let depth = conn.transaction_depth;
+        if depth > 0 {
+            if depth == 1 {
+                conn.queue_simple_query(ROLLBACK_ANSI_TRANSACTION)
+            } else {
+                conn.queue_simple_query(&rollback_savepoint_sql(depth))
+            }
             conn.transaction_depth -= 1;
         }
+    }
+}
+
+/// Transaction initiation options for Postgres.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PgTransactionOptions {
+    pub(crate) deferrable: bool,
+    pub(crate) read_only: bool,
+    pub(crate) iso_level: Option<PgIsolationLevel>,
+}
+
+impl PgTransactionOptions {
+    pub fn deferrable(mut self) -> Self {
+        self.deferrable = true;
+        self
+    }
+
+    pub fn read_only(mut self) -> Self {
+        self.read_only = true;
+        self
+    }
+
+    pub fn isolation_level(mut self, level: PgIsolationLevel) -> Self {
+        self.iso_level.replace(level);
+        self
+    }
+
+    pub(crate) fn sql(&self) -> String {
+        let mut sql = String::with_capacity(64);
+        sql.push_str("BEGIN");
+        match self.iso_level {
+            None => (),
+            Some(PgIsolationLevel::ReadUncommitted) => {
+                sql.push_str(" ISOLATION LEVEL READ UNCOMMITTED")
+            }
+            Some(PgIsolationLevel::ReadCommitted) => {
+                sql.push_str(" ISOLATION LEVEL READ COMMITTED")
+            }
+            Some(PgIsolationLevel::RepeatableRead) => {
+                sql.push_str(" ISOLATION LEVEL REPEATABLE READ")
+            }
+            Some(PgIsolationLevel::Serializable) => sql.push_str(" ISOLATION LEVEL SERIALIZABLE"),
+        }
+        if self.read_only {
+            sql.push_str(" READ ONLY");
+        }
+        if self.deferrable {
+            sql.push_str(" DEFERRABLE");
+        }
+        sql
+    }
+}
+
+impl From<PgIsolationLevel> for PgTransactionOptions {
+    fn from(iso_level: PgIsolationLevel) -> Self {
+        Self {
+            iso_level: Some(iso_level),
+            ..Default::default()
+        }
+    }
+}
+
+/// Transaction isolation levels for Postgres.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PgIsolationLevel {
+    ReadUncommitted,
+    ReadCommitted,
+    RepeatableRead,
+    Serializable,
+}
+
+impl Default for PgIsolationLevel {
+    fn default() -> Self {
+        Self::ReadCommitted
     }
 }

--- a/sqlx-core/src/sqlite/connection/mod.rs
+++ b/sqlx-core/src/sqlite/connection/mod.rs
@@ -5,7 +5,9 @@ use std::ptr::NonNull;
 use futures_core::future::BoxFuture;
 use futures_intrusive::sync::MutexGuard;
 use futures_util::future;
-use libsqlite3_sys::sqlite3;
+use libsqlite3_sys::{
+    sqlite3, sqlite3_txn_state, SQLITE_TXN_NONE, SQLITE_TXN_READ, SQLITE_TXN_WRITE,
+};
 
 pub(crate) use handle::{ConnectionHandle, ConnectionHandleRaw};
 
@@ -15,6 +17,7 @@ use crate::error::Error;
 use crate::sqlite::connection::establish::EstablishParams;
 use crate::sqlite::connection::worker::ConnectionWorker;
 use crate::sqlite::statement::VirtualStatement;
+use crate::sqlite::transaction::{SqliteTransactionOptions, SqliteTransactionState};
 use crate::sqlite::{Sqlite, SqliteConnectOptions};
 use crate::transaction::Transaction;
 
@@ -160,11 +163,14 @@ impl Connection for SqliteConnection {
         Box::pin(self.worker.ping())
     }
 
-    fn begin(&mut self) -> BoxFuture<'_, Result<Transaction<'_, Self::Database>, Error>>
+    fn begin_with(
+        &mut self,
+        options: SqliteTransactionOptions,
+    ) -> BoxFuture<'_, Result<Transaction<'_, Self::Database>, Error>>
     where
         Self: Sized,
     {
-        Transaction::begin(self)
+        Transaction::begin_with(self, options)
     }
 
     fn cached_statements_size(&self) -> usize {
@@ -214,6 +220,18 @@ impl LockedSqliteHandle<'_> {
         compare: impl Fn(&str, &str) -> Ordering + Send + Sync + 'static,
     ) -> Result<(), Error> {
         collation::create_collation(&mut self.guard.handle, name, compare)
+    }
+
+    /// Fetch the current transaction state of the connection.
+    pub fn transaction_state(&mut self) -> Result<SqliteTransactionState, Error> {
+        let state =
+            match unsafe { sqlite3_txn_state(self.as_raw_handle().as_ptr(), std::ptr::null()) } {
+                SQLITE_TXN_NONE => SqliteTransactionState::None,
+                SQLITE_TXN_READ => SqliteTransactionState::Read,
+                SQLITE_TXN_WRITE => SqliteTransactionState::Write,
+                _ => return Err(Error::Protocol("Invalid transaction state".into())),
+            };
+        Ok(state)
     }
 }
 

--- a/sqlx-core/src/sqlite/mod.rs
+++ b/sqlx-core/src/sqlite/mod.rs
@@ -16,7 +16,10 @@ pub use options::{
 pub use query_result::SqliteQueryResult;
 pub use row::SqliteRow;
 pub use statement::SqliteStatement;
-pub use transaction::SqliteTransactionManager;
+pub use transaction::{
+    SqliteTransactionBehavior, SqliteTransactionManager, SqliteTransactionOptions,
+    SqliteTransactionState,
+};
 pub use type_info::SqliteTypeInfo;
 pub use value::{SqliteValue, SqliteValueRef};
 

--- a/sqlx-core/src/sqlite/transaction.rs
+++ b/sqlx-core/src/sqlite/transaction.rs
@@ -9,9 +9,13 @@ pub struct SqliteTransactionManager;
 
 impl TransactionManager for SqliteTransactionManager {
     type Database = Sqlite;
+    type Options = SqliteTransactionOptions;
 
-    fn begin(conn: &mut SqliteConnection) -> BoxFuture<'_, Result<(), Error>> {
-        Box::pin(conn.worker.begin())
+    fn begin_with(
+        conn: &mut SqliteConnection,
+        options: SqliteTransactionOptions,
+    ) -> BoxFuture<'_, Result<(), Error>> {
+        Box::pin(conn.worker.begin(options))
     }
 
     fn commit(conn: &mut SqliteConnection) -> BoxFuture<'_, Result<(), Error>> {
@@ -25,4 +29,55 @@ impl TransactionManager for SqliteTransactionManager {
     fn start_rollback(conn: &mut SqliteConnection) {
         conn.worker.start_rollback().ok();
     }
+}
+
+/// Transaction initiation options for SQLite.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SqliteTransactionOptions {
+    pub(crate) behavior: SqliteTransactionBehavior,
+}
+
+impl SqliteTransactionOptions {
+    pub fn behavior(mut self, behavior: SqliteTransactionBehavior) -> Self {
+        self.behavior = behavior;
+        self
+    }
+}
+
+impl From<SqliteTransactionBehavior> for SqliteTransactionOptions {
+    fn from(behavior: SqliteTransactionBehavior) -> Self {
+        Self { behavior }
+    }
+}
+
+/// Transaction behaviors for SQLite.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SqliteTransactionBehavior {
+    Deferred,
+    Immediate,
+    Exclusive,
+}
+
+impl SqliteTransactionBehavior {
+    pub(crate) fn sql(&self) -> &'static str {
+        match self {
+            Self::Deferred => "BEGIN DEFERRED",
+            Self::Immediate => "BEGIN IMMEDIATE",
+            Self::Exclusive => "BEGIN EXCLUSIVE",
+        }
+    }
+}
+
+impl Default for SqliteTransactionBehavior {
+    fn default() -> Self {
+        Self::Deferred
+    }
+}
+
+/// Transaction state enum for a SQLite connection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SqliteTransactionState {
+    None,
+    Read,
+    Write,
 }

--- a/tests/mysql/mysql.rs
+++ b/tests/mysql/mysql.rs
@@ -488,16 +488,16 @@ async fn it_can_use_transaction_options() -> anyhow::Result<()> {
     }
 
     let mut conn1 = new::<MySql>().await?;
-    let mut conn2 = new::<MySql>().await?;
-
-    assert_eq!(check_in_transaction(&mut conn1).await?, false);
-    assert_eq!(check_read_only(&mut conn1).await?, false);
     conn1
         .execute(
             "CREATE TABLE IF NOT EXISTS _sqlx_txn_test (id INTEGER PRIMARY KEY);\
             TRUNCATE _sqlx_txn_test",
         )
         .await?;
+    assert_eq!(check_in_transaction(&mut conn1).await?, false);
+    assert_eq!(check_read_only(&mut conn1).await?, false);
+
+    let mut conn2 = new::<MySql>().await?;
 
     // Verify read-uncommitted transaction
 


### PR DESCRIPTION
This adds `begin_with` methods for creating transactions with additional options. The exact options object varies depending upon the backend. For MS-SQL and AnyDatabase the options are currently just `()` although this could be extended, with each backend transaction option struct potentially supporting `From<AnyTransactionOptions>`.

MySQL and Postgres both support the same ANSI isolation levels, although they are currently separate enums which could potentially be combined.

As much as possible, the tests try to verify that the correct transaction options have been applied.

Related to #481, #853, #851