### PR TITLE
pool fixes and breaking changes

### DIFF
--- a/sqlx-bench/benches/pg_pool.rs
+++ b/sqlx-bench/benches/pg_pool.rs
@@ -26,7 +26,7 @@ fn do_bench_acquire(b: &mut Bencher, concurrent: u32, fair: bool) {
     let pool = sqlx_rt::block_on(
         PgPoolOptions::new()
             // we don't want timeouts because we want to see how the pool degrades
-            .connect_timeout(Duration::from_secs(3600))
+            .acquire_timeout(Duration::from_secs(3600))
             // force the pool to start full
             .min_connections(50)
             .max_connections(50)

--- a/sqlx-core/src/any/connection/mod.rs
+++ b/sqlx-core/src/any/connection/mod.rs
@@ -136,6 +136,22 @@ impl Connection for AnyConnection {
         }
     }
 
+    fn close_hard(self) -> BoxFuture<'static, Result<(), Error>> {
+        match self.0 {
+            #[cfg(feature = "postgres")]
+            AnyConnectionKind::Postgres(conn) => conn.close_hard(),
+
+            #[cfg(feature = "mysql")]
+            AnyConnectionKind::MySql(conn) => conn.close_hard(),
+
+            #[cfg(feature = "sqlite")]
+            AnyConnectionKind::Sqlite(conn) => conn.close_hard(),
+
+            #[cfg(feature = "mssql")]
+            AnyConnectionKind::Mssql(conn) => conn.close_hard(),
+        }
+    }
+
     fn ping(&mut self) -> BoxFuture<'_, Result<(), Error>> {
         delegate_to_mut!(self.ping())
     }

--- a/sqlx-core/src/connection.rs
+++ b/sqlx-core/src/connection.rs
@@ -20,6 +20,12 @@ pub trait Connection: Send {
     /// will be faster at cleaning up resources.
     fn close(self) -> BoxFuture<'static, Result<(), Error>>;
 
+    /// Immediately close the connection without sending a graceful shutdown.
+    ///
+    /// This should still at least send a TCP `FIN` frame to let the server know we're dying.
+    #[doc(hidden)]
+    fn close_hard(self) -> BoxFuture<'static, Result<(), Error>>;
+
     /// Checks if a connection to the database is still valid.
     fn ping(&mut self) -> BoxFuture<'_, Result<(), Error>>;
 

--- a/sqlx-core/src/error.rs
+++ b/sqlx-core/src/error.rs
@@ -165,6 +165,11 @@ pub trait DatabaseError: 'static + Send + Sync + StdError {
     #[doc(hidden)]
     fn into_error(self: Box<Self>) -> Box<dyn StdError + Send + Sync + 'static>;
 
+    #[doc(hidden)]
+    fn is_transient_in_connect_phase(&self) -> bool {
+        false
+    }
+
     /// Returns the name of the constraint that triggered the error, if applicable.
     /// If the error was caused by a conflict of a unique index, this will be the index name.
     ///

--- a/sqlx-core/src/mssql/connection/mod.rs
+++ b/sqlx-core/src/mssql/connection/mod.rs
@@ -55,6 +55,10 @@ impl Connection for MssqlConnection {
         }
     }
 
+    fn close_hard(self) -> BoxFuture<'static, Result<(), Error>> {
+        self.close()
+    }
+
     fn ping(&mut self) -> BoxFuture<'_, Result<(), Error>> {
         // NOTE: we do not use `SELECT 1` as that *could* interact with any ongoing transactions
         self.execute("/* SQLx ping */").map_ok(|_| ()).boxed()

--- a/sqlx-core/src/mysql/connection/mod.rs
+++ b/sqlx-core/src/mysql/connection/mod.rs
@@ -56,6 +56,13 @@ impl Connection for MySqlConnection {
         })
     }
 
+    fn close_hard(mut self) -> BoxFuture<'static, Result<(), Error>> {
+        Box::pin(async move {
+            self.stream.shutdown().await?;
+            Ok(())
+        })
+    }
+
     fn ping(&mut self) -> BoxFuture<'_, Result<(), Error>> {
         Box::pin(async move {
             self.stream.wait_until_ready().await?;

--- a/sqlx-core/src/pool/connection.rs
+++ b/sqlx-core/src/pool/connection.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Debug, Formatter};
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use futures_intrusive::sync::SemaphoreReleaser;
 
@@ -9,7 +9,8 @@ use crate::connection::Connection;
 use crate::database::Database;
 use crate::error::Error;
 
-use super::inner::{DecrementSizeGuard, SharedPool};
+use super::inner::{DecrementSizeGuard, PoolInner};
+use crate::pool::options::PoolConnectionMetadata;
 use std::future::Future;
 
 /// A connection managed by a [`Pool`][crate::pool::Pool].
@@ -17,17 +18,17 @@ use std::future::Future;
 /// Will be returned to the pool on-drop.
 pub struct PoolConnection<DB: Database> {
     live: Option<Live<DB>>,
-    pub(crate) pool: Arc<SharedPool<DB>>,
+    pub(crate) pool: Arc<PoolInner<DB>>,
 }
 
 pub(super) struct Live<DB: Database> {
     pub(super) raw: DB::Connection,
-    pub(super) created: Instant,
+    pub(super) created_at: Instant,
 }
 
 pub(super) struct Idle<DB: Database> {
     pub(super) live: Live<DB>,
-    pub(super) since: Instant,
+    pub(super) idle_since: Instant,
 }
 
 /// RAII wrapper for connections being handled by functions that may drop them
@@ -36,7 +37,7 @@ pub(super) struct Floating<DB: Database, C> {
     pub(super) guard: DecrementSizeGuard<DB>,
 }
 
-const DEREF_ERR: &str = "(bug) connection already released to pool";
+const EXPECT_MSG: &str = "BUG: inner connection already taken!";
 
 impl<DB: Database> Debug for PoolConnection<DB> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -49,13 +50,13 @@ impl<DB: Database> Deref for PoolConnection<DB> {
     type Target = DB::Connection;
 
     fn deref(&self) -> &Self::Target {
-        &self.live.as_ref().expect(DEREF_ERR).raw
+        &self.live.as_ref().expect(EXPECT_MSG).raw
     }
 }
 
 impl<DB: Database> DerefMut for PoolConnection<DB> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.live.as_mut().expect(DEREF_ERR).raw
+        &mut self.live.as_mut().expect(EXPECT_MSG).raw
     }
 }
 
