### PR TITLE
fix(deps): update to libsqlite3-sys v0.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,9 +1546,9 @@ checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
+checksum = "9f0455f2c1bc9a7caa792907026e469c1d91761fb0ea37cbb16427c77280cf35"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ rand_xoshiro = "0.6.0"
 hex = "0.4.3"
 tempdir = "0.3.7"
 # Needed to test SQLCipher
-libsqlite3-sys = { version = "0.24", features = ["bundled-sqlcipher"] }
+libsqlite3-sys = { version = "0.25.1", features = ["bundled-sqlcipher"] }
 
 #
 # Any

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -135,7 +135,7 @@ itoa = "1.0.1"
 ipnetwork = { version = "0.19.0", default-features = false, optional = true }
 mac_address = { version = "1.1.2", default-features = false, optional = true }
 libc = "0.2.112"
-libsqlite3-sys = { version = "0.24.1", optional = true, default-features = false, features = [
+libsqlite3-sys = { version = "0.25.1", optional = true, default-features = false, features = [
     "pkg-config",
     "vcpkg",
     "bundled",

--- a/sqlx-core/src/sqlite/statement/unlock_notify.rs
+++ b/sqlx-core/src/sqlite/statement/unlock_notify.rs
@@ -48,7 +48,7 @@ impl Notify {
     }
 
     fn wait(&self) {
-        let _ = self
+        let _unused = self
             .condvar
             .wait_while(self.mutex.lock().unwrap(), |fired| !*fired)
             .unwrap();


### PR DESCRIPTION
v0.25.1 the latest published version of libsqlite3-sys, and upgrades sqlite to 3.39.2:
https://github.com/rusqlite/rusqlite/blob/sys0.25.1/libsqlite3-sys/sqlite3/bindgen_bundled_version.rs#L3

Which contains the first SQLite version containing the fix to [CVE-2022-35737](https://nvd.nist.gov/vuln/detail/CVE-2022-35737).

More details on the vulnerability:
https://blog.trailofbits.com/2022/10/25/sqlite-vulnerability-july-2022-library-api/