### PR TITLE
Fix panics on unknown Postgres type oid when decoding

### DIFF
--- a/sqlx-core/src/postgres/types/array.rs
+++ b/sqlx-core/src/postgres/types/array.rs
@@ -134,7 +134,12 @@ where
                 let element_type_oid = Oid(buf.get_u32());
                 let element_type_info: PgTypeInfo = PgTypeInfo::try_from_oid(element_type_oid)
                     .or_else(|| value.type_info.try_array_element().map(Cow::into_owned))
-                    .unwrap_or_else(|| PgTypeInfo(PgType::DeclareWithOid(element_type_oid)));
+                    .ok_or_else(|| {
+                        BoxDynError::from(format!(
+                            "failed to resolve array element type for oid {}",
+                            element_type_oid.0
+                        ))
+                    })?;
 
                 // length of the array axis
                 let len = buf.get_i32();

--- a/sqlx-core/src/query_builder.rs
+++ b/sqlx-core/src/query_builder.rs
@@ -224,7 +224,7 @@ where
     ///     // e.g. collect it to a `Vec` first.
     ///     b.push_bind(user.id)
     ///         .push_bind(user.username)
-    ///         .push_bind(user.email)    
+    ///         .push_bind(user.email)
     ///         .push_bind(user.password);
     /// });
     ///
@@ -310,6 +310,7 @@ where
 /// A wrapper around `QueryBuilder` for creating comma(or other token)-separated lists.
 ///
 /// See [`QueryBuilder::separated()`] for details.
+#[allow(explicit_outlives_requirements)]
 pub struct Separated<'qb, 'args: 'qb, DB, Sep>
 where
     DB: Database,


### PR DESCRIPTION
Postgres arrays and records do not fully support custom types. When encountering an unknown OID, they currently default to using `PgTypeInfo::with_oid`. This is invalid as it breaks the invariant that decoding only uses resolved types, leading to panics.

This commit returns an error instead of panicking. This is merely a mitigation: a proper fix would actually add full support for custom Postgres types. Full support involves more work, so it may still be useful to fix this immediate issue.

Related issues:
- https://github.com/launchbadge/sqlx/issues/1672
- https://github.com/launchbadge/sqlx/issues/1797