### PR TITLE
Fix panic in Postgres Bytes decode

### DIFF
--- a/sqlx-core/src/postgres/types/bytes.rs
+++ b/sqlx-core/src/postgres/types/bytes.rs
@@ -55,7 +55,11 @@ impl Decode<'_, Postgres> for Vec<u8> {
             PgValueFormat::Binary => value.as_bytes()?.to_owned(),
             PgValueFormat::Text => {
                 // BYTEA is formatted as \x followed by hex characters
-                hex::decode(&value.as_str()?[2..])?
+                let text = value
+                    .as_bytes()?
+                    .strip_prefix(b"\\x")
+                    .ok_or("text does not start with \\x")?;
+                hex::decode(text)?
             }
         })
     }


### PR DESCRIPTION
This function can panic due to slicing out of bounds when the server
responds without the `\x` prefix. With this commit we instead error and
also ensure that the prefix is what we expect instead of blindly
removing it.

Not directly related to the panic, we replace as_str() with as_bytes()
because there is no reason to perform a utf8 validity check when
hex::decode already checks that the content is valid.