### PR TITLE
Avoid panic when streaming packets are empty

### DIFF
--- a/sqlx-core/src/mysql/connection/stream.rs
+++ b/sqlx-core/src/mysql/connection/stream.rs
@@ -148,7 +148,7 @@ impl MySqlStream {
         // TODO: packet compression
         // TODO: packet joining
 
-        if payload.get(0).ok_or(err_protocol!("Packet empty"))? == 0xff {
+        if payload.get(0).ok_or(err_protocol!("Packet empty"))?.eq(&0xff) {
             self.waiting.pop_front();
 
             // instead of letting this packet be looked at everywhere, we check here

--- a/sqlx-core/src/mysql/connection/stream.rs
+++ b/sqlx-core/src/mysql/connection/stream.rs
@@ -148,7 +148,7 @@ impl MySqlStream {
         // TODO: packet compression
         // TODO: packet joining
 
-        if payload.get(0).ok_or("Packet empty")? == 0xff {
+        if payload.get(0).ok_or(err_protocol!("Packet empty"))? == 0xff {
             self.waiting.pop_front();
 
             // instead of letting this packet be looked at everywhere, we check here

--- a/sqlx-core/src/mysql/connection/stream.rs
+++ b/sqlx-core/src/mysql/connection/stream.rs
@@ -148,7 +148,11 @@ impl MySqlStream {
         // TODO: packet compression
         // TODO: packet joining
 
-        if payload.get(0).ok_or(err_protocol!("Packet empty"))?.eq(&0xff) {
+        if payload
+            .get(0)
+            .ok_or(err_protocol!("Packet empty"))?
+            .eq(&0xff)
+        {
             self.waiting.pop_front();
 
             // instead of letting this packet be looked at everywhere, we check here

--- a/sqlx-core/src/mysql/connection/stream.rs
+++ b/sqlx-core/src/mysql/connection/stream.rs
@@ -148,7 +148,7 @@ impl MySqlStream {
         // TODO: packet compression
         // TODO: packet joining
 
-        if payload[0] == 0xff {
+        if payload.get(0).ok_or("Packet empty")? == 0xff {
             self.waiting.pop_front();
 
             // instead of letting this packet be looked at everywhere, we check here


### PR DESCRIPTION
Same issue as #1667, but fixes another instance of panicking.

Where those changes added a check for `.is_empty()` before the access, I've just changed it to return an `Err` instead of the implicit panic.

I used a `Error::Protocol` since this seems to fit into "unexpected or invalid data", but another error type could make more sense.