### PR TITLE
Fix `prepare` race condition in workspaces

### DIFF
--- a/sqlx-cli/src/prepare.rs
+++ b/sqlx-cli/src/prepare.rs
@@ -180,7 +180,15 @@ hint: This command only works in the manifest directory of a Cargo package."#
         bail!("`cargo check` failed with status: {}", check_status);
     }
 
-    let pattern = metadata.target_directory().join("sqlx/query-*.json");
+    // Use a separate sub-directory for each crate in a workspace. This avoids a race condition
+    // where `prepare` can pull in queries from multiple crates if they happen to be generated
+    // simultaneously (e.g. Rust Analyzer building in the background).
+    let current_package_name = metadata.current_package().name();
+    let pattern = metadata
+        .target_directory()
+        .join("sqlx")
+        .join(current_package_name)
+        .join("query-*.json");
 
     let mut data = BTreeMap::new();
 

--- a/sqlx-cli/src/prepare.rs
+++ b/sqlx-cli/src/prepare.rs
@@ -180,14 +180,22 @@ hint: This command only works in the manifest directory of a Cargo package."#
         bail!("`cargo check` failed with status: {}", check_status);
     }
 
-    // Use a separate sub-directory for each crate in a workspace. This avoids a race condition
-    // where `prepare` can pull in queries from multiple crates if they happen to be generated
-    // simultaneously (e.g. Rust Analyzer building in the background).
-    let current_package_name = metadata.current_package().name();
+    let package_dir = if merge {
+        // Merge queries from all workspace crates.
+        "**"
+    } else {
+        // Use a separate sub-directory for each crate in a workspace. This avoids a race condition
+        // where `prepare` can pull in queries from multiple crates if they happen to be generated
+        // simultaneously (e.g. Rust Analyzer building in the background).
+        metadata
+            .current_package()
+            .map(|pkg| pkg.name())
+            .context("Resolving the crate package for the current working directory failed")?
+    };
     let pattern = metadata
         .target_directory()
         .join("sqlx")
-        .join(current_package_name)
+        .join(package_dir)
         .join("query-*.json");
 
     let mut data = BTreeMap::new();

--- a/sqlx-cli/tests/assets/sample_metadata.json
+++ b/sqlx-cli/tests/assets/sample_metadata.json
@@ -30506,7 +30506,7 @@
         "features": []
       }
     ],
-    "root": null
+    "root": "b_in_workspace_lib 0.1.0 (path+file:///home/user/problematic/workspace/b_in_workspace_lib)"
   },
   "target_directory": "/home/user/problematic/workspace/target",
   "version": 1,

