### PR TITLE
customizable db locking during migration

### DIFF
--- a/sqlx-core/src/migrate/migrator.rs
+++ b/sqlx-core/src/migrate/migrator.rs
@@ -9,7 +9,7 @@ use std::slice;
 pub struct Migrator {
     pub migrations: Cow<'static, [Migration]>,
     pub ignore_missing: bool,
-    pub locking: bool
+    pub locking: bool,
 }
 
 fn validate_applied_migrations(
@@ -57,7 +57,7 @@ impl Migrator {
         Ok(Self {
             migrations: Cow::Owned(source.resolve().await.map_err(MigrateError::Source)?),
             ignore_missing: false,
-            locking: true
+            locking: true,
         })
     }
 
@@ -68,7 +68,7 @@ impl Migrator {
     }
 
     /// Specify whether or not to lock database during migration. Defaults to `true`.
-    /// 
+    ///
     /// ### Warning
     /// Disabling locking can lead to errors or data loss if multiple clients attempt to apply migrations simultaneously
     /// without some sort of mutual exclusion.

--- a/sqlx-core/src/migrate/migrator.rs
+++ b/sqlx-core/src/migrate/migrator.rs
@@ -67,7 +67,14 @@ impl Migrator {
         self
     }
 
-    /// Specify whether to lock database during migration (recommended, incompatible with some pgwire DBs like cockroachdb - therefore the option)
+    /// Specify whether or not to lock database during migration. Defaults to `true`.
+    /// 
+    /// ### Warning
+    /// Disabling locking can lead to errors or data loss if multiple clients attempt to apply migrations simultaneously
+    /// without some sort of mutual exclusion.
+    ///
+    /// This should only be used if the database does not support locking, e.g. CockroachDB which talks the Postgres
+    /// protocol but does not support advisory locks used by SQLx's migrations support for Postgres.
     pub fn set_locking(&mut self, locking: bool) -> &Self {
         self.locking = locking;
         self

--- a/sqlx-macros/src/migrate.rs
+++ b/sqlx-macros/src/migrate.rs
@@ -146,6 +146,7 @@ pub(crate) fn expand_migrator(path: &Path) -> crate::Result<TokenStream> {
                 #(#migrations),*
             ]),
             ignore_missing: false,
+            locking: true,
         }
     })
 }

--- a/src/macros/test.md
+++ b/src/macros/test.md
@@ -132,6 +132,7 @@ use sqlx::PgPool;
 #   static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate::Migrator {
 #       migrations: Cow::Borrowed(&[]),
 #       ignore_missing: false,
+#       locking: true,
 #   };
 # } 
 


### PR DESCRIPTION
 ? - Why 
Various pgwire databases such as CockroachDB do not support such a feature. 

> [iodb] running migrations failed: Execute(Database(PgDatabaseError { severity: Error, code: "42883", message: "unknown function: pg_advisory_lock()", detail: None, hint: None, position: None, where: None, schema: None, table: None, column: None, data_type: None, constraint: None, file: Some("name_resolution.go"), line: Some(205), routine: Some("ResolveFunction") }))

In such scenarios the only way to perform migrations is without locking

This PR allows the end user to choose whether to lock the DB when running migrations or not.
Default behaviour is maintained and DBs are still locked on default.

Example:
`sqlx::migrate!().set_locking(false).run(&pool).await`


(Changes have been tested & are actively used in development of our app)