### PR TITLE
support flatten attribute in FromRow macro

### DIFF
--- a/sqlx-core/src/from_row.rs
+++ b/sqlx-core/src/from_row.rs
@@ -92,6 +92,36 @@ use crate::row::Row;
 /// will set the value of the field `location` to the default value of `Option<String>`,
 /// which is `None`.
 ///
+/// ### `flatten`
+///
+/// If you want to handle a field that implements [`FromRow`],
+/// you can use the `flatten` attribute to specify that you want
+/// it to use [`FromRow`] for parsing rather than the usual method.
+/// For example:
+///
+/// ```rust,ignore
+/// #[derive(sqlx::FromRow)]
+/// struct Address {
+///     country: String,
+///     city: String,
+///     road: String,
+/// }
+///
+/// #[derive(sqlx::FromRow)]
+/// struct User {
+///     id: i32,
+///     name: String,
+///     #[sqlx(flatten)]
+///     address: Address,
+/// }
+/// ```
+/// Given a query such as:
+///
+/// ```sql
+/// SELECT id, name, country, city, road FROM users;
+/// ```
+///
+/// This field is compatible with the `default` attribute.
 pub trait FromRow<'r, R: Row>: Sized {
     fn from_row(row: &'r R) -> Result<Self, Error>;
 }

--- a/sqlx-macros/src/derives/attributes.rs
+++ b/sqlx-macros/src/derives/attributes.rs
@@ -70,6 +70,7 @@ pub struct SqlxContainerAttributes {
 pub struct SqlxChildAttributes {
     pub rename: Option<String>,
     pub default: bool,
+    pub flatten: bool,
 }
 
 pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContainerAttributes> {
@@ -177,6 +178,7 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
 pub fn parse_child_attributes(input: &[Attribute]) -> syn::Result<SqlxChildAttributes> {
     let mut rename = None;
     let mut default = false;
+    let mut flatten = false;
 
     for attr in input.iter().filter(|a| a.path.is_ident("sqlx")) {
         let meta = attr
@@ -193,6 +195,7 @@ pub fn parse_child_attributes(input: &[Attribute]) -> syn::Result<SqlxChildAttri
                             ..
                         }) if path.is_ident("rename") => try_set!(rename, val.value(), value),
                         Meta::Path(path) if path.is_ident("default") => default = true,
+                        Meta::Path(path) if path.is_ident("flatten") => flatten = true,
                         u => fail!(u, "unexpected attribute"),
                     },
                     u => fail!(u, "unexpected attribute"),
@@ -201,7 +204,11 @@ pub fn parse_child_attributes(input: &[Attribute]) -> syn::Result<SqlxChildAttri
         }
     }
 
-    Ok(SqlxChildAttributes { rename, default })
+    Ok(SqlxChildAttributes {
+        rename,
+        default,
+        flatten,
+    })
 }
 
 pub fn check_transparent_attributes(


### PR DESCRIPTION
Adding `#[sqlx(flatten)]` field attribute in a `FromRow` macro to handle a field that implements `FromRow`

This is a task of #156 : _"Handle a field that is impl FromRow. A parallel from serde_json would perhaps make this #[sqlx(flatten)]"_

