### PR TITLE
Bump ipnetwork to 0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [[#2057]]: Make begin,commit,rollback cancel-safe in sqlite  [[@madadam]]
 * [[#2058]]: fix typo in documentation [[@lovasoa]]
 * [[#2067]]: fix(docs): close code block in query_builder.rs [[@abonander]]
-* [[#2069]]: Fix `prepare` race condition in workspaces [[@cycraig]]
+* [[#2069]]: Fix `prepare` race condition in workspaces [[@cycraig]]\
+    * NOTE: this changes the directory structure under `target/` that `cargo sqlx prepare` depends on.
+      If you use offline mode in your workflow, please rerun `cargo install sqlx-cli` to upgrade.
 * [[#2072]]: SqliteConnectOptions typo [[@fasterthanlime]]
 * [[#2074]]: fix: mssql uses unsigned for tinyint instead of signed [[@he4d]]
 * [[#2081]]: close unnamed portal after each executed extended query [[@DXist]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1445,9 +1445,9 @@ checksum = "24c3f4eff5495aee4c0399d7b6a0dc2b6e81be84242ffbfcf253ebacccc1d0cb"
 
 [[package]]
 name = "ipnetwork"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f84f1612606f3753f205a4e9a2efd6fe5b4c573a6269b2cc6c3003d44a0d127"
+checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
 
 [[package]]
 name = "itertools"

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -132,7 +132,7 @@ generic-array = { version = "0.14.4", default-features = false, optional = true 
 hex = "0.4.3"
 hmac = { version = "0.12.0", default-features = false, optional = true }
 itoa = "1.0.1"
-ipnetwork = { version = "0.19.0", default-features = false, optional = true }
+ipnetwork = { version = "0.20.0", default-features = false, optional = true }
 mac_address = { version = "1.1.2", default-features = false, optional = true }
 libc = "0.2.112"
 libsqlite3-sys = { version = "0.24.1", optional = true, default-features = false, features = [


### PR DESCRIPTION
Similar to #1426, bumps the `ipnetwork` dependency to 0.20.

Diff: https://github.com/achanda/ipnetwork/compare/v0.19.0...v0.20.0