### PR TITLE
Multi app migration support

### DIFF
--- a/sqlx-core/src/any/migrate.rs
+++ b/sqlx-core/src/any/migrate.rs
@@ -229,4 +229,20 @@ impl Migrate for AnyConnection {
             }
         }
     }
+
+    fn get_migrate_table_name(&self) -> String {
+        match &self.0 {
+            #[cfg(feature = "postgres")]
+            AnyConnectionKind::Postgres(conn) => conn.get_migrate_table_name(),
+
+            #[cfg(feature = "mysql")]
+            AnyConnectionKind::MySql(conn) => conn.get_migrate_table_name(),
+
+            #[cfg(feature = "sqlite")]
+            AnyConnectionKind::Sqlite(conn) => conn.get_migrate_table_name(),
+
+            #[cfg(feature = "mssql")]
+            AnyConnectionKind::Mssql(_conn) => unimplemented!(),
+        }
+    }
 }

--- a/sqlx-core/src/migrate/migrate.rs
+++ b/sqlx-core/src/migrate/migrate.rs
@@ -1,6 +1,7 @@
 use crate::error::Error;
 use crate::migrate::{AppliedMigration, MigrateError, Migration};
 use futures_core::future::BoxFuture;
+use std::env;
 use std::time::Duration;
 
 pub trait MigrateDatabase {
@@ -69,4 +70,10 @@ pub trait Migrate {
         &'e mut self,
         migration: &'m Migration,
     ) -> BoxFuture<'m, Result<Duration, MigrateError>>;
+
+    // reads names for migration table form env variable MIGRATE_TABLE_NAME, if variable is not set
+    // it will default to _sqlx_migrations. This enables multiple schema/app support in one DB.
+    fn get_migrate_table_name(&self) -> String {
+        env::var("MIGRATE_TABLE_NAME").unwrap_or("_sqlx_migrations".to_string())
+    }
 }

--- a/sqlx-core/src/sqlite/migrate.rs
+++ b/sqlx-core/src/sqlite/migrate.rs
@@ -68,8 +68,9 @@ impl Migrate for SqliteConnection {
         Box::pin(async move {
             // language=SQLite
             self.execute(
-                r#"
-CREATE TABLE IF NOT EXISTS _sqlx_migrations (
+                format!(
+                    r#"
+CREATE TABLE IF NOT EXISTS {} (
     version BIGINT PRIMARY KEY,
     description TEXT NOT NULL,
     installed_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -78,6 +79,9 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
     execution_time BIGINT NOT NULL
 );
                 "#,
+                    self.get_migrate_table_name()
+                )
+                .as_str(),
             )
             .await?;
 
@@ -89,7 +93,11 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
         Box::pin(async move {
             // language=SQLite
             let row = query_as(
-                "SELECT version, NOT success FROM _sqlx_migrations ORDER BY version DESC LIMIT 1",
+                format!(
+                    "SELECT version, NOT success FROM {} ORDER BY version DESC LIMIT 1",
+                    self.get_migrate_table_name()
+                )
+                .as_str(),
             )
             .fetch_optional(self)
             .await?;
@@ -102,7 +110,11 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
         Box::pin(async move {
             // language=SQLite
             let row: Option<(i64,)> = query_as(
-                "SELECT version FROM _sqlx_migrations WHERE success = false ORDER BY version LIMIT 1",
+                format!(
+                    "SELECT version FROM {} WHERE success = false ORDER BY version LIMIT 1",
+                    self.get_migrate_table_name()
+                )
+                .as_str(),
             )
             .fetch_optional(self)
             .await?;
@@ -116,10 +128,15 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
     ) -> BoxFuture<'_, Result<Vec<AppliedMigration>, MigrateError>> {
         Box::pin(async move {
             // language=SQLite
-            let rows: Vec<(i64, Vec<u8>)> =
-                query_as("SELECT version, checksum FROM _sqlx_migrations ORDER BY version")
-                    .fetch_all(self)
-                    .await?;
+            let rows: Vec<(i64, Vec<u8>)> = query_as(
+                format!(
+                    "SELECT version, checksum FROM {} ORDER BY version",
+                    self.get_migrate_table_name()
+                )
+                .as_str(),
+            )
+            .fetch_all(self)
+            .await?;
 
             let migrations = rows
                 .into_iter()
@@ -147,11 +164,16 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
     ) -> BoxFuture<'m, Result<(), MigrateError>> {
         Box::pin(async move {
             // language=SQL
-            let checksum: Option<Vec<u8>> =
-                query_scalar("SELECT checksum FROM _sqlx_migrations WHERE version = ?1")
-                    .bind(migration.version)
-                    .fetch_optional(self)
-                    .await?;
+            let checksum: Option<Vec<u8>> = query_scalar(
+                format!(
+                    "SELECT checksum FROM {} WHERE version = ?1",
+                    self.get_migrate_table_name()
+                )
+                .as_str(),
+            )
+            .bind(migration.version)
+            .fetch_optional(self)
+            .await?;
 
             if let Some(checksum) = checksum {
                 if checksum == &*migration.checksum {
@@ -181,10 +203,14 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
 
             // language=SQL
             let _ = query(
-                r#"
-    INSERT INTO _sqlx_migrations ( version, description, success, checksum, execution_time )
+                format!(
+                    r#"
+    INSERT INTO {} ( version, description, success, checksum, execution_time )
     VALUES ( ?1, ?2, TRUE, ?3, ?4 )
                 "#,
+                    self.get_migrate_table_name()
+                )
+                .as_str(),
             )
             .bind(migration.version)
             .bind(&*migration.description)
@@ -212,10 +238,16 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
             let elapsed = start.elapsed();
 
             // language=SQL
-            let _ = query(r#"DELETE FROM _sqlx_migrations WHERE version = ?1"#)
-                .bind(migration.version)
-                .execute(self)
-                .await?;
+            let _ = query(
+                format!(
+                    r#"DELETE FROM {} WHERE version = ?1"#,
+                    self.get_migrate_table_name()
+                )
+                .as_str(),
+            )
+            .bind(migration.version)
+            .execute(self)
+            .await?;
 
             Ok(elapsed)
         })


### PR DESCRIPTION
I've encountered a need to run multiple separate migrations from different apps having different schemas while using the same DB. I've seen that this feature has been requested and referenced in multiple issues:

- [sqlx::migrate!() single DB multiple application support ](https://github.com/launchbadge/sqlx/issues/1698)
- [Migrations with namespaces](https://github.com/launchbadge/sqlx/issues/1356)
- [Migration table renaming](https://github.com/launchbadge/sqlx/issues/946)

My approach is to enable this functionality by setting env variable, if variable is not set migrations table will default to `_sqlx_migrations `. I am flexible to changing that solution or extending CLI with command line parameters, but I'd say it would be beneficial to have this feature in place. 

Signed-off-by: Emil Majchrzak <majchrzamemil@github.com>