### PR TITLE
Fix type info access in `Any` database driver

### DIFF
--- a/sqlx-core/src/any/error.rs
+++ b/sqlx-core/src/any/error.rs
@@ -1,0 +1,16 @@
+use std::any::type_name;
+
+use crate::any::Any;
+use crate::database::Database;
+use crate::error::BoxDynError;
+use crate::type_info::TypeInfo;
+use crate::types::Type;
+
+pub(super) fn mismatched_types<T: Type<Any>>(ty: &<Any as Database>::TypeInfo) -> BoxDynError {
+    format!(
+        "mismatched types; Rust type `{}` is not compatible with SQL type `{}`",
+        type_name::<T>(),
+        ty.name()
+    )
+    .into()
+}

--- a/sqlx-core/src/any/error.rs
+++ b/sqlx-core/src/any/error.rs
@@ -1,12 +1,12 @@
 use std::any::type_name;
 
+use crate::any::type_info::AnyTypeInfo;
 use crate::any::Any;
-use crate::database::Database;
 use crate::error::BoxDynError;
 use crate::type_info::TypeInfo;
 use crate::types::Type;
 
-pub(super) fn mismatched_types<T: Type<Any>>(ty: &<Any as Database>::TypeInfo) -> BoxDynError {
+pub(super) fn mismatched_types<T: Type<Any>>(ty: &AnyTypeInfo) -> BoxDynError {
     format!(
         "mismatched types; Rust type `{}` is not compatible with SQL type `{}`",
         type_name::<T>(),

--- a/sqlx-core/src/any/mod.rs
+++ b/sqlx-core/src/any/mod.rs
@@ -15,6 +15,7 @@ mod arguments;
 pub(crate) mod column;
 mod connection;
 mod database;
+mod error;
 mod kind;
 mod options;
 mod query_result;

--- a/sqlx-core/src/any/row.rs
+++ b/sqlx-core/src/any/row.rs
@@ -1,8 +1,13 @@
+use crate::any::error::mismatched_types;
 use crate::any::{Any, AnyColumn, AnyColumnIndex};
 use crate::column::ColumnIndex;
 use crate::database::HasValueRef;
+use crate::decode::Decode;
 use crate::error::Error;
 use crate::row::Row;
+use crate::type_info::TypeInfo;
+use crate::types::Type;
+use crate::value::ValueRef;
 
 #[cfg(feature = "postgres")]
 use crate::postgres::PgRow;
@@ -66,6 +71,30 @@ impl Row for AnyRow {
             #[cfg(feature = "mssql")]
             AnyRowKind::Mssql(row) => row.try_get_raw(index).map(Into::into),
         }
+    }
+
+    fn try_get<'r, T, I>(&'r self, index: I) -> Result<T, Error>
+    where
+        I: ColumnIndex<Self>,
+        T: Decode<'r, Self::Database> + Type<Self::Database>,
+    {
+        let value = self.try_get_raw(&index)?;
+
+        if !value.is_null() {
+            let ty = value.type_info();
+
+            if !ty.is_null() && !T::compatible(&ty) {
+                return Err(Error::ColumnDecode {
+                    index: format!("{:?}", index),
+                    source: mismatched_types::<T>(&ty),
+                });
+            }
+        }
+
+        T::decode(value).map_err(|source| Error::ColumnDecode {
+            index: format!("{:?}", index),
+            source,
+        })
     }
 }
 

--- a/sqlx-core/src/error.rs
+++ b/sqlx-core/src/error.rs
@@ -138,9 +138,8 @@ impl Error {
 pub(crate) fn mismatched_types<DB: Database, T: Type<DB>>(ty: &DB::TypeInfo) -> BoxDynError {
     // TODO: `#name` only produces `TINYINT` but perhaps we want to show `TINYINT(1)`
     format!(
-        "mismatched types; Rust type `{}` (as SQL type `{}`) is not compatible with SQL type `{}`",
+        "mismatched types; Rust type `{}` is not compatible with SQL type `{}`",
         type_name::<T>(),
-        T::type_info().name(),
         ty.name()
     )
     .into()

--- a/sqlx-core/src/error.rs
+++ b/sqlx-core/src/error.rs
@@ -138,8 +138,9 @@ impl Error {
 pub(crate) fn mismatched_types<DB: Database, T: Type<DB>>(ty: &DB::TypeInfo) -> BoxDynError {
     // TODO: `#name` only produces `TINYINT` but perhaps we want to show `TINYINT(1)`
     format!(
-        "mismatched types; Rust type `{}` is not compatible with SQL type `{}`",
+        "mismatched types; Rust type `{}` (as SQL type `{}`) is not compatible with SQL type `{}`",
         type_name::<T>(),
+        T::type_info().name(),
         ty.name()
     )
     .into()


### PR DESCRIPTION
Close #1408.

The `Type<Any>::type_info()` is not implemented currently and doesn't seem to be any time soon.

https://github.com/launchbadge/sqlx/blob/826e63fc11fc43ce92099b6844d8a9155bf38356/sqlx-core/src/any/type.rs#L11