### PR TITLE
fix: agree one a single default runtime for the whole workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,9 +884,9 @@ name = "files"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-std",
  "dotenv",
  "sqlx",
+ "tokio",
 ]
 
 [[package]]
@@ -1298,14 +1298,13 @@ name = "json"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-std",
  "dotenv",
  "futures",
- "paw",
  "serde",
  "serde_json",
  "sqlx",
  "structopt",
+ "tokio",
 ]
 
 [[package]]
@@ -1750,33 +1749,6 @@ name = "paste"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
-
-[[package]]
-name = "paw"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c0fc9b564dbc3dc2ed7c92c0c144f4de340aa94514ce2b446065417c4084e9"
-dependencies = [
- "paw-attributes",
- "paw-raw",
-]
-
-[[package]]
-name = "paw-attributes"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f35583365be5d148e959284f42526841917b7bfa09e2d1a7ad5dde2cf0eaa39"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "paw-raw"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f0b59668fe80c5afe998f0c0bf93322bf2cd66cafeeb80581f291716f3467f2"
 
 [[package]]
 name = "pem-rfc7468"
@@ -2584,20 +2556,19 @@ name = "sqlx-example-mysql-todos"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-std",
  "futures",
- "paw",
  "sqlx",
  "structopt",
+ "tokio",
 ]
 
 [[package]]
 name = "sqlx-example-postgres-listen"
 version = "0.1.0"
 dependencies = [
- "async-std",
  "futures",
  "sqlx",
+ "tokio",
 ]
 
 [[package]]
@@ -2605,14 +2576,13 @@ name = "sqlx-example-postgres-mockable-todos"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-std",
  "async-trait",
  "dotenv",
  "futures",
  "mockall",
- "paw",
  "sqlx",
  "structopt",
+ "tokio",
 ]
 
 [[package]]
@@ -2620,21 +2590,20 @@ name = "sqlx-example-postgres-todos"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-std",
  "dotenv",
  "futures",
- "paw",
  "sqlx",
  "structopt",
+ "tokio",
 ]
 
 [[package]]
 name = "sqlx-example-postgres-transaction"
 version = "0.1.0"
 dependencies = [
- "async-std",
  "futures",
  "sqlx",
+ "tokio",
 ]
 
 [[package]]
@@ -2642,11 +2611,10 @@ name = "sqlx-example-sqlite-todos"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-std",
  "futures",
- "paw",
  "sqlx",
  "structopt",
+ "tokio",
 ]
 
 [[package]]
@@ -2732,7 +2700,6 @@ checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
  "clap 2.34.0",
  "lazy_static",
- "paw",
  "structopt-derive",
 ]
 
@@ -2896,10 +2863,11 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.19.2"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
+checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ authors = [
 ]
 
 [package.metadata.docs.rs]
-features = ["all", "runtime-async-std-native-tls"]
+features = ["all", "runtime-tokio-native-tls"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]

--- a/examples/mysql/todos/Cargo.toml
+++ b/examples/mysql/todos/Cargo.toml
@@ -6,8 +6,7 @@ workspace = "../../../"
 
 [dependencies]
 anyhow = "1.0"
-async-std = { version = "1.8.0", features = [ "attributes" ] }
 futures = "0.3"
-paw = "1.0"
-sqlx = { path = "../../../", features = [ "mysql", "runtime-async-std-native-tls" ] }
-structopt = { version = "0.3", features = [ "paw" ] }
+sqlx = { path = "../../../", features = [ "mysql", "runtime-tokio-native-tls" ] }
+structopt = "0.3"
+tokio = { version = "1.20.0", features = ["macros"]}

--- a/examples/mysql/todos/src/main.rs
+++ b/examples/mysql/todos/src/main.rs
@@ -14,9 +14,9 @@ enum Command {
     Done { id: u64 },
 }
 
