### PR TITLE
Postgres OID resolution query does not take into account current `search_path`

### DIFF
--- a/sqlx-postgres/src/connection/describe.rs
+++ b/sqlx-postgres/src/connection/describe.rs
@@ -344,17 +344,13 @@ WHERE rngtypid = $1
         }
 
         // language=SQL
-        let (oid,): (Oid,) = query_as(
-            "
-SELECT $1::regtype::oid
-                ",
-        )
-        .bind(name)
-        .fetch_optional(&mut *self)
-        .await?
-        .ok_or_else(|| Error::TypeNotFound {
-            type_name: String::from(name),
-        })?;
+        let (oid,): (Oid,) = query_as("SELECT $1::regtype::oid")
+            .bind(name)
+            .fetch_optional(&mut *self)
+            .await?
+            .ok_or_else(|| Error::TypeNotFound {
+                type_name: String::from(name),
+            })?;
 
         self.cache_type_oid.insert(name.to_string().into(), oid);
         Ok(oid)

--- a/sqlx-postgres/src/connection/describe.rs
+++ b/sqlx-postgres/src/connection/describe.rs
@@ -346,7 +346,7 @@ WHERE rngtypid = $1
         // language=SQL
         let (oid,): (Oid,) = query_as(
             "
-SELECT oid FROM pg_catalog.pg_type WHERE typname ILIKE $1
+SELECT $1::regtype::oid
                 ",
         )
         .bind(name)

--- a/sqlx-postgres/src/connection/mod.rs
+++ b/sqlx-postgres/src/connection/mod.rs
@@ -176,6 +176,8 @@ impl Connection for PgConnection {
 
     fn clear_cached_statements(&mut self) -> BoxFuture<'_, Result<(), Error>> {
         Box::pin(async move {
+            self.cache_type_oid.clear();
+
             let mut cleared = 0_usize;
 
             self.wait_until_ready().await?;


### PR DESCRIPTION
## Problem

The current strategy employed to resolve a user-defined type name to an OID does not take into account the current `search_path`. This might cause some issues if we have different types with the same name in different schemas.

I noticed this behaviour because I'm working on a project that uses Postgres schemas to isolate integration tests by creating a new schema for each one, which means that I have a lot of types with the same name in different schemas.

```sql
CREATE TYPE status AS ENUM('open', 'closed');

CREATE SCHEMA test123;
CREATE TYPE test123.status AS ENUM('open', 'closed');
```

As an example, if we open a new connection and set the `search_path` to `test123`, `INSERT`s referencing the enum `status` start failing:

```rust
#[derive(sqlx::Type)]
#[sqlx(type_name = "status", rename_all = "lowercase")]
enum Status {
    Open,
    Closed
}

// Open a connection and set `search_path` to `test123`
let mut conn: PgConnection = todo!();
sqlx::query("SET search_path = 'test123'").execute(&mut conn).await.unwrap();

// Try inserting some data in a table using the `status` enum.
// This query fails with an error saying that the type `status` cannot be converted to `test123.status`.
sqlx::query("INSERT INTO some_table(id, status) VALUES ($1, $2)")
    .bind(123 as i32)
    .bind(Status::Open)
    .execute(&mut conn)
    .await
    .unwrap(); // This panics
```

The root of the error lies in the resolution of the type name `status` to OID that `sqlx` does when encoding the parameters for the `INSERT`, because the `status` name has been unexpectedly resolved to the `public.status` enum, and not to the `test123.status` enum.

The query used to resolve the name involves a `SELECT` from the table `pg_catalog.pg_type`, which is not namespaced, and thus, if we have multiple types with the same name, it will select one of them at random (even if in my tests, the `public` schema always was first, but I have no idea whether this is granted or not).

## Proposed solution

Postgres has a native syntax to resolve type names to OIDs, which is `'some_type':regtype::oid`, which correctly takes into account the current `search_path`. This PR proposes changing the current query with:

```sqlx
SELECT $1::regtype::oid
```

In order to respect the `search_path` of the current connection.

## Drawbacks

The first drawback I can think of is caching. Connections cache the `type name => oid` mappings for obvious performance reasons, and this change would make the cached mappings invalid _if_ the `search_path` changes after a type has been resolved.

We _could_ decide to expose methods on the connections to manually clear the type cache (like we have right now for statements), but I'm not exactly sure it is worth it.

Also, please note that I have no idea whether this is a breaking change or not. I ran all the Postgres tests locally and they were green.