### PR TITLE
feat: metric observer & pool wait timing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,18 +1659,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1622113ce508488160cff04e6abc60960e676d330e1ca0f77c0b8df17c81438f"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95af56fee93df76d721d356ac1ca41fccf168bc448eb14049234df764ba3e76"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2393,6 +2393,7 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
+ "pin-project",
  "rand",
  "regex",
  "rsa",

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -158,6 +158,7 @@ memchr = { version = "2.4.1", default-features = false }
 num-bigint = { version = "0.4.0", default-features = false, optional = true, features = ["std"] }
 once_cell = "1.9.0"
 percent-encoding = "2.1.0"
+pin-project = "1.0.10"
 rand = { version = "0.8.4", default-features = false, optional = true, features = ["std", "std_rng"] }
 regex = { version = "1.5.5", optional = true }
 rsa = { version = "0.6.0", optional = true }

--- a/sqlx-core/src/pool/inner.rs
+++ b/sqlx-core/src/pool/inner.rs
@@ -1,4 +1,7 @@
-use super::{connection::{Floating, Idle, Live}, PoolMetricsObserver};
+use super::{
+    connection::{Floating, Idle, Live},
+    PoolMetricsObserver,
+};
 use crate::connection::ConnectOptions;
 use crate::connection::Connection;
 use crate::database::Database;
@@ -173,7 +176,7 @@ impl<DB: Database> SharedPool<DB> {
                     // Decorate the semaphore permit acquisition to record the
                     // duration it takes to be granted (or timed out).
                     let permit = PollWallClockRecorder::new(
-                        |d| self.options.metric_observer.permit_wait_time(d), 
+                        |d| self.options.metric_observer.permit_wait_time(d),
                         self.semaphore.acquire(1),
                     ).await;
 

--- a/sqlx-core/src/pool/metrics.rs
+++ b/sqlx-core/src/pool/metrics.rs
@@ -1,0 +1,85 @@
+//! Pool metric / event instrumentation.
+
+use std::{ops::Deref, sync::Arc, time::Duration};
+
+/// An observer of [`Pool`] metrics.
+///
+/// ```rust
+/// use std::sync::Arc;
+/// use sqlx::pool::PoolMetricsObserver;
+///
+/// #[derive(Default)]
+/// struct Observer;
+///
+/// impl PoolMetricsObserver for Observer {
+///     fn permit_wait_time(&self, time: std::time::Duration) {
+///         println!(
+///             "waited {} milliseconds to get a slot in the connection pool",
+///             time.as_millis()
+///         );
+///     }
+/// }
+///
+/// # #[cfg(feature = "any")]
+/// # async fn _example() -> Result<(), sqlx::Error> {
+/// # let database_url = "";
+/// // Initialise the observer as a dyn PoolMetricsObserver
+/// let metrics: Arc<dyn PoolMetricsObserver> = Arc::new(Observer::default());
+///
+/// // Configure the pool to push metrics to the observer
+/// # use sqlx_core::any::AnyPoolOptions;
+/// # use sqlx::Executor;
+/// let pool = AnyPoolOptions::new()
+///     .max_connections(1)
+///     .metrics_observer(Arc::clone(&metrics))
+///     .connect(&database_url)
+///     .await?;
+///
+/// // Use the pool and see the wait times!
+/// pool.execute("SELECT 1;").await?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// [`Pool`]: crate::pool::Pool
+pub trait PoolMetricsObserver: Send + Sync {
+    /// Called with the [`Duration`] spent waiting on a permit for a connection
+    /// to be granted from the underlying connection pool, each time a permit
+    /// acquisition attempt completes (successfully or not).
+    ///
+    /// # Blocking
+    ///
+    /// The [`acquire()`] call blocks while this method is called by the
+    /// connection pool. Implementations should aim to return relatively
+    /// quickly.
+    ///
+    /// # Semantics
+    ///
+    /// This value is incremented once a connection permit is granted, and does
+    /// NOT include the time taken to perform any liveness checks on connections
+    /// or time taken to establish a connection, if needed.
+    ///
+    /// If a [connection timeout][1] expires while waiting for a connection from
+    /// the pool, the duration of time waiting for the permit is included in
+    /// this measurement.
+    ///
+    /// NOTE: this may report a small wait duration even if connection permits
+    /// are immediately available when calling [`acquire()`], as acquiring one
+    /// is not instantaneous.
+    ///
+    /// [1]: crate::pool::PoolOptions::connect_timeout()
+    /// [`acquire()`]: crate::pool::Pool::acquire()
+    /// [`Pool`]: crate::pool::Pool
+    fn permit_wait_time(&self, time: Duration) {
+        let _ = time;
+    }
+}
+
+impl<T> PoolMetricsObserver for Arc<T>
+where
+    T: PoolMetricsObserver,
+{
+    fn permit_wait_time(&self, time: Duration) {
+        self.deref().permit_wait_time(time)
+    }
+}

--- a/sqlx-core/src/pool/metrics.rs
+++ b/sqlx-core/src/pool/metrics.rs
@@ -83,3 +83,11 @@ where
         self.deref().permit_wait_time(time)
     }
 }
