### PR TITLE
Add regression tests for sqlite explain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,9 +1546,9 @@ checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
+checksum = "9f0455f2c1bc9a7caa792907026e469c1d91761fb0ea37cbb16427c77280cf35"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ rand_xoshiro = "0.6.0"
 hex = "0.4.3"
 tempdir = "0.3.7"
 # Needed to test SQLCipher
-libsqlite3-sys = { version = "0.24", features = ["bundled-sqlcipher"] }
+libsqlite3-sys = { version = "0.25", features = ["bundled-sqlcipher"] }
 
 #
 # Any

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -135,7 +135,7 @@ itoa = "1.0.1"
 ipnetwork = { version = "0.19.0", default-features = false, optional = true }
 mac_address = { version = "1.1.2", default-features = false, optional = true }
 libc = "0.2.112"
-libsqlite3-sys = { version = "0.24.1", optional = true, default-features = false, features = [
+libsqlite3-sys = { version = "0.25.1", optional = true, default-features = false, features = [
     "pkg-config",
     "vcpkg",
     "bundled",

--- a/sqlx-core/src/mysql/testing/mod.rs
+++ b/sqlx-core/src/mysql/testing/mod.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write;
+use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -152,7 +153,11 @@ async fn test_context(args: &TestArgs) -> Result<TestContext<MySql>, Error> {
             // Close connections ASAP if left in the idle queue.
             .idle_timeout(Some(Duration::from_secs(1)))
             .parent(master_pool.clone()),
-        connect_opts: master_pool.connect_options().clone().database(&new_db_name),
+        connect_opts: master_pool
+            .connect_options()
+            .deref()
+            .clone()
+            .database(&new_db_name),
         db_name: new_db_name,
     })
 }

--- a/sqlx-core/src/postgres/testing/mod.rs
+++ b/sqlx-core/src/postgres/testing/mod.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write;
+use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -159,7 +160,11 @@ async fn test_context(args: &TestArgs) -> Result<TestContext<Postgres>, Error> {
             // Close connections ASAP if left in the idle queue.
             .idle_timeout(Some(Duration::from_secs(1)))
             .parent(master_pool.clone()),
-        connect_opts: master_pool.connect_options().clone().database(&new_db_name),
+        connect_opts: master_pool
+            .connect_options()
+            .deref()
+            .clone()
+            .database(&new_db_name),
         db_name: new_db_name,
     })
 }