-#[async_std::main]
-#[paw::main]
-async fn main(args: Args) -> anyhow::Result<()> {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::from_args_safe()?;
     let pool = MySqlPool::connect(&env::var("DATABASE_URL")?).await?;
 
     match args.cmd {

--- a/examples/postgres/files/Cargo.toml
+++ b/examples/postgres/files/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-async-std = { version = "1.8.0", features = [ "attributes" ] }
-sqlx = { path = "../../../", features = ["postgres", "offline", "runtime-async-std-native-tls"] }
+sqlx = { path = "../../../", features = ["postgres", "offline", "runtime-tokio-native-tls"] }
+tokio = { version = "1.20.0", features = ["macros"]}
 dotenv = "0.15.0"

--- a/examples/postgres/files/src/main.rs
+++ b/examples/postgres/files/src/main.rs
@@ -26,7 +26,7 @@ impl Display for PostWithAuthorQuery {
     }
 }
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let pool = PgPool::connect(&dotenv::var("DATABASE_URL")?).await?;
 

--- a/examples/postgres/json/Cargo.toml
+++ b/examples/postgres/json/Cargo.toml
@@ -6,11 +6,10 @@ workspace = "../../../"
 
 [dependencies]
 anyhow = "1.0"
-async-std = { version = "1.6.0", features = [ "attributes" ] }
 dotenv = "0.15.0"
 futures = "0.3"
-paw = "1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlx = { path = "../../../", features = ["postgres", "json"] }
-structopt = { version = "0.3", features = ["paw"] }
+structopt = "0.3"
+tokio = { version = "1.20.0", features = ["macros"]}

--- a/examples/postgres/json/src/main.rs
+++ b/examples/postgres/json/src/main.rs
@@ -30,9 +30,9 @@ struct Row {
     person: Json<Person>,
 }
 
-#[async_std::main]
-#[paw::main]
-async fn main(args: Args) -> anyhow::Result<()> {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::from_args_safe()?;
     let pool = PgPool::connect(&dotenv::var("DATABASE_URL")?).await?;
 
     match args.cmd {

--- a/examples/postgres/listen/Cargo.toml
+++ b/examples/postgres/listen/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 workspace = "../../../"
 
 [dependencies]
-async-std = { version = "1.8.0", features = [ "attributes", "unstable" ] }
 sqlx = { path = "../../../", features = [ "postgres", "tls" ] }
 futures = "0.3.1"
+tokio = { version = "1.20.0", features = ["macros"]}

--- a/examples/postgres/listen/src/main.rs
+++ b/examples/postgres/listen/src/main.rs
@@ -1,4 +1,3 @@
-use async_std::stream;
 use futures::StreamExt;
 use futures::TryStreamExt;
 use sqlx::postgres::PgListener;
@@ -6,7 +5,7 @@ use sqlx::{Executor, PgPool};
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::time::Duration;
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Building PG pool.");
     let conn_str =

--- a/examples/postgres/mockable-todos/Cargo.toml
+++ b/examples/postgres/mockable-todos/Cargo.toml
@@ -6,11 +6,10 @@ workspace = "../../../"
 
 [dependencies]
 anyhow = "1.0"
-async-std = { version = "1.4.0", features = [ "attributes" ] }
 futures = "0.3"
-paw = "1.0"
-sqlx = { path = "../../../", features = ["postgres", "offline", "runtime-async-std-native-tls"] }
-structopt = { version = "0.3", features = ["paw"] }
+sqlx = { path = "../../../", features = ["postgres", "offline", "runtime-tokio-native-tls"] }
+structopt = "0.3"
+tokio = { version = "1.20.0", features = ["macros"]}
 dotenv = "0.15.0"
 async-trait = "0.1.41"
 mockall = "0.11"

--- a/examples/postgres/mockable-todos/src/main.rs
+++ b/examples/postgres/mockable-todos/src/main.rs
@@ -16,10 +16,10 @@ enum Command {
     Done { id: i64 },
 }
 
-#[async_std::main]
-#[paw::main]
-async fn main(args: Args) -> anyhow::Result<()> {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
+    let args = Args::from_args_safe()?;
     let pool = PgPool::connect(&env::var("DATABASE_URL")?).await?;
     let todo_repo = PostgresTodoRepo::new(pool);
     let mut writer = std::io::stdout();

--- a/examples/postgres/todos/Cargo.toml
+++ b/examples/postgres/todos/Cargo.toml
@@ -6,9 +6,8 @@ workspace = "../../../"
 
 [dependencies]
 anyhow = "1.0"
-async-std = { version = "1.8.0", features = [ "attributes" ] }
 futures = "0.3"
-paw = "1.0"
-sqlx = { path = "../../../", features = ["postgres", "offline", "runtime-async-std-native-tls"] }
-structopt = { version = "0.3", features = ["paw"] }
+sqlx = { path = "../../../", features = ["postgres", "offline", "runtime-tokio-native-tls"] }
+structopt = "0.3"
+tokio = { version = "1.20.0", features = ["macros"]}
 dotenv = "0.15.0"

--- a/examples/postgres/todos/src/main.rs
+++ b/examples/postgres/todos/src/main.rs
@@ -14,9 +14,9 @@ enum Command {
     Done { id: i64 },
 }
 
-#[async_std::main]
-#[paw::main]
-async fn main(args: Args) -> anyhow::Result<()> {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::from_args_safe()?;
     let pool = PgPool::connect(&env::var("DATABASE_URL")?).await?;
 
     match args.cmd {

--- a/examples/postgres/transaction/Cargo.toml
+++ b/examples/postgres/transaction/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 workspace = "../../../"
 
 [dependencies]
-async-std = { version = "1.8.0", features = [ "attributes", "unstable" ] }
-sqlx = { path = "../../../", features = [ "postgres", "tls", "runtime-async-std-native-tls" ] }
+sqlx = { path = "../../../", features = [ "postgres", "tls", "runtime-tokio-native-tls" ] }
 futures = "0.3.1"
+tokio = { version = "1.20.0", features = ["macros"]}

--- a/examples/postgres/transaction/src/main.rs
+++ b/examples/postgres/transaction/src/main.rs
@@ -60,7 +60,7 @@ async fn commit_example(
     Ok(())
 }
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let conn_str =
         std::env::var("DATABASE_URL").expect("Env var DATABASE_URL is required for this example.");

--- a/examples/sqlite/todos/Cargo.toml
+++ b/examples/sqlite/todos/Cargo.toml
@@ -6,8 +6,7 @@ workspace = "../../../"
 
 [dependencies]
 anyhow = "1.0"
-async-std = { version = "1.8.0", features = [ "attributes" ] }
 futures = "0.3"
-paw = "1.0"
-sqlx = { path = "../../../", features = ["sqlite"] }
-structopt = { version = "0.3", features = ["paw"] }
+sqlx = { path = "../../../", features = ["sqlite", "runtime-tokio-native-tls"] }
+structopt = "0.3"
+tokio = { version = "1.20.0", features = ["macros"]}

--- a/examples/sqlite/todos/src/main.rs
+++ b/examples/sqlite/todos/src/main.rs
@@ -14,9 +14,9 @@ enum Command {
     Done { id: i64 },
 }
 
-#[async_std::main]
-#[paw::main]
-async fn main(args: Args) -> anyhow::Result<()> {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Args::from_args_safe()?;
     let pool = SqlitePool::connect(&env::var("DATABASE_URL")?).await?;
 
     match args.cmd {

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 
 [package.metadata.docs.rs]
-features = ["all-databases", "all-types", "offline", "runtime-async-std-native-tls"]
+features = ["all-databases", "all-types", "offline", "runtime-tokio-native-tls"]
 
 [features]
 default = ["migrate"]

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -16,7 +16,7 @@ authors = [
 proc-macro = true
 
 [features]
-default = ["runtime-async-std-native-tls", "migrate"]
+default = ["runtime-tokio-native-tls", "migrate"]
 migrate = ["sha2", "sqlx-core/migrate"]
 
 # runtimes


### PR DESCRIPTION
This fixes `cargo check --workspace` and rust-analyzer.

Also see <https://github.com/launchbadge/sqlx/discussions/1956>.