### PR TITLE
Exposing the Oid of PostgreSQL types

### DIFF
--- a/sqlx-core/src/postgres/type_info.rs
+++ b/sqlx-core/src/postgres/type_info.rs
@@ -165,6 +165,11 @@ impl PgTypeInfo {
         self.0.kind()
     }
 
+    /// Returns the OID for this type.
+    pub fn oid(&self) -> Oid {
+        self.0.oid()
+    }
+
     #[doc(hidden)]
     pub fn __type_feature_gate(&self) -> Option<&'static str> {
         if [


### PR DESCRIPTION
This PR closes #1111. It adds a function to retrieve OIDs, which is very useful in very dynamic schemas, such as DBMSs or when you want to provide a more low-level interface to the DB.