### PR TITLE
fix: ensure migration progress is not lost for PG, mysql and sqlite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,6 +203,11 @@ name = "sqlite-test-attr"
 path = "tests/sqlite/test-attr.rs"
 required-features = ["sqlite", "macros", "migrate"]
 
+[[test]]
+name = "sqlite-migrate"
+path = "tests/sqlite/migrate.rs"
+required-features = ["sqlite", "macros", "migrate"]
+
 #
 # MySQL
 #
@@ -230,6 +235,11 @@ required-features = ["mysql", "macros"]
 [[test]]
 name = "mysql-test-attr"
 path = "tests/mysql/test-attr.rs"
+required-features = ["mysql", "macros", "migrate"]
+
+[[test]]
+name = "mysql-migrate"
+path = "tests/mysql/migrate.rs"
 required-features = ["mysql", "macros", "migrate"]
 
 #
@@ -264,6 +274,11 @@ required-features = ["postgres", "macros"]
 [[test]]
 name = "postgres-test-attr"
 path = "tests/postgres/test-attr.rs"
+required-features = ["postgres", "macros", "migrate"]
+
+[[test]]
+name = "postgres-migrate"
+path = "tests/postgres/migrate.rs"
 required-features = ["postgres", "macros", "migrate"]
 
 #

--- a/sqlx-core/src/migrate/migration_type.rs
+++ b/sqlx-core/src/migrate/migration_type.rs
@@ -1,5 +1,5 @@
 /// Migration Type represents the type of migration
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum MigrationType {
     /// Simple migration are single file migrations with no up / down queries
     Simple,

--- a/sqlx-core/src/mysql/migrate.rs
+++ b/sqlx-core/src/mysql/migrate.rs
@@ -1,4 +1,4 @@
-use crate::connection::ConnectOptions;
+use crate::connection::{ConnectOptions, Connection};
 use crate::error::Error;
 use crate::executor::Executor;
 use crate::migrate::MigrateError;
@@ -209,28 +209,48 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
         migration: &'m Migration,
     ) -> BoxFuture<'m, Result<Duration, MigrateError>> {
         Box::pin(async move {
+            // Use a single transaction for the actual migration script and the essential bookeeping so we never
+            // execute migrations twice. See https://github.com/launchbadge/sqlx/issues/1966.
+            // The `execution_time` however can only be measured for the whole transaction. This value _only_ exists for
+            // data lineage and debugging reasons, so it is not super important if it is lost. So we initialize it to -1
+            // and update it once the actual transaction completed.
+            let mut tx = self.begin().await?;
             let start = Instant::now();
-
-            let res = self.execute(&*migration.sql).await;
-
-            let elapsed = start.elapsed();
 
             // language=MySQL
             let _ = query(
                 r#"
     INSERT INTO _sqlx_migrations ( version, description, success, checksum, execution_time )
-    VALUES ( ?, ?, ?, ?, ? )
+    VALUES ( ?, ?, TRUE, ?, -1 )
                 "#,
             )
             .bind(migration.version)
             .bind(&*migration.description)
-            .bind(res.is_ok())
             .bind(&*migration.checksum)
-            .bind(elapsed.as_nanos() as i64)
-            .execute(self)
+            .execute(&mut tx)
             .await?;
 
-            res?;
+            let _ = tx.execute(&*migration.sql).await?;
+
+            tx.commit().await?;
+
+            // Update `elapsed_time`.
+            // NOTE: The process may disconnect/die at this point, so the elapsed time value might be lost. We accept
+            //       this small risk since this value is not super important.
+
+            let elapsed = start.elapsed();
+
+            let _ = query(
+                r#"
+    UPDATE _sqlx_migrations
+    SET execution_time = ?
+    WHERE version = ?
+                "#,
+            )
+            .bind(elapsed.as_nanos() as i64)
+            .bind(migration.version)
+            .execute(self)
+            .await?;
 
             Ok(elapsed)
         })

