### PR TITLE
Add JSON support to `FromRow` derive

### DIFF
--- a/sqlx-core/src/from_row.rs
+++ b/sqlx-core/src/from_row.rs
@@ -1,5 +1,4 @@
-use crate::error::Error;
-use crate::row::Row;
+use crate::{error::Error, row::Row};
 
 /// A record that can be built from a row returned by the database.
 ///
@@ -210,6 +209,48 @@ use crate::row::Row;
 ///
 /// In MySql, `BigInt` type matches `i64`, but you can convert it to `u64` by `try_from`.
 ///
+/// #### `json`
+///
+/// If your database supports a JSON type, you can leverage `#[sqlx(json)]`
+/// to automatically integrate JSON deserialization in your [`FromRow`] implementation using [`serde`](https://docs.rs/serde/latest/serde/).
+///
+/// ```rust,ignore
+/// #[derive(serde::Deserialize)]
+/// struct Data {
+///     field1: String,
+///     field2: u64
+/// }
+///
+/// #[derive(sqlx::FromRow)]
+/// struct User {
+///     id: i32,
+///     name: String,
+///     #[sqlx(json)]
+///     metadata: Data
+/// }
+/// ```
+///
+/// Given a query like the following:
+///
+/// ```sql
+/// SELECT
+///     1 AS id,
+///     'Name' AS name,
+///     JSON_OBJECT('field1', 'value1', 'field2', 42) AS metadata
+/// ```
+///
+/// The `metadata` field will be deserialized used its `serde::Deserialize` implementation:
+///
+/// ```rust,ignore
+/// User {
+///     id: 1,
+///     name: "Name",
+///     metadata: Data {
+///         field1: "value1",
+///         field2: 42
+///     }
+/// }
+/// ```
 pub trait FromRow<'r, R: Row>: Sized {
     fn from_row(row: &'r R) -> Result<Self, Error>;
 }

