### PR TITLE
Document how to connect to a SQLite file

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,12 @@ Differences from `query()`:
     ```
     DATABASE_URL=mysql://localhost/my_database
     ```
+    
+    For a file-based database like SQLite, you must set absolute path using `$PWD` variable, where `$PWD` will be set to the location of the `.env` file.
+    
+    ```
+    DATABASE_URL=sqlite://$PWD/my_database.db
+    ```
 
 [dotenv]: https://github.com/dotenv-rs/dotenv#examples
 


### PR DESCRIPTION
SQLite file is different from all other services due to it being a local file rather than a service.  Configuring relative path fails to build one of the steps, whereas setting invalid file also fails the build but at a different stage. Using the $PWD seems to be the only solution I found.

## Update
Seems $PWD is not really needed, but there are clearly some limitations and issues with using sqlite, relative paths, and workspaces. See also https://github.com/launchbadge/sqlx/issues/1399