### PR TITLE
Use cargo check consistently in `prepare`

### DIFF
--- a/sqlx-cli/src/metadata.rs
+++ b/sqlx-cli/src/metadata.rs
@@ -56,8 +56,8 @@ pub struct Metadata {
     ///
     /// Typically `target` at the workspace root, but can be overridden
     target_directory: PathBuf,
-    /// Package metadata for the crate in the current working directory, None if run from
-    /// a workspace with the `merged` flag.
+    /// Crate in the current working directory, empty if run from a
+    /// virtual workspace root.
     current_package: Option<Package>,
 }
 
@@ -110,8 +110,8 @@ impl FromStr for Metadata {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let cargo_metadata: CargoMetadata = serde_json::from_str(s)?;
 
-        // Extract the package for the current working directory, will be empty if running
-        // from a workspace root.
+        // Extract the package in the current working directory, empty if run from a
+        // virtual workspace root.
         let current_package: Option<Package> = cargo_metadata.root_package().map(Package::from);
 
         let CargoMetadata {


### PR DESCRIPTION
# Description of change

Small PR to change `cargo sqlx prepare` to always use `cargo check`. 

Currently, `prepare` invokes `cargo rustc` by default but switches to `check` when the `--merged` flag is used. This can lead to confusion since certain flags passed to `cargo check` will be rejected by `cargo rustc` when running `prepare`.

The current behaviour also contradicts the [`sqlx-cli` README](https://github.com/launchbadge/sqlx/blob/3f7111f05de2984aa00ad00fe6a670bca9db0aa0/sqlx-cli/README.md#include-queries-behind-feature-flags-such-as-queries-inside-of-tests), which states:

> In order for sqlx to be able to find queries behind certain feature flags you need to turn them on by passing arguments to rustc.
>
> This is how you would turn all targets and features on.
> ```
> cargo sqlx prepare -- --all-targets --all-features
> ```

Which actually fails with the following error:

```
error: extra arguments to `rustc` can only be passed to one target, consider filtering
the package by passing, e.g., `--lib` or `--bin NAME` to specify a single target
error: `cargo check` failed with status: exit code: 101   
```

But passes with `--merged`, regardless of whether the current directory is a workspace root or a sub-crate.
`cargo sqlx prepare --merged -- --all-targets --all-features`

This PR ensures it works with or without `--merged`.

When the working directory is a crate in a workspace, it still only builds the queries for it and not the entire workspace.
Is there any reason to retain the behaviour of using `rustc` directly? Edit: does this negatively affect plans for #1706?

This arose from the following comment thread: https://github.com/launchbadge/sqlx/pull/2069#issuecomment-1226870482

Alternative: update the documentation/README.md to specify `--merged` must be used to combine the queries of multiple targets, even when in a single crate.

P.S. sorry for spamming PRs.

## Type of change

Bug fix to match the intended behaviour, but might technically be a breaking change as it changes which flags are accepted or not.

## How the change has been tested

`cd sqlx-cli && cargo test` and running `cargo sqlx prepare -- --all-targets --all-features` in a sample project.