--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -360,8 +360,8 @@ impl BranchStateHash {
         let mut cur = vec![];
         for (k, v) in &st.p {
             match v {
-                CursorDataType::Normal(hm) => {
-                    for (i, col) in hm {
+                CursorDataType::Normal { cols, .. } => {
+                    for (i, col) in cols {
                         cur.push((*k, *i, Some(col.clone())));
                     }
                 }

--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -4,6 +4,7 @@ use crate::sqlite::connection::{execute, ConnectionState};
 use crate::sqlite::type_info::DataType;
 use crate::sqlite::SqliteTypeInfo;
 use crate::HashMap;
+use std::collections::HashSet;
 use std::str::from_utf8;
 
 // affinity
@@ -121,7 +122,7 @@ const OP_CONCAT: &str = "Concat";
 const OP_RESULT_ROW: &str = "ResultRow";
 const OP_HALT: &str = "Halt";
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 struct ColumnType {
     pub datatype: DataType,
     pub nullable: Option<bool>,
@@ -145,7 +146,7 @@ impl ColumnType {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 enum RegDataType {
     Single(ColumnType),
     Record(Vec<ColumnType>),
@@ -341,6 +342,49 @@ struct QueryState {
     pub result: Option<Vec<(Option<SqliteTypeInfo>, Option<bool>)>>,
 }
 
+#[derive(Debug, Hash, PartialEq, Eq)]
+struct BranchStateHash {
+    instruction: usize,
+    registers: Vec<(i64, RegDataType)>,
+    cursors: Vec<(i64, i64, Option<ColumnType>)>,
+}
+
+impl BranchStateHash {
+    pub fn from_query_state(st: &QueryState) -> Self {
+        let mut reg = vec![];
+        for (k, v) in &st.r {
+            reg.push((*k, v.clone()));
+        }
+        reg.sort_by_key(|v| v.0);
+
+        let mut cur = vec![];
+        for (k, v) in &st.p {
+            match v {
+                CursorDataType::Normal(hm) => {
+                    for (i, col) in hm {
+                        cur.push((*k, *i, Some(col.clone())));
+                    }
+                }
+                CursorDataType::Pseudo(i) => {
+                    cur.push((*k, *i, None));
+                }
+            }
+        }
+        cur.sort_by(|a, b| {
+            if a.0 == b.0 {
+                a.1.cmp(&b.1)
+            } else {
+                a.0.cmp(&b.0)
+            }
+        });
+        Self {
+            instruction: st.program_i,
+            registers: reg,
+            cursors: cur,
+        }
+    }
+}
+
 // Opcode Reference: https://sqlite.org/opcode.html
 pub(super) fn explain(
     conn: &mut ConnectionState,
@@ -365,6 +409,8 @@ pub(super) fn explain(
         program_i: 0,
         result: None,
     }];
+
+    let mut visited_branch_state: HashSet<BranchStateHash> = HashSet::new();
 
     let mut result_states = Vec::new();
 
@@ -407,7 +453,12 @@ pub(super) fn explain(
 
                     let mut branch_state = state.clone();
                     branch_state.program_i = p2 as usize;
-                    states.push(branch_state);
+
+                    let bs_hash = BranchStateHash::from_query_state(&branch_state);
+                    if !visited_branch_state.contains(&bs_hash) {
+                        visited_branch_state.insert(bs_hash);
+                        states.push(branch_state);
+                    }
 
                     state.program_i += 1;
                     continue;
@@ -520,15 +571,27 @@ pub(super) fn explain(
 
                     let mut branch_state = state.clone();
                     branch_state.program_i = p1 as usize;
-                    states.push(branch_state);
+                    let bs_hash = BranchStateHash::from_query_state(&branch_state);
+                    if !visited_branch_state.contains(&bs_hash) {
+                        visited_branch_state.insert(bs_hash);
+                        states.push(branch_state);
+                    }
 
                     let mut branch_state = state.clone();
                     branch_state.program_i = p2 as usize;
-                    states.push(branch_state);
+                    let bs_hash = BranchStateHash::from_query_state(&branch_state);
+                    if !visited_branch_state.contains(&bs_hash) {
+                        visited_branch_state.insert(bs_hash);
+                        states.push(branch_state);
+                    }
 
                     let mut branch_state = state.clone();
                     branch_state.program_i = p3 as usize;
-                    states.push(branch_state);
+                    let bs_hash = BranchStateHash::from_query_state(&branch_state);
+                    if !visited_branch_state.contains(&bs_hash) {
+                        visited_branch_state.insert(bs_hash);
+                        states.push(branch_state);
+                    }
                 }
 
                 OP_COLUMN => {

--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -88,6 +88,7 @@ const OP_OPEN_WRITE: &str = "OpenWrite";
 const OP_OPEN_EPHEMERAL: &str = "OpenEphemeral";
 const OP_OPEN_AUTOINDEX: &str = "OpenAutoindex";
 const OP_AGG_FINAL: &str = "AggFinal";
+const OP_AGG_VALUE: &str = "AggValue";
 const OP_AGG_STEP: &str = "AggStep";
 const OP_FUNCTION: &str = "Function";
 const OP_MOVE: &str = "Move";
@@ -727,11 +728,16 @@ pub(super) fn explain(
                     //else we don't know about the cursor
                 }
 
-                OP_AGG_STEP => {
+                OP_AGG_STEP | OP_AGG_VALUE => {
                     //assume that AGG_FINAL will be called
                     let p4 = from_utf8(p4).map_err(Error::protocol)?;
 
-                    if p4.starts_with("count(") {
+                    if p4.starts_with("count(")
+                        || p4.starts_with("row_number(")
+                        || p4.starts_with("rank(")
+                        || p4.starts_with("dense_rank(")
+                        || p4.starts_with("ntile(")
+                    {
                         // count(_) -> INTEGER
                         state.r.insert(
                             p3,
@@ -749,7 +755,12 @@ pub(super) fn explain(
                 OP_AGG_FINAL => {
                     let p4 = from_utf8(p4).map_err(Error::protocol)?;
 
-                    if p4.starts_with("count(") {
+                    if p4.starts_with("count(")
+                        || p4.starts_with("row_number(")
+                        || p4.starts_with("rank(")
+                        || p4.starts_with("dense_rank(")
+                        || p4.starts_with("ntile(")
+                    {
                         // count(_) -> INTEGER
                         state.r.insert(
                             p1,

--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -67,7 +67,11 @@ const OP_SEEK_LT: &str = "SeekLT";
 const OP_SEEK_ROW_ID: &str = "SeekRowId";
 const OP_SEEK_SCAN: &str = "SeekScan";
 const OP_SEQUENCE_TEST: &str = "SequenceTest";
+const OP_SORT: &str = "Sort";
+const OP_SORTER_DATA: &str = "SorterData";
+const OP_SORTER_INSERT: &str = "SorterInsert";
 const OP_SORTER_NEXT: &str = "SorterNext";
+const OP_SORTER_OPEN: &str = "SorterOpen";
 const OP_SORTER_SORT: &str = "SorterSort";
 const OP_V_FILTER: &str = "VFilter";
 const OP_V_NEXT: &str = "VNext";
@@ -180,29 +184,36 @@ impl RegDataType {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 enum CursorDataType {
-    Normal(HashMap<i64, ColumnType>),
+    Normal {
+        cols: HashMap<i64, ColumnType>,
+        is_empty: Option<bool>,
+    },
     Pseudo(i64),
 }
 
 impl CursorDataType {
-    fn from_sparse_record(record: &HashMap<i64, ColumnType>) -> Self {
-        Self::Normal(
-            record
+    fn from_sparse_record(record: &HashMap<i64, ColumnType>, is_empty: Option<bool>) -> Self {
+        Self::Normal {
+            cols: record
                 .iter()
                 .map(|(&colnum, &datatype)| (colnum, datatype))
                 .collect(),
-        )
+            is_empty,
+        }
     }
 
-    fn from_dense_record(record: &Vec<ColumnType>) -> Self {
-        Self::Normal((0..).zip(record.iter().copied()).collect())
+    fn from_dense_record(record: &Vec<ColumnType>, is_empty: Option<bool>) -> Self {
+        Self::Normal {
+            cols: (0..).zip(record.iter().copied()).collect(),
+            is_empty,
+        }
     }
 
     fn map_to_dense_record(&self, registers: &HashMap<i64, RegDataType>) -> Vec<ColumnType> {
         match self {
-            Self::Normal(record) => {
-                let mut rowdata = vec![ColumnType::default(); record.len()];
-                for (idx, col) in record.iter() {
+            Self::Normal { cols, .. } => {
+                let mut rowdata = vec![ColumnType::default(); cols.len()];
+                for (idx, col) in cols.iter() {
                     rowdata[*idx as usize] = col.clone();
                 }
                 rowdata
@@ -219,11 +230,18 @@ impl CursorDataType {
         registers: &HashMap<i64, RegDataType>,
     ) -> HashMap<i64, ColumnType> {
         match self {
-            Self::Normal(c) => c.clone(),
+            Self::Normal { cols, .. } => cols.clone(),
             Self::Pseudo(i) => match registers.get(i) {
                 Some(RegDataType::Record(r)) => (0..).zip(r.iter().copied()).collect(),
                 _ => HashMap::new(),
             },
+        }
+    }
+
+    fn is_empty(&self) -> Option<bool> {
+        match self {
+            Self::Normal { is_empty, .. } => *is_empty,
+            Self::Pseudo(_) => Some(false), //pseudo cursors have exactly one row
         }
     }
 }
@@ -379,11 +397,11 @@ pub(super) fn explain(
                 | OP_GE | OP_GO_SUB | OP_GT | OP_IDX_GE | OP_IDX_GT | OP_IDX_LE | OP_IDX_LT
                 | OP_IF | OP_IF_NO_HOPE | OP_IF_NOT | OP_IF_NOT_OPEN | OP_IF_NOT_ZERO
                 | OP_IF_NULL_ROW | OP_IF_POS | OP_IF_SMALLER | OP_INCR_VACUUM | OP_IS_NULL
-                | OP_IS_NULL_OR_TYPE | OP_LE | OP_LAST | OP_LT | OP_MUST_BE_INT | OP_NE
-                | OP_NEXT | OP_NO_CONFLICT | OP_NOT_EXISTS | OP_NOT_NULL | OP_ONCE | OP_PREV
-                | OP_PROGRAM | OP_ROW_SET_READ | OP_ROW_SET_TEST | OP_SEEK_GE | OP_SEEK_GT
-                | OP_SEEK_LE | OP_SEEK_LT | OP_SEEK_ROW_ID | OP_SEEK_SCAN | OP_SEQUENCE_TEST
-                | OP_SORTER_NEXT | OP_SORTER_SORT | OP_V_FILTER | OP_V_NEXT | OP_REWIND => {
+                | OP_IS_NULL_OR_TYPE | OP_LE | OP_LT | OP_MUST_BE_INT | OP_NE | OP_NEXT
+                | OP_NO_CONFLICT | OP_NOT_EXISTS | OP_NOT_NULL | OP_ONCE | OP_PREV | OP_PROGRAM
+                | OP_ROW_SET_READ | OP_ROW_SET_TEST | OP_SEEK_GE | OP_SEEK_GT | OP_SEEK_LE
+                | OP_SEEK_LT | OP_SEEK_ROW_ID | OP_SEEK_SCAN | OP_SEQUENCE_TEST
+                | OP_SORTER_NEXT | OP_V_FILTER | OP_V_NEXT => {
                     // goto <p2> or next instruction (depending on actual values)
                     state.visited[state.program_i] = true;
 
@@ -393,6 +411,35 @@ pub(super) fn explain(
 
                     state.program_i += 1;
                     continue;
+                }
+
+                OP_REWIND | OP_LAST | OP_SORT | OP_SORTER_SORT => {
+                    // goto <p2> if cursor p1 is empty, else next instruction
+                    state.visited[state.program_i] = true;
+
+                    if let Some(cursor) = state.p.get(&p1) {
+                        if matches!(cursor.is_empty(), None | Some(true)) {
+                            //only take this branch if the cursor is empty
+
+                            let mut branch_state = state.clone();
+                            branch_state.program_i = p2 as usize;
+
+                            if let Some(CursorDataType::Normal { is_empty, .. }) =
+                                branch_state.p.get_mut(&p1)
+                            {
+                                *is_empty = Some(true);
+                            }
+                            states.push(branch_state);
+                        }
+
+                        if matches!(cursor.is_empty(), None | Some(false)) {
+                            //only take this branch if the cursor is non-empty
+                            state.program_i += 1;
+                            continue;
+                        }
+                    }
+
+                    break;
                 }
 
                 OP_INIT_COROUTINE => {
@@ -503,7 +550,7 @@ pub(super) fn explain(
                     }
                 }
 
-                OP_ROW_DATA => {
+                OP_ROW_DATA | OP_SORTER_DATA => {
                     //Get entire row from cursor p1, store it into register p2
                     if let Some(record) = state.p.get(&p1) {
                         let rowdata = record.map_to_dense_record(&state.r);
@@ -528,11 +575,14 @@ pub(super) fn explain(
                     state.r.insert(p3, RegDataType::Record(record));
                 }
 
-                OP_INSERT | OP_IDX_INSERT => {
+                OP_INSERT | OP_IDX_INSERT | OP_SORTER_INSERT => {
                     if let Some(RegDataType::Record(record)) = state.r.get(&p2) {
-                        if let Some(CursorDataType::Normal(row)) = state.p.get_mut(&p1) {
+                        if let Some(CursorDataType::Normal { cols, is_empty }) =
+                            state.p.get_mut(&p1)
+                        {
                             // Insert the record into wherever pointer p1 is
-                            *row = (0..).zip(record.iter().copied()).collect();
+                            *cols = (0..).zip(record.iter().copied()).collect();
+                            *is_empty = Some(false);
                         }
                     }
                     //Noop if the register p2 isn't a record, or if pointer p1 does not exist
@@ -548,24 +598,35 @@ pub(super) fn explain(
                         if let Some(columns) = root_block_cols.get(&p2) {
                             state
                                 .p
-                                .insert(p1, CursorDataType::from_sparse_record(columns));
+                                .insert(p1, CursorDataType::from_sparse_record(columns, None));
                         } else {
-                            state
-                                .p
-                                .insert(p1, CursorDataType::Normal(HashMap::with_capacity(6)));
+                            state.p.insert(
+                                p1,
+                                CursorDataType::Normal {
+                                    cols: HashMap::with_capacity(6),
+                                    is_empty: None,
+                                },
+                            );
                         }
                     } else {
-                        state
-                            .p
-                            .insert(p1, CursorDataType::Normal(HashMap::with_capacity(6)));
+                        state.p.insert(
+                            p1,
+                            CursorDataType::Normal {
+                                cols: HashMap::with_capacity(6),
+                                is_empty: None,
+                            },
+                        );
                     }
                 }
 
-                OP_OPEN_EPHEMERAL | OP_OPEN_AUTOINDEX => {
+                OP_OPEN_EPHEMERAL | OP_OPEN_AUTOINDEX | OP_SORTER_OPEN => {
                     //Create a new pointer which is referenced by p1
                     state.p.insert(
                         p1,
-                        CursorDataType::from_dense_record(&vec![ColumnType::null(); p2 as usize]),
+                        CursorDataType::from_dense_record(
+                            &vec![ColumnType::null(); p2 as usize],
+                            Some(true),
+                        ),
                     );
                 }
 
@@ -594,8 +655,9 @@ pub(super) fn explain(
 
                 OP_NULL_ROW => {
                     // all columns in cursor X are potentially nullable
-                    if let Some(CursorDataType::Normal(ref mut cursor)) = state.p.get_mut(&p1) {
-                        for ref mut col in cursor.values_mut() {
+                    if let Some(CursorDataType::Normal { ref mut cols, .. }) = state.p.get_mut(&p1)
+                    {
+                        for ref mut col in cols.values_mut() {
                             col.nullable = Some(true);
                         }
                     }
@@ -649,10 +711,37 @@ pub(super) fn explain(
                     }
                 }
 
-                OP_COPY | OP_MOVE | OP_SCOPY | OP_INT_COPY => {
+                OP_SCOPY | OP_INT_COPY => {
                     // r[p2] = r[p1]
                     if let Some(v) = state.r.get(&p1).cloned() {
                         state.r.insert(p2, v);
+                    }
+                }
+
+                OP_COPY => {
+                    // r[p2..=p2+p3] = r[p1..=p1+p3]
+                    if p3 >= 0 {
+                        for i in 0..=p3 {
+                            let src = p1 + i;
+                            let dst = p2 + i;
+                            if let Some(v) = state.r.get(&src).cloned() {
+                                state.r.insert(dst, v);
+                            }
+                        }
+                    }
+                }
+
+                OP_MOVE => {
+                    // r[p2..p2+p3] = r[p1..p1+p3]; r[p1..p1+p3] = null
+                    if p3 >= 1 {
+                        for i in 0..p3 {
+                            let src = p1 + i;
+                            let dst = p2 + i;
+                            if let Some(v) = state.r.get(&src).cloned() {
+                                state.r.insert(dst, v);
+                                state.r.insert(src, RegDataType::Single(ColumnType::null()));
+                            }
+                        }
                     }
                 }
 


### PR DESCRIPTION
<details><summary>Original: Fix SQLx+Sqlite incorrectly inferring column as nullable when using ORDER BY and LIMIT in the same query</summary>

* Issue reproduction repo: https://github.com/0rvar/sqlx-sqlite-option-repro
* Issue introduced in PR https://github.com/launchbadge/sqlx/pull/1816

**Status**: added a failing test, reading through the opcode state machine in `explain`.
Tips and ideas are appreciated.

Related:
* https://github.com/launchbadge/sqlx/issues/1852

Semi-related: 
* https://github.com/launchbadge/sqlx/issues/2127
* https://github.com/launchbadge/sqlx/issues/1294

</details>

It seems the original issue was already fixed in 0.7-dev.
I changed this PR to add more tests for the issues in 0.6 if they are of interest - otherwise, feel free to just close this.