### PR TITLE
Add example with external query files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,6 +874,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "files"
+version = "0.1.0"
+
+[[package]]
 name = "filetime"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,6 +876,12 @@ dependencies = [
 [[package]]
 name = "files"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-std",
+ "dotenv",
+ "sqlx",
+]
 
 [[package]]
 name = "filetime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "sqlx-cli",
     "sqlx-bench",
     "examples/mysql/todos",
+    "examples/postgres/files",
     "examples/postgres/json",
     "examples/postgres/listen",
     "examples/postgres/todos",

--- a/examples/postgres/files/Cargo.toml
+++ b/examples/postgres/files/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "files"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/examples/postgres/files/Cargo.toml
+++ b/examples/postgres/files/Cargo.toml
@@ -6,3 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0"
+async-std = { version = "1.8.0", features = [ "attributes" ] }
+sqlx = { path = "../../../", features = ["postgres", "offline", "runtime-async-std-native-tls"] }
+dotenv = "0.15.0"

--- a/examples/postgres/files/README.md
+++ b/examples/postgres/files/README.md
@@ -1,0 +1,36 @@
+# Query files Example
+
+## Description
+
+This example demonstrates storing external files to use for querying data.
+Encapsulating your SQL queries can be helpful in several ways, assisting with intellisense,
+etc.
+
+
+## Setup
+
+1. Declare the database URL
+
+    ```
+    export DATABASE_URL="postgres://postgres:password@localhost/files"
+    ```
+
+2. Create the database.
+
+    ```
+    $ sqlx db create
+    ```
+
+3. Run sql migrations
+
+    ```
+    $ sqlx migrate run
+    ```
+
+## Usage
+
+Run the project
+
+```
+cargo run files
+```

--- a/examples/postgres/files/migrations/20220712221654_files.sql
+++ b/examples/postgres/files/migrations/20220712221654_files.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS users
+(
+    id       BIGSERIAL PRIMARY KEY,
+    username TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS posts
+(
+    id      BIGSERIAL PRIMARY KEY,
+    title   TEXT NOT NULL,
+    body    TEXT NOT NULL,
+    user_id BIGINT NOT NULL
+        REFERENCES users (id) ON DELETE CASCADE
+);

--- a/examples/postgres/files/queries/insert_seed_data.sql
+++ b/examples/postgres/files/queries/insert_seed_data.sql
@@ -1,0 +1,11 @@
+-- seed some data to work with
+WITH inserted_users_cte AS (
+    INSERT INTO users (username)
+        VALUES ('user1'),
+               ('user2')
+        RETURNING id as "user_id"
+)
+INSERT INTO posts (title, body, user_id)
+VALUES ('user1 post1 title', 'user1 post1 body', (SELECT user_id FROM inserted_users_cte FETCH FIRST ROW ONLY)),
+       ('user1 post2 title', 'user1 post2 body', (SELECT user_id FROM inserted_users_cte FETCH FIRST ROW ONLY)),
+       ('user2 post1 title', 'user2 post2 body', (SELECT user_id FROM inserted_users_cte OFFSET 1 LIMIT 1));

--- a/examples/postgres/files/queries/list_all_posts.sql
+++ b/examples/postgres/files/queries/list_all_posts.sql
@@ -1,0 +1,7 @@
+SELECT p.id as "post_id",
+       p.title,
+       p.body,
+       u.id as "author_id",
+       u.username as "author_username"
+FROM users u
+         JOIN posts p on u.id = p.user_id;

--- a/examples/postgres/files/src/main.rs
+++ b/examples/postgres/files/src/main.rs
@@ -1,0 +1,48 @@
+use sqlx::{query_file, query_file_as, query_file_unchecked, FromRow, PgPool};
+use std::fmt::{Display, Formatter};
+
+#[derive(FromRow)]
+struct PostWithAuthorQuery {
+    pub post_id: i64,
+    pub title: String,
+    pub body: String,
+    pub author_id: i64,
+    pub author_username: String,
+}
+
+impl Display for PostWithAuthorQuery {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            r#"
+            post_id: {},
+            title: {},
+            body: {},
+            author_id: {},
+            author_username: {}
+        "#,
+            self.post_id, self.title, self.body, self.author_id, self.author_username
+        )
+    }
+}
+
+#[async_std::main]
+async fn main() -> anyhow::Result<()> {
+    let pool = PgPool::connect(&dotenv::var("DATABASE_URL")?).await?;
+
+    // we can use a tranditional wrapper around the `query!()` macro using files
+    query_file!("queries/insert_seed_data.sql")
+        .execute(&pool)
+        .await?;
+
+    // we can also use `query_file_as!()` similarly to `query_as!()` to map our database models
+    let posts_with_authors = query_file_as!(PostWithAuthorQuery, "queries/list_all_posts.sql")
+        .fetch_all(&pool)
+        .await?;
+
+    for post_with_author in posts_with_authors {
+        println!("{}", post_with_author);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
@abonander - _Original PR went stale, cleaned up my fork to exclude those superfluous commits as my original PR looks like it was closed due to no changes detected between forks_

First and foremost, after being relatively new to Rust, sqlx made it incredibly easy to dive right into data-driven applications with a great straightforward API and docs to match. The docs touch on `query_file!()` and `query_as_file!()` (along with the other variants), but I thought it would be nice to include a Postgres-based example as well (recently did this in a personal project). Great work!

