### PR TITLE
Sqlite explain plan log efficiency

### DIFF
--- a/sqlx-core/src/logger.rs
+++ b/sqlx-core/src/logger.rs
@@ -89,28 +89,24 @@ pub(crate) struct QueryPlanLogger<'q, O: Debug + Hash + Eq, R: Debug + Hash + Eq
     sql: &'q str,
     unknown_operations: HashSet<O>,
     results: HashSet<R>,
-    program: Vec<P>,
+    program: &'q [P],
     settings: LogSettings,
 }
 
 #[cfg(feature = "sqlite")]
 impl<'q, O: Debug + Hash + Eq, R: Debug + Hash + Eq, P: Debug> QueryPlanLogger<'q, O, R, P> {
-    pub(crate) fn new(sql: &'q str, settings: LogSettings) -> Self {
+    pub(crate) fn new(sql: &'q str, program: &'q [P], settings: LogSettings) -> Self {
         Self {
             sql,
             unknown_operations: HashSet::new(),
             results: HashSet::new(),
-            program: Vec::new(),
+            program,
             settings,
         }
     }
 
     pub(crate) fn add_result(&mut self, result: R) {
         self.results.insert(result);
-    }
-
-    pub(crate) fn add_program(&mut self, program: Vec<P>) {
-        self.program = program;
     }
 
     pub(crate) fn add_unknown_operation(&mut self, operation: O) {

--- a/sqlx-core/src/logger.rs
+++ b/sqlx-core/src/logger.rs
@@ -105,6 +105,19 @@ impl<'q, O: Debug + Hash + Eq, R: Debug, P: Debug> QueryPlanLogger<'q, O, R, P> 
         }
     }
 
+    pub(crate) fn log_enabled(&self) -> bool {
+        if let Some(_lvl) = self
+            .settings
+            .statements_level
+            .to_level()
+            .filter(|lvl| log::log_enabled!(target: "sqlx::explain", *lvl))
+        {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     pub(crate) fn add_result(&mut self, result: R) {
         self.results.push(result);
     }

--- a/sqlx-core/src/logger.rs
+++ b/sqlx-core/src/logger.rs
@@ -85,28 +85,28 @@ impl<'q> Drop for QueryLogger<'q> {
 }
 
 #[cfg(feature = "sqlite")]
-pub(crate) struct QueryPlanLogger<'q, O: Debug + Hash + Eq, R: Debug + Hash + Eq, P: Debug> {
+pub(crate) struct QueryPlanLogger<'q, O: Debug + Hash + Eq, R: Debug, P: Debug> {
     sql: &'q str,
     unknown_operations: HashSet<O>,
-    results: HashSet<R>,
+    results: Vec<R>,
     program: &'q [P],
     settings: LogSettings,
 }
 
 #[cfg(feature = "sqlite")]
-impl<'q, O: Debug + Hash + Eq, R: Debug + Hash + Eq, P: Debug> QueryPlanLogger<'q, O, R, P> {
+impl<'q, O: Debug + Hash + Eq, R: Debug, P: Debug> QueryPlanLogger<'q, O, R, P> {
     pub(crate) fn new(sql: &'q str, program: &'q [P], settings: LogSettings) -> Self {
         Self {
             sql,
             unknown_operations: HashSet::new(),
-            results: HashSet::new(),
+            results: Vec::new(),
             program,
             settings,
         }
     }
 
     pub(crate) fn add_result(&mut self, result: R) {
-        self.results.insert(result);
+        self.results.push(result);
     }
 
     pub(crate) fn add_unknown_operation(&mut self, operation: O) {
@@ -152,9 +152,7 @@ impl<'q, O: Debug + Hash + Eq, R: Debug + Hash + Eq, P: Debug> QueryPlanLogger<'
 }
 
 #[cfg(feature = "sqlite")]
-impl<'q, O: Debug + Hash + Eq, R: Debug + Hash + Eq, P: Debug> Drop
-    for QueryPlanLogger<'q, O, R, P>
-{
+impl<'q, O: Debug + Hash + Eq, R: Debug, P: Debug> Drop for QueryPlanLogger<'q, O, R, P> {
     fn drop(&mut self) {
         self.finish();
     }

--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -753,9 +753,12 @@ pub(super) fn explain(
                             .collect(),
                     );
 
-                    let program_history: Vec<&(i64, String, i64, i64, i64, Vec<u8>)> =
-                        state.history.iter().map(|i| &program[*i]).collect();
-                    logger.add_result((program_history, state.result.clone()));
+                    if logger.log_enabled() {
+                        let program_history: Vec<&(i64, String, i64, i64, i64, Vec<u8>)> =
+                            state.history.iter().map(|i| &program[*i]).collect();
+                        logger.add_result((program_history, state.result.clone()));
+                    }
+
                     result_states.push(state.clone());
                 }
 

--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -328,16 +328,16 @@ pub(super) fn explain(
     conn: &mut ConnectionState,
     query: &str,
 ) -> Result<(Vec<SqliteTypeInfo>, Vec<Option<bool>>), Error> {
-    let mut logger = crate::logger::QueryPlanLogger::new(query, conn.log_settings.clone());
-
     let root_block_cols = root_block_columns(conn)?;
     let program: Vec<(i64, String, i64, i64, i64, Vec<u8>)> =
         execute::iter(conn, &format!("EXPLAIN {}", query), None, false)?
             .filter_map(|res| res.map(|either| either.right()).transpose())
             .map(|row| FromRow::from_row(&row?))
             .collect::<Result<Vec<_>, Error>>()?;
-    logger.add_program(program.clone());
     let program_size = program.len();
+
+    let mut logger =
+        crate::logger::QueryPlanLogger::new(query, &program, conn.log_settings.clone());
 
     let mut states = vec![QueryState {
         visited: vec![false; program_size],
@@ -588,7 +588,7 @@ pub(super) fn explain(
                             );
                         }
 
-                        _ => logger.add_unknown_operation(program[state.program_i].clone()),
+                        _ => logger.add_unknown_operation(&program[state.program_i]),
                     }
                 }
 
@@ -753,8 +753,8 @@ pub(super) fn explain(
                             .collect(),
                     );
 
-                    let program_history: Vec<(i64, String, i64, i64, i64, Vec<u8>)> =
-                        state.history.iter().map(|i| program[*i].clone()).collect();
+                    let program_history: Vec<&(i64, String, i64, i64, i64, Vec<u8>)> =
+                        state.history.iter().map(|i| &program[*i]).collect();
                     logger.add_result((program_history, state.result.clone()));
                     result_states.push(state.clone());
                 }
@@ -766,7 +766,7 @@ pub(super) fn explain(
                 _ => {
                     // ignore unsupported operations
                     // if we fail to find an r later, we just give up
-                    logger.add_unknown_operation(program[state.program_i].clone());
+                    logger.add_unknown_operation(&program[state.program_i]);
                 }
             }
 


### PR DESCRIPTION
Reduce overhead of sqlite explain plan logging.

Partial fix for #1921

Very rough 
`initial 
real    3m26.159s 
user    3m23.611s 
sys     0m1.920s  

capture program & operations by reference 
real    3m7.704s 
user    3m6.264s 
sys     0m0.754s 

use Vec instead of HashSet for results 
real    1m24.922s              
user    1m24.317s              
sys     0m0.562s               

check logging enabled before cloning result 
real    1m17.668s                    
user    1m17.047s                    
sys     0m0.521s
`