### PR TITLE
Add dynamic credentials support to Postgres

### DIFF
--- a/sqlx-core/src/postgres/connection/sasl.rs
+++ b/sqlx-core/src/postgres/connection/sasl.rs
@@ -89,12 +89,13 @@ pub(crate) async fn authenticate(
         }
     };
 
+    let password = match &options.password {
+        Some(pw) => pw.password().await.unwrap(),
+        None => Default::default(),
+    };
+
     // SaltedPassword := Hi(Normalize(password), salt, i)
-    let salted_password = hi(
-        options.password.as_deref().unwrap_or_default(),
-        &cont.salt,
-        cont.iterations,
-    )?;
+    let salted_password = hi(&password, &cont.salt, cont.iterations)?;
 
     // ClientKey := HMAC(SaltedPassword, "Client Key")
     let mut mac = Hmac::<Sha256>::new_from_slice(&salted_password).map_err(Error::protocol)?;

--- a/sqlx-core/src/postgres/options/password_provider.rs
+++ b/sqlx-core/src/postgres/options/password_provider.rs
@@ -1,0 +1,26 @@
+use std::sync::Arc;
+
+use futures_core::future::BoxFuture;
+
+use crate::error::Error;
+
+#[derive(Clone)]
+pub enum PgPassword {
+    Static(String),
+    Dynamic(Arc<dyn Fn() -> BoxFuture<'static, Result<String, Error>> + 'static + Send + Sync>),
+}
+
+impl PgPassword {
+    pub async fn password(&self) -> Result<String, Error> {
+        match &self {
+            PgPassword::Static(password) => Ok(password.clone()),
+            PgPassword::Dynamic(closure) => closure().await,
+        }
+    }
+}
+
+impl std::fmt::Debug for PgPassword {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        todo!()
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/launchbadge/sqlx/issues/445.

We've been using this in development to refresh RDS tokens and it works pretty well. Some outstanding work is left to do error typing properly.