### PR TITLE
Add documentation for `IpAddr` support in Postgres

### DIFF
--- a/sqlx-core/src/postgres/types/mod.rs
+++ b/sqlx-core/src/postgres/types/mod.rs
@@ -72,6 +72,13 @@
 //! | Rust type                             | Postgres type(s)                                     |
 //! |---------------------------------------|------------------------------------------------------|
 //! | `ipnetwork::IpNetwork`                | INET, CIDR                                           |
+//! | `std::net::IpAddr`                    | INET, CIDR                                           |
+//!
+//! Note that because `IpAddr` does not support network prefixes, it is an error to attempt to decode
+//! an `IpAddr` from a `INET` or `CIDR` value with a network prefix smaller than the address' full width:
+//! `/32` for IPv4 addresses and `/128` for IPv6 addresses.
+//!
+//! `IpNetwork` does not have this limitation.
 //!
 //! ### [`mac_address`](https://crates.io/crates/mac_address)
 //!


### PR DESCRIPTION
This PR updates the documentation to reflect #1822 