### PR TITLE
Expose `connect_options` for initialized pools and `database` on the `PgConnectOptions`

### DIFF
--- a/sqlx-core/src/pool/mod.rs
+++ b/sqlx-core/src/pool/mod.rs
@@ -435,6 +435,11 @@ impl<DB: Database> Pool<DB> {
     pub fn num_idle(&self) -> usize {
         self.0.num_idle()
     }
+
+    /// Get the connection options for this pool
+    pub fn connect_options(&self) -> &<DB::Connection as Connection>::Options {
+        &self.0.connect_options
+    }
 }
 
 #[cfg(all(

--- a/sqlx-core/src/pool/mod.rs
+++ b/sqlx-core/src/pool/mod.rs
@@ -440,6 +440,11 @@ impl<DB: Database> Pool<DB> {
     pub fn connect_options(&self) -> &<DB::Connection as Connection>::Options {
         &self.0.connect_options
     }
+
+    /// Get the options for this pool
+    pub fn options(&self) -> &PoolOptions<DB> {
+        &self.0.options
+    }
 }
 
 #[cfg(all(

--- a/sqlx-core/src/postgres/options/mod.rs
+++ b/sqlx-core/src/postgres/options/mod.rs
@@ -260,6 +260,20 @@ impl PgConnectOptions {
         self
     }
 
+    /// Get the current database name.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use sqlx_core::postgres::PgConnectOptions;
+    /// let options = PgConnectOptions::new()
+    ///     .database("postgres");
+    /// assert!(options.get_database().is_some());
+    /// ```
+    pub fn get_database(&self) -> Option<&str> {
+        self.database.as_deref()
+    }
+
     /// Sets whether or with what priority a secure SSL TCP/IP connection will be negotiated
     /// with the server.
     ///


### PR DESCRIPTION
This is a PoC PR which is related to https://github.com/launchbadge/sqlx/issues/1853

The idea is to expose PoolOptions and ConnectionOptions after the pool has been created.

This would allow easy database deletion and modification without having to save the options used during creation for the whole duration of the program.