### PR TITLE
Don't cache sqlite connections for macros

### DIFF
--- a/sqlx-macros/src/query/mod.rs
+++ b/sqlx-macros/src/query/mod.rs
@@ -187,64 +187,62 @@ pub fn expand_input(input: QueryMacroInput) -> crate::Result<TokenStream> {
     feature = "sqlite"
 ))]
 fn expand_from_db(input: QueryMacroInput, db_url: &str) -> crate::Result<TokenStream> {
-    use sqlx_core::any::{AnyConnection, AnyConnectionKind};
-
-    static CONNECTION_CACHE: Lazy<AsyncMutex<BTreeMap<String, AnyConnection>>> =
-        Lazy::new(|| AsyncMutex::new(BTreeMap::new()));
+    use sqlx_core::any::AnyConnection;
 
     let maybe_expanded: crate::Result<TokenStream> = block_on(async {
-        let mut cache = CONNECTION_CACHE.lock().await;
+        let parsed_db_url = Url::parse(db_url)?;
 
-        if !cache.contains_key(db_url) {
-            let parsed_db_url = Url::parse(db_url)?;
-
-            let conn = match parsed_db_url.scheme() {
-                #[cfg(feature = "sqlite")]
-                "sqlite" => {
-                    use sqlx_core::connection::ConnectOptions;
-                    use sqlx_core::sqlite::{SqliteConnectOptions, SqliteJournalMode};
-                    use std::str::FromStr;
-
-                    let sqlite_conn = SqliteConnectOptions::from_str(db_url)?
-                        // Connections in `CONNECTION_CACHE` won't get dropped so disable journaling
-                        // to avoid `.db-wal` and `.db-shm` files from lingering around
-                        .journal_mode(SqliteJournalMode::Off)
-                        .connect()
-                        .await?;
-                    AnyConnection::from(sqlite_conn)
-                }
-                _ => AnyConnection::connect(db_url).await?,
-            };
-
-            let _ = cache.insert(db_url.to_owned(), conn);
-        }
-
-        let conn_item = cache.get_mut(db_url).expect("Item was just inserted");
-        match conn_item.private_get_mut() {
-            #[cfg(feature = "postgres")]
-            AnyConnectionKind::Postgres(conn) => {
-                let data = QueryData::from_db(conn, &input.sql).await?;
-                expand_with_data(input, data, false)
-            }
-            #[cfg(feature = "mssql")]
-            AnyConnectionKind::Mssql(conn) => {
-                let data = QueryData::from_db(conn, &input.sql).await?;
-                expand_with_data(input, data, false)
-            }
-            #[cfg(feature = "mysql")]
-            AnyConnectionKind::MySql(conn) => {
-                let data = QueryData::from_db(conn, &input.sql).await?;
-                expand_with_data(input, data, false)
-            }
+        match parsed_db_url.scheme() {
+            // SQLite is not used in the connection cache due to issues with newly created
+            // databases seemingly being locked for several seconds when journaling is off. This
+            // isn't a huge issue since the intent of the connection cache was to make connections
+            // to remote databases much faster. Relevant links:
+            // - https://github.com/launchbadge/sqlx/pull/1782#issuecomment-1089226716
+            // - https://github.com/launchbadge/sqlx/issues/1929
             #[cfg(feature = "sqlite")]
-            AnyConnectionKind::Sqlite(conn) => {
-                let data = QueryData::from_db(conn, &input.sql).await?;
+            "sqlite" => {
+                use sqlx_core::connection::ConnectOptions;
+                use sqlx_core::sqlite::SqliteConnectOptions;
+                use std::str::FromStr;
+
+                let mut conn = SqliteConnectOptions::from_str(db_url)?.connect().await?;
+                let data = QueryData::from_db(&mut conn, &input.sql).await?;
                 expand_with_data(input, data, false)
             }
-            // Variants depend on feature flags
-            #[allow(unreachable_patterns)]
-            item => {
-                return Err(format!("Missing expansion needed for: {:?}", item).into());
+            _ => {
+                static CONNECTION_CACHE: Lazy<AsyncMutex<BTreeMap<String, AnyConnection>>> =
+                    Lazy::new(|| AsyncMutex::new(BTreeMap::new()));
+
+                let mut cache = CONNECTION_CACHE.lock().await;
+
+                if !cache.contains_key(db_url) {
+                    let conn = AnyConnection::connect(db_url).await?;
+                    let _ = cache.insert(db_url.to_owned(), conn);
+                }
+
+                let conn_item = cache.get_mut(db_url).expect("Item was just inserted");
+                match conn_item.private_get_mut() {
+                    #[cfg(feature = "postgres")]
+                    sqlx_core::any::AnyConnectionKind::Postgres(conn) => {
+                        let data = QueryData::from_db(conn, &input.sql).await?;
+                        expand_with_data(input, data, false)
+                    }
+                    #[cfg(feature = "mssql")]
+                    sqlx_core::any::AnyConnectionKind::Mssql(conn) => {
+                        let data = QueryData::from_db(conn, &input.sql).await?;
+                        expand_with_data(input, data, false)
+                    }
+                    #[cfg(feature = "mysql")]
+                    sqlx_core::any::AnyConnectionKind::MySql(conn) => {
+                        let data = QueryData::from_db(conn, &input.sql).await?;
+                        expand_with_data(input, data, false)
+                    }
+                    // Variants depend on feature flags
+                    #[allow(unreachable_patterns)]
+                    item => {
+                        return Err(format!("Missing expansion needed for: {:?}", item).into());
+                    }
+                }
             }
         }
     });

--- a/sqlx-macros/src/query/mod.rs
+++ b/sqlx-macros/src/query/mod.rs
@@ -207,6 +207,7 @@ fn expand_from_db(input: QueryMacroInput, db_url: &str) -> crate::Result<TokenSt
 
                 let mut conn = SqliteConnectOptions::from_str(db_url)?.connect().await?;
                 let data = QueryData::from_db(&mut conn, &input.sql).await?;
+                conn.close().await?;
                 expand_with_data(input, data, false)
             }
             _ => {


### PR DESCRIPTION
Fixes #1929 

This works around the issue mentioned in #1929 by not including SQLite for the cached connection. I've confirmed using the repro provided in the issue that this no longer runs into the problem of the database reporting that it's busy for several seconds after being reset when journaling is turned off.

It is worth noting that I still don't really know what the root cause of the issue is...

---

Random other things I've noticed regarding the issue:

- I'm not able to repro nearly as much using `check` instead of `clippy`
  - Reproed 10/10 times with `clippy`, but 1/10 with `check`
- Even with the fix I still noticed lingering `-shm` and `-wal` files very rarely after running the repro script. I'm not really sure how to inspect them, so I don't know why they occasionally stick around