### PR TITLE
Extended query pipeline to execute multiple independent queries in a single batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2738,6 +2738,7 @@ dependencies = [
  "tokio",
  "trybuild",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,8 @@ hex = "0.4.3"
 tempdir = "0.3.7"
 # Needed to test SQLCipher
 libsqlite3-sys = { version = "*", features = ["bundled-sqlcipher"] }
+# Used to test PgExtendedQueryPipeline
+uuid = "1"
 
 #
 # Any
@@ -274,6 +276,11 @@ required-features = ["postgres", "macros"]
 name = "postgres-test-attr"
 path = "tests/postgres/test-attr.rs"
 required-features = ["postgres", "macros", "migrate"]
+
+[[test]]
+name = "postgres-pipeline"
+path = "tests/postgres/pipeline.rs"
+required-features = ["postgres", "macros", "migrate", "uuid"]
 
 #
 # Microsoft SQL Server (MSSQL)

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -160,7 +160,7 @@ sqlformat = "0.2.0"
 thiserror = "1.0.30"
 time = { version = "0.3.2", features = ["macros", "formatting", "parsing"], optional = true }
 tokio-stream = { version = "0.1.8", features = ["fs"], optional = true }
-smallvec = "1.7.0"
+smallvec = { version = "1.7.0", features = ["const_generics"] }
 url = { version = "2.2.2", default-features = false }
 uuid = { version = "1.0", default-features = false, optional = true, features = ["std"] }
 webpki-roots = { version = "0.22.0", optional = true }

--- a/sqlx-core/src/postgres/mod.rs
+++ b/sqlx-core/src/postgres/mod.rs
@@ -13,6 +13,7 @@ mod io;
 mod listener;
 mod message;
 mod options;
+mod pipeline;
 mod query_result;
 mod row;
 mod statement;
@@ -37,6 +38,7 @@ pub use error::{PgDatabaseError, PgErrorPosition};
 pub use listener::{PgListener, PgNotification};
 pub use message::PgSeverity;
 pub use options::{PgConnectOptions, PgSslMode};
+pub use pipeline::PgExtendedQueryPipeline;
 pub use query_result::PgQueryResult;
 pub use row::PgRow;
 pub use statement::PgStatement;
@@ -51,6 +53,8 @@ pub type PgPool = crate::pool::Pool<Postgres>;
 /// An alias for [`PoolOptions`][crate::pool::PoolOptions], specialized for Postgres.
 pub type PgPoolOptions = crate::pool::PoolOptions<Postgres>;
 
+/// An alias for [`Query`][crate::query::Query], specialized for Postgres.
+pub type PgQuery<'q> = crate::query::Query<'q, Postgres, PgArguments>;
 /// An alias for [`Executor<'_, Database = Postgres>`][Executor].
 pub trait PgExecutor<'c>: Executor<'c, Database = Postgres> {}
 impl<'c, T: Executor<'c, Database = Postgres>> PgExecutor<'c> for T {}

--- a/sqlx-core/src/postgres/pipeline.rs
+++ b/sqlx-core/src/postgres/pipeline.rs
@@ -1,0 +1,106 @@
+use crate::connection::LogSettings;
+use crate::error::Error;
+use crate::executor::Execute;
+use crate::logger::QueryLogger;
+use crate::postgres::statement::PgStatementMetadata;
+use crate::postgres::{PgArguments, PgPool, PgQueryResult, Postgres};
+use either::Either;
+use futures_core::Stream;
+use futures_util::{stream, StreamExt, TryStreamExt};
+use smallvec::SmallVec;
+use std::sync::Arc;
+
+// tuple that contains the data required to run a query
+//
+// (sql, arguments, persistent, metadata_options)
+type QueryContext<'q> = (
+    &'q str,
+    Option<PgArguments>,
+    bool,
+    Option<Arc<PgStatementMetadata>>,
+);
+
+/// Pipeline of independent queries.
+///
+/// Query pipeline allows to issue multiple independent queries via extended
+/// query protocol in a single batch, write Sync command and wait for the result sets of all queries.
+///
+/// If there is no explicit transaction than queries will run in an implicit
+/// transaction with shortest possible duration.
+///
+/// It's assumed that the queries produce small enough result sets that together
+/// fit in client's memory. Pipeline doesn't use server side cursors.
+///
+/// Simple queries are not supported due to focus on efficient execution of the
+/// same queries with different parameters.
+/// Though technically the implicit transaction may commit by a single simple
+/// Query instead of the final Sync.
+///
+/// CockroachDB specifics: This transaction could be automatically retried by
+/// the database gateway node during contention with other transactions as long as it can
+/// buffer all result sets (see
+/// https://www.cockroachlabs.com/docs/stable/transactions.html#automatic-retries).
+pub struct PgExtendedQueryPipeline<'q, const N: usize> {
+    queries: SmallVec<[QueryContext<'q>; N]>,
+}
+
+impl<'q, const N: usize> PgExtendedQueryPipeline<'q, N> {
+    pub fn push(&mut self, mut query: impl Execute<'q, Postgres>) {
+        self.queries.push((
+            query.sql(),
+            query.take_arguments(),
+            query.persistent(),
+            query.statement().map(|s| Arc::clone(&s.metadata)),
+        ))
+    }
+
+    pub async fn execute(
+        self: PgExtendedQueryPipeline<'q, N>,
+        pool: &PgPool,
+    ) -> Result<SmallVec<[PgQueryResult; N]>, Error> {
+        let mut conn = pool.acquire().await?;
+        let pgresults = conn
+            .fetch_pipeline(self)
+            .await?
+            .filter_map(|pgresult_or_row_result| async move {
+                match pgresult_or_row_result {
+                    Ok(Either::Left(pgresult)) => Some(Ok(pgresult)),
+                    // filter data rows
+                    Ok(Either::Right(_)) => None,
+                    Err(e) => Some(Err(e)),
+                }
+            })
+            .try_collect()
+            .await?;
+        Ok(pgresults)
+    }
+
+    pub(crate) fn query_loggers_stack(
+        &self,
+        log_settings: &LogSettings,
+    ) -> SmallVec<[QueryLogger<'q>; N]> {
+        self.queries
+            .iter()
+            .rev()
+            .map(|(q_ref, _, _, _)| QueryLogger::new(*q_ref, log_settings.clone()))
+            .collect()
+    }
+
+    pub(crate) fn into_querycontext_stream(self) -> impl Stream<Item = QueryContext<'q>> {
+        stream::iter(self.queries)
+    }
+}
+
+impl<'q, E, const N: usize> From<E> for PgExtendedQueryPipeline<'q, N>
+where
+    E: Execute<'q, Postgres>,
+{
+    /// Query pipeline has at least one query.
+    fn from(query: E) -> Self {
+        let mut pipeline = Self {
+            queries: SmallVec::new(),
+        };
+        pipeline.push(query);
+        pipeline
+    }
+}

