### PR TITLE
Fix expansion of `sqlx(flatten)`

### DIFF
--- a/sqlx-macros/src/derives/row.rs
+++ b/sqlx-macros/src/derives/row.rs
@@ -74,7 +74,7 @@ fn expand_derive_from_row_struct(
 
             let expr: Expr = if attributes.flatten {
                 predicates.push(parse_quote!(#ty: ::sqlx::FromRow<#lifetime, R>));
-                parse_quote!(#ty::from_row(row))
+                parse_quote!(<#ty as ::sqlx::FromRow<#lifetime, R>>::from_row(row))
             } else {
                 predicates.push(parse_quote!(#ty: ::sqlx::decode::Decode<#lifetime, R::Database>));
                 predicates.push(parse_quote!(#ty: ::sqlx::types::Type<R::Database>));


### PR DESCRIPTION
Given a generic type like `A<B>` before `sqlx` would produce
`A<B>::from_row(row)` which is invalid syntax.
Now it produces `<A<B> as ::sqlx::FromRow<'a, R>>`.
This also fixes a bug for non-generic types where an inherent method
might have been called instead of the `::sqlx::FromRow::from_row` method
because UFCS wasn't used.