### PR TITLE
Add i16 support for `Any` Type.

### DIFF
--- a/sqlx-core/src/any/types.rs
+++ b/sqlx-core/src/any/types.rs
@@ -5,6 +5,7 @@
 //! | Rust type                             | SQL type(s)                                          |
 //! |---------------------------------------|------------------------------------------------------|
 //! | `bool`                                | BOOLEAN                                              |
+//! | `i16`                                 | SMALLINT                                             |
 //! | `i32`                                 | INT                                                  |
 //! | `i64`                                 | BIGINT                                               |
 //! | `f32`                                 | FLOAT                                                |
@@ -21,6 +22,7 @@
 
 impl_any_type!(bool);
 
+impl_any_type!(i16);
 impl_any_type!(i32);
 impl_any_type!(i64);
 
@@ -34,6 +36,7 @@ impl_any_type!(String);
 
 impl_any_encode!(bool);
 
+impl_any_encode!(i16);
 impl_any_encode!(i32);
 impl_any_encode!(i64);
 
@@ -47,6 +50,7 @@ impl_any_encode!(String);
 
 impl_any_decode!(bool);
 
+impl_any_decode!(i16);
 impl_any_decode!(i32);
 impl_any_decode!(i64);
 

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -1037,7 +1037,7 @@ CREATE TABLE heating_bills (
             &self,
             buf: &mut sqlx::postgres::PgArgumentBuffer,
         ) -> sqlx::encode::IsNull {
-            self.0.encode(buf)
+            <i16 as sqlx::Encode<Postgres>>::encode(self.0, buf)
         }
     }
 


### PR DESCRIPTION
All four databases of PostgreSQL, MySQL, SQLite, and MSSQL supported by SQLx support `i16` Type, but `Any` Type's support for `i16` seems to be missing.