### PR TITLE
Fix compile time verification performance regression for sqlite

### DIFF
--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -179,7 +179,7 @@ impl RegDataType {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, )]
+#[derive(Debug, Clone, Eq, PartialEq)]
 enum CursorDataType {
     Normal(HashMap<i64, ColumnType>),
     Pseudo(i64),


### PR DESCRIPTION
The sqlite CTE feature (#1816) introduced severe performance degradation, and this PR attempts to fix it.

This patch drastically reduces search space by adding memorization based on register type and cursor data type. Pushing new states on to the Stack is guarded by a `HashSet`, where if no new information is gained about an instruction (i.e. different register/cursor data type), the instruction will not be searched again. 

Now the example query in #1921 only takes 5s to verify instead of several minutes. It might be possible to further optimize this by stop tracking unnecessary information, which could save a lot of memory allocations. 

