### PR TITLE
docs: `master` -> `main`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,8 @@ You can use this document to figure out how and where to start.
 
 - Fork the repository on GitHub.
 - Create a branch on your fork.
-  - You can usually base it on the `master` branch.
-  - Make sure not to commit directly to `master`.
+  - You can usually base it on the `main` branch.
+  - Make sure not to commit directly to `main`.
 - Make commits of logical and atomic units.
 - Make sure you have added the necessary tests for your changes.
 - Push your changes to a topic branch in your fork of the repository.


### PR DESCRIPTION
Small change, but since the `master` branch may still exists locally for some people or in some forks, this may safe quite some time. Had to rebase + fix one of my PRs due to this.