### PR TITLE
chore: replace `dotenv` with `dotenvy`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,10 +768,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "7e851a83c30366fd01d75b913588e95e74a1705c1ecc5d58b1f8e1a6d556525f"
+dependencies = [
+ "dirs",
+]
 
 [[package]]
 name = "downcast"
@@ -884,7 +887,7 @@ name = "files"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "dotenv",
+ "dotenvy",
  "sqlx",
  "tokio",
 ]
@@ -1298,7 +1301,7 @@ name = "json"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "dotenv",
+ "dotenvy",
  "futures",
  "serde",
  "serde_json",
@@ -2424,7 +2427,7 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-std",
- "dotenv",
+ "dotenvy",
  "env_logger",
  "futures",
  "hex",
@@ -2449,7 +2452,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "criterion",
- "dotenv",
+ "dotenvy",
  "once_cell",
  "sqlx",
  "sqlx-rt",
@@ -2466,7 +2469,7 @@ dependencies = [
  "chrono",
  "clap 3.2.10",
  "console",
- "dotenv",
+ "dotenvy",
  "filetime",
  "futures",
  "glob",
@@ -2577,7 +2580,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "dotenv",
+ "dotenvy",
  "futures",
  "mockall",
  "sqlx",
@@ -2590,7 +2593,7 @@ name = "sqlx-example-postgres-todos"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "dotenv",
+ "dotenvy",
  "futures",
  "sqlx",
  "structopt",
@@ -2621,7 +2624,7 @@ dependencies = [
 name = "sqlx-macros"
 version = "0.6.0"
 dependencies = [
- "dotenv",
+ "dotenvy",
  "either",
  "heck 0.4.0",
  "hex",
@@ -2658,7 +2661,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-std",
- "dotenv",
+ "dotenvy",
  "env_logger",
  "sqlx",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ futures = "0.3.19"
 env_logger = "0.9.0"
 async-std = { version = "1.10.0", features = ["attributes"] }
 tokio = { version = "1.15.0", features = ["full"] }
-dotenv = "0.15.0"
+dotenvy = "0.15.0"
 trybuild = "1.0.53"
 sqlx-rt = { path = "./sqlx-rt" }
 sqlx-test = { path = "./sqlx-test" }

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Differences from `query()`:
     queries against; the database does not have to contain any data but must be the same
     kind (MySQL, Postgres, etc.) and have the same schema as the database you will be connecting to at runtime.
 
-    For convenience, you can use [a `.env` file][dotenv] to set DATABASE_URL so that you don't have to pass it every time:
+    For convenience, you can use [a `.env` file][dotenv]<sup>1</sup> to set DATABASE_URL so that you don't have to pass it every time:
 
     ```
     DATABASE_URL=mysql://localhost/my_database
@@ -422,6 +422,9 @@ putting the following in your `Cargo.toml` (More information in the
 [profile.dev.package.sqlx-macros]
 opt-level = 3
 ```
+
+<sup>1</sup> The `dotenv` crate itself appears abandoned as of [December 2021](https://github.com/dotenv-rs/dotenv/issues/74)
+so we now use the `dotenvy` crate instead. The file format is the same.
 
 ## Safety
 

--- a/examples/postgres/files/Cargo.toml
+++ b/examples/postgres/files/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2021"
 anyhow = "1.0"
 sqlx = { path = "../../../", features = ["postgres", "offline", "runtime-tokio-native-tls"] }
 tokio = { version = "1.20.0", features = ["macros"]}
-dotenv = "0.15.0"
+dotenvy = "0.15.0"

--- a/examples/postgres/files/src/main.rs
+++ b/examples/postgres/files/src/main.rs
@@ -28,7 +28,7 @@ impl Display for PostWithAuthorQuery {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let pool = PgPool::connect(&dotenv::var("DATABASE_URL")?).await?;
+    let pool = PgPool::connect(&dotenvy::var("DATABASE_URL")?).await?;
 
     // we can use a tranditional wrapper around the `query!()` macro using files
     query_file!("queries/insert_seed_data.sql")

--- a/examples/postgres/json/Cargo.toml
+++ b/examples/postgres/json/Cargo.toml
@@ -6,7 +6,7 @@ workspace = "../../../"
 
 [dependencies]
 anyhow = "1.0"
-dotenv = "0.15.0"
+dotenvy = "0.15.0"
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/examples/postgres/json/src/main.rs
+++ b/examples/postgres/json/src/main.rs
@@ -33,7 +33,7 @@ struct Row {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::from_args_safe()?;
-    let pool = PgPool::connect(&dotenv::var("DATABASE_URL")?).await?;
+    let pool = PgPool::connect(&dotenvy::var("DATABASE_URL")?).await?;
 
     match args.cmd {
         Some(Command::Add) => {

--- a/examples/postgres/mockable-todos/Cargo.toml
+++ b/examples/postgres/mockable-todos/Cargo.toml
@@ -10,6 +10,6 @@ futures = "0.3"
 sqlx = { path = "../../../", features = ["postgres", "offline", "runtime-tokio-native-tls"] }
 structopt = "0.3"
 tokio = { version = "1.20.0", features = ["macros"]}
-dotenv = "0.15.0"
+dotenvy = "0.15.0"
 async-trait = "0.1.41"
 mockall = "0.11"

--- a/examples/postgres/mockable-todos/src/main.rs
+++ b/examples/postgres/mockable-todos/src/main.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use dotenv;
 use sqlx::postgres::PgPool;
 use std::{env, io::Write, sync::Arc};
 use structopt::StructOpt;
@@ -18,7 +17,7 @@ enum Command {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
     let args = Args::from_args_safe()?;
     let pool = PgPool::connect(&env::var("DATABASE_URL")?).await?;
     let todo_repo = PostgresTodoRepo::new(pool);

--- a/examples/postgres/todos/Cargo.toml
+++ b/examples/postgres/todos/Cargo.toml
@@ -10,4 +10,4 @@ futures = "0.3"
 sqlx = { path = "../../../", features = ["postgres", "offline", "runtime-tokio-native-tls"] }
 structopt = "0.3"
 tokio = { version = "1.20.0", features = ["macros"]}
-dotenv = "0.15.0"
+dotenvy = "0.15.0"

--- a/sqlx-bench/Cargo.toml
+++ b/sqlx-bench/Cargo.toml
@@ -37,7 +37,7 @@ sqlite = ["sqlx/sqlite"]
 
 [dependencies]
 criterion = "0.3.3"
-dotenv = "0.15.0"
+dotenvy = "0.15.0"
 once_cell = "1.4"
 sqlx = { version = "0.6", path = "../", default-features = false, features = ["macros"] }
 sqlx-rt = { version = "0.6", path = "../sqlx-rt", default-features = false }

--- a/sqlx-bench/benches/pg_pool.rs
+++ b/sqlx-bench/benches/pg_pool.rs
@@ -34,7 +34,7 @@ fn do_bench_acquire(b: &mut Bencher, concurrent: u32, fair: bool) {
             .test_before_acquire(false)
             .__fair(fair)
             .connect(
-                &dotenv::var("DATABASE_URL").expect("DATABASE_URL must be set to run benchmarks"),
+                &dotenvy::var("DATABASE_URL").expect("DATABASE_URL must be set to run benchmarks"),
             ),
     )
     .expect("failed to open PgPool");

--- a/sqlx-cli/Cargo.toml
+++ b/sqlx-cli/Cargo.toml
@@ -25,7 +25,7 @@ name = "cargo-sqlx"
 path = "src/bin/cargo-sqlx.rs"
 
 [dependencies]
-dotenv = "0.15.0"
+dotenvy = "0.15.0"
 tokio = { version = "1.15.0", features = ["macros", "rt", "rt-multi-thread"] }
 sqlx = { version = "0.6.0", path = "..", default-features = false, features = [
     "migrate",

--- a/sqlx-cli/src/bin/cargo-sqlx.rs
+++ b/sqlx-cli/src/bin/cargo-sqlx.rs
@@ -1,6 +1,5 @@
 use clap::Parser;
 use console::style;
-use dotenv::dotenv;
 use sqlx_cli::Opt;
 use std::process;
 
@@ -14,7 +13,7 @@ enum Cli {
 
 #[tokio::main]
 async fn main() {
-    dotenv().ok();
+    dotenvy::dotenv().ok();
     let Cli::Sqlx(opt) = Cli::parse();
 
     if let Err(error) = sqlx_cli::run(opt).await {

--- a/sqlx-cli/src/bin/sqlx.rs
+++ b/sqlx-cli/src/bin/sqlx.rs
@@ -1,11 +1,10 @@
 use clap::Parser;
 use console::style;
-use dotenv::dotenv;
 use sqlx_cli::Opt;
 
 #[tokio::main]
 async fn main() {
-    dotenv().ok();
+    dotenvy::dotenv().ok();
     // no special handling here
     if let Err(error) = sqlx_cli::run(Opt::parse()).await {
         println!("{} {}", style("error:").bold().red(), error);

--- a/sqlx-core/src/mssql/protocol/col_meta_data.rs
+++ b/sqlx-core/src/mssql/protocol/col_meta_data.rs
@@ -16,6 +16,7 @@ pub(crate) struct ColumnData {
     // The user type ID of the data type of the column. Depending on the TDS version that is used,
     // valid values are 0x0000 or 0x00000000, with the exceptions of data type
     // TIMESTAMP (0x0050 or 0x00000050) and alias types (greater than 0x00FF or 0x000000FF).
+    #[allow(dead_code)]
     pub(crate) user_type: u32,
 
     pub(crate) flags: Flags,

--- a/sqlx-core/src/mssql/protocol/done.rs
+++ b/sqlx-core/src/mssql/protocol/done.rs
@@ -9,6 +9,7 @@ pub(crate) struct Done {
 
     // The token of the current SQL statement. The token value is provided and controlled by the
     // application layer, which utilizes TDS. The TDS layer does not evaluate the value.
+    #[allow(dead_code)]
     cursor_command: u16,
 
     // The count of rows that were affected by the SQL statement. The value of DoneRowCount is

--- a/sqlx-core/src/mssql/protocol/order.rs
+++ b/sqlx-core/src/mssql/protocol/order.rs
@@ -4,6 +4,7 @@ use crate::error::Error;
 
 #[derive(Debug)]
 pub(crate) struct Order {
+    #[allow(dead_code)]
     columns: Bytes,
 }
 

--- a/sqlx-core/src/mssql/protocol/return_status.rs
+++ b/sqlx-core/src/mssql/protocol/return_status.rs
@@ -4,6 +4,7 @@ use crate::error::Error;
 
 #[derive(Debug)]
 pub(crate) struct ReturnStatus {
+    #[allow(dead_code)]
     value: i32,
 }
 

--- a/sqlx-core/src/sqlite/migrate.rs
+++ b/sqlx-core/src/sqlite/migrate.rs
@@ -27,8 +27,7 @@ impl MigrateDatabase for Sqlite {
             }
 
             // Opening a connection to sqlite creates the database
-            let _ = SqliteConnectOptions::from_str(url)?
-                .create_if_missing(true)
+            let _ = opts
                 .connect()
                 .await?
                 // Ensure WAL mode tempfiles are cleaned up

--- a/sqlx-core/src/sqlite/options/mod.rs
+++ b/sqlx-core/src/sqlite/options/mod.rs
@@ -154,7 +154,7 @@ impl SqliteConnectOptions {
     ///
     /// SQLx chooses to enable this by default so that foreign keys function as expected,
     /// compared to other database flavors.
-    pub fn foreign_keys(mut self, on: bool) -> Self {
+    pub fn foreign_keys(self, on: bool) -> Self {
         self.pragma("foreign_keys", if on { "ON" } else { "OFF" })
     }
 
@@ -187,14 +187,14 @@ impl SqliteConnectOptions {
     ///
     /// For consistency, any commands in `sqlx-cli` which create a SQLite database will create it
     /// in WAL mode.
-    pub fn journal_mode(mut self, mode: SqliteJournalMode) -> Self {
+    pub fn journal_mode(self, mode: SqliteJournalMode) -> Self {
         self.pragma("journal_mode", mode.as_str())
     }
 
     /// Sets the [locking mode](https://www.sqlite.org/pragma.html#pragma_locking_mode) for the database connection.
     ///
     /// The default locking mode is NORMAL.
-    pub fn locking_mode(mut self, mode: SqliteLockingMode) -> Self {
+    pub fn locking_mode(self, mode: SqliteLockingMode) -> Self {
         self.pragma("locking_mode", mode.as_str())
     }
 
@@ -238,7 +238,7 @@ impl SqliteConnectOptions {
     ///
     /// The default synchronous settings is FULL. However, if durability is not a concern,
     /// then NORMAL is normally all one needs in WAL mode.
-    pub fn synchronous(mut self, synchronous: SqliteSynchronous) -> Self {
+    pub fn synchronous(self, synchronous: SqliteSynchronous) -> Self {
         self.pragma("synchronous", synchronous.as_str())
     }
 
@@ -248,7 +248,7 @@ impl SqliteConnectOptions {
     ///
     /// For existing databases, a change to this value does not take effect unless a
     /// [`VACUUM` command](https://www.sqlite.org/lang_vacuum.html) is executed.
-    pub fn auto_vacuum(mut self, auto_vacuum: SqliteAutoVacuum) -> Self {
+    pub fn auto_vacuum(self, auto_vacuum: SqliteAutoVacuum) -> Self {
         self.pragma("auto_vacuum", auto_vacuum.as_str())
     }
 
@@ -259,7 +259,7 @@ impl SqliteConnectOptions {
     /// For existing databases, a change to this value does not take effect unless a
     /// [`VACUUM` command](https://www.sqlite.org/lang_vacuum.html) is executed.
     /// However, it cannot be changed in WAL mode.
-    pub fn page_size(mut self, page_size: u32) -> Self {
+    pub fn page_size(self, page_size: u32) -> Self {
         self.pragma("page_size", page_size.to_string())
     }
 

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -78,7 +78,7 @@ bit-vec = ["sqlx-core/bit-vec"]
 json = ["sqlx-core/json", "serde_json"]
 
 [dependencies]
-dotenv = { version = "0.15.0", default-features = false }
+dotenvy = { version = "0.15.0", default-features = false }
 hex = { version = "0.4.3", optional = true }
 heck = { version = "0.4", features = ["unicode"] }
 either = "1.6.1"

--- a/sqlx-macros/src/query/mod.rs
+++ b/sqlx-macros/src/query/mod.rs
@@ -84,14 +84,14 @@ static METADATA: Lazy<Metadata> = Lazy::new(|| {
 
     #[cfg_attr(not(procmacro2_semver_exempt), allow(unused_variables))]
     let env_path = if env_path.exists() {
-        let res = dotenv::from_path(&env_path);
+        let res = dotenvy::from_path(&env_path);
         if let Err(e) = res {
             panic!("failed to load environment from {:?}, {}", env_path, e);
         }
 
         Some(env_path)
     } else {
-        dotenv::dotenv().ok()
+        dotenvy::dotenv().ok()
     };
 
     // tell the compiler to watch the `.env` for changes, if applicable

--- a/sqlx-macros/src/query/mod.rs
+++ b/sqlx-macros/src/query/mod.rs
@@ -7,7 +7,6 @@ use std::sync::{Arc, Mutex};
 use once_cell::sync::Lazy;
 use proc_macro2::TokenStream;
 use syn::Type;
-use url::Url;
 
 pub use input::QueryMacroInput;
 use quote::{format_ident, quote};
@@ -189,7 +188,6 @@ pub fn expand_input(input: QueryMacroInput) -> crate::Result<TokenStream> {
 ))]
 fn expand_from_db(input: QueryMacroInput, db_url: &str) -> crate::Result<TokenStream> {
     use sqlx_core::any::{AnyConnectOptions, AnyConnection};
-    use std::str::FromStr;
 
     let connect_opts = AnyConnectOptions::from_str(db_url)?;
 

--- a/sqlx-test/Cargo.toml
+++ b/sqlx-test/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 sqlx = { default-features = false, path = ".." }
 env_logger = "0.9.0"
-dotenv = "0.15.0"
+dotenvy = "0.15.0"
 anyhow = "1.0.26"
 async-std = { version = "1.8.0", features = [ "attributes" ] }
 tokio = { version = "1.0.1", features = [ "full" ] }

--- a/sqlx-test/src/lib.rs
+++ b/sqlx-test/src/lib.rs
@@ -3,12 +3,12 @@ use sqlx::{Connection, Database, Pool};
 use std::env;
 
 pub fn setup_if_needed() {
-    let _ = dotenv::dotenv();
+    let _ = dotenvy::dotenv();
     let _ = env_logger::builder().is_test(true).try_init();
 }
 
 // Make a new connection
-// Ensure [dotenv] and [env_logger] have been setup
+// Ensure [dotenvy] and [env_logger] have been setup
 pub async fn new<DB>() -> anyhow::Result<DB::Connection>
 where
     DB: Database,
@@ -19,7 +19,7 @@ where
 }
 
 // Make a new pool
-// Ensure [dotenv] and [env_logger] have been setup
+// Ensure [dotenvy] and [env_logger] have been setup
 pub async fn pool<DB>() -> anyhow::Result<Pool<DB>>
 where
     DB: Database,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -8,7 +8,7 @@
 /// # #[cfg(all(feature = "mysql", feature = "_rt-async-std"))]
 /// # #[async_std::main]
 /// # async fn main() -> sqlx::Result<()>{
-/// # let db_url = dotenv::var("DATABASE_URL").expect("DATABASE_URL must be set");
+/// # let db_url = dotenvy::var("DATABASE_URL").expect("DATABASE_URL must be set");
 /// #
 /// # if !(db_url.starts_with("mysql") || db_url.starts_with("mariadb")) { return Ok(()) }
 /// # let mut conn = sqlx::MySqlConnection::connect(db_url).await?;
@@ -43,7 +43,7 @@
 /// ## Requirements
 /// * The `DATABASE_URL` environment variable must be set at build-time to point to a database
 /// server with the schema that the query string will be checked against. All variants of `query!()`
-/// use [dotenv] so this can be in a `.env` file instead.
+/// use [dotenv]<sup>1</sup> so this can be in a `.env` file instead.
 ///
 ///     * Or, `sqlx-data.json` must exist at the workspace root. See [Offline Mode](#offline-mode-requires-the-offline-feature)
 ///       below.
@@ -59,7 +59,11 @@
 ///     * The schema of the database URL (e.g. `postgres://` or `mysql://`) will be used to
 ///       determine the database type.
 ///
+/// <sup>1</sup> The `dotenv` crate itself appears abandoned as of [December 2021](https://github.com/dotenv-rs/dotenv/issues/74)
+/// so we now use the [`dotenvy`] crate instead. The file format is the same.
+///
 /// [dotenv]: https://crates.io/crates/dotenv
+/// [dotenvy]: https://crates.io/crates/dotenvy
 /// ## Query Arguments
 /// Like `println!()` and the other formatting macros, you can add bind parameters to your SQL
 /// and this macro will typecheck passed arguments and error on missing ones:
@@ -69,7 +73,7 @@
 /// # #[cfg(all(feature = "mysql", feature = "_rt-async-std"))]
 /// # #[async_std::main]
 /// # async fn main() -> sqlx::Result<()>{
-/// # let db_url = dotenv::var("DATABASE_URL").expect("DATABASE_URL must be set");
+/// # let db_url = dotenvy::var("DATABASE_URL").expect("DATABASE_URL must be set");
 /// #
 /// # if !(db_url.starts_with("mysql") || db_url.starts_with("mariadb")) { return Ok(()) }
 /// # let mut conn = sqlx::mysql::MySqlConnection::connect(db_url).await?;
@@ -354,7 +358,7 @@ macro_rules! query_unchecked (
 /// # #[cfg(all(feature = "mysql", feature = "_rt-async-std"))]
 /// # #[async_std::main]
 /// # async fn main() -> sqlx::Result<()>{
-/// # let db_url = dotenv::var("DATABASE_URL").expect("DATABASE_URL must be set");
+/// # let db_url = dotenvy::var("DATABASE_URL").expect("DATABASE_URL must be set");
 /// #
 /// # if !(db_url.starts_with("mysql") || db_url.starts_with("mariadb")) { return Ok(()) }
 /// # let mut conn = sqlx::MySqlConnection::connect(db_url).await?;
@@ -426,7 +430,7 @@ macro_rules! query_file_unchecked (
 /// # #[cfg(all(feature = "mysql", feature = "_rt-async-std"))]
 /// # #[async_std::main]
 /// # async fn main() -> sqlx::Result<()>{
-/// # let db_url = dotenv::var("DATABASE_URL").expect("DATABASE_URL must be set");
+/// # let db_url = dotenvy::var("DATABASE_URL").expect("DATABASE_URL must be set");
 /// #
 /// # if !(db_url.starts_with("mysql") || db_url.starts_with("mariadb")) { return Ok(()) }
 /// # let mut conn = sqlx::MySqlConnection::connect(db_url).await?;
@@ -567,7 +571,7 @@ macro_rules! query_as (
 /// # #[cfg(all(feature = "mysql", feature = "_rt-async-std"))]
 /// # #[async_std::main]
 /// # async fn main() -> sqlx::Result<()>{
-/// # let db_url = dotenv::var("DATABASE_URL").expect("DATABASE_URL must be set");
+/// # let db_url = dotenvy::var("DATABASE_URL").expect("DATABASE_URL must be set");
 /// #
 /// # if !(db_url.starts_with("mysql") || db_url.starts_with("mariadb")) { return Ok(()) }
 /// # let mut conn = sqlx::MySqlConnection::connect(db_url).await?;

--- a/tests/any/pool.rs
+++ b/tests/any/pool.rs
@@ -23,7 +23,7 @@ async fn pool_should_invoke_after_connect() -> anyhow::Result<()> {
                 })
             }
         })
-        .connect(&dotenv::var("DATABASE_URL")?)
+        .connect(&dotenvy::var("DATABASE_URL")?)
         .await?;
 
     let _ = pool.acquire().await?;
@@ -44,7 +44,7 @@ async fn pool_should_be_returned_failed_transactions() -> anyhow::Result<()> {
     let pool = AnyPoolOptions::new()
         .max_connections(2)
         .acquire_timeout(Duration::from_secs(3))
-        .connect(&dotenv::var("DATABASE_URL")?)
+        .connect(&dotenvy::var("DATABASE_URL")?)
         .await?;
 
     let query = "blah blah";

--- a/tests/any/pool.rs
+++ b/tests/any/pool.rs
@@ -1,4 +1,4 @@
-use sqlx::any::{AnyConnectOptions, AnyKind, AnyPoolOptions};
+use sqlx::any::{AnyConnectOptions, AnyPoolOptions};
 use sqlx::Executor;
 use std::sync::atomic::AtomicI32;
 use std::sync::{
@@ -81,7 +81,7 @@ async fn test_pool_callbacks() -> anyhow::Result<()> {
     let conn_options: AnyConnectOptions = std::env::var("DATABASE_URL")?.parse()?;
 
     #[cfg(feature = "mssql")]
-    if conn_options.kind() == AnyKind::Mssql {
+    if conn_options.kind() == sqlx::any::AnyKind::Mssql {
         // MSSQL doesn't support `CREATE TEMPORARY TABLE`,
         // because why follow conventions when you can subvert them?
         // Instead, you prepend `#` to the table name for a session-local temporary table

--- a/tests/mssql/mssql.rs
+++ b/tests/mssql/mssql.rs
@@ -43,7 +43,7 @@ async fn it_can_select_expression_by_name() -> anyhow::Result<()> {
 
 #[sqlx_macros::test]
 async fn it_can_fail_to_connect() -> anyhow::Result<()> {
-    let mut url = dotenv::var("DATABASE_URL")?;
+    let mut url = dotenvy::var("DATABASE_URL")?;
     url = url.replace("Password", "NotPassword");
 
     let res = MssqlConnection::connect(&url).await;

--- a/tests/mysql/mysql.rs
+++ b/tests/mysql/mysql.rs
@@ -81,7 +81,7 @@ async fn it_executes_with_pool() -> anyhow::Result<()> {
         .min_connections(2)
         .max_connections(2)
         .test_before_acquire(false)
-        .connect(&dotenv::var("DATABASE_URL")?)
+        .connect(&dotenvy::var("DATABASE_URL")?)
         .await?;
 
     let rows = pool.fetch_all("SELECT 1; SELECT 2").await?;

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -547,7 +547,7 @@ async fn pool_smoke_test() -> anyhow::Result<()> {
         .acquire_timeout(Duration::from_secs(5))
         .min_connections(1)
         .max_connections(1)
-        .connect(&dotenv::var("DATABASE_URL")?)
+        .connect(&dotenvy::var("DATABASE_URL")?)
         .await?;
 
     // spin up more tasks than connections available, and ensure we don't deadlock
@@ -1655,7 +1655,7 @@ CREATE TABLE issue_1254 (id INT4 PRIMARY KEY, pairs PAIR[]);
 async fn test_advisory_locks() -> anyhow::Result<()> {
     let pool = PgPoolOptions::new()
         .max_connections(2)
-        .connect(&dotenv::var("DATABASE_URL")?)
+        .connect(&dotenvy::var("DATABASE_URL")?)
         .await?;
 
     let lock1 = Arc::new(PgAdvisoryLock::new("sqlx-postgres-tests-1"));

--- a/tests/sqlite/sqlite.rs
+++ b/tests/sqlite/sqlite.rs
@@ -194,7 +194,7 @@ async fn it_executes_with_pool() -> anyhow::Result<()> {
         .min_connections(2)
         .max_connections(2)
         .test_before_acquire(false)
-        .connect(&dotenv::var("DATABASE_URL")?)
+        .connect(&dotenvy::var("DATABASE_URL")?)
         .await?;
 
     let rows = pool.fetch_all("SELECT 1; SElECT 2").await?;

--- a/tests/ui-tests.rs
+++ b/tests/ui-tests.rs
@@ -32,7 +32,7 @@ fn ui_tests() {
     }
 
     if cfg!(feature = "sqlite") {
-        if dotenv::var("DATABASE_URL").map_or(true, |v| {
+        if dotenvy::var("DATABASE_URL").map_or(true, |v| {
             Path::is_relative(v.trim_start_matches("sqlite://").as_ref())
         }) {
             // this isn't `Trybuild`'s fault: https://github.com/dtolnay/trybuild/issues/69#issuecomment-620329526


### PR DESCRIPTION
The former appears to be unmaintained and the latter is a drop-in replacement.

Also fixed all compiler warnings.