### PR TITLE
Only pass `$RUSTFLAGS` in `cargo sqlx prepare --merged` when set

### DIFF
--- a/sqlx-cli/src/prepare.rs
+++ b/sqlx-cli/src/prepare.rs
@@ -129,25 +129,27 @@ hint: This command only works in the manifest directory of a Cargo package."#
     let _ = remove_dir_all(metadata.target_directory.join("sqlx"));
 
     let check_status = if merge {
-        let check_status = Command::new(&cargo).arg("clean").status()?;
+        let clean_status = Command::new(&cargo).arg("clean").status()?;
 
-        if !check_status.success() {
-            bail!("`cargo clean` failed with status: {}", check_status);
+        if !clean_status.success() {
+            bail!("`cargo clean` failed with status: {}", clean_status);
         }
 
-        let mut rustflags = env::var("RUSTFLAGS").unwrap_or_default();
-        rustflags.push_str(&format!(
-            " --cfg __sqlx_recompile_trigger=\"{}\"",
-            SystemTime::UNIX_EPOCH.elapsed()?.as_millis()
-        ));
-
-        Command::new(&cargo)
+        let mut check_command = Command::new(&cargo);
+        check_command
             .arg("check")
             .args(cargo_args)
-            .env("RUSTFLAGS", rustflags)
             .env("SQLX_OFFLINE", "false")
-            .env("DATABASE_URL", url)
-            .status()?
+            .env("DATABASE_URL", url);
+
+        // `cargo check` recompiles on changed rust flags which can be set either via the env var
+        // or through the `rustflags` field in `$CARGO_HOME/config` when the env var isn't set.
+        // Because of this we only pass in `$RUSTFLAGS` when present
+        if let Ok(rustflags) = env::var("RUSTFLAGS") {
+            check_command.env("RUSTFLAGS", rustflags);
+        }
+
+        check_command.status()?
     } else {
         Command::new(&cargo)
             .arg("rustc")


### PR DESCRIPTION
_Splitting off a distinct portion of #1802_

This PR does two things:

1. Removes the ever-changing `--cfg` which doesn't have an impact since a `cargo clean` is run in `--merged`
2. Only passes `$RUSTFLAGS` to `cargo check` when it is set

`cargo check` will fully recompile on changed flags, so 2. is important when the user has rust flags set in `$CARGO_HOME/config`. This PR makes it so that running the following when `rustflags` is set in the cargo config

```
$ cargo sqlx prepare --merged
$ cargo check
```

will do one full recompile (from the `cargo clean` used in `--merged`) instead of the previous two (the extra being from changed rust flags between the `cargo check` used in `--merged` and the regular `cargo check`)

This was noticed while implementing #1802 where running `cargo check` after `cargo sqlx prepare --merged` would do a full recompile due to `rustflags` being set in my cargo config. I decided to split it off into a separate PR because it's a small change that still has a notable impact on DX