### PR TITLE
fix(docs): close code block in query_builder.rs

### DIFF
--- a/sqlx-core/src/query_builder.rs
+++ b/sqlx-core/src/query_builder.rs
@@ -379,7 +379,8 @@ where
     /// // 65535 / 4 = 16383 (rounded down)
     /// // 16383 * 4 = 65532
     /// assert_eq!(arguments.len(), 65532);
-    ///  }
+    /// }
+    /// ```
     pub fn push_tuples<I, F>(&mut self, tuples: I, mut push_tuple: F) -> &mut Self
     where
         I: IntoIterator,


### PR DESCRIPTION
@danielakhterov and I were playing around with counting lines using regex and noticed that SQLx had an odd number of ` ``` ` and got a little nerd-sniped trying to find it.