### PR TITLE
Allow using complex types in `try_from` when deriving `FromRow`

### DIFF
--- a/sqlx-macros-core/src/derives/attributes.rs
+++ b/sqlx-macros-core/src/derives/attributes.rs
@@ -3,7 +3,7 @@ use quote::{quote, quote_spanned};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::token::Comma;
-use syn::{Attribute, DeriveInput, Field, Lit, Meta, MetaNameValue, NestedMeta, Variant};
+use syn::{Attribute, DeriveInput, Field, Lit, Meta, MetaNameValue, NestedMeta, Type, Variant};
 
 macro_rules! assert_attribute {
     ($e:expr, $err:expr, $input:expr) => {
@@ -62,7 +62,7 @@ pub struct SqlxChildAttributes {
     pub rename: Option<String>,
     pub default: bool,
     pub flatten: bool,
-    pub try_from: Option<Ident>,
+    pub try_from: Option<Type>,
 }
 
 pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContainerAttributes> {

--- a/tests/mysql/macros.rs
+++ b/tests/mysql/macros.rs
@@ -460,7 +460,7 @@ async fn test_try_from_attr_with_complex_type() -> anyhow::Result<()> {
     let (mut conn, id) = with_test_row(&mut conn).await?;
 
     let record = sqlx::query_as::<_, Record>("select id from tweet")
-        .fetch_one(&mut conn)
+        .fetch_one(&mut *conn)
         .await?;
 
     assert_eq!(record.id, id.0 as u64);

--- a/tests/mysql/macros.rs
+++ b/tests/mysql/macros.rs
@@ -435,4 +435,37 @@ async fn test_try_from_attr_with_flatten() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[sqlx_macros::test]
+async fn test_try_from_attr_with_complex_type() -> anyhow::Result<()> {
+    mod m {
+        #[derive(sqlx::Type)]
+        #[sqlx(transparent)]
+        pub struct ComplexType<T>(T);
+
+        impl std::convert::TryFrom<ComplexType<i64>> for u64 {
+            type Error = std::num::TryFromIntError;
+            fn try_from(value: ComplexType<i64>) -> Result<Self, Self::Error> {
+                u64::try_from(value.0)
+            }
+        }
+    }
+
+    #[derive(sqlx::FromRow)]
+    struct Record {
+        #[sqlx(try_from = "m::ComplexType<i64>")]
+        id: u64,
+    }
+
+    let mut conn = new::<MySql>().await?;
+    let (mut conn, id) = with_test_row(&mut conn).await?;
+
+    let record = sqlx::query_as::<_, Record>("select id from tweet")
+        .fetch_one(&mut conn)
+        .await?;
+
+    assert_eq!(record.id, id.0 as u64);
+
+    Ok(())
+}
+
 // we don't emit bind parameter type-checks for MySQL so testing the overrides is redundant


### PR DESCRIPTION
Hello :wave: 

The new attribute `try_from` for the `FromRow` derive introduced by #1081 expects the value of `try_from` to be a simple identifier instead of a full-fledged type. This means that that attribute cannot be used unless the referenced type is already in scope.

```rust
#[derive(sqlx::FromRow)]
struct Record {
    #[sqlx(try_from = "SomeType")] // <- This is fine
    id: u64,
}

#[derive(sqlx::FromRow)]
struct Record {
    #[sqlx(try_from = "another::SomeType")] // <- This currently fails, but it should be allowed
    id: u64,
}
```

This PR allows using complex types as the argument of `try_from` instead of just simple identifiers.