--- a/sqlx-macros-core/src/derives/row.rs
+++ b/sqlx-macros-core/src/derives/row.rs
@@ -123,7 +123,7 @@ fn expand_derive_from_row_struct(
                     predicates
                         .push(parse_quote!(::sqlx::types::Json<#try_from>: ::sqlx::decode::Decode<#lifetime, R::Database>));
                     predicates.push(parse_quote!(::sqlx::types::Json<#try_from>: ::sqlx::types::Type<R::Database>));
-                    
+
                     parse_quote!(
                         row.try_get::<::sqlx::types::Json<_>, _>(#id_s).and_then(|v|
                             <#ty as ::std::convert::TryFrom::<#try_from>>::try_from(v.0)

--- a/sqlx-macros-core/src/derives/row.rs
+++ b/sqlx-macros-core/src/derives/row.rs
@@ -78,45 +78,67 @@ fn expand_derive_from_row_struct(
                 ));
             }
 
-            let expr: Expr = match (attributes.flatten, attributes.try_from) {
-                (true, None) => {
-                    predicates.push(parse_quote!(#ty: ::sqlx::FromRow<#lifetime, R>));
-                    parse_quote!(<#ty as ::sqlx::FromRow<#lifetime, R>>::from_row(row))
-                }
-                (false, None) => {
+            let id_s = attributes
+                .rename
+                .or_else(|| Some(id.to_string().trim_start_matches("r#").to_owned()))
+                .map(|s| match container_attributes.rename_all {
+                    Some(pattern) => rename_all(&s, pattern),
+                    None => s,
+                })
+                .unwrap();
+
+            let expr: Expr = match (attributes.flatten, attributes.try_from, attributes.json) {
+                // <No attributes>
+                (false, None, false) => {
                     predicates
                         .push(parse_quote!(#ty: ::sqlx::decode::Decode<#lifetime, R::Database>));
                     predicates.push(parse_quote!(#ty: ::sqlx::types::Type<R::Database>));
 
-                    let id_s = attributes
-                        .rename
-                        .or_else(|| Some(id.to_string().trim_start_matches("r#").to_owned()))
-                        .map(|s| match container_attributes.rename_all {
-                            Some(pattern) => rename_all(&s, pattern),
-                            None => s,
-                        })
-                        .unwrap();
                     parse_quote!(row.try_get(#id_s))
                 }
-                (true,Some(try_from)) => {
+                // Flatten
+                (true, None, false) => {
+                    predicates.push(parse_quote!(#ty: ::sqlx::FromRow<#lifetime, R>));
+                    parse_quote!(<#ty as ::sqlx::FromRow<#lifetime, R>>::from_row(row))
+                }
+                // Flatten + Try from
+                (true, Some(try_from), false) => {
                     predicates.push(parse_quote!(#try_from: ::sqlx::FromRow<#lifetime, R>));
                     parse_quote!(<#try_from as ::sqlx::FromRow<#lifetime, R>>::from_row(row).and_then(|v| <#ty as ::std::convert::TryFrom::<#try_from>>::try_from(v).map_err(|e| ::sqlx::Error::ColumnNotFound("FromRow: try_from failed".to_string())))) 
                 }
-                (false,Some(try_from)) => {
+                // Flatten + Json
+                (true, _, true) => {
+                    panic!("Cannot use both flatten and json")
+                }
+                // Try from
+                (false, Some(try_from), false) => {
                     predicates
                         .push(parse_quote!(#try_from: ::sqlx::decode::Decode<#lifetime, R::Database>));
                     predicates.push(parse_quote!(#try_from: ::sqlx::types::Type<R::Database>)); 
 
-                    let id_s = attributes
-                        .rename
-                        .or_else(|| Some(id.to_string().trim_start_matches("r#").to_owned()))
-                        .map(|s| match container_attributes.rename_all {
-                            Some(pattern) => rename_all(&s, pattern),
-                            None => s,
-                        })
-                        .unwrap();
                     parse_quote!(row.try_get(#id_s).and_then(|v| <#ty as ::std::convert::TryFrom::<#try_from>>::try_from(v).map_err(|e| ::sqlx::Error::ColumnNotFound("FromRow: try_from failed".to_string()))))
                 }
+                // Try from + Json
+                (false, Some(try_from), true) => {
+                    predicates
+                        .push(parse_quote!(::sqlx::types::Json<#try_from>: ::sqlx::decode::Decode<#lifetime, R::Database>));
+                    predicates.push(parse_quote!(::sqlx::types::Json<#try_from>: ::sqlx::types::Type<R::Database>));
+                    
+                    parse_quote!(
+                        row.try_get::<::sqlx::types::Json<_>, _>(#id_s).and_then(|v|
+                            <#ty as ::std::convert::TryFrom::<#try_from>>::try_from(v.0)
+                            .map_err(|e| ::sqlx::Error::ColumnNotFound("FromRow: try_from failed".to_string()))
+                        )
+                    )
+                },
+                // Json
+                (false, None, true) => {
+                    predicates
+                        .push(parse_quote!(::sqlx::types::Json<#ty>: ::sqlx::decode::Decode<#lifetime, R::Database>));
+                    predicates.push(parse_quote!(::sqlx::types::Json<#ty>: ::sqlx::types::Type<R::Database>));
+
+                    parse_quote!(row.try_get::<::sqlx::types::Json<_>, _>(#id_s).map(|x| x.0))
+                },
             };
 
             if attributes.default {


### PR DESCRIPTION
Hello :wave: 

This PR is a proposal to discuss JSON support for the `FromRow` derive. The proposal is to add a new `json` attribute to indicate that a field should be decoded using `sqlx::types::Json` instead of the field type.

## Motivation

The currently existing derive for `FromRow` allows quick and easy type conversions using `TryFrom`. This saves us a lot of boilerplate code just for the sake of converting types. Unfortunately `TryFrom`-based conversions are not enough for json values:

```rust
#[derive(FromRow)]
struct Record {
  #[sqlx(try_from = "i64")]
  counter: u64,
  #[sqlx(try_from = "Json<Metadata>")] // <- Does not work
  metadata: Metadata
}

#[derive(serde::Deserialize)]
struct Metadata {
  some: String,
  fields: String.
}
```

Due to Rust's rules, we can't just add an `impl<T> From<Json<T>> for T` as that would violate the orphan rules, so at the moment, we are stuck with one of two solutions:

1. Change the type of the `metadata` field from `Metadata` to `Json<Metadata>`.
2. Manually implement `FromRow`.

Neither of these two solutions are ideal IMHO, hence this proposal of adding a new `json` attribute that will take care of the JSON deserialization and all the necessary type conversions. Using this new attribute, the previous example would become:

```rust
#[derive(FromRow)]
struct Record {
    #[sqlx(try_from = "i64")]
    counter: u64,
    #[sqlx(json)] // <- New attribute
    metadata: Metadata
}

#[derive(serde::Deserialize)]
struct Metadata {
    some: String,
    fields: String.
}
```

## Example generated code

The example above would (roughly) expand to:

```rust
#[derive(serde::Deserialize)]
struct Metadata {
    some: String,
    fields: String.
}

struct Record {
    counter: u64,
    metadata: Metadata
}

impl<'a, R: sqlx::Row> sqlx::FromRow<'a, R> for Record
where
    &'a str: sqlx::ColumnIndex<R>,
    i64: sqlx::decode::Decode<'a, R::Database>,
    i64: sqlx::types::Type<R::Database>,
    sqlx::types::Json<Metadata>: sqlx::decode::Decode<'a, R::Database>, // <- New bound
    sqlx::types::Json<Metadata>: sqlx::types::Type<R::Database>, // <- New bound
{
    fn from_row(row: &'a R) -> sqlx::Result<Self> {
        // Code generated by `try_from`.
        let counter = row.try_get("counter")
            .and_then(|v| <u64 as ::std::convert::TryFrom::<i64>>::try_from(v)
                .map_err(|e| ::sqlx::Error::ColumnNotFound("FromRow: try_from failed".to_string())
            ))?;

        // NEW: Code generated by json. Uses `try_get` with `sqlx::types::Json` instead of `Metadata`.
        let metadata: Metadata = row.try_get::<sqlx::types::Json<_>, _>("metadata").map(|x| x.0)?;

        Ok(Record {
            counter,
            metadata,
        })
    }
}
```

## Interactions with the already existing attributes

- `rename` and `default`. They work as before, no interference with `json`.
- `flatten`. I don't think it makes sense to use both `flatten` and `json` on the same field, so this combination is rejected.
- `try_from`. If we have a field`#[sqlx(json, try_from = "X")] field: Y`, the value will be first deserialized to `X` and then converted using `std::convert::TryFrom` to `Y`.