### PR TITLE
feat: expose pool permit wait times

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,18 +1645,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1622113ce508488160cff04e6abc60960e676d330e1ca0f77c0b8df17c81438f"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95af56fee93df76d721d356ac1ca41fccf168bc448eb14049234df764ba3e76"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2378,6 +2378,7 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
+ "pin-project",
  "rand",
  "regex",
  "rsa",

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -158,6 +158,7 @@ memchr = { version = "2.4.1", default-features = false }
 num-bigint = { version = "0.4.0", default-features = false, optional = true, features = ["std"] }
 once_cell = "1.9.0"
 percent-encoding = "2.1.0"
+pin-project = "1.0.10"
 rand = { version = "0.8.4", default-features = false, optional = true, features = ["std", "std_rng"] }
 regex = { version = "1.5.5", optional = true }
 rsa = { version = "0.6.0", optional = true }

--- a/sqlx-core/src/pool/mod.rs
+++ b/sqlx-core/src/pool/mod.rs
@@ -419,6 +419,36 @@ impl<DB: Database> Pool<DB> {
         self.0.size()
     }
 
+    /// Return the [`Duration`] this pool has spent waiting on a permit for a
+    /// connection to be granted from the underlying connection pool.
+    ///
+    /// If this value is consistently increasing by a non-negligible amount, it
+    /// indicates requests are blocked waiting on a connection from the pool
+    /// (saturation of the connection pool) and more connections may be needed
+    /// to handle the workload peak.
+    ///
+    /// Reading this measurement is cheap.
+    ///
+    /// # Semantics
+    ///
+    /// This value is incremented once a connection permit is granted, and does
+    /// NOT include the time taken to perform any liveness checks on connections
+    /// or time taken to establish a connection, if needed.
+    ///
+    /// If a [connection timeout][1] expires while waiting for a connection from
+    /// the pool, the duration of time waiting for the permit is included in
+    /// this measurement.
+    ///
+    /// NOTE: this may increment by a small duration even if connection permits
+    /// are immediately available when calling [`acquire()`], as acquiring one
+    /// is not instantaneous.
+    ///
+    /// [1]: sqlx::pool::PoolOptions::connect_timeout
+    /// [`acquire()`]: Self::acquire()
+    pub fn pool_wait_duration(&self) -> Duration {
+        self.0.pool_wait_duration()
+    }
+
     /// Returns the number of connections active and idle (not in use).
     ///
     /// This will block until the number of connections stops changing for at


### PR DESCRIPTION
First off, big show of appreciation to the authors for this library - it must be a lot of work, but it's great 🎉 

We (@influxdata / [IOx](https://github.com/influxdata/influxdb_iox/)) have been making use of sqlx to interact with our database catalog, a fundamental building block that maintains metadata state for the system (the store used to back the equivalent of `INFORMATION_SCHEMA` views in other databases). This can be a frequently hit resource.

While we're careful to minimise requests to the catalog, in some situations we have been saturating the available connections in the connection pool, leading to long waits to acquire a connection (and at times timeouts being hit waiting for this to complete). 

We would love a way to measure this saturation, so this PR proposes capturing a cumulative sum of pool permit wait times and exposing them on through a [`Pool::pool_wait_duration()`](https://github.com/domodwyer/sqlx/blob/bdaea311c26c0e74ad7c06fb6d863a784bfe7216/sqlx-core/src/pool/mod.rs#L422-L450) call. 

We have tried to tackle this without an invasive change to sqlx, but this either leads to inaccurate measurements (decorating the `Acquire` trait conflates pool wait time with connection dial time, for example. Or perhaps polling [`Pool::num_idle()` ][idle] and building a histogram of values, but this polling this is expensive and the low sampling rate relative to high connection churn rate makes this practically useless). 

Hopefully it is a helpful metric for others too 🎉 

[idle]:https://github.com/domodwyer/sqlx/blob/bdaea311c26c0e74ad7c06fb6d863a784bfe7216/sqlx-core/src/pool/inner.rs#L74-L77

---

* feat: expose pool permit wait times (bdaea311)

      This commit adds a new pool_wait_duration() method to the Pool, returning the
      total duration of time this Pool instance has spent waiting to acquire a
      permit from the pool semaphore (rounded to the nearest millisecond).

      This allows users to quantify the saturation of the connection pool
      (USE-style metrics) and identify when the workload exceeds the available pool
      capacity.

      Both measuring the pool permit wait duration, and retrieving the measured
      value are cheap operations.