--- a/sqlx-core/src/mysql/migrate.rs
+++ b/sqlx-core/src/mysql/migrate.rs
@@ -261,17 +261,22 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
         migration: &'m Migration,
     ) -> BoxFuture<'m, Result<Duration, MigrateError>> {
         Box::pin(async move {
+            // Use a single transaction for the actual migration script and the essential bookeeping so we never
+            // execute migrations twice. See https://github.com/launchbadge/sqlx/issues/1966.
+            let mut tx = self.begin().await?;
             let start = Instant::now();
 
-            self.execute(&*migration.sql).await?;
-
-            let elapsed = start.elapsed();
+            tx.execute(&*migration.sql).await?;
 
             // language=SQL
             let _ = query(r#"DELETE FROM _sqlx_migrations WHERE version = ?"#)
                 .bind(migration.version)
-                .execute(self)
+                .execute(&mut tx)
                 .await?;
+
+            tx.commit().await?;
+
+            let elapsed = start.elapsed();
 
             Ok(elapsed)
         })

--- a/sqlx-core/src/postgres/migrate.rs
+++ b/sqlx-core/src/postgres/migrate.rs
@@ -222,23 +222,44 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
             let mut tx = self.begin().await?;
             let start = Instant::now();
 
+            // Use a single transaction for the actual migration script and the essential bookeeping so we never
+            // execute migrations twice. See https://github.com/launchbadge/sqlx/issues/1966.
+            // The `execution_time` however can only be measured for the whole transaction. This value _only_ exists for
+            // data lineage and debugging reasons, so it is not super important if it is lost. So we initialize it to -1
+            // and update it once the actual transaction completed.
             let _ = tx.execute(&*migration.sql).await?;
 
+            // language=SQL
+            let _ = query(
+                r#"
+    INSERT INTO _sqlx_migrations ( version, description, success, checksum, execution_time )
+    VALUES ( $1, $2, TRUE, $3, -1 )
+                "#,
+            )
+            .bind(migration.version)
+            .bind(&*migration.description)
+            .bind(&*migration.checksum)
+            .execute(&mut tx)
+            .await?;
+
             tx.commit().await?;
+
+            // Update `elapsed_time`.
+            // NOTE: The process may disconnect/die at this point, so the elapsed time value might be lost. We accept
+            //       this small risk since this value is not super important.
 
             let elapsed = start.elapsed();
 
             // language=SQL
             let _ = query(
                 r#"
-    INSERT INTO _sqlx_migrations ( version, description, success, checksum, execution_time )
-    VALUES ( $1, $2, TRUE, $3, $4 )
+    UPDATE _sqlx_migrations
+    SET execution_time = $1
+    WHERE version = $2
                 "#,
             )
-            .bind(migration.version)
-            .bind(&*migration.description)
-            .bind(&*migration.checksum)
             .bind(elapsed.as_nanos() as i64)
+            .bind(migration.version)
             .execute(self)
             .await?;
 

--- a/sqlx-core/src/sqlite/migrate.rs
+++ b/sqlx-core/src/sqlite/migrate.rs
@@ -173,23 +173,44 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
             let mut tx = self.begin().await?;
             let start = Instant::now();
 
+            // Use a single transaction for the actual migration script and the essential bookeeping so we never
+            // execute migrations twice. See https://github.com/launchbadge/sqlx/issues/1966.
+            // The `execution_time` however can only be measured for the whole transaction. This value _only_ exists for
+            // data lineage and debugging reasons, so it is not super important if it is lost. So we initialize it to -1
+            // and update it once the actual transaction completed.
             let _ = tx.execute(&*migration.sql).await?;
 
+            // language=SQL
+            let _ = query(
+                r#"
+    INSERT INTO _sqlx_migrations ( version, description, success, checksum, execution_time )
+    VALUES ( ?1, ?2, TRUE, ?3, -1 )
+                "#,
+            )
+            .bind(migration.version)
+            .bind(&*migration.description)
+            .bind(&*migration.checksum)
+            .execute(&mut tx)
+            .await?;
+
             tx.commit().await?;
+
+            // Update `elapsed_time`.
+            // NOTE: The process may disconnect/die at this point, so the elapsed time value might be lost. We accept
+            //       this small risk since this value is not super important.
 
             let elapsed = start.elapsed();
 
             // language=SQL
             let _ = query(
                 r#"
-    INSERT INTO _sqlx_migrations ( version, description, success, checksum, execution_time )
-    VALUES ( ?1, ?2, TRUE, ?3, ?4 )
+    UPDATE _sqlx_migrations
+    SET execution_time = ?1
+    WHERE version = ?2
                 "#,
             )
-            .bind(migration.version)
-            .bind(&*migration.description)
-            .bind(&*migration.checksum)
             .bind(elapsed.as_nanos() as i64)
+            .bind(migration.version)
             .execute(self)
             .await?;
 

--- a/sqlx-core/src/sqlite/migrate.rs
+++ b/sqlx-core/src/sqlite/migrate.rs
@@ -223,20 +223,22 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
         migration: &'m Migration,
     ) -> BoxFuture<'m, Result<Duration, MigrateError>> {
         Box::pin(async move {
+            // Use a single transaction for the actual migration script and the essential bookeeping so we never
+            // execute migrations twice. See https://github.com/launchbadge/sqlx/issues/1966.
             let mut tx = self.begin().await?;
             let start = Instant::now();
 
             let _ = tx.execute(&*migration.sql).await?;
 
-            tx.commit().await?;
-
-            let elapsed = start.elapsed();
-
             // language=SQL
             let _ = query(r#"DELETE FROM _sqlx_migrations WHERE version = ?1"#)
                 .bind(migration.version)
-                .execute(self)
+                .execute(&mut tx)
                 .await?;
+
+            tx.commit().await?;
+
+            let elapsed = start.elapsed();
 
             Ok(elapsed)
         })

--- a/sqlx-test/src/lib.rs
+++ b/sqlx-test/src/lib.rs
@@ -1,7 +1,6 @@
 use sqlx::pool::PoolOptions;
 use sqlx::{Connection, Database, Pool};
 use std::env;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 pub fn setup_if_needed() {
     let _ = dotenvy::dotenv();
@@ -223,32 +222,4 @@ macro_rules! Postgres_query_for_test_prepared_type {
     () => {
         "SELECT ({0} is not distinct from $1)::int4, {0}, $2"
     };
-}
-
-/// Global lock that prevents multiple tests in this module to be executed at the same time.
-static GLOBAL_LOCK: AtomicBool = AtomicBool::new(false);
-
-/// Simple lock guard that should not be used in production but that is `Send` (i.e. can easily be used with tokio).
-///
-/// This may be helpful for tests that modify the database state, e.g. migrations.
-pub struct SimpleLockGuard;
-
-impl SimpleLockGuard {
-    /// Acquire global lock.
-    pub fn acquire() -> Self {
-        loop {
-            let was_locked = GLOBAL_LOCK.fetch_or(true, Ordering::SeqCst);
-            if !was_locked {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(10));
-        }
-        Self
-    }
-}
-
-impl Drop for SimpleLockGuard {
-    fn drop(&mut self) {
-        GLOBAL_LOCK.store(false, Ordering::SeqCst);
-    }
 }

--- a/tests/migrate/macro.rs
+++ b/tests/migrate/macro.rs
@@ -12,6 +12,7 @@ async fn same_output() -> anyhow::Result<()> {
     for (e, r) in EMBEDDED.iter().zip(runtime.iter()) {
         assert_eq!(e.version, r.version);
         assert_eq!(e.description, r.description);
+        assert_eq!(e.migration_type, r.migration_type);
         assert_eq!(e.sql, r.sql);
         assert_eq!(e.checksum, r.checksum);
     }

--- a/tests/migrate/macro.rs
+++ b/tests/migrate/macro.rs
@@ -1,21 +1,29 @@
 use sqlx::migrate::Migrator;
 use std::path::Path;
 
-static EMBEDDED: Migrator = sqlx::migrate!("tests/migrate/migrations");
+static EMBEDDED_SIMPLE: Migrator = sqlx::migrate!("tests/migrate/migrations_simple");
+static EMBEDDED_REVERSIBLE: Migrator = sqlx::migrate!("tests/migrate/migrations_reversible");
 
 #[sqlx_macros::test]
 async fn same_output() -> anyhow::Result<()> {
-    let runtime = Migrator::new(Path::new("tests/migrate/migrations")).await?;
+    let runtime_simple = Migrator::new(Path::new("tests/migrate/migrations_simple")).await?;
+    let runtime_reversible =
+        Migrator::new(Path::new("tests/migrate/migrations_reversible")).await?;
 
-    assert_eq!(runtime.migrations.len(), EMBEDDED.migrations.len());
+    assert_same(&EMBEDDED_SIMPLE, &runtime_simple);
+    assert_same(&EMBEDDED_REVERSIBLE, &runtime_reversible);
 
-    for (e, r) in EMBEDDED.iter().zip(runtime.iter()) {
+    Ok(())
+}
+
+fn assert_same(embedded: &Migrator, runtime: &Migrator) {
+    assert_eq!(runtime.migrations.len(), embedded.migrations.len());
+
+    for (e, r) in embedded.iter().zip(runtime.iter()) {
         assert_eq!(e.version, r.version);
         assert_eq!(e.description, r.description);
         assert_eq!(e.migration_type, r.migration_type);
         assert_eq!(e.sql, r.sql);
         assert_eq!(e.checksum, r.checksum);
     }
-
-    Ok(())
 }

--- a/tests/migrate/migrations/20200723212833_tweet.sql
+++ b/tests/migrate/migrations/20200723212833_tweet.sql
@@ -1,6 +1,0 @@
-CREATE TABLE tweet (
-    id BIGINT NOT NULL PRIMARY KEY,
-    text TEXT NOT NULL,
-    is_sent BOOLEAN NOT NULL DEFAULT TRUE,
-    owner_id BIGINT
-);

--- a/tests/migrate/migrations/20200723212841_accounts.sql
+++ b/tests/migrate/migrations/20200723212841_accounts.sql
@@ -1,5 +1,0 @@
-CREATE TABLE accounts (
-    id INTEGER NOT NULL PRIMARY KEY,
-    name TEXT NOT NULL,
-    is_active BOOLEAN
-);

--- a/tests/migrate/migrations_reversible/20220721124650_add_table.down.sql
+++ b/tests/migrate/migrations_reversible/20220721124650_add_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE migrations_reversible_test;

--- a/tests/migrate/migrations_reversible/20220721124650_add_table.up.sql
+++ b/tests/migrate/migrations_reversible/20220721124650_add_table.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE migrations_reversible_test (
+    some_id BIGINT NOT NULL PRIMARY KEY,
+    some_payload BIGINT NOT NUll
+);
+
+INSERT INTO migrations_reversible_test (some_id, some_payload)
+VALUES (1, 100);

--- a/tests/migrate/migrations_reversible/20220721125033_modify_column.down.sql
+++ b/tests/migrate/migrations_reversible/20220721125033_modify_column.down.sql
@@ -1,0 +1,2 @@
+UPDATE migrations_reversible_test
+SET some_payload = some_payload - 1;

--- a/tests/migrate/migrations_reversible/20220721125033_modify_column.up.sql
+++ b/tests/migrate/migrations_reversible/20220721125033_modify_column.up.sql
@@ -1,0 +1,2 @@
+UPDATE migrations_reversible_test
+SET some_payload = some_payload + 1;

--- a/tests/migrate/migrations_simple/20220721115250_add_test_table.sql
+++ b/tests/migrate/migrations_simple/20220721115250_add_test_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE migrations_simple_test (
+    some_id BIGINT NOT NULL PRIMARY KEY,
+    some_payload BIGINT NOT NUll
+);
+
+INSERT INTO migrations_simple_test (some_id, some_payload)
+VALUES (1, 100);

--- a/tests/migrate/migrations_simple/20220721115524_convert_type.sql
+++ b/tests/migrate/migrations_simple/20220721115524_convert_type.sql
@@ -1,0 +1,34 @@
+-- Perform a tricky conversion of the payload.
+--
+-- This script will only succeed once and will fail if executed twice.
+
+-- set up temporary target column
+ALTER TABLE migrations_simple_test
+ADD some_payload_tmp TEXT;
+
+-- perform conversion
+-- This will fail if `some_payload` is already a string column due to the addition.
+-- We add a suffix after the addition to ensure that the SQL database does not silently cast the string back to an 
+-- integer.
+UPDATE migrations_simple_test
+SET some_payload_tmp = CONCAT(CAST((some_payload + 10) AS TEXT), '_suffix');
+
+-- remove original column including the content
+ALTER TABLE migrations_simple_test
+DROP COLUMN some_payload;
+
+-- prepare new payload column (nullable, so we can copy over the data)
+ALTER TABLE migrations_simple_test
+ADD some_payload TEXT;
+
+-- copy new values
+UPDATE migrations_simple_test
+SET some_payload = some_payload_tmp;
+
+-- "freeze" column
+ALTER TABLE migrations_simple_test
+ALTER COLUMN some_payload SET NOT NULL;
+
+-- clean up
+ALTER TABLE migrations_simple_test
+DROP COLUMN some_payload_tmp;

--- a/tests/mysql/migrate.rs
+++ b/tests/mysql/migrate.rs
@@ -1,16 +1,12 @@
 use sqlx::migrate::Migrator;
 use sqlx::mysql::{MySql, MySqlConnection};
+use sqlx::pool::PoolConnection;
 use sqlx::Executor;
 use sqlx::Row;
 use std::path::Path;
 
-use sqlx_test::{new, SimpleLockGuard};
-
-#[sqlx_macros::test]
-async fn simple() -> anyhow::Result<()> {
-    let _guard = SimpleLockGuard::acquire();
-
-    let mut conn = new::<MySql>().await?;
+#[sqlx::test(migrations = false)]
+async fn simple(mut conn: PoolConnection<MySql>) -> anyhow::Result<()> {
     clean_up(&mut conn).await?;
 
     let migrator = Migrator::new(Path::new("tests/mysql/migrations_simple")).await?;
@@ -31,11 +27,8 @@ async fn simple() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[sqlx_macros::test]
-async fn reversible() -> anyhow::Result<()> {
-    let _guard = SimpleLockGuard::acquire();
-
-    let mut conn = new::<MySql>().await?;
+#[sqlx::test(migrations = false)]
+async fn reversible(mut conn: PoolConnection<MySql>) -> anyhow::Result<()> {
     clean_up(&mut conn).await?;
 
     let migrator = Migrator::new(Path::new("tests/mysql/migrations_reversible")).await?;

--- a/tests/mysql/migrate.rs
+++ b/tests/mysql/migrate.rs
@@ -1,0 +1,85 @@
+use sqlx::migrate::Migrator;
+use sqlx::mysql::{MySql, MySqlConnection};
+use sqlx::Executor;
+use sqlx::Row;
+use std::path::Path;
+
+use sqlx_test::{new, SimpleLockGuard};
+
+#[sqlx_macros::test]
+async fn simple() -> anyhow::Result<()> {
+    let _guard = SimpleLockGuard::acquire();
+
+    let mut conn = new::<MySql>().await?;
+    clean_up(&mut conn).await?;
+
+    let migrator = Migrator::new(Path::new("tests/mysql/migrations_simple")).await?;
+
+    // run migration
+    migrator.run(&mut conn).await?;
+
+    // check outcome
+    let res: String = conn
+        .fetch_one("SELECT some_payload FROM migrations_simple_test")
+        .await?
+        .get(0);
+    assert_eq!(res, "110_suffix");
+
+    // running it a 2nd time should still work
+    migrator.run(&mut conn).await?;
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
+async fn reversible() -> anyhow::Result<()> {
+    let _guard = SimpleLockGuard::acquire();
+
+    let mut conn = new::<MySql>().await?;
+    clean_up(&mut conn).await?;
+
+    let migrator = Migrator::new(Path::new("tests/mysql/migrations_reversible")).await?;
+
+    // run migration
+    migrator.run(&mut conn).await?;
+
+    // check outcome
+    let res: i64 = conn
+        .fetch_one("SELECT some_payload FROM migrations_reversible_test")
+        .await?
+        .get(0);
+    assert_eq!(res, 101);
+
+    // roll back nothing (last version)
+    migrator.undo(&mut conn, 20220721125033).await?;
+
+    // check outcome
+    let res: i64 = conn
+        .fetch_one("SELECT some_payload FROM migrations_reversible_test")
+        .await?
+        .get(0);
+    assert_eq!(res, 101);
+
+    // roll back one version
+    migrator.undo(&mut conn, 20220721124650).await?;
+
+    // check outcome
+    let res: i64 = conn
+        .fetch_one("SELECT some_payload FROM migrations_reversible_test")
+        .await?
+        .get(0);
+    assert_eq!(res, 100);
+
+    Ok(())
+}
+
+/// Ensure that we have a clean initial state.
+async fn clean_up(conn: &mut MySqlConnection) -> anyhow::Result<()> {
+    conn.execute("DROP TABLE migrations_simple_test").await.ok();
+    conn.execute("DROP TABLE migrations_reversible_test")
+        .await
+        .ok();
+    conn.execute("DROP TABLE _sqlx_migrations").await.ok();
+
+    Ok(())
+}

--- a/tests/mysql/migrations_reversible/20220721124650_add_table.down.sql
+++ b/tests/mysql/migrations_reversible/20220721124650_add_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE migrations_reversible_test;

--- a/tests/mysql/migrations_reversible/20220721124650_add_table.up.sql
+++ b/tests/mysql/migrations_reversible/20220721124650_add_table.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE migrations_reversible_test (
+    some_id BIGINT NOT NULL PRIMARY KEY,
+    some_payload BIGINT NOT NUll
+);
+
+INSERT INTO migrations_reversible_test (some_id, some_payload)
+VALUES (1, 100);

--- a/tests/mysql/migrations_reversible/20220721125033_modify_column.down.sql
+++ b/tests/mysql/migrations_reversible/20220721125033_modify_column.down.sql
@@ -1,0 +1,2 @@
+UPDATE migrations_reversible_test
+SET some_payload = some_payload - 1;

--- a/tests/mysql/migrations_reversible/20220721125033_modify_column.up.sql
+++ b/tests/mysql/migrations_reversible/20220721125033_modify_column.up.sql
@@ -1,0 +1,2 @@
+UPDATE migrations_reversible_test
+SET some_payload = some_payload + 1;

--- a/tests/mysql/migrations_simple/20220721115250_add_test_table.sql
+++ b/tests/mysql/migrations_simple/20220721115250_add_test_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE migrations_simple_test (
+    some_id BIGINT NOT NULL PRIMARY KEY,
+    some_payload BIGINT NOT NUll
+);
+
+INSERT INTO migrations_simple_test (some_id, some_payload)
+VALUES (1, 100);

--- a/tests/mysql/migrations_simple/20220721115524_convert_type.sql
+++ b/tests/mysql/migrations_simple/20220721115524_convert_type.sql
@@ -1,0 +1,34 @@
+-- Perform a tricky conversion of the payload.
+--
+-- This script will only succeed once and will fail if executed twice.
+
+-- set up temporary target column
+ALTER TABLE migrations_simple_test
+ADD some_payload_tmp TEXT;
+
+-- perform conversion
+-- This will fail if `some_payload` is already a string column due to the addition.
+-- We add a suffix after the addition to ensure that the SQL database does not silently cast the string back to an 
+-- integer.
+UPDATE migrations_simple_test
+SET some_payload_tmp = CONCAT(CAST((some_payload + 10) AS CHAR(3)), '_suffix');
+
+-- remove original column including the content
+ALTER TABLE migrations_simple_test
+DROP COLUMN some_payload;
+
+-- prepare new payload column (nullable, so we can copy over the data)
+ALTER TABLE migrations_simple_test
+ADD some_payload TEXT;
+
+-- copy new values
+UPDATE migrations_simple_test
+SET some_payload = some_payload_tmp;
+
+-- "freeze" column
+ALTER TABLE migrations_simple_test
+MODIFY some_payload TEXT NOT NULL;
+
+-- clean up
+ALTER TABLE migrations_simple_test
+DROP COLUMN some_payload_tmp;

--- a/tests/postgres/migrate.rs
+++ b/tests/postgres/migrate.rs
@@ -1,0 +1,85 @@
+use sqlx::migrate::Migrator;
+use sqlx::postgres::{PgConnection, Postgres};
+use sqlx::Executor;
+use sqlx::Row;
+use std::path::Path;
+
+use sqlx_test::{new, SimpleLockGuard};
+
+#[sqlx_macros::test]
+async fn simple() -> anyhow::Result<()> {
+    let _guard = SimpleLockGuard::acquire();
+
+    let mut conn = new::<Postgres>().await?;
+    clean_up(&mut conn).await?;
+
+    let migrator = Migrator::new(Path::new("tests/postgres/migrations_simple")).await?;
+
+    // run migration
+    migrator.run(&mut conn).await?;
+
+    // check outcome
+    let res: String = conn
+        .fetch_one("SELECT some_payload FROM migrations_simple_test")
+        .await?
+        .get(0);
+    assert_eq!(res, "110_suffix");
+
+    // running it a 2nd time should still work
+    migrator.run(&mut conn).await?;
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
+async fn reversible() -> anyhow::Result<()> {
+    let _guard = SimpleLockGuard::acquire();
+
+    let mut conn = new::<Postgres>().await?;
+    clean_up(&mut conn).await?;
+
+    let migrator = Migrator::new(Path::new("tests/postgres/migrations_reversible")).await?;
+
+    // run migration
+    migrator.run(&mut conn).await?;
+
+    // check outcome
+    let res: i64 = conn
+        .fetch_one("SELECT some_payload FROM migrations_reversible_test")
+        .await?
+        .get(0);
+    assert_eq!(res, 101);
+
+    // roll back nothing (last version)
+    migrator.undo(&mut conn, 20220721125033).await?;
+
+    // check outcome
+    let res: i64 = conn
+        .fetch_one("SELECT some_payload FROM migrations_reversible_test")
+        .await?
+        .get(0);
+    assert_eq!(res, 101);
+
+    // roll back one version
+    migrator.undo(&mut conn, 20220721124650).await?;
+
+    // check outcome
+    let res: i64 = conn
+        .fetch_one("SELECT some_payload FROM migrations_reversible_test")
+        .await?
+        .get(0);
+    assert_eq!(res, 100);
+
+    Ok(())
+}
+
+/// Ensure that we have a clean initial state.
+async fn clean_up(conn: &mut PgConnection) -> anyhow::Result<()> {
+    conn.execute("DROP TABLE migrations_simple_test").await.ok();
+    conn.execute("DROP TABLE migrations_reversible_test")
+        .await
+        .ok();
+    conn.execute("DROP TABLE _sqlx_migrations").await.ok();
+
+    Ok(())
+}

--- a/tests/postgres/migrate.rs
+++ b/tests/postgres/migrate.rs
@@ -1,16 +1,12 @@
 use sqlx::migrate::Migrator;
+use sqlx::pool::PoolConnection;
 use sqlx::postgres::{PgConnection, Postgres};
 use sqlx::Executor;
 use sqlx::Row;
 use std::path::Path;
 
-use sqlx_test::{new, SimpleLockGuard};
-
-#[sqlx_macros::test]
-async fn simple() -> anyhow::Result<()> {
-    let _guard = SimpleLockGuard::acquire();
-
-    let mut conn = new::<Postgres>().await?;
+#[sqlx::test(migrations = false)]
+async fn simple(mut conn: PoolConnection<Postgres>) -> anyhow::Result<()> {
     clean_up(&mut conn).await?;
 
     let migrator = Migrator::new(Path::new("tests/postgres/migrations_simple")).await?;
@@ -31,11 +27,8 @@ async fn simple() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[sqlx_macros::test]
-async fn reversible() -> anyhow::Result<()> {
-    let _guard = SimpleLockGuard::acquire();
-
-    let mut conn = new::<Postgres>().await?;
+#[sqlx::test(migrations = false)]
+async fn reversible(mut conn: PoolConnection<Postgres>) -> anyhow::Result<()> {
     clean_up(&mut conn).await?;
 
     let migrator = Migrator::new(Path::new("tests/postgres/migrations_reversible")).await?;

--- a/tests/postgres/migrations_reversible/20220721124650_add_table.down.sql
+++ b/tests/postgres/migrations_reversible/20220721124650_add_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE migrations_reversible_test;

--- a/tests/postgres/migrations_reversible/20220721124650_add_table.up.sql
+++ b/tests/postgres/migrations_reversible/20220721124650_add_table.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE migrations_reversible_test (
+    some_id BIGINT NOT NULL PRIMARY KEY,
+    some_payload BIGINT NOT NUll
+);
+
+INSERT INTO migrations_reversible_test (some_id, some_payload)
+VALUES (1, 100);

--- a/tests/postgres/migrations_reversible/20220721125033_modify_column.down.sql
+++ b/tests/postgres/migrations_reversible/20220721125033_modify_column.down.sql
@@ -1,0 +1,2 @@
+UPDATE migrations_reversible_test
+SET some_payload = some_payload - 1;

--- a/tests/postgres/migrations_reversible/20220721125033_modify_column.up.sql
+++ b/tests/postgres/migrations_reversible/20220721125033_modify_column.up.sql
@@ -1,0 +1,2 @@
+UPDATE migrations_reversible_test
+SET some_payload = some_payload + 1;

--- a/tests/postgres/migrations_simple/20220721115250_add_test_table.sql
+++ b/tests/postgres/migrations_simple/20220721115250_add_test_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE migrations_simple_test (
+    some_id BIGINT NOT NULL PRIMARY KEY,
+    some_payload BIGINT NOT NUll
+);
+
+INSERT INTO migrations_simple_test (some_id, some_payload)
+VALUES (1, 100);

--- a/tests/postgres/migrations_simple/20220721115524_convert_type.sql
+++ b/tests/postgres/migrations_simple/20220721115524_convert_type.sql
@@ -1,0 +1,34 @@
+-- Perform a tricky conversion of the payload.
+--
+-- This script will only succeed once and will fail if executed twice.
+
+-- set up temporary target column
+ALTER TABLE migrations_simple_test
+ADD some_payload_tmp TEXT;
+
+-- perform conversion
+-- This will fail if `some_payload` is already a string column due to the addition.
+-- We add a suffix after the addition to ensure that the SQL database does not silently cast the string back to an 
+-- integer.
+UPDATE migrations_simple_test
+SET some_payload_tmp = CONCAT(CAST((some_payload + 10) AS TEXT), '_suffix');
+
+-- remove original column including the content
+ALTER TABLE migrations_simple_test
+DROP COLUMN some_payload;
+
+-- prepare new payload column (nullable, so we can copy over the data)
+ALTER TABLE migrations_simple_test
+ADD some_payload TEXT;
+
+-- copy new values
+UPDATE migrations_simple_test
+SET some_payload = some_payload_tmp;
+
+-- "freeze" column
+ALTER TABLE migrations_simple_test
+ALTER COLUMN some_payload SET NOT NULL;
+
+-- clean up
+ALTER TABLE migrations_simple_test
+DROP COLUMN some_payload_tmp;

--- a/tests/sqlite/migrate.rs
+++ b/tests/sqlite/migrate.rs
@@ -1,0 +1,85 @@
+use sqlx::migrate::Migrator;
+use sqlx::sqlite::{Sqlite, SqliteConnection};
+use sqlx::Executor;
+use sqlx::Row;
+use std::path::Path;
+
+use sqlx_test::{new, SimpleLockGuard};
+
+#[sqlx_macros::test]
+async fn simple() -> anyhow::Result<()> {
+    let _guard = SimpleLockGuard::acquire();
+
+    let mut conn = new::<Sqlite>().await?;
+    clean_up(&mut conn).await?;
+
+    let migrator = Migrator::new(Path::new("tests/sqlite/migrations_simple")).await?;
+
+    // run migration
+    migrator.run(&mut conn).await?;
+
+    // check outcome
+    let res: String = conn
+        .fetch_one("SELECT some_payload FROM migrations_simple_test")
+        .await?
+        .get(0);
+    assert_eq!(res, "110_suffix");
+
+    // running it a 2nd time should still work
+    migrator.run(&mut conn).await?;
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
+async fn reversible() -> anyhow::Result<()> {
+    let _guard = SimpleLockGuard::acquire();
+
+    let mut conn = new::<Sqlite>().await?;
+    clean_up(&mut conn).await?;
+
+    let migrator = Migrator::new(Path::new("tests/sqlite/migrations_reversible")).await?;
+
+    // run migration
+    migrator.run(&mut conn).await?;
+
+    // check outcome
+    let res: i64 = conn
+        .fetch_one("SELECT some_payload FROM migrations_reversible_test")
+        .await?
+        .get(0);
+    assert_eq!(res, 101);
+
+    // roll back nothing (last version)
+    migrator.undo(&mut conn, 20220721125033).await?;
+
+    // check outcome
+    let res: i64 = conn
+        .fetch_one("SELECT some_payload FROM migrations_reversible_test")
+        .await?
+        .get(0);
+    assert_eq!(res, 101);
+
+    // roll back one version
+    migrator.undo(&mut conn, 20220721124650).await?;
+
+    // check outcome
+    let res: i64 = conn
+        .fetch_one("SELECT some_payload FROM migrations_reversible_test")
+        .await?
+        .get(0);
+    assert_eq!(res, 100);
+
+    Ok(())
+}
+
+/// Ensure that we have a clean initial state.
+async fn clean_up(conn: &mut SqliteConnection) -> anyhow::Result<()> {
+    conn.execute("DROP TABLE migrations_simple_test").await.ok();
+    conn.execute("DROP TABLE migrations_reversible_test")
+        .await
+        .ok();
+    conn.execute("DROP TABLE _sqlx_migrations").await.ok();
+
+    Ok(())
+}

--- a/tests/sqlite/migrate.rs
+++ b/tests/sqlite/migrate.rs
@@ -1,16 +1,12 @@
 use sqlx::migrate::Migrator;
+use sqlx::pool::PoolConnection;
 use sqlx::sqlite::{Sqlite, SqliteConnection};
 use sqlx::Executor;
 use sqlx::Row;
 use std::path::Path;
 
-use sqlx_test::{new, SimpleLockGuard};
-
-#[sqlx_macros::test]
-async fn simple() -> anyhow::Result<()> {
-    let _guard = SimpleLockGuard::acquire();
-
-    let mut conn = new::<Sqlite>().await?;
+#[sqlx::test(migrations = false)]
+async fn simple(mut conn: PoolConnection<Sqlite>) -> anyhow::Result<()> {
     clean_up(&mut conn).await?;
 
     let migrator = Migrator::new(Path::new("tests/sqlite/migrations_simple")).await?;
@@ -31,11 +27,8 @@ async fn simple() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[sqlx_macros::test]
-async fn reversible() -> anyhow::Result<()> {
-    let _guard = SimpleLockGuard::acquire();
-
-    let mut conn = new::<Sqlite>().await?;
+#[sqlx::test(migrations = false)]
+async fn reversible(mut conn: PoolConnection<Sqlite>) -> anyhow::Result<()> {
     clean_up(&mut conn).await?;
 
     let migrator = Migrator::new(Path::new("tests/sqlite/migrations_reversible")).await?;

--- a/tests/sqlite/migrations_reversible/20220721124650_add_table.down.sql
+++ b/tests/sqlite/migrations_reversible/20220721124650_add_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE migrations_reversible_test;

--- a/tests/sqlite/migrations_reversible/20220721124650_add_table.up.sql
+++ b/tests/sqlite/migrations_reversible/20220721124650_add_table.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE migrations_reversible_test (
+    some_id BIGINT NOT NULL PRIMARY KEY,
+    some_payload BIGINT NOT NUll
+);
+
+INSERT INTO migrations_reversible_test (some_id, some_payload)
+VALUES (1, 100);

--- a/tests/sqlite/migrations_reversible/20220721125033_modify_column.down.sql
+++ b/tests/sqlite/migrations_reversible/20220721125033_modify_column.down.sql
@@ -1,0 +1,2 @@
+UPDATE migrations_reversible_test
+SET some_payload = some_payload - 1;

--- a/tests/sqlite/migrations_reversible/20220721125033_modify_column.up.sql
+++ b/tests/sqlite/migrations_reversible/20220721125033_modify_column.up.sql
@@ -1,0 +1,2 @@
+UPDATE migrations_reversible_test
+SET some_payload = some_payload + 1;

--- a/tests/sqlite/migrations_simple/20220721115250_add_test_table.sql
+++ b/tests/sqlite/migrations_simple/20220721115250_add_test_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE migrations_simple_test (
+    some_id BIGINT NOT NULL PRIMARY KEY,
+    some_payload BIGINT NOT NUll
+);
+
+INSERT INTO migrations_simple_test (some_id, some_payload)
+VALUES (1, 100);

--- a/tests/sqlite/migrations_simple/20220721115524_convert_type.sql
+++ b/tests/sqlite/migrations_simple/20220721115524_convert_type.sql
@@ -1,0 +1,30 @@
+-- Perform a tricky conversion of the payload.
+--
+-- This script will only succeed once and will fail if executed twice.
+
+-- set up temporary target column
+ALTER TABLE migrations_simple_test
+ADD some_payload_tmp TEXT;
+
+-- perform conversion
+-- This will fail if `some_payload` is already a string column due to the addition.
+-- We add a suffix after the addition to ensure that the SQL database does not silently cast the string back to an 
+-- integer.
+UPDATE migrations_simple_test
+SET some_payload_tmp = CAST((some_payload + 10) AS TEXT) || '_suffix';
+
+-- remove original column including the content
+ALTER TABLE migrations_simple_test
+DROP COLUMN some_payload;
+
+-- prepare new payload column (nullable, so we can copy over the data)
+ALTER TABLE migrations_simple_test
+ADD some_payload TEXT;
+
+-- copy new values
+UPDATE migrations_simple_test
+SET some_payload = some_payload_tmp;
+
+-- clean up
+ALTER TABLE migrations_simple_test
+DROP COLUMN some_payload_tmp;


### PR DESCRIPTION
Fixes #1966.

The same issue existed for other database types, so I've fixed them as well. I couldn't find any runtime tests for migrations yet, so I've extended the migrations testing code to include some.