### PR TITLE
Support Rust arrays in Postgres

### DIFF
--- a/sqlx-core/src/postgres/types/bytes.rs
+++ b/sqlx-core/src/postgres/types/bytes.rs
@@ -24,6 +24,12 @@ impl PgHasArrayType for Vec<u8> {
     }
 }
 
+impl<const N: usize> PgHasArrayType for [u8; N] {
+    fn array_type_info() -> PgTypeInfo {
+        <[&[u8]] as Type<Postgres>>::type_info()
+    }
+}
+
 impl Encode<'_, Postgres> for &'_ [u8] {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> IsNull {
         buf.extend_from_slice(self);
@@ -38,6 +44,12 @@ impl Encode<'_, Postgres> for Vec<u8> {
     }
 }
 
+impl<const N: usize> Encode<'_, Postgres> for [u8; N] {
+    fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> IsNull {
+        <&[u8] as Encode<Postgres>>::encode(self.as_slice(), buf)
+    }
+}
+
 impl<'r> Decode<'r, Postgres> for &'r [u8] {
     fn decode(value: PgValueRef<'r>) -> Result<Self, BoxDynError> {
         match value.format() {
@@ -49,18 +61,33 @@ impl<'r> Decode<'r, Postgres> for &'r [u8] {
     }
 }
 
+fn text_hex_decode_input(value: PgValueRef<'_>) -> Result<&[u8], BoxDynError> {
+    // BYTEA is formatted as \x followed by hex characters
+    value
+        .as_bytes()?
+        .strip_prefix(b"\\x")
+        .ok_or("text does not start with \\x")
+        .map_err(Into::into)
+}
+
 impl Decode<'_, Postgres> for Vec<u8> {
     fn decode(value: PgValueRef<'_>) -> Result<Self, BoxDynError> {
         Ok(match value.format() {
             PgValueFormat::Binary => value.as_bytes()?.to_owned(),
-            PgValueFormat::Text => {
-                // BYTEA is formatted as \x followed by hex characters
-                let text = value
-                    .as_bytes()?
-                    .strip_prefix(b"\\x")
-                    .ok_or("text does not start with \\x")?;
-                hex::decode(text)?
-            }
+            PgValueFormat::Text => hex::decode(text_hex_decode_input(value)?)?,
         })
+    }
+}
+
+impl<const N: usize> Decode<'_, Postgres> for [u8; N] {
+    fn decode(value: PgValueRef<'_>) -> Result<Self, BoxDynError> {
+        let mut bytes = [0u8; N];
+        match value.format() {
+            PgValueFormat::Binary => {
+                bytes = value.as_bytes()?.try_into()?;
+            }
+            PgValueFormat::Text => hex::decode_to_slice(text_hex_decode_input(value)?, &mut bytes)?,
+        };
+        Ok(bytes)
     }
 }

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -15,12 +15,20 @@ test_type!(null_vec<Vec<Option<i16>>>(Postgres,
     "array[10,NULL,50]::int2[]" == vec![Some(10_i16), None, Some(50)],
 ));
 
+test_type!(null_array<[Option<i16>; 3]>(Postgres,
+    "array[10,NULL,50]::int2[]" == vec![Some(10_i16), None, Some(50)],
+));
+
 test_type!(bool<bool>(Postgres,
     "false::boolean" == false,
     "true::boolean" == true
 ));
 
 test_type!(bool_vec<Vec<bool>>(Postgres,
+    "array[true,false,true]::bool[]" == vec![true, false, true],
+));
+
+test_type!(bool_array<[bool; 3]>(Postgres,
     "array[true,false,true]::bool[]" == vec![true, false, true],
 ));
 
@@ -39,6 +47,14 @@ test_prepared_type!(byte_slice<&[u8]>(Postgres,
         == &[0xDE_u8, 0xAD, 0xBE, 0xEF][..],
     "E'\\\\x0000000052'::bytea"
         == &[0_u8, 0, 0, 0, 0x52][..]
+));
+
+test_type!(byte_array_empty<[u8; 0]>(Postgres,
+    "E'\\\\x'::bytea" == [0_u8; 0],
+));
+
+test_type!(byte_array<[u8; 4]>(Postgres,
+    "E'\\\\xDEADBEEF'::bytea" == [0xDE_u8, 0xAD, 0xBE, 0xEF],
 ));
 
 test_type!(str<&str>(Postgres,
@@ -62,6 +78,10 @@ test_type!(string_vec<Vec<String>>(Postgres,
 
     "array['Hello, World', '', 'Goodbye']::text[]"
         == vec!["Hello, World", "", "Goodbye"]
+));
+
+test_type!(string_array<[String; 3]>(Postgres,
+    "array['one','two','three']::text[]" == ["one","two","three"],
 ));
 
 test_type!(i8(
@@ -89,6 +109,14 @@ test_type!(i32_vec<Vec<i32>>(Postgres,
     "'{1050}'::int[]" == vec![1050_i32],
     "'{}'::int[]" == Vec::<i32>::new(),
     "'{1,3,-5}'::int[]" == vec![1_i32, 3, -5]
+));
+
+test_type!(i32_array_empty<[i32; 0]>(Postgres,
+    "'{}'::int[]" == [0_i32; 0],
+));
+
+test_type!(i32_array<[i32; 4]>(Postgres,
+    "'{5,10,50,100}'::int[]" == [5_i32, 10, 50, 100],
 ));
 
 test_type!(i64(Postgres, "9358295312::bigint" == 9358295312_i64));
@@ -339,10 +367,16 @@ mod json {
         "'[\"Hello\", \"World!\"]'::json" == json!(["Hello", "World!"])
     ));
 
-    test_type!(json_array<Vec<JsonValue>>(
+    test_type!(json_vec<Vec<JsonValue>>(
         Postgres,
         "SELECT ({0}::jsonb[] is not distinct from $1::jsonb[])::int4, {0} as _2, $2 as _3",
         "array['\"😎\"'::json, '\"🙋‍♀️\"'::json]::json[]" == vec![json!("😎"), json!("🙋‍♀️")],
+    ));
+
+    test_type!(json_array<[JsonValue; 2]>(
+        Postgres,
+        "SELECT ({0}::jsonb[] is not distinct from $1::jsonb[])::int4, {0} as _2, $2 as _3",
+        "array['\"😎\"'::json, '\"🙋‍♀️\"'::json]::json[]" == [json!("😎"), json!("🙋‍♀️")],
     ));
 
     test_type!(jsonb<JsonValue>(


### PR DESCRIPTION
For generic arrays `[T; N]` and a specialized implementation for byte arrays `[u8; N]`.

I am not very confident that I have tested this change sufficiently. Feel free to detail more tests that should be added.

Related to https://github.com/launchbadge/sqlx/issues/1180 .