--- a/sqlx-macros/src/query/mod.rs
+++ b/sqlx-macros/src/query/mod.rs
@@ -31,6 +31,8 @@ struct Metadata {
     offline: bool,
     database_url: Option<String>,
     #[cfg(feature = "offline")]
+    package_name: String,
+    #[cfg(feature = "offline")]
     target_dir: PathBuf,
     #[cfg(feature = "offline")]
     workspace_root: Arc<Mutex<Option<PathBuf>>>,
@@ -75,6 +77,11 @@ static METADATA: Lazy<Metadata> = Lazy::new(|| {
         .into();
 
     #[cfg(feature = "offline")]
+    let package_name: String = env("CARGO_PKG_NAME")
+      .expect("`CARGO_PKG_NAME` must be set")
+      .into();
+
+    #[cfg(feature = "offline")]
     let target_dir = env("CARGO_TARGET_DIR").map_or_else(|_| "target".into(), |dir| dir.into());
 
     // If a .env file exists at CARGO_MANIFEST_DIR, load environment variables from this,
@@ -109,6 +116,8 @@ static METADATA: Lazy<Metadata> = Lazy::new(|| {
         manifest_dir,
         offline,
         database_url,
+        #[cfg(feature = "offline")]
+        package_name,
         #[cfg(feature = "offline")]
         target_dir,
         #[cfg(feature = "offline")]
@@ -402,7 +411,10 @@ where
     // If the build is offline, the cache is our input so it's pointless to also write data for it.
     #[cfg(feature = "offline")]
     if !offline {
-        let save_dir = METADATA.target_dir.join("sqlx");
+        // Use separate directories for each crate in a workspace. This avoids a race condition
+        // where `cargo sqlx prepare` can pull in queries from multiple crates if they happen to
+        // be built at the same time (e.g. Rust Analyzer building in the background).
+        let save_dir = METADATA.target_dir.join("sqlx").join(&METADATA.package_name);
         std::fs::create_dir_all(&save_dir)?;
         data.save_in(save_dir, input.src_span)?;
     }

--- a/sqlx-macros/src/query/mod.rs
+++ b/sqlx-macros/src/query/mod.rs
@@ -78,8 +78,8 @@ static METADATA: Lazy<Metadata> = Lazy::new(|| {
 
     #[cfg(feature = "offline")]
     let package_name: String = env("CARGO_PKG_NAME")
-      .expect("`CARGO_PKG_NAME` must be set")
-      .into();
+        .expect("`CARGO_PKG_NAME` must be set")
+        .into();
 
     #[cfg(feature = "offline")]
     let target_dir = env("CARGO_TARGET_DIR").map_or_else(|_| "target".into(), |dir| dir.into());
@@ -411,10 +411,13 @@ where
     // If the build is offline, the cache is our input so it's pointless to also write data for it.
     #[cfg(feature = "offline")]
     if !offline {
-        // Use separate directories for each crate in a workspace. This avoids a race condition
-        // where `cargo sqlx prepare` can pull in queries from multiple crates if they happen to
-        // be built at the same time (e.g. Rust Analyzer building in the background).
-        let save_dir = METADATA.target_dir.join("sqlx").join(&METADATA.package_name);
+        // Use a separate sub-directory for each crate in a workspace. This avoids a race condition
+        // where `prepare` can pull in queries from multiple crates if they happen to be generated
+        // simultaneously (e.g. Rust Analyzer building in the background).
+        let save_dir = METADATA
+            .target_dir
+            .join("sqlx")
+            .join(&METADATA.package_name);
         std::fs::create_dir_all(&save_dir)?;
         data.save_in(save_dir, input.src_span)?;
     }


### PR DESCRIPTION
# Description of change

Small PR to change the target directory for offline query caches from `target/sqlx` to `target/sqlx/<CRATE_NAME>`, which fixes the behaviour seen in #2049. CC @djc 

The problem is essentially a race condition: there is a period between `cargo sqlx prepare` deleting the `target/sqlx` directory and reading the queries from it, during which time another process could build/check one of the other crates in the workspace and populate it.

BEFORE, queries for all crates in a workspace would share the `target/sqlx` directory:
```
target/sqlx
├── query-2b192bf413d46a28226de2ad754a382043c483cf55c04d19bdfa916dcbf0e7ae.json
├── query-95d796755ea0ade4578c91d102407ae003487e40922284cdd6f5c8cbc8d0b5e2.json
└── query-e46f12d720e0911c9280a1b43d7aab30beef94861713fa686db77cfe30702792.json
```

AFTER this PR, queries will be placed under their respective crate names:
```
target/sqlx
├── crate-b
│   └── query-2b192bf413d46a28226de2ad754a382043c483cf55c04d19bdfa916dcbf0e7ae.json
├── crate_ç
│   └── query-4750859a2a2de4ee1e5a5c2cf07ba4ca66a31824e0f4504e21640a42081d95c0.json
└── cratea
    └── query-95d796755ea0ade4578c91d102407ae003487e40922284cdd6f5c8cbc8d0b5e2.json
```

You can validate the current and corrected behaviour in the following example workspace https://github.com/cycraig/sqlx_prepare_bug , which can (sometimes) reproduce the non-deterministic behaviour of pulling different queries into `sqlx-data.json` when multiple crates are being compiled during `cargo sqlx prepare` using `sqlx 0.6.1` (it doesn't happen often for me, depends a lot on timing).

Note that crate names should be fine to create directories from, `cargo` does it all the time in the `target` directory. I'm not aware of any platforms where this would be an issue.

~I believe `resolve.root` returned by `cargo metadata` should always be populated using any recent `cargo` version; the convenience `.root_package()` function I used has been around for two years at least but I did have to update the test fixture to include it (was `null`). Only the `prepare` command uses `Metadata` as far as I know, and it requires a non-virtual manifest, so it would error anyway if `resolve` is missing, e.g. when run in workspace roots.~ Edit: failed to account for `cargo sqlx prepare --merged` initially, updated PR.

Edit: I kept the behaviour of `prepare` nuking the entire `target/sqlx` directory just in case. ~Deleting only the relevant sub-crate directory would only be a minor optimisation and it's unclear to me what else it might affect.~ The entire directory should be deleted for `cargo sqlx prepare --merged` anyway.

Edit2: one alternative to this approach might be to pass an environment variable to the `cargo check` invocation in `cargo sqlx prepare` to use a different sub-directory during query caching, but I don't see any advantage to that.

## Related Issue

Resolves #2049.

## Type of change

Not sure if this qualifies as a breaking change, does anyone depend on the location of the query caches in `target/sqlx`? Otherwise it's just a bug fix.

## How the change has been tested

`cd sqlx-cli && cargo test` and manually running the example in https://github.com/cycraig/sqlx_prepare_bug

