### PR TITLE
close unnamed portal after each executed extended query

### DIFF
--- a/sqlx-core/src/postgres/message/close.rs
+++ b/sqlx-core/src/postgres/message/close.rs
@@ -9,7 +9,8 @@ const CLOSE_STATEMENT: u8 = b'S';
 #[allow(dead_code)]
 pub enum Close {
     Statement(Oid),
-    Portal(Oid),
+    // None selects the unnamed portal
+    Portal(Option<Oid>),
 }
 
 impl Encode<'_> for Close {
@@ -26,7 +27,7 @@ impl Encode<'_> for Close {
 
             Close::Portal(id) => {
                 buf.push(CLOSE_PORTAL);
-                buf.put_portal_name(Some(*id));
+                buf.put_portal_name(*id);
             }
         })
     }


### PR DESCRIPTION
This allows to free server resources earlier and run the same logic as simple Query does:

"The simple Query message is approximately equivalent to the series Parse, Bind, portal Describe, Execute, Close, Sync,"