### PR TITLE
Fix nullability check for inner joins in postgres

### DIFF
--- a/sqlx-core/src/postgres/connection/describe.rs
+++ b/sqlx-core/src/postgres/connection/describe.rs
@@ -466,10 +466,8 @@ fn visit_plan(plan: &Plan, outputs: &[String], nullables: &mut Vec<Option<bool>>
     if let Some(plan_outputs) = &plan.output {
         // all outputs of a Full Join must be marked nullable
         // otherwise, all outputs of the inner half of an outer join must be marked nullable
-        if let Some("Full") | Some("Inner") = plan
-            .join_type
-            .as_deref()
-            .or(plan.parent_relation.as_deref())
+        if plan.join_type.as_deref() == Some("Full")
+            || plan.parent_relation.as_deref() == Some("Inner")
         {
             for output in plan_outputs {
                 if let Some(i) = outputs.iter().position(|o| o == output) {

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -841,8 +841,8 @@ async fn test_describe_outer_join_nullable() -> anyhow::Result<()> {
     let describe = conn
         .describe(
             "select tweet.id
-from (values (null)) vals(val)
-         inner join tweet on false",
+    from tweet
+    inner join products on products.name = tweet.text",
         )
         .await?;
 


### PR DESCRIPTION
`Some("Inner")` is only relevant when looking at the parent relation for left and right joins, it should not be used when checking the `join_type` of the plan.