--- a/tests/postgres/pipeline.rs
+++ b/tests/postgres/pipeline.rs
@@ -1,0 +1,130 @@
+// Test PgExtendedQueryPipeline
+
+use sqlx::postgres::PgExtendedQueryPipeline;
+use sqlx::PgPool;
+use uuid::{uuid, Uuid};
+
+const MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("tests/postgres/migrations");
+
+async fn cleanup_test_data(
+    pool: &PgPool,
+    user_id: Uuid,
+    post_id: Uuid,
+    comment_id: Uuid,
+) -> sqlx::Result<()> {
+    sqlx::query("DELETE FROM comment WHERE comment_id = $1")
+        .bind(comment_id)
+        .execute(pool)
+        .await?;
+    sqlx::query("DELETE FROM post WHERE post_id = $1")
+        .bind(post_id)
+        .execute(pool)
+        .await?;
+    sqlx::query("DELETE FROM \"user\" WHERE user_id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+// Ensure the test data exists or not
+//
+// not_exists == true => the test data shouldn't exist
+// not_exists == false => the test data is expected to exist
+async fn ensure_test_data(
+    not_exists: bool,
+    user_id: Uuid,
+    post_id: Uuid,
+    comment_id: Uuid,
+    pool: &PgPool,
+) -> sqlx::Result<()> {
+    let user_exists_query =
+        sqlx::query_scalar("SELECT exists(SELECT 1 FROM \"user\" WHERE user_id = $1)")
+            .bind(user_id);
+    let post_exists_query =
+        sqlx::query_scalar("SELECT exists(SELECT 1 FROM post WHERE post_id = $1)").bind(post_id);
+    let comment_exists_query =
+        sqlx::query_scalar("SELECT exists(SELECT 1 FROM comment WHERE comment_id = $1)")
+            .bind(comment_id);
+
+    let user_exists: bool = user_exists_query.fetch_one(pool).await?;
+    assert!(not_exists ^ user_exists);
+
+    let post_exists: bool = post_exists_query.fetch_one(pool).await?;
+    assert!(not_exists ^ post_exists);
+
+    let comment_exists: bool = comment_exists_query.fetch_one(pool).await?;
+    assert!(not_exists ^ comment_exists);
+    Ok(())
+}
+
+#[sqlx::test(migrations = "tests/postgres/migrations")]
+async fn it_executes_pipeline(pool: PgPool) -> sqlx::Result<()> {
+    // 0. ensure the clean state
+
+    let user_id = uuid!("6592b7c0-b531-4613-ace5-94246b7ce0c3");
+    let post_id = uuid!("252c1d98-a9b0-4f18-8298-e59058bdfe16");
+    let comment_id = uuid!("fbbbb7dc-dc6f-4649-b663-8d3636035164");
+
+    cleanup_test_data(&pool, user_id, post_id, comment_id).await?;
+    ensure_test_data(true, user_id, post_id, comment_id, &pool).await?;
+
+    // 1. construct pipeline of 3 inserts
+
+    const EXPECTED_QUERIES_IN_PIPELINE: usize = 3;
+
+    // query with parameters
+    let user_insert_query = sqlx::query(
+        "
+        INSERT INTO \"user\" (user_id, username)
+        VALUES
+        ($1, $2)
+    ",
+    )
+    .bind(user_id)
+    .bind("alice");
+
+    let mut pipeline =
+        PgExtendedQueryPipeline::<EXPECTED_QUERIES_IN_PIPELINE>::from(user_insert_query);
+
+    // query without parameters
+    let post_insert_query = sqlx::query(
+        "
+        INSERT INTO post (post_id, user_id, content)
+        VALUES
+        ('252c1d98-a9b0-4f18-8298-e59058bdfe16', '6592b7c0-b531-4613-ace5-94246b7ce0c3', 'test post')
+    ",
+    );
+
+    pipeline.push(post_insert_query);
+
+    let comment_insert_query = sqlx::query(
+        "
+        INSERT INTO comment (comment_id, post_id, user_id, content)
+        VALUES
+        ($1, $2, $3, $4)
+    ",
+    )
+    .bind(comment_id)
+    .bind(post_id)
+    .bind(user_id)
+    .bind("test comment");
+
+    pipeline.push(comment_insert_query);
+
+    // 2. execute pipeline and validate PgQueryResult values
+    let query_results = pipeline.execute(&pool).await?;
+
+    for result in query_results {
+        // each insert created a row
+        assert_eq!(result.rows_affected(), 1);
+    }
+
+    // 3. assert the data was inserted
+    ensure_test_data(false, user_id, post_id, comment_id, &pool).await?;
+
+    // 4. cleanup
+    cleanup_test_data(&pool, user_id, post_id, comment_id).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds support for [pipelined query execution](https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-PIPELINING)  that uses extended query protocol to run multiple independent queries and finishes the pipeline with `Sync` message.

When there is no explicit transaction the pipelined queries run within an implicit transaction. In case of [CockroachDB](https://www.cockroachlabs.com/docs/stable/transactions.html#automatic-retries) the transaction could be automatically retried on conflict as long as the database server is able to fully buffer the response data.

This image illustrates the pipelined execution but only for a single query. The implemented pipeline prepares all batched queries outside of the implicit transaction.
<img src="https://segmentfault.com/img/bVbjrIW?w=421&h=341"/>

The implementation could be extended with

- ExecutePgPipeline trait, implemented for transaction, connection and pool instances
- FetchPgPipeline trait, implemented for transaction and connection