### PR TITLE
fix(sqlx-cli): fix the build

### DIFF
--- a/sqlx-cli/src/prepare.rs
+++ b/sqlx-cli/src/prepare.rs
@@ -172,7 +172,7 @@ hint: This command only works in the manifest directory of a Cargo package."#
             ))
             .env("SQLX_OFFLINE", "false")
             .env("DATABASE_URL", url)
-            .env("CARGO_TARGET_DIR", metadata.target_directory.clone())
+            .env("CARGO_TARGET_DIR", metadata.target_directory().clone())
             .status()?
     };
 


### PR DESCRIPTION
This fixes the build after 7d8ded9a1afa3775d14ee00fd12b30636d7a0a7f:

```
error[E0616]: field `target_directory` of struct `metadata::Metadata` is private
   --> sqlx-cli/src/prepare.rs:175:47
    |
175 |             .env("CARGO_TARGET_DIR", metadata.target_directory.clone())
    |                                               ^^^^^^^^^^^^^^^^ private field
    |
help: a method `target_directory` also exists, call it with parentheses
    |
175 |             .env("CARGO_TARGET_DIR", metadata.target_directory().clone())
    |                                                               ++
```