### PR TITLE
Fix migration checksum comparison during `migrate info`

### DIFF
--- a/sqlx-cli/src/migrate.rs
+++ b/sqlx-cli/src/migrate.rs
@@ -130,6 +130,11 @@ pub async fn info(migration_source: &str, uri: &str) -> anyhow::Result<()> {
         .collect();
 
     for migration in migrator.iter() {
+        if migration.migration_type.is_down_migration() {
+            // Skipping down migrations
+            continue;
+        }
+
         let applied = applied_migrations.get(&migration.version);
 
         let (status_msg, mismatched_checksum) = if let Some(applied) = applied {


### PR DESCRIPTION
When running `sqlx migrate info`, the applied migrations checksums are
compared against the checksums of the local migration files. While the
checksums of applied migrations are stored correctly in the database as
sha384sum values, the `migrate info` command was incorrectly comparing
these against the checksums of down-migrations in cases where reversible
migrations are being used (e.g. when migrations end in `.up.sql` and
`.down.sql`).

This fixes the issue by skipping over any migrations with the
`MigrationType::ReversibleDown` type, using the same idiom as is used
when running migrations (with `migrate run`).

Issue introduced in #1680
Partially resolves #1158