### PR TITLE
chore: Switch to sha1 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2615,10 +2615,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.0"
+name = "sha1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+checksum = "c77f4e7f65455545c2153c1253d25056825e77ee2533f0e41deb65a93a34852f"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2832,7 +2832,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
- "sha-1",
+ "sha1",
  "sha2",
  "smallvec",
  "sqlformat",

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -25,7 +25,7 @@ postgres = [
     "md-5",
     "sha2",
     "base64",
-    "sha-1",
+    "sha1",
     "rand",
     "hmac",
     "futures-channel/sink",
@@ -36,7 +36,7 @@ postgres = [
     "hkdf"
 ]
 mysql = [
-    "sha-1",
+    "sha1",
     "sha2",
     "generic-array",
     "num-bigint",
@@ -154,7 +154,7 @@ rustls = { version = "0.20.1", features = ["dangerous_configuration"], optional 
 rustls-pemfile = { version = "1.0", optional = true }
 serde = { version = "1.0.132", features = ["derive", "rc"], optional = true }
 serde_json = { version = "1.0.73", features = ["raw_value"], optional = true }
-sha-1 = { version = "0.10.0", default-features = false, optional = true }
+sha1 = { version = "0.10.1", default-features = false, optional = true }
 sha2 = { version = "0.10.0", default-features = false, optional = true }
 sqlformat = "0.2.0"
 thiserror = "1.0.30"


### PR DESCRIPTION
The `sha-1` crate will be deprecated in favor of `sha1`. See https://github.com/RustCrypto/hashes#crate-names for details.