### PR TITLE
Add extension support for SQLite

### DIFF
--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         with:
           key: ${{ runner.os }}-check-${{ matrix.runtime }}-${{ matrix.tls }}
-          
+
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -144,6 +144,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - run: mkdir /tmp/sqlite3-lib && wget -O /tmp/sqlite3-lib/ipaddr.so https://github.com/nalgeon/sqlean/releases/download/0.15.2/ipaddr.so
+
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -164,6 +166,8 @@ jobs:
             --test-threads=1
         env:
           DATABASE_URL: sqlite://tests/sqlite/sqlite.db
+          RUSTFLAGS: --cfg sqlite_ipaddr
+          LD_LIBRARY_PATH: /tmp/sqlite3-lib
 
   postgres:
     name: Postgres

--- a/sqlx-core/src/sqlite/error.rs
+++ b/sqlx-core/src/sqlite/error.rs
@@ -35,6 +35,13 @@ impl SqliteError {
             message: message.to_owned(),
         }
     }
+
+    /// For errors during extension load, the error message is supplied via a separate pointer
+    pub(crate) fn extension(handle: *mut sqlite3, error_msg: &CStr) -> Self {
+        let mut err = Self::new(handle);
+        err.message = unsafe { from_utf8_unchecked(error_msg.to_bytes()).to_owned() };
+        err
+    }
 }
 
 impl Display for SqliteError {

--- a/tests/sqlite/sqlite.rs
+++ b/tests/sqlite/sqlite.rs
@@ -204,6 +204,21 @@ async fn it_executes_with_pool() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(sqlite_ipaddr)]
+#[sqlx_macros::test]
+async fn it_opens_with_extension() -> anyhow::Result<()> {
+    use std::str::FromStr;
+
+    let opts = SqliteConnectOptions::from_str(&dotenvy::var("DATABASE_URL")?)?.extension("ipaddr");
+
+    let mut conn = SqliteConnection::connect_with(&opts).await?;
+    conn.execute("SELECT ipmasklen('192.168.16.12/24');")
+        .await?;
+    conn.close().await?;
+
+    Ok(())
+}
+
 #[sqlx_macros::test]
 async fn it_opens_in_memory() -> anyhow::Result<()> {
     // If the filename is ":memory:", then a private, temporary in-memory database


### PR DESCRIPTION
Implements #1460

I was trying to find a way to use extensions (specifically [`vsv`](https://github.com/nalgeon/sqlean/blob/main/docs/vsv.md) and [`spatialite`](https://www.gaia-gis.it/fossil/libspatialite/index)) with SQLite from Rust, and while Rusqlite supports them, my perferred SQL crate did not, hence this PR to try and rectify that situation.

I found the issue mentioned above and took note of the suggestions made, that we should probably implement this as conservatively as we can, please see the commit message for more specifics.

## Testing
I would appreciate some guidance on how to test this from the integration test suite. Something like this will exercise the code in question, the more difficult problem is "How do we get the extension shared object to the test context?".

```rust
#[sqlx_macros::test]
async fn it_opens_with_extension() -> anyhow::Result<()> {
    let opts = SqliteConnectOptions::from_str(&dotenvy::var("DATABASE_URL")?)?
        .extension("vsv");

    let conn = SqliteConnection::connect_with(&opts).await?;
    conn.close().await?;

    Ok(())
}
```

Just sticking a compiled object in isn't appropriate, as it's architecture and OS dependent, and unlike the other databases we don't spin a Docker container up, otherwise we could modify it to add an extension package.

Would it be possible to add a simple extension as a `.c` file and have a `build.rs` compile it only in a test context? [`sqlite3-ipaddr`](https://github.com/nalgeon/sqlean/blob/main/src/sqlite3-ipaddr.c) would be a good minimal example as it's only a few hundred lines long and has no external dependencies except for `sqlite3ext.h`.