@@ -72,25 +73,20 @@ impl<DB: Database> AsMut<DB::Connection> for PoolConnection<DB> {
 }
 
 impl<DB: Database> PoolConnection<DB> {
-    /// Explicitly release a connection from the pool
-    #[deprecated = "renamed to `.detach()` for clarity"]
-    pub fn release(self) -> DB::Connection {
-        self.detach()
-    }
-
     /// Detach this connection from the pool, allowing it to open a replacement.
     ///
     /// Note that if your application uses a single shared pool, this
-    /// effectively lets the application exceed the `max_connections` setting.
+    /// effectively lets the application exceed the [`max_connections`] setting.
+    ///
+    /// If [`min_connections`] is nonzero, a task will be spawned to replace this connection.
     ///
     /// If you want the pool to treat this connection as permanently checked-out,
     /// use [`.leak()`][Self::leak] instead.
+    ///
+    /// [`max_connections`]: crate::pool::PoolOptions::max_connections
+    /// [`min_connections`]: crate::pool::PoolOptions::min_connections
     pub fn detach(mut self) -> DB::Connection {
-        self.live
-            .take()
-            .expect("PoolConnection double-dropped")
-            .float(self.pool.clone())
-            .detach()
+        self.take_live().float(self.pool.clone()).detach()
     }
 
     /// Detach this connection from the pool, treating it as permanently checked-out.
@@ -99,7 +95,11 @@ impl<DB: Database> PoolConnection<DB> {
     ///
     /// If you don't want to impact the pool's capacity, use [`.detach()`][Self::detach] instead.
     pub fn leak(mut self) -> DB::Connection {
-        self.live.take().expect("PoolConnection double-dropped").raw
+        self.take_live().raw
+    }
+
+    fn take_live(&mut self) -> Live<DB> {
+        self.live.take().expect(EXPECT_MSG)
     }
 
     /// Test the connection to make sure it is still live before returning it to the pool.
@@ -109,34 +109,21 @@ impl<DB: Database> PoolConnection<DB> {
         // float the connection in the pool before we move into the task
         // in case the returned `Future` isn't executed, like if it's spawned into a dying runtime
         // https://github.com/launchbadge/sqlx/issues/1396
-        let floating = self.live.take().map(|live| live.float(self.pool.clone()));
+        // Type hints seem to be broken by `Option` combinators in IntelliJ Rust right now (6/22).
+        let floating: Option<Floating<DB, Live<DB>>> =
+            self.live.take().map(|live| live.float(self.pool.clone()));
+
+        let pool = self.pool.clone();
 
         async move {
-            let mut floating = if let Some(floating) = floating {
-                floating
+            let returned_to_pool = if let Some(floating) = floating {
+                floating.return_to_pool().await
             } else {
-                return;
+                false
             };
 
-            // test the connection on-release to ensure it is still viable,
-            // and flush anything time-sensitive like transaction rollbacks
-            // if an Executor future/stream is dropped during an `.await` call, the connection
-            // is likely to be left in an inconsistent state, in which case it should not be
-            // returned to the pool; also of course, if it was dropped due to an error
-            // this is simply a band-aid as SQLx-next connections should be able
-            // to recover from cancellations
-            if let Err(e) = floating.raw.ping().await {
-                log::warn!(
-                    "error occurred while testing the connection on-release: {}",
-                    e
-                );
-
-                // we now consider the connection to be broken; just drop it to close
-                // trying to close gracefully might cause something weird to happen
-                drop(floating);
-            } else {
-                // if the connection is still viable, release it to the pool
-                floating.release();
+            if !returned_to_pool {
+                pool.min_connections_maintenance(None).await;
             }
         }
     }
@@ -145,7 +132,8 @@ impl<DB: Database> PoolConnection<DB> {
 /// Returns the connection to the [`Pool`][crate::pool::Pool] it was checked-out from.
 impl<DB: Database> Drop for PoolConnection<DB> {
     fn drop(&mut self) {
-        if self.live.is_some() {
+        // We still need to spawn a task to maintain `min_connections`.
+        if self.live.is_some() || self.pool.options.min_connections > 0 {
             #[cfg(not(feature = "_rt-async-std"))]
             if let Ok(handle) = sqlx_rt::Handle::try_current() {
                 handle.spawn(self.return_to_pool());
@@ -158,7 +146,7 @@ impl<DB: Database> Drop for PoolConnection<DB> {
 }
 
 impl<DB: Database> Live<DB> {
-    pub fn float(self, pool: Arc<SharedPool<DB>>) -> Floating<DB, Self> {
+    pub fn float(self, pool: Arc<PoolInner<DB>>) -> Floating<DB, Self> {
         Floating {
             inner: self,
             // create a new guard from a previously leaked permit
@@ -169,7 +157,7 @@ impl<DB: Database> Live<DB> {
     pub fn into_idle(self) -> Idle<DB> {
         Idle {
             live: self,
-            since: Instant::now(),
+            idle_since: Instant::now(),
         }
     }
 }
@@ -193,24 +181,21 @@ impl<DB: Database> Floating<DB, Live<DB>> {
         Self {
             inner: Live {
                 raw: conn,
-                created: Instant::now(),
+                created_at: Instant::now(),
             },
             guard,
         }
     }
 
-    pub fn attach(self, pool: &Arc<SharedPool<DB>>) -> PoolConnection<DB> {
+    pub fn reattach(self) -> PoolConnection<DB> {
         let Floating { inner, guard } = self;
 
-        debug_assert!(
-            guard.same_pool(pool),
-            "BUG: attaching connection to different pool"
-        );
+        let pool = Arc::clone(&guard.pool);
 
         guard.cancel();
         PoolConnection {
             live: Some(inner),
-            pool: Arc::clone(pool),
+            pool,
         }
     }
 
@@ -218,9 +203,66 @@ impl<DB: Database> Floating<DB, Live<DB>> {
         self.guard.pool.clone().release(self);
     }
 
-    pub async fn close(self) -> Result<(), Error> {
+    /// Return the connection to the pool.
+    ///
+    /// Returns `true` if the connection was successfully returned, `false` if it was closed.
+    async fn return_to_pool(mut self) -> bool {
+        // Immediately close the connection.
+        if self.guard.pool.is_closed() {
+            self.close().await;
+            return false;
+        }
+
+        if let Some(test) = &self.guard.pool.options.after_release {
+            let meta = self.metadata();
+            match (test)(&mut self.inner.raw, meta).await {
+                Ok(true) => (),
+                Ok(false) => {
+                    self.close().await;
+                    return false;
+                }
+                Err(e) => {
+                    log::warn!("error from after_release: {}", e);
+                    // Connection is broken, don't try to gracefully close as
+                    // something weird might happen.
+                    self.close_hard().await;
+                    return false;
+                }
+            }
+        }
+
+        // test the connection on-release to ensure it is still viable,
+        // and flush anything time-sensitive like transaction rollbacks
+        // if an Executor future/stream is dropped during an `.await` call, the connection
+        // is likely to be left in an inconsistent state, in which case it should not be
+        // returned to the pool; also of course, if it was dropped due to an error
+        // this is simply a band-aid as SQLx-next connections should be able
+        // to recover from cancellations
+        if let Err(e) = self.raw.ping().await {
+            log::warn!(
+                "error occurred while testing the connection on-release: {}",
+                e
+            );
+
+            // Connection is broken, don't try to gracefully close.
+            self.close_hard().await;
+            false
+        } else {
+            // if the connection is still viable, release it to the pool
+            self.release();
+            true
+        }
+    }
+
+    pub async fn close(self) {
+        // This isn't used anywhere that we care about the return value
+        let _ = self.inner.raw.close().await;
+
         // `guard` is dropped as intended
-        self.inner.raw.close().await
+    }
+
+    pub async fn close_hard(self) {
+        let _ = self.inner.raw.close_hard().await;
     }
 
     pub fn detach(self) -> DB::Connection {
@@ -233,12 +275,19 @@ impl<DB: Database> Floating<DB, Live<DB>> {
             guard: self.guard,
         }
     }
+
+    pub fn metadata(&self) -> PoolConnectionMetadata {
+        PoolConnectionMetadata {
+            age: self.created_at.elapsed(),
+            idle_for: Duration::ZERO,
+        }
+    }
 }
 
 impl<DB: Database> Floating<DB, Idle<DB>> {
     pub fn from_idle(
         idle: Idle<DB>,
-        pool: Arc<SharedPool<DB>>,
+        pool: Arc<PoolInner<DB>>,
         permit: SemaphoreReleaser<'_>,
     ) -> Self {
         Self {
@@ -259,11 +308,26 @@ impl<DB: Database> Floating<DB, Idle<DB>> {
     }
 
     pub async fn close(self) -> DecrementSizeGuard<DB> {
-        // `guard` is dropped as intended
         if let Err(e) = self.inner.live.raw.close().await {
             log::debug!("error occurred while closing the pool connection: {}", e);
         }
         self.guard
+    }
+
+    pub async fn close_hard(self) -> DecrementSizeGuard<DB> {
+        let _ = self.inner.live.raw.close_hard().await;
+
+        self.guard
+    }
+
+    pub fn metadata(&self) -> PoolConnectionMetadata {
+        // Use a single `now` value for consistency.
+        let now = Instant::now();
+
+        PoolConnectionMetadata {
+            age: self.created_at.duration_since(now),
+            idle_for: self.idle_since.duration_since(now),
+        }
     }
 }
 

--- a/sqlx-core/src/pool/inner.rs
+++ b/sqlx-core/src/pool/inner.rs
@@ -3,36 +3,37 @@ use crate::connection::ConnectOptions;
 use crate::connection::Connection;
 use crate::database::Database;
 use crate::error::Error;
-use crate::pool::{deadline_as_timeout, PoolOptions};
+use crate::pool::{deadline_as_timeout, CloseEvent, PoolOptions};
 use crossbeam_queue::ArrayQueue;
 
 use futures_intrusive::sync::{Semaphore, SemaphoreReleaser};
 
 use std::cmp;
-use std::mem;
-use std::ptr;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::future::Future;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
 use std::sync::Arc;
 
+use crate::pool::options::PoolConnectionMetadata;
 use std::time::{Duration, Instant};
 
-/// Ihe number of permits to release to wake all waiters, such as on `SharedPool::close()`.
+/// Ihe number of permits to release to wake all waiters, such as on `PoolInner::close()`.
 ///
 /// This should be large enough to realistically wake all tasks waiting on the pool without
 /// potentially overflowing the permits count in the semaphore itself.
 const WAKE_ALL_PERMITS: usize = usize::MAX / 2;
 
-pub(crate) struct SharedPool<DB: Database> {
+pub(crate) struct PoolInner<DB: Database> {
     pub(super) connect_options: <DB::Connection as Connection>::Options,
     pub(super) idle_conns: ArrayQueue<Idle<DB>>,
     pub(super) semaphore: Semaphore,
     pub(super) size: AtomicU32,
+    pub(super) num_idle: AtomicUsize,
     is_closed: AtomicBool,
     pub(super) on_closed: event_listener::Event,
     pub(super) options: PoolOptions<DB>,
 }
 
-impl<DB: Database> SharedPool<DB> {
+impl<DB: Database> PoolInner<DB> {
     pub(super) fn new_arc(
         options: PoolOptions<DB>,
         connect_options: <DB::Connection as Connection>::Options,
@@ -50,6 +51,7 @@ impl<DB: Database> SharedPool<DB> {
             idle_conns: ArrayQueue::new(capacity),
             semaphore: Semaphore::new(options.fair, capacity),
             size: AtomicU32::new(0),
+            num_idle: AtomicUsize::new(0),
             is_closed: AtomicBool::new(false),
             on_closed: event_listener::Event::new(),
             options,
@@ -57,7 +59,7 @@ impl<DB: Database> SharedPool<DB> {
 
         let pool = Arc::new(pool);
 
-        spawn_reaper(&pool);
+        spawn_maintenance_tasks(&pool);
 
         pool
     }
@@ -67,15 +69,19 @@ impl<DB: Database> SharedPool<DB> {
     }
 
     pub(super) fn num_idle(&self) -> usize {
-        // NOTE: This is very expensive
-        self.idle_conns.len()
+        // We don't use `self.idle_conns.len()` as it waits for the internal
+        // head and tail pointers to stop changing for a moment before calculating the length,
+        // which may take a long time at high levels of churn.
+        //
+        // By maintaining our own atomic count, we avoid that issue entirely.
+        self.num_idle.load(Ordering::Acquire)
     }
 
     pub(super) fn is_closed(&self) -> bool {
         self.is_closed.load(Ordering::Acquire)
     }
 
-    pub(super) async fn close(self: &Arc<Self>) {
+    pub(super) fn close<'a>(self: &'a Arc<Self>) -> impl Future<Output = ()> + 'a {
         let already_closed = self.is_closed.swap(true, Ordering::AcqRel);
 
         if !already_closed {
@@ -86,14 +92,28 @@ impl<DB: Database> SharedPool<DB> {
             self.on_closed.notify(usize::MAX);
         }
 
-        // wait for all permits to be released
-        let _permits = self
-            .semaphore
-            .acquire(WAKE_ALL_PERMITS + (self.options.max_connections as usize))
-            .await;
+        async move {
+            // Close any currently idle connections in the pool.
+            while let Some(idle) = self.idle_conns.pop() {
+                let _ = idle.live.float((*self).clone()).close().await;
+            }
 
-        while let Some(idle) = self.idle_conns.pop() {
-            let _ = idle.live.float((*self).clone()).close().await;
+            // Wait for all permits to be released.
+            let _permits = self
+                .semaphore
+                .acquire(WAKE_ALL_PERMITS + (self.options.max_connections as usize))
+                .await;
+
+            // Clean up any remaining connections.
+            while let Some(idle) = self.idle_conns.pop() {
+                let _ = idle.live.float((*self).clone()).close().await;
+            }
+        }
+    }
+
+    pub(crate) fn close_event(&self) -> CloseEvent {
+        CloseEvent {
+            listener: (!self.is_closed()).then(|| self.on_closed.listen()),
         }
     }
 
@@ -112,19 +132,15 @@ impl<DB: Database> SharedPool<DB> {
         permit: SemaphoreReleaser<'a>,
     ) -> Result<Floating<DB, Idle<DB>>, SemaphoreReleaser<'a>> {
         if let Some(idle) = self.idle_conns.pop() {
+            self.num_idle.fetch_sub(1, Ordering::AcqRel);
             Ok(Floating::from_idle(idle, (*self).clone(), permit))
         } else {
             Err(permit)
         }
     }
 
-    pub(super) fn release(&self, mut floating: Floating<DB, Live<DB>>) {
-        if let Some(test) = &self.options.after_release {
-            if !test(&mut floating.raw) {
-                // drop the connection and do not return it to the pool
-                return;
-            }
-        }
+    pub(super) fn release(&self, floating: Floating<DB, Live<DB>>) {
+        // `options.after_release` is invoked by `PoolConnection::release_to_pool()`.
 
         let Floating { inner: idle, guard } = floating.into_idle();
 
@@ -135,11 +151,11 @@ impl<DB: Database> SharedPool<DB> {
         // NOTE: we need to make sure we drop the permit *after* we push to the idle queue
         // don't decrease the size
         guard.release_permit();
+
+        self.num_idle.fetch_add(1, Ordering::AcqRel);
     }
 
     /// Try to atomically increment the pool size for a new connection.
-    ///
-    /// Returns `None` if we are at max_connections or if the pool is closed.
     pub(super) fn try_increment_size<'a>(
         self: &'a Arc<Self>,
         permit: SemaphoreReleaser<'a>,
@@ -157,16 +173,15 @@ impl<DB: Database> SharedPool<DB> {
         }
     }
 
-    #[allow(clippy::needless_lifetimes)]
     pub(super) async fn acquire(self: &Arc<Self>) -> Result<Floating<DB, Live<DB>>, Error> {
         if self.is_closed() {
             return Err(Error::PoolClosed);
         }
 
-        let deadline = Instant::now() + self.options.connect_timeout;
+        let deadline = Instant::now() + self.options.acquire_timeout;
 
         sqlx_rt::timeout(
-            self.options.connect_timeout,
+            self.options.acquire_timeout,
             async {
                 loop {
                     let permit = self.semaphore.acquire(1).await;
@@ -179,7 +194,7 @@ impl<DB: Database> SharedPool<DB> {
                     let guard = match self.pop_idle(permit) {
 
                         // Then, check that we can use it...
-                        Ok(conn) => match check_conn(conn, &self.options).await {
+                        Ok(conn) => match check_idle_conn(conn, &self.options).await {
 
                             // All good!
                             Ok(live) => return Ok(live),
@@ -198,7 +213,7 @@ impl<DB: Database> SharedPool<DB> {
                     };
 
                     // Attempt to connect...
-                    return self.connection(deadline, guard).await;
+                    return self.connect(deadline, guard).await;
                 }
             }
         )
@@ -206,7 +221,7 @@ impl<DB: Database> SharedPool<DB> {
             .map_err(|_| Error::PoolTimedOut)?
     }
 
-    pub(super) async fn connection(
+    pub(super) async fn connect(
         self: &Arc<Self>,
         deadline: Instant,
         guard: DecrementSizeGuard<DB>,
@@ -226,21 +241,35 @@ impl<DB: Database> SharedPool<DB> {
             match sqlx_rt::timeout(timeout, self.connect_options.connect()).await {
                 // successfully established connection
                 Ok(Ok(mut raw)) => {
-                    if let Some(callback) = &self.options.after_connect {
-                        callback(&mut raw).await?;
-                    }
+                    // See comment on `PoolOptions::after_connect`
+                    let meta = PoolConnectionMetadata {
+                        age: Duration::ZERO,
+                        idle_for: Duration::ZERO,
+                    };
 
-                    return Ok(Floating::new_live(raw, guard));
+                    let res = if let Some(callback) = &self.options.after_connect {
+                        callback(&mut raw, meta).await
+                    } else {
+                        Ok(())
+                    };
+
+                    match res {
+                        Ok(()) => return Ok(Floating::new_live(raw, guard)),
+                        Err(e) => {
+                            log::error!("error returned from after_connect: {:?}", e);
+                            // The connection is broken, don't try to close nicely.
+                            let _ = raw.close_hard().await;
+
+                            // Fall through to the backoff.
+                        }
+                    }
                 }
 
                 // an IO error while connecting is assumed to be the system starting up
                 Ok(Err(Error::Io(e))) if e.kind() == std::io::ErrorKind::ConnectionRefused => (),
 
-                // TODO: Handle other database "boot period"s
-
-                // [postgres] the database system is starting up
-                // TODO: Make this check actually check if this is postgres
-                Ok(Err(Error::Database(error))) if error.code().as_deref() == Some("57P03") => (),
+                // We got a transient database error, retry.
+                Ok(Err(Error::Database(error))) if error.is_transient_in_connect_phase() => (),
 
                 // Any other error while connection should immediately
                 // terminate and bubble the error up
@@ -250,42 +279,86 @@ impl<DB: Database> SharedPool<DB> {
                 Err(_) => return Err(Error::PoolTimedOut),
             }
 
-            // If the connection is refused wait in exponentially
+            // If the connection is refused, wait in exponentially
             // increasing steps for the server to come up,
             // capped by a factor of the remaining time until the deadline
             sqlx_rt::sleep(backoff).await;
             backoff = cmp::min(backoff * 2, max_backoff);
         }
     }
+
+    /// Try to maintain `min_connections`, returning any errors (including `PoolTimedOut`).
+    pub async fn try_min_connections(self: &Arc<Self>, deadline: Instant) -> Result<(), Error> {
+        macro_rules! unwrap_or_return {
+            ($expr:expr) => {
+                match $expr {
+                    Some(val) => val,
+                    None => return Ok(()),
+                }
+            };
+        }
+
+        while self.size() < self.options.min_connections {
+            // Don't wait for a semaphore permit.
+            //
+            // If no extra permits are available then we shouldn't be trying to spin up
+            // connections anyway.
+            let permit = unwrap_or_return!(self.semaphore.try_acquire(1));
+
+            // We must always obey `max_connections`.
+            let guard = unwrap_or_return!(self.try_increment_size(permit).ok());
+
+            // We skip `after_release` since the connection was never provided to user code
+            // besides `after_connect`, if they set it.
+            self.release(self.connect(deadline, guard).await?);
+        }
+
+        Ok(())
+    }
+
+    /// Attempt to maintain `min_connections`, logging if unable.
+    pub async fn min_connections_maintenance(self: &Arc<Self>, deadline: Option<Instant>) {
+        let deadline = deadline.unwrap_or_else(|| {
+            // Arbitrary default deadline if the caller doesn't care.
+            Instant::now() + Duration::from_secs(300)
+        });
+
+        match self.try_min_connections(deadline).await {
+            Ok(()) => (),
+            Err(Error::PoolClosed) => (),
+            Err(Error::PoolTimedOut) => {
+                log::debug!("unable to complete `min_connections` maintenance before deadline")
+            }
+            Err(e) => log::debug!("error while maintaining min_connections: {:?}", e),
+        }
+    }
 }
 
-// NOTE: Function names here are bizarre. Helpful help would be appreciated.
-
-fn is_beyond_lifetime<DB: Database>(live: &Live<DB>, options: &PoolOptions<DB>) -> bool {
-    // check if connection was within max lifetime (or not set)
+/// Returns `true` if the connection has exceeded `options.max_lifetime` if set, `false` otherwise.
+fn is_beyond_max_lifetime<DB: Database>(live: &Live<DB>, options: &PoolOptions<DB>) -> bool {
     options
         .max_lifetime
-        .map_or(false, |max| live.created.elapsed() > max)
+        .map_or(false, |max| live.created_at.elapsed() > max)
 }
 
-fn is_beyond_idle<DB: Database>(idle: &Idle<DB>, options: &PoolOptions<DB>) -> bool {
-    // if connection wasn't idle too long (or not set)
+/// Returns `true` if the connection has exceeded `options.idle_timeout` if set, `false` otherwise.
+fn is_beyond_idle_timeout<DB: Database>(idle: &Idle<DB>, options: &PoolOptions<DB>) -> bool {
     options
         .idle_timeout
-        .map_or(false, |timeout| idle.since.elapsed() > timeout)
+        .map_or(false, |timeout| idle.idle_since.elapsed() > timeout)
 }
 
-async fn check_conn<DB: Database>(
+async fn check_idle_conn<DB: Database>(
     mut conn: Floating<DB, Idle<DB>>,
     options: &PoolOptions<DB>,
 ) -> Result<Floating<DB, Live<DB>>, DecrementSizeGuard<DB>> {
     // If the connection we pulled has expired, close the connection and
     // immediately create a new connection
-    if is_beyond_lifetime(&conn, options) {
-        // we're closing the connection either way
-        // close the connection but don't really care about the result
+    if is_beyond_max_lifetime(&conn, options) {
         return Err(conn.close().await);
-    } else if options.test_before_acquire {
+    }
+
+    if options.test_before_acquire {
         // Check that the connection is still live
         if let Err(e) = conn.ping().await {
             // an error here means the other end has hung up or we lost connectivity
@@ -293,18 +366,22 @@ async fn check_conn<DB: Database>(
             // the error itself here isn't necessarily unexpected so WARN is too strong
             log::info!("ping on idle connection returned error: {}", e);
             // connection is broken so don't try to close nicely
-            return Err(conn.close().await);
+            return Err(conn.close_hard().await);
         }
-    } else if let Some(test) = &options.before_acquire {
-        match test(&mut conn.live.raw).await {
+    }
+
+    if let Some(test) = &options.before_acquire {
+        let meta = conn.metadata();
+        match test(&mut conn.live.raw, meta).await {
             Ok(false) => {
-                // connection was rejected by user-defined hook
+                // connection was rejected by user-defined hook, close nicely
                 return Err(conn.close().await);
             }
 
             Err(error) => {
-                log::info!("in `before_acquire`: {}", error);
-                return Err(conn.close().await);
+                log::warn!("error from `before_acquire`: {}", error);
+                // connection is broken so don't try to close nicely
+                return Err(conn.close_hard().await);
             }
 
             Ok(true) => {}
@@ -315,29 +392,53 @@ async fn check_conn<DB: Database>(
     Ok(conn.into_live())
 }
 
-/// if `max_lifetime` or `idle_timeout` is set, spawn a task that reaps senescent connections
-fn spawn_reaper<DB: Database>(pool: &Arc<SharedPool<DB>>) {
+fn spawn_maintenance_tasks<DB: Database>(pool: &Arc<PoolInner<DB>>) {
+    let pool = Arc::clone(&pool);
+
     let period = match (pool.options.max_lifetime, pool.options.idle_timeout) {
         (Some(it), None) | (None, Some(it)) => it,
 
         (Some(a), Some(b)) => cmp::min(a, b),
 
-        (None, None) => return,
+        (None, None) => {
+            if pool.options.min_connections > 0 {
+                sqlx_rt::spawn(async move {
+                    pool.min_connections_maintenance(None).await;
+                });
+            }
+
+            return;
+        }
     };
 
-    let pool = Arc::clone(&pool);
-
     sqlx_rt::spawn(async move {
-        while !pool.is_closed() {
-            if !pool.idle_conns.is_empty() {
-                do_reap(&pool).await;
-            }
-            sqlx_rt::sleep(period).await;
-        }
+        // Immediately cancel this task if the pool is closed.
+        let _ = pool
+            .close_event()
+            .do_until(async {
+                while !pool.is_closed() {
+                    let next_run = Instant::now() + period;
+
+                    pool.min_connections_maintenance(Some(next_run)).await;
+
+                    if let Some(duration) = next_run.checked_duration_since(Instant::now()) {
+                        // `async-std` doesn't have a `sleep_until()`
+                        sqlx_rt::sleep(duration).await;
+                    } else {
+                        sqlx_rt::yield_now().await;
+                    }
+
+                    // Don't run the reaper right away.
+                    if !pool.idle_conns.is_empty() {
+                        do_reap(&pool).await;
+                    }
+                }
+            })
+            .await;
     });
 }
 
-async fn do_reap<DB: Database>(pool: &Arc<SharedPool<DB>>) {
+async fn do_reap<DB: Database>(pool: &Arc<PoolInner<DB>>) {
     // reap at most the current size minus the minimum idle
     let max_reaped = pool.size().saturating_sub(pool.options.min_connections);
 
@@ -346,7 +447,8 @@ async fn do_reap<DB: Database>(pool: &Arc<SharedPool<DB>>) {
         // only connections waiting in the queue
         .filter_map(|_| pool.try_acquire())
         .partition::<Vec<_>, _>(|conn| {
-            is_beyond_idle(conn, &pool.options) || is_beyond_lifetime(conn, &pool.options)
+            is_beyond_idle_timeout(conn, &pool.options)
+                || is_beyond_max_lifetime(conn, &pool.options)
         });
 
     for conn in keep {
@@ -364,28 +466,23 @@ async fn do_reap<DB: Database>(pool: &Arc<SharedPool<DB>>) {
 /// Will decrement the pool size if dropped, to avoid semantically "leaking" connections
 /// (where the pool thinks it has more connections than it does).
 pub(in crate::pool) struct DecrementSizeGuard<DB: Database> {
-    pub(crate) pool: Arc<SharedPool<DB>>,
-    dropped: bool,
+    pub(crate) pool: Arc<PoolInner<DB>>,
+    cancelled: bool,
 }
 
 impl<DB: Database> DecrementSizeGuard<DB> {
     /// Create a new guard that will release a semaphore permit on-drop.
-    pub fn new_permit(pool: Arc<SharedPool<DB>>) -> Self {
+    pub fn new_permit(pool: Arc<PoolInner<DB>>) -> Self {
         Self {
             pool,
-            dropped: false,
+            cancelled: false,
         }
     }
 
-    pub fn from_permit(pool: Arc<SharedPool<DB>>, mut permit: SemaphoreReleaser<'_>) -> Self {
+    pub fn from_permit(pool: Arc<PoolInner<DB>>, mut permit: SemaphoreReleaser<'_>) -> Self {
         // here we effectively take ownership of the permit
         permit.disarm();
         Self::new_permit(pool)
-    }
-
-    /// Return `true` if the internal references point to the same fields in `SharedPool`.
-    pub fn same_pool(&self, pool: &SharedPool<DB>) -> bool {
-        ptr::eq(&*self.pool, pool)
     }
 
     /// Release the semaphore permit without decreasing the pool size.
@@ -394,18 +491,18 @@ impl<DB: Database> DecrementSizeGuard<DB> {
         self.cancel();
     }
 
-    pub fn cancel(self) {
-        mem::forget(self);
+    pub fn cancel(mut self) {
+        self.cancelled = true;
     }
 }
 
 impl<DB: Database> Drop for DecrementSizeGuard<DB> {
     fn drop(&mut self) {
-        assert!(!self.dropped, "double-dropped!");
-        self.dropped = true;
-        self.pool.size.fetch_sub(1, Ordering::SeqCst);
+        if !self.cancelled {
+            self.pool.size.fetch_sub(1, Ordering::AcqRel);
 
-        // and here we release the permit we got on construction
-        self.pool.semaphore.release(1);
+            // and here we release the permit we got on construction
+            self.pool.semaphore.release(1);
+        }
     }
 }

--- a/sqlx-core/src/pool/options.rs
+++ b/sqlx-core/src/pool/options.rs
@@ -1,38 +1,99 @@
 use crate::connection::Connection;
 use crate::database::Database;
 use crate::error::Error;
-use crate::pool::inner::SharedPool;
+use crate::pool::inner::PoolInner;
 use crate::pool::Pool;
 use futures_core::future::BoxFuture;
-use sqlx_rt::spawn;
-use std::cmp;
 use std::fmt::{self, Debug, Formatter};
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+/// Configuration options for [`Pool`][super::Pool].
+///
+/// ### Callback Functions: Why Do I Need `Box::pin()`?
+/// Essentially, because it's impossible to write generic bounds that describe a closure
+/// with a higher-ranked lifetime parameter, returning a future with that same lifetime.
+///
+/// Ideally, you could define it like this:
+/// ```rust,ignore
+/// async fn takes_foo_callback(f: impl for<'a> Fn(&'a mut Foo) -> impl Future<'a, Output = ()>)
+/// ```
+///
+/// However, the compiler does not allow using `impl Trait` in the return type of an `impl Fn`.
+///
+/// And if you try to do it like this:
+/// ```rust,ignore
+/// async fn takes_foo_callback<F, Fut>(f: F)
+/// where
+///     F: for<'a> Fn(&'a mut Foo) -> Fut,
+///     Fut: for<'a> Future<Output = ()> + 'a
+/// ```
+///
+/// There's no way to tell the compiler that those two `'a`s should be the same lifetime.
+///
+/// It's possible to make this work with a custom trait, but it's fiddly and requires naming
+///  the type of the closure parameter.
+///
+/// Having the closure return `BoxFuture` allows us to work around this, as all the type information
+/// fits into a single generic parameter.
+///
+/// We still need to `Box` the future internally to give it a concrete type to avoid leaking a type
+/// parameter everywhere, and `Box` is in the prelude so it doesn't need to be manually imported,
+/// so having the closure return `Pin<Box<dyn Future>` directly is the path of least resistance from
+/// the perspectives of both API designer and consumer.
 pub struct PoolOptions<DB: Database> {
     pub(crate) test_before_acquire: bool,
     pub(crate) after_connect: Option<
         Box<
-            dyn Fn(&mut DB::Connection) -> BoxFuture<'_, Result<(), Error>> + 'static + Send + Sync,
-        >,
-    >,
-    pub(crate) before_acquire: Option<
-        Box<
-            dyn Fn(&mut DB::Connection) -> BoxFuture<'_, Result<bool, Error>>
+            dyn Fn(&mut DB::Connection, PoolConnectionMetadata) -> BoxFuture<'_, Result<(), Error>>
                 + 'static
                 + Send
                 + Sync,
         >,
     >,
-    pub(crate) after_release:
-        Option<Box<dyn Fn(&mut DB::Connection) -> bool + 'static + Send + Sync>>,
+    pub(crate) before_acquire: Option<
+        Box<
+            dyn Fn(
+                    &mut DB::Connection,
+                    PoolConnectionMetadata,
+                ) -> BoxFuture<'_, Result<bool, Error>>
+                + 'static
+                + Send
+                + Sync,
+        >,
+    >,
+    pub(crate) after_release: Option<
+        Box<
+            dyn Fn(
+                    &mut DB::Connection,
+                    PoolConnectionMetadata,
+                ) -> BoxFuture<'_, Result<bool, Error>>
+                + 'static
+                + Send
+                + Sync,
+        >,
+    >,
     pub(crate) max_connections: u32,
-    pub(crate) connect_timeout: Duration,
+    pub(crate) acquire_timeout: Duration,
     pub(crate) min_connections: u32,
     pub(crate) max_lifetime: Option<Duration>,
     pub(crate) idle_timeout: Option<Duration>,
     pub(crate) fair: bool,
+}
+
+/// Metadata for the connection being processed by a [`PoolOptions`] callback.
+#[derive(Debug)] // Don't want to commit to any other trait impls yet.
+#[non_exhaustive] // So we can safely add fields in the future.
+pub struct PoolConnectionMetadata {
+    /// The duration since the connection was first opened.
+    ///
+    /// For [`after_connect`][PoolOptions::after_connect], this is [`Duration::ZERO`].
+    pub age: Duration,
+
+    /// The duration that the connection spent in the idle queue.
+    ///
+    /// Only relevant for [`before_acquire`][PoolOptions::before_acquire].
+    /// For other callbacks, this is [`Duration::ZERO`].
+    pub idle_for: Duration,
 }
 
 impl<DB: Database> Default for PoolOptions<DB> {
@@ -42,15 +103,23 @@ impl<DB: Database> Default for PoolOptions<DB> {
 }
 
 impl<DB: Database> PoolOptions<DB> {
+    /// Returns a default "sane" configuration, suitable for testing or light-duty applications.
+    ///
+    /// Production applications will likely want to at least modify
+    /// [`max_connections`][Self::max_connections].
+    ///
+    /// See the source of this method for the current default values.
     pub fn new() -> Self {
         Self {
+            // User-specifiable routines
             after_connect: None,
-            test_before_acquire: true,
             before_acquire: None,
             after_release: None,
+            test_before_acquire: true,
+            // A production application will want to set a higher limit than this.
             max_connections: 10,
             min_connections: 0,
-            connect_timeout: Duration::from_secs(30),
+            acquire_timeout: Duration::from_secs(30),
             idle_timeout: Some(Duration::from_secs(10 * 60)),
             max_lifetime: Some(Duration::from_secs(30 * 60)),
             fair: true,
@@ -58,16 +127,12 @@ impl<DB: Database> PoolOptions<DB> {
     }
 
     /// Set the maximum number of connections that this pool should maintain.
+    ///
+    /// Be mindful of the connection limits for your database as well as other applications
+    /// which may want to connect to the same database (or even multiple instances of the same
+    /// application in high-availability deployments).
     pub fn max_connections(mut self, max: u32) -> Self {
         self.max_connections = max;
-        self
-    }
-
-    /// Set the amount of time to attempt connecting to the database.
-    ///
-    /// If this timeout elapses, [`Pool::acquire`] will return an error.
-    pub fn connect_timeout(mut self, timeout: Duration) -> Self {
-        self.connect_timeout = timeout;
         self
     }
 
@@ -75,13 +140,44 @@ impl<DB: Database> PoolOptions<DB> {
     ///
     /// When the pool is built, this many connections will be automatically spun up.
     ///
-    /// If any connection is reaped by [`max_lifetime`] or [`idle_timeout`] and it brings
-    /// the connection count below this amount, a new connection will be opened to replace it.
+    /// If any connection is reaped by [`max_lifetime`] or [`idle_timeout`], or explicitly closed,
+    /// and it brings the connection count below this amount, a new connection will be opened to
+    /// replace it.
+    ///
+    /// This is only done on a best-effort basis, however. The routine that maintains this value
+    /// has a deadline so it doesn't wait forever if the database is being slow or returning errors.
+    ///
+    /// This value is clamped internally to not exceed [`max_connections`].
+    ///
+    /// We've chosen not to assert `min_connections <= max_connections` anywhere
+    /// because it shouldn't break anything internally if the condition doesn't hold,
+    /// and if the application allows either value to be dynamically set
+    /// then it should be checking this condition itself and returning
+    /// a nicer error than a panic anyway.
     ///
     /// [`max_lifetime`]: Self::max_lifetime
     /// [`idle_timeout`]: Self::idle_timeout
+    /// [`max_connections`]: Self::max_connections
     pub fn min_connections(mut self, min: u32) -> Self {
         self.min_connections = min;
+        self
+    }
+
+    /// Set the maximum amount of time to spend waiting for a connection in [`Pool::acquire()`].
+    ///
+    /// Caps the total amount of time `Pool::acquire()` can spend waiting across multiple phases:
+    ///
+    /// * First, it may need to wait for a permit from the semaphore, which grants it the privilege
+    ///   of opening a connection or popping one from the idle queue.
+    /// * If an existing idle connection is acquired, by default it will be checked for liveness
+    ///   and integrity before being returned, which may require executing a command on the
+    ///   connection. This can be disabled with [`test_before_acquire(false)`][Self::test_before_acquire].
+    ///     * If [`before_acquire`][Self::before_acquire] is set, that will also be executed.
+    /// * If a new connection needs to be opened, that will obviously require I/O, handshaking,
+    ///   and initialization commands.
+    ///     * If [`after_connect`][Self::after_connect] is set, that will also be executed.
+    pub fn acquire_timeout(mut self, timeout: Duration) -> Self {
+        self.acquire_timeout = timeout;
         self
     }
 
@@ -106,7 +202,7 @@ impl<DB: Database> PoolOptions<DB> {
 
     /// Set a maximum idle duration for individual connections.
     ///
-    /// Any connection with an idle duration longer than this will be closed.
+    /// Any connection that remains in the idle queue longer than this will be closed.
     ///
     /// For usage-based database server billing, this can be a cost saver.
     pub fn idle_timeout(mut self, timeout: impl Into<Option<Duration>>) -> Self {
@@ -141,38 +237,102 @@ impl<DB: Database> PoolOptions<DB> {
         self
     }
 
-    /// Perform an action after connecting to the database.
+    /// Perform an asynchronous action after connecting to the database.
     ///
-    /// # Example
+    /// If the operation returns with an error then the error is logged, the connection is closed
+    /// and a new one is opened in its place and the callback is invoked again.
+    ///
+    /// This occurs in a backoff loop to avoid high CPU usage and spamming logs during a transient
+    /// error condition.
+    ///
+    /// Note that this may be called for internally opened connections, such as when maintaining
+    /// [`min_connections`][Self::min_connections], that are then immediately returned to the pool
+    /// without invoking [`after_release`][Self::after_release].
+    ///
+    /// # Example: Additional Parameters
+    /// This callback may be used to set additional configuration parameters
+    /// that are not exposed by the database's `ConnectOptions`.
+    ///
+    /// This example is written for PostgreSQL but can likely be adapted to other databases.
     ///
     /// ```no_run
     /// # async fn f() -> Result<(), Box<dyn std::error::Error>> {
-    /// use sqlx_core::executor::Executor;
-    /// use sqlx_core::postgres::PgPoolOptions;
-    /// // PostgreSQL
-    /// let pool = PgPoolOptions::new()
-    ///     .after_connect(|conn| Box::pin(async move {
-    ///        conn.execute("SET application_name = 'your_app';").await?;
-    ///        conn.execute("SET search_path = 'my_schema';").await?;
+    /// use sqlx::Executor;
+    /// use sqlx::postgres::PgPoolOptions;
     ///
-    ///        Ok(())
-    ///     }))
+    /// let pool = PgPoolOptions::new()
+    ///     .after_connect(|conn, _meta| Box::pin(async move {
+    ///         // When directly invoking `Executor` methods,
+    ///         // it is possible to execute multiple statements with one call.
+    ///         conn.execute("SET application_name = 'your_app'; SET search_path = 'my_schema';")
+    ///             .await?;
+    ///
+    ///         Ok(())
+    ///     }))    
     ///     .connect("postgres:// …").await?;
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// For a discussion on why `Box::pin()` is required, see [the type-level docs][Self].
     pub fn after_connect<F>(mut self, callback: F) -> Self
     where
-        for<'c> F:
-            Fn(&'c mut DB::Connection) -> BoxFuture<'c, Result<(), Error>> + 'static + Send + Sync,
+        // We're passing the `PoolConnectionMetadata` here mostly for future-proofing.
+        // `age` and `idle_for` are obviously not useful for fresh connections.
+        for<'c> F: Fn(&'c mut DB::Connection, PoolConnectionMetadata) -> BoxFuture<'c, Result<(), Error>>
+            + 'static
+            + Send
+            + Sync,
     {
         self.after_connect = Some(Box::new(callback));
         self
     }
 
+    /// Perform an asynchronous action on a previously idle connection before giving it out.
+    ///
+    /// Alongside the connection, the closure gets [`PoolConnectionMetadata`] which contains
+    /// potentially useful information such as the connection's age and the duration it was
+    /// idle.
+    ///
+    /// If the operation returns `Ok(true)`, the connection is returned to the task that called
+    /// [`Pool::acquire`].
+    ///
+    /// If the operation returns `Ok(false)` or an error, the error is logged (if applicable)
+    /// and then the connection is closed and [`Pool::acquire`] tries again with another idle
+    /// connection. If it runs out of idle connections, it opens a new connection instead.
+    ///
+    /// This is *not* invoked for new connections. Use [`after_connect`][Self::after_connect]
+    /// for those.
+    ///
+    /// # Example: Custom `test_before_acquire` Logic
+    /// If you only want to ping connections if they've been idle a certain amount of time,
+    /// you can implement your own logic here:
+    ///
+    /// This example is written for Postgres but should be trivially adaptable to other databases.
+    /// ```no_run
+    /// # async fn f() -> Result<(), Box<dyn std::error::Error>> {
+    /// use sqlx::{Connection, Executor};
+    /// use sqlx::postgres::PgPoolOptions;
+    ///
+    /// let pool = PgPoolOptions::new()
+    ///     .test_before_acquire(false)
+    ///     .before_acquire(|conn, meta| Box::pin(async move {
+    ///         // One minute
+    ///         if meta.idle_for.as_secs() > 60 {
+    ///             conn.ping().await?;
+    ///         }
+    ///
+    ///         Ok(true)
+    ///     }))
+    ///     .connect("postgres:// …").await?;
+    /// # Ok(())
+    /// # }
+    ///```
+    ///
+    /// For a discussion on why `Box::pin()` is required, see [the type-level docs][Self].
     pub fn before_acquire<F>(mut self, callback: F) -> Self
     where
-        for<'c> F: Fn(&'c mut DB::Connection) -> BoxFuture<'c, Result<bool, Error>>
+        for<'c> F: Fn(&'c mut DB::Connection, PoolConnectionMetadata) -> BoxFuture<'c, Result<bool, Error>>
             + 'static
             + Send
             + Sync,
@@ -181,67 +341,130 @@ impl<DB: Database> PoolOptions<DB> {
         self
     }
 
+    /// Perform an asynchronous action on a connection before it is returned to the pool.
+    ///
+    /// Alongside the connection, the closure gets [`PoolConnectionMetadata`] which contains
+    /// potentially useful information such as the connection's age.
+    ///
+    /// If the operation returns `Ok(true)`, the connection is returned to the pool's idle queue.
+    /// If the operation returns `Ok(false)` or an error, the error is logged (if applicable)
+    /// and the connection is closed, allowing a task waiting on [`Pool::acquire`] to
+    /// open a new one in its place.
+    ///
+    /// # Example (Postgres): Close Memory-Hungry Connections
+    /// Instead of relying on [`max_lifetime`][Self::max_lifetime] to close connections,
+    /// we can monitor their memory usage directly and close any that have allocated too much.
+    ///
+    /// Note that this is purely an example showcasing a possible use for this callback
+    /// and may be flawed as it has not been tested.
+    ///
+    /// This example queries [`pg_backend_memory_contexts`](https://www.postgresql.org/docs/current/view-pg-backend-memory-contexts.html)
+    /// which is only allowed for superusers.
+    ///
+    /// ```no_run
+    /// # async fn f() -> Result<(), Box<dyn std::error::Error>> {
+    /// use sqlx::{Connection, Executor};
+    /// use sqlx::postgres::PgPoolOptions;
+    ///
+    /// let pool = PgPoolOptions::new()
+    ///     // Let connections live as long as they want.
+    ///     .max_lifetime(None)
+    ///     .after_release(|conn, meta| Box::pin(async move {
+    ///         // Only check connections older than 6 hours.
+    ///         if meta.age.as_secs() < 6 * 60 * 60 {
+    ///             return Ok(true);
+    ///         }
+    ///
+    ///         let total_memory_usage: i64 = sqlx::query_scalar(
+    ///             "select sum(used_bytes) from pg_backend_memory_contexts"
+    ///         )
+    ///         .fetch_one(conn)
+    ///         .await?;
+    ///
+    ///         // Close the connection if the backend memory usage exceeds 256 MiB.
+    ///         Ok(total_memory_usage <= (2 << 28))
+    ///     }))
+    ///     .connect("postgres:// …").await?;
+    /// # Ok(())
+    /// # }
     pub fn after_release<F>(mut self, callback: F) -> Self
     where
-        F: Fn(&mut DB::Connection) -> bool + 'static + Send + Sync,
+        for<'c> F: Fn(&'c mut DB::Connection, PoolConnectionMetadata) -> BoxFuture<'c, Result<bool, Error>>
+            + 'static
+            + Send
+            + Sync,
     {
         self.after_release = Some(Box::new(callback));
         self
     }
 
-    /// Creates a new pool from this configuration and immediately establishes one connection.
-    pub async fn connect(self, uri: &str) -> Result<Pool<DB>, Error> {
-        self.connect_with(uri.parse()?).await
+    /// Create a new pool from this `PoolOptions` and immediately open at least one connection.
+    ///
+    /// This ensures the configuration is correct.
+    ///
+    /// The total number of connections opened is <code>min(1, [min_connections][Self::min_connections])</code>.
+    ///
+    /// Refer to the relevant `ConnectOptions` impl for your database for the expected URL format:
+    ///
+    /// * Postgres: [`PgConnectOptions`][crate::postgres::PgConnectOptions]
+    /// * MySQL: [`MySqlConnectOptions`][crate::mysql::MySqlConnectOptions]
+    /// * SQLite: [`SqliteConnectOptions`][crate::sqlite::SqliteConnectOptions]
+    /// * MSSQL: [`MssqlConnectOptions`][crate::mssql::MssqlConnectOptions]
+    pub async fn connect(self, url: &str) -> Result<Pool<DB>, Error> {
+        self.connect_with(url.parse()?).await
     }
 
-    /// Creates a new pool from this configuration and immediately establishes one connection.
+    /// Create a new pool from this `PoolOptions` and immediately open at least one connection.
+    ///
+    /// This ensures the configuration is correct.
+    ///
+    /// The total number of connections opened is <code>min(1, [min_connections][Self::min_connections])</code>.
     pub async fn connect_with(
         self,
         options: <DB::Connection as Connection>::Options,
     ) -> Result<Pool<DB>, Error> {
-        let shared = SharedPool::new_arc(self, options);
+        // Don't take longer than `acquire_timeout` starting from when this is called.
+        let deadline = Instant::now() + self.acquire_timeout;
 
-        init_min_connections(&shared).await?;
+        let inner = PoolInner::new_arc(self, options);
 
-        Ok(Pool(shared))
-    }
-
-    /// Creates a new pool from this configuration and will establish a connections as the pool
-    /// starts to be used.
-    pub fn connect_lazy(self, uri: &str) -> Result<Pool<DB>, Error> {
-        Ok(self.connect_lazy_with(uri.parse()?))
-    }
-
-    /// Creates a new pool from this configuration and will establish a connections as the pool
-    /// starts to be used.
-    pub fn connect_lazy_with(self, options: <DB::Connection as Connection>::Options) -> Pool<DB> {
-        let shared = SharedPool::new_arc(self, options);
-
-        let _ = spawn({
-            let shared = Arc::clone(&shared);
-            async move {
-                let _ = init_min_connections(&shared).await;
-            }
-        });
-
-        Pool(shared)
-    }
-}
-
-async fn init_min_connections<DB: Database>(pool: &Arc<SharedPool<DB>>) -> Result<(), Error> {
-    for _ in 0..cmp::max(pool.options.min_connections, 1) {
-        let deadline = Instant::now() + pool.options.connect_timeout;
-        let permit = pool.semaphore.acquire(1).await;
-
-        // this guard will prevent us from exceeding `max_size`
-        if let Ok(guard) = pool.try_increment_size(permit) {
-            // [connect] will raise an error when past deadline
-            let conn = pool.connection(deadline, guard).await?;
-            pool.release(conn);
+        if inner.options.min_connections > 0 {
+            // If the idle reaper is spawned then this will race with the call from that task
+            // and may not report any connection errors.
+            inner.try_min_connections(deadline).await?;
         }
+
+        // If `min_connections` is nonzero then we'll likely just pull a connection
+        // from the idle queue here, but it should at least get tested first.
+        let conn = inner.acquire().await?;
+        inner.release(conn);
+
+        Ok(Pool(inner))
     }
 
-    Ok(())
+    /// Create a new pool from this `PoolOptions`, but don't open any connections right now.
+    ///
+    /// If [`min_connections`][Self::min_connections] is set, a background task will be spawned to
+    /// optimistically establish that many connections for the pool.
+    ///
+    /// Refer to the relevant `ConnectOptions` impl for your database for the expected URL format:
+    ///
+    /// * Postgres: [`PgConnectOptions`][crate::postgres::PgConnectOptions]
+    /// * MySQL: [`MySqlConnectOptions`][crate::mysql::MySqlConnectOptions]
+    /// * SQLite: [`SqliteConnectOptions`][crate::sqlite::SqliteConnectOptions]
+    /// * MSSQL: [`MssqlConnectOptions`][crate::mssql::MssqlConnectOptions]
+    pub fn connect_lazy(self, url: &str) -> Result<Pool<DB>, Error> {
+        Ok(self.connect_lazy_with(url.parse()?))
+    }
+
+    /// Create a new pool from this `PoolOptions`, but don't open any connections right now.
+    ///
+    /// If [`min_connections`][Self::min_connections] is set, a background task will be spawned to
+    /// optimistically establish that many connections for the pool.
+    pub fn connect_lazy_with(self, options: <DB::Connection as Connection>::Options) -> Pool<DB> {
+        // `min_connections` is guaranteed by the idle reaper now.
+        Pool(PoolInner::new_arc(self, options))
+    }
 }
 
 impl<DB: Database> Debug for PoolOptions<DB> {
@@ -249,7 +472,7 @@ impl<DB: Database> Debug for PoolOptions<DB> {
         f.debug_struct("PoolOptions")
             .field("max_connections", &self.max_connections)
             .field("min_connections", &self.min_connections)
-            .field("connect_timeout", &self.connect_timeout)
+            .field("connect_timeout", &self.acquire_timeout)
             .field("max_lifetime", &self.max_lifetime)
             .field("idle_timeout", &self.idle_timeout)
             .field("test_before_acquire", &self.test_before_acquire)

--- a/sqlx-core/src/postgres/error.rs
+++ b/sqlx-core/src/postgres/error.rs
@@ -185,6 +185,20 @@ impl DatabaseError for PgDatabaseError {
         self
     }
 
+    fn is_transient_in_connect_phase(&self) -> bool {
+        // https://www.postgresql.org/docs/current/errcodes-appendix.html
+        [
+            // too_many_connections
+            // This may be returned if we just un-gracefully closed a connection,
+            // give the database a chance to notice it and clean it up.
+            "53300",
+            // cannot_connect_now
+            // Returned if the database is still starting up.
+            "57P03",
+        ]
+        .contains(&self.code())
+    }
+
     fn constraint(&self) -> Option<&str> {
         self.constraint()
     }

--- a/sqlx-core/src/sqlite/connection/mod.rs
+++ b/sqlx-core/src/sqlite/connection/mod.rs
@@ -155,6 +155,13 @@ impl Connection for SqliteConnection {
         })
     }
 
+    fn close_hard(self) -> BoxFuture<'static, Result<(), Error>> {
+        Box::pin(async move {
+            drop(self);
+            Ok(())
+        })
+    }
+
     /// Ensure the background worker thread is alive and accepting commands.
     fn ping(&mut self) -> BoxFuture<'_, Result<(), Error>> {
         Box::pin(self.worker.ping())

--- a/tests/any/pool.rs
+++ b/tests/any/pool.rs
@@ -12,7 +12,7 @@ async fn pool_should_invoke_after_connect() -> anyhow::Result<()> {
     let pool = AnyPoolOptions::new()
         .after_connect({
             let counter = counter.clone();
-            move |_conn| {
+            move |_conn, _meta| {
                 let counter = counter.clone();
                 Box::pin(async move {
                     counter.fetch_add(1, Ordering::SeqCst);
@@ -41,7 +41,7 @@ async fn pool_should_invoke_after_connect() -> anyhow::Result<()> {
 async fn pool_should_be_returned_failed_transactions() -> anyhow::Result<()> {
     let pool = AnyPoolOptions::new()
         .max_connections(2)
-        .connect_timeout(Duration::from_secs(3))
+        .acquire_timeout(Duration::from_secs(3))
         .connect(&dotenv::var("DATABASE_URL")?)
         .await?;
 


### PR DESCRIPTION
* Fixed leak of `Arc<SharedPool>` in `DecrementSizeGuard::cancel()`
* Renamed `PoolOptions::connect_timeout` to `acquire_timeout` for clarity.
* Fixed `/* SQLx ping */` showing up in Postgres query logs
* Made `.close()` a regular function that returns a `Future`
* Deleted deprecated method `PoolConnection::release()`
* Document why connection might be dropped if `Pool::acquire()` is cancelled
* Added connection metadata to pool lifecycle callbacks
* Improved guarantees for `min_connections`
* Fixed `num_idle()` to not spin forever at high load
* Improved documentation across the `pool` module

Closes #1869
Closes #1862 
Closes #1824 
Closes #1743 
Closes #561