### PR TITLE
added flag for PIPES_AS_CONCAT connection setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
  "getrandom",
  "instant",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "tokio",
 ]
 
@@ -1067,6 +1067,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85dcb89d2b10c5f6133de2efd8c11959ce9dbb46a2f7a4cab208c4eeda6ce1ab"
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "futures"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,7 +1769,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -1952,7 +1958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.3",
  "subtle",
 ]
 
@@ -2177,13 +2183,26 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -2193,8 +2212,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2211,7 +2245,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -2236,6 +2270,15 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2332,7 +2375,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.3",
  "smallvec",
  "subtle",
  "zeroize",
@@ -2661,9 +2704,9 @@ dependencies = [
 
 [[package]]
 name = "sqlformat"
-version = "0.1.8"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b7922be017ee70900be125523f38bdd644f4f06a1b16e8fa5a8ee8c34bffd4"
+checksum = "f87e292b4291f154971a43c3774364e2cbcaec599d3f5bf6fa9d122885dbc38a"
 dependencies = [
  "itertools",
  "nom",
@@ -2680,8 +2723,9 @@ dependencies = [
  "env_logger",
  "futures",
  "hex",
+ "libsqlite3-sys",
  "paste",
- "rand",
+ "rand 0.8.5",
  "rand_xoshiro",
  "serde",
  "serde_json",
@@ -2689,6 +2733,7 @@ dependencies = [
  "sqlx-macros",
  "sqlx-rt",
  "sqlx-test",
+ "tempdir",
  "time 0.3.11",
  "tokio",
  "trybuild",
@@ -2779,7 +2824,7 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "regex",
  "rsa",
  "rust_decimal",
@@ -2824,7 +2869,7 @@ dependencies = [
  "axum",
  "dotenvy",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "regex",
  "serde",
  "serde_json",
@@ -3014,6 +3059,16 @@ name = "sync_wrapper"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all 0.5.3",
+]
 
 [[package]]
 name = "tempfile"

--- a/sqlx-core/src/mysql/options/connect.rs
+++ b/sqlx-core/src/mysql/options/connect.rs
@@ -42,20 +42,19 @@ impl ConnectOptions for MySqlConnectOptions {
             // https://mathiasbynens.be/notes/mysql-utf8mb4
 
             let mut options = String::new();
-            
-            // Check `disable_pipes_as_concat` flag
-            // For PlanetScale connections, PIPES_AS_CONCAT must not be set
-            match self.disable_pipes_as_concat {
-                true => options.push_str(r#"SET sql_mode=(SELECT CONCAT(@@sql_mode, ',NO_ENGINE_SUBSTITUTION')),"#),
-                false => options.push_str(r#"SET sql_mode=(SELECT CONCAT(@@sql_mode, ',PIPES_AS_CONCAT,NO_ENGINE_SUBSTITUTION')),"#)
-            }
-
             options.push_str(r#"time_zone='+00:00',"#);
             options.push_str(&format!(
                 r#"NAMES {} COLLATE {};"#,
                 conn.stream.charset.as_str(),
                 conn.stream.collation.as_str()
             ));
+            if self.pipes_as_concat {
+                options.push_str(r#"SET sql_mode=(SELECT CONCAT(@@sql_mode, ',PIPES_AS_CONCAT,NO_ENGINE_SUBSTITUTION')),"#);
+            } else {
+                options.push_str(
+                    r#"SET sql_mode=(SELECT CONCAT(@@sql_mode, ',NO_ENGINE_SUBSTITUTION')),"#,
+                );
+            }
 
             conn.execute(&*options).await?;
 

--- a/sqlx-core/src/mysql/options/connect.rs
+++ b/sqlx-core/src/mysql/options/connect.rs
@@ -42,7 +42,14 @@ impl ConnectOptions for MySqlConnectOptions {
             // https://mathiasbynens.be/notes/mysql-utf8mb4
 
             let mut options = String::new();
-            options.push_str(r#"SET sql_mode=(SELECT CONCAT(@@sql_mode, ',PIPES_AS_CONCAT,NO_ENGINE_SUBSTITUTION')),"#);
+            
+            // Check `disable_pipes_as_concat` flag
+            // For PlanetScale connections, PIPES_AS_CONCAT must not be set
+            match self.disable_pipes_as_concat {
+                true => options.push_str(r#"SET sql_mode=(SELECT CONCAT(@@sql_mode, ',NO_ENGINE_SUBSTITUTION')),"#),
+                false => options.push_str(r#"SET sql_mode=(SELECT CONCAT(@@sql_mode, ',PIPES_AS_CONCAT,NO_ENGINE_SUBSTITUTION')),"#)
+            }
+
             options.push_str(r#"time_zone='+00:00',"#);
             options.push_str(&format!(
                 r#"NAMES {} COLLATE {};"#,

--- a/sqlx-core/src/mysql/options/connect.rs
+++ b/sqlx-core/src/mysql/options/connect.rs
@@ -42,12 +42,6 @@ impl ConnectOptions for MySqlConnectOptions {
             // https://mathiasbynens.be/notes/mysql-utf8mb4
 
             let mut options = String::new();
-            options.push_str(r#"time_zone='+00:00',"#);
-            options.push_str(&format!(
-                r#"NAMES {} COLLATE {};"#,
-                conn.stream.charset.as_str(),
-                conn.stream.collation.as_str()
-            ));
             if self.pipes_as_concat {
                 options.push_str(r#"SET sql_mode=(SELECT CONCAT(@@sql_mode, ',PIPES_AS_CONCAT,NO_ENGINE_SUBSTITUTION')),"#);
             } else {
@@ -55,6 +49,12 @@ impl ConnectOptions for MySqlConnectOptions {
                     r#"SET sql_mode=(SELECT CONCAT(@@sql_mode, ',NO_ENGINE_SUBSTITUTION')),"#,
                 );
             }
+            options.push_str(r#"time_zone='+00:00',"#);
+            options.push_str(&format!(
+                r#"NAMES {} COLLATE {};"#,
+                conn.stream.charset.as_str(),
+                conn.stream.collation.as_str()
+            ));
 
             conn.execute(&*options).await?;
 

--- a/sqlx-core/src/mysql/options/mod.rs
+++ b/sqlx-core/src/mysql/options/mod.rs
@@ -65,6 +65,7 @@ pub struct MySqlConnectOptions {
     pub(crate) charset: String,
     pub(crate) collation: Option<String>,
     pub(crate) log_settings: LogSettings,
+    pub(crate) disable_pipes_as_concat: bool,
 }
 
 impl Default for MySqlConnectOptions {
@@ -89,6 +90,7 @@ impl MySqlConnectOptions {
             ssl_ca: None,
             statement_cache_capacity: 100,
             log_settings: Default::default(),
+            disable_pipes_as_concat: true
         }
     }
 

--- a/sqlx-core/src/mysql/options/mod.rs
+++ b/sqlx-core/src/mysql/options/mod.rs
@@ -65,7 +65,7 @@ pub struct MySqlConnectOptions {
     pub(crate) charset: String,
     pub(crate) collation: Option<String>,
     pub(crate) log_settings: LogSettings,
-    pub(crate) disable_pipes_as_concat: bool,
+    pub(crate) pipes_as_concat: bool,
 }
 
 impl Default for MySqlConnectOptions {
@@ -90,7 +90,7 @@ impl MySqlConnectOptions {
             ssl_ca: None,
             statement_cache_capacity: 100,
             log_settings: Default::default(),
-            disable_pipes_as_concat: true
+            pipes_as_concat: true,
         }
     }
 
@@ -212,6 +212,16 @@ impl MySqlConnectOptions {
     /// the `charset`.
     pub fn collation(mut self, collation: &str) -> Self {
         self.collation = Some(collation.to_owned());
+        self
+    }
+
+    /// Sets the flag that enables or disables the `PIPES_AS_CONCAT` connection setting
+    ///
+    /// The default value is set to true, but some MySql databases such as PlanetScale
+    /// error out with this connection setting so it needs to be set false in such
+    /// instances
+    pub fn pipes_as_concat(mut self, flag_val: bool) -> Self {
+        self.pipes_as_concat = flag_val;
         self
     }
 }


### PR DESCRIPTION
Fix for PlanetScale (and other) databases that throw an error when the `PIPES_AS_CONCAT` connection setting is set.

#2034

Added a flag to `MySqlConnectSettings` struct that defaults to true, per [request](https://github.com/launchbadge/sqlx/pull/2037#issuecomment-1211369489).