### PR TITLE
Fix sqlite compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ rand_xoshiro = "0.6.0"
 hex = "0.4.3"
 tempdir = "0.3.7"
 # Needed to test SQLCipher
-libsqlite3-sys = { version = "0.24", features = ["bundled-sqlcipher"] }
+libsqlite3-sys = { version = "0.25", features = ["bundled-sqlcipher"] }
 
 #
 # Any

--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -360,8 +360,8 @@ impl BranchStateHash {
         let mut cur = vec![];
         for (k, v) in &st.p {
             match v {
-                CursorDataType::Normal(hm) => {
-                    for (i, col) in hm {
+                CursorDataType::Normal { cols, .. } => {
+                    for (i, col) in cols {
                         cur.push((*k, *i, Some(col.clone())));
                     }
                 }


### PR DESCRIPTION
# Description

Small change to fix compilation errors on the [0.7-dev](https://github.com/launchbadge/sqlx/tree/0.7-dev) branch from merging #1946, #1960 and #2094 (nothing was wrong with any of those PRs, just a merging thing).

## Motivation

Compilation errors blocking further work. Figured it would be better to fix them in a separate PR.

### Error 1:
```rust
error: failed to select a version for `libsqlite3-sys`.
    ... required by package `sqlx v0.6.2 (<...>\sqlx)`
    ... which satisfies path dependency `sqlx` (locked to 0.6.2) of package `files v0.1.0 (<...>\sqlx\examples\postgres\files)`
versions that meet the requirements `^0.24` are: 0.24.2, 0.24.1, 0.24.0                                
```

### Error 2:

```rust
   Compiling sqlx-core v0.6.2 (<...>\sqlx\sqlx-core)
error[E0532]: expected tuple struct or tuple variant, found struct variant `CursorDataType::Normal`
   --> sqlx-core\src\sqlite\connection\explain.rs:363:17
    |
188 | /     Normal {
189 | |         cols: HashMap<i64, ColumnType>,
190 | |         is_empty: Option<bool>,
191 | |     },
    | |_____- `CursorDataType::Normal` defined here
...
363 |                   CursorDataType::Normal(hm) => {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
help: use struct pattern syntax instead
    |
363 |                 CursorDataType::Normal { cols, is_empty } => {
    |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
help: consider importing this tuple variant instead
```