### PR TITLE
fix: use hygenic macro path

### DIFF
--- a/sqlx-macros/src/test_attr.rs
+++ b/sqlx-macros/src/test_attr.rs
@@ -52,7 +52,7 @@ fn expand_simple(input: syn::ItemFn) -> TokenStream {
     let attrs = &input.attrs;
 
     quote! {
-        #[test]
+        #[::core::prelude::v1::test]
         #(#attrs)*
         fn #name() #ret {
             ::sqlx::test_block_on(async { #body })
@@ -105,7 +105,7 @@ fn expand_advanced(args: syn::AttributeArgs, input: syn::ItemFn) -> crate::Resul
     };
 
     Ok(quote! {
-        #[test]
+        #[::core::prelude::v1::test]
         #(#attrs)*
         fn #name() #ret {
             async fn inner(#inputs) #ret {


### PR DESCRIPTION
When the `#[sqlx::test]` macro is imported using `#[macro_use]` such as in the following example:

```rust
extern crate sqlx;

mod tests {
    #[test]
    fn something() {}
}
```

then the `#[test]` generated by the macro will refer to itself instead of the standard Rust `#[test]` macro. This will cause `rustc` to recursively expand it and produce the following error message:

```
thread 'rustc' has overflowed its stack
fatal runtime error: stack overflow
```

Instead, we can just refer to the standard macro by using its fully qualified path.

This PR:
* Swaps `#[test]` usages in `#[sqlx::test]` for their hygenic path to prevent recursive expansion alongside `#[macro_use]`

Closes #2017.