+
+impl PoolMetricsObserver for Option<Arc<dyn PoolMetricsObserver>> {
+    fn permit_wait_time(&self, time: Duration) {
+        if let Some(v) = self {
+            v.permit_wait_time(time)
+        }
+    }
+}

--- a/sqlx-core/src/pool/mod.rs
+++ b/sqlx-core/src/pool/mod.rs
@@ -87,10 +87,12 @@ mod maybe;
 
 mod connection;
 mod inner;
+mod metrics;
 mod options;
 
 pub use self::connection::PoolConnection;
 pub(crate) use self::maybe::MaybePoolConnection;
+pub use self::metrics::PoolMetricsObserver;
 pub use self::options::PoolOptions;
 
 /// An asynchronous pool of SQLx database connections.

--- a/sqlx-core/src/pool/options.rs
+++ b/sqlx-core/src/pool/options.rs
@@ -232,11 +232,8 @@ impl<DB: Database> PoolOptions<DB> {
 
     /// Push [`Pool`] metric / events to the specified [`PoolMetricsObserver`]
     /// implementation.
-    pub fn metrics_observer(
-        mut self,
-        observer: impl Into<Option<Arc<dyn PoolMetricsObserver>>>,
-    ) -> Self {
-        self.metric_observer = observer.into();
+    pub fn metrics_observer(mut self, observer: impl PoolMetricsObserver) -> Self {
+        self.metric_observer = Some(observer.__into_dyn_arc());
         self
     }
 }

--- a/tests/any/pool.rs
+++ b/tests/any/pool.rs
@@ -70,7 +70,7 @@ async fn pool_wait_duration_counter_increases() -> anyhow::Result<()> {
     const DELAY_MS: u64 = 10;
 
     let recorder_state = Arc::new(Mutex::new(Vec::with_capacity(2)));
-    let metrics: Arc<dyn PoolMetricsObserver> = Arc::new(MetricRecorder {
+    let metrics = Arc::new(MetricRecorder {
         wait: Arc::clone(&recorder_state),
     });
 
@@ -148,7 +148,19 @@ async fn pool_wait_duration_counter_increases() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[derive(Debug, Default)]
+// Static asserts that various types are accepted.
+#[sqlx_macros::test]
+fn assert_metric_types() {
+    let metrics = MetricRecorder {
+        wait: Default::default(),
+    };
+
+    AnyPoolOptions::new()
+        .metrics_observer(metrics.clone())
+        .metrics_observer(Arc::new(metrics));
+}
+
+#[derive(Debug, Default, Clone)]
 struct MetricRecorder {
     wait: Arc<Mutex<Vec<Duration>>>,
 }

--- a/tests/any/pool.rs
+++ b/tests/any/pool.rs
@@ -1,7 +1,7 @@
-use sqlx::any::AnyPoolOptions;
+use sqlx::{any::AnyPoolOptions, pool::PoolMetricsObserver};
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
-    Arc,
+    Arc, Mutex,
 };
 use std::time::Duration;
 
@@ -63,4 +63,98 @@ async fn pool_should_be_returned_failed_transactions() -> anyhow::Result<()> {
     drop(tx);
 
     Ok(())
+}
+
+#[sqlx_macros::test]
+async fn pool_wait_duration_counter_increases() -> anyhow::Result<()> {
+    const DELAY_MS: u64 = 10;
+
+    let recorder_state = Arc::new(Mutex::new(Vec::with_capacity(2)));
+    let metrics: Arc<dyn PoolMetricsObserver> = Arc::new(MetricRecorder {
+        wait: Arc::clone(&recorder_state),
+    });
+
+    let pool = Arc::new(
+        AnyPoolOptions::new()
+            .max_connections(1)
+            .metrics_observer(Arc::clone(&metrics))
+            .connect(&dotenv::var("DATABASE_URL")?)
+            .await?,
+    );
+
+    let conn_1 = pool.acquire().await?;
+
+    // Grab a timestamp before conn_2 starts waiting, and compute the duration
+    // once the task handle is joined to derive an upper bound on the pool wait
+    // time.
+    let started_at = std::time::Instant::now();
+
+    // A signal to indicate the second acquisition task spawned below has been
+    // scheduled and is executing.
+    let (tx, spawned) = futures::channel::oneshot::channel();
+
+    // This acquire blocks for conn_1 to be returned to the pool
+    let handle = sqlx_rt::spawn({
+        let pool = Arc::clone(&pool);
+        async move {
+            tx.send(()).expect("test not listening");
+            let _conn_2 = pool.acquire().await?;
+            Result::<(), anyhow::Error>::Ok(())
+        }
+    });
+
+    // Wait for the second acquisition attempt to spawn and begin executing.
+    spawned.await.expect("task panic");
+
+    // Wait a known duration of time and then drop conn_1, unblocking conn_2.
+    sqlx_rt::sleep(Duration::from_millis(DELAY_MS)).await;
+    drop(conn_1);
+
+    // Allow conn_2 to be acquired, and then immediately returning, joining the
+    // task handle.
+    let _ = handle.await.expect("acquire() task failed");
+
+    // At this point, conn_2 would have been acquired and immediately dropped.
+    //
+    // Now conn_2 has definitely stopped waiting (as acquire() returned and the
+    // task was joined), the upper bound on pool wait time can be derived.
+    let upper_bound = started_at.elapsed();
+
+    // Inspecting the wait times should show 2 permit acquisitions.
+    let waits = recorder_state.lock().unwrap().clone();
+    assert_eq!(waits.len(), 2);
+
+    // We can derive a upper and lower bound for the permit acquisition duration
+    // of conn_2, and use it to verify it is correctly recorded.
+    //
+    // The permit wait time MUST be at least, or equal to, DELAY_MS and no more
+    // than upper_bound.
+    let wait = waits[1];
+    assert!(
+        wait.as_millis() as u64 >= DELAY_MS,
+        "expected at least {}, got {} when validating {:?}",
+        DELAY_MS,
+        wait.as_millis(),
+        waits,
+    );
+    assert!(
+        wait < upper_bound,
+        "expected at most {:?}, got {:?} when validating {:?}",
+        upper_bound,
+        wait,
+        waits
+    );
+
+    Ok(())
+}
+
+#[derive(Debug, Default)]
+struct MetricRecorder {
+    wait: Arc<Mutex<Vec<Duration>>>,
+}
+
+impl PoolMetricsObserver for MetricRecorder {
+    fn permit_wait_time(&self, time: Duration) {
+        self.wait.lock().unwrap().push(time)
+    }
 }


### PR DESCRIPTION
This PR implements observer-based `Pool` metric instrumentation, and captures the time taken to acquire a connection permit from the connection pool.

A follow-on from https://github.com/launchbadge/sqlx/pull/1860.

---

* feat: metric observer & pool wait timing (b7e797e6)

      This commit adds the public PoolMetricsObserver trait for end users to 
      optionally implement, in order to receive metric / event data from the 
      underlying connection Pool.

      PoolMetricsObserver currently exposes a single metric: the duration of time
      spent waiting for a permit from the connection pool semaphore. This allows
      users to quantify the saturation of the connection pool
      (USE-style metrics) and identify when the workload exceeds the available pool
      capacity.

      A default no-op method implementation is provided so end-users can choose
      which metrics they care about, and not have to implement the full set of
      methods.