### PR TITLE
Use unlock notify also on `sqlite3_exec` 

### DIFF
--- a/sqlx-core/src/sqlite/statement/mod.rs
+++ b/sqlx-core/src/sqlite/statement/mod.rs
@@ -9,6 +9,7 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 mod handle;
+pub(super) mod unlock_notify;
 mod r#virtual;
 
 pub(crate) use handle::StatementHandle;

--- a/sqlx-core/src/sqlite/statement/unlock_notify.rs
+++ b/sqlx-core/src/sqlite/statement/unlock_notify.rs
@@ -1,0 +1,61 @@
+use std::ffi::c_void;
+use std::os::raw::c_int;
+use std::slice;
+use std::sync::{Condvar, Mutex};
+
+use libsqlite3_sys::{sqlite3, sqlite3_unlock_notify, SQLITE_OK};
+
+use crate::sqlite::SqliteError;
+
+// Wait for unlock notification (https://www.sqlite.org/unlock_notify.html)
+pub unsafe fn wait(conn: *mut sqlite3) -> Result<(), SqliteError> {
+    let notify = Notify::new();
+
+    if sqlite3_unlock_notify(
+        conn,
+        Some(unlock_notify_cb),
+        &notify as *const Notify as *mut Notify as *mut _,
+    ) != SQLITE_OK
+    {
+        return Err(SqliteError::new(conn));
+    }
+
+    notify.wait();
+
+    Ok(())
+}
+
+unsafe extern "C" fn unlock_notify_cb(ptr: *mut *mut c_void, len: c_int) {
+    let ptr = ptr as *mut &Notify;
+    let slice = slice::from_raw_parts(ptr, len as usize);
+
+    for notify in slice {
+        notify.fire();
+    }
+}
+
+struct Notify {
+    mutex: Mutex<bool>,
+    condvar: Condvar,
+}
+
+impl Notify {
+    fn new() -> Self {
+        Self {
+            mutex: Mutex::new(false),
+            condvar: Condvar::new(),
+        }
+    }
+
+    fn wait(&self) {
+        let _ = self
+            .condvar
+            .wait_while(self.mutex.lock().unwrap(), |fired| !*fired)
+            .unwrap();
+    }
+
+    fn fire(&self) {
+        *self.mutex.lock().unwrap() = true;
+        self.condvar.notify_one();
+    }
+}


### PR DESCRIPTION
Closes #2021

Note the SQLite [documentation about unlock notify](https://www.sqlite.org/unlock_notify.html) doesn't mention `sqlite3_exec` but it's just a convenience shortcut for `sqlite3_prepare_v2`, `sqlite3_step`, and `sqlite3_finalize`, so I think it should still apply. 