### PR TITLE
Add an option to enable/disable pretty print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [[#2057]]: Make begin,commit,rollback cancel-safe in sqlite  [[@madadam]]
 * [[#2058]]: fix typo in documentation [[@lovasoa]]
 * [[#2067]]: fix(docs): close code block in query_builder.rs [[@abonander]]
-* [[#2069]]: Fix `prepare` race condition in workspaces [[@cycraig]]
+* [[#2069]]: Fix `prepare` race condition in workspaces [[@cycraig]]\
+    * NOTE: this changes the directory structure under `target/` that `cargo sqlx prepare` depends on.
+      If you use offline mode in your workflow, please rerun `cargo install sqlx-cli` to upgrade.
 * [[#2072]]: SqliteConnectOptions typo [[@fasterthanlime]]
 * [[#2074]]: fix: mssql uses unsigned for tinyint instead of signed [[@he4d]]
 * [[#2081]]: close unnamed portal after each executed extended query [[@DXist]]

--- a/sqlx-core/src/any/options.rs
+++ b/sqlx-core/src/any/options.rs
@@ -233,4 +233,29 @@ impl ConnectOptions for AnyConnectOptions {
         };
         self
     }
+
+    fn pretty_print(&mut self, pretty_print: bool) -> &mut Self {
+        match &mut self.0 {
+            #[cfg(feature = "postgres")]
+            AnyConnectOptionsKind::Postgres(o) => {
+                o.pretty_print(pretty_print);
+            }
+
+            #[cfg(feature = "mysql")]
+            AnyConnectOptionsKind::MySql(o) => {
+                o.pretty_print(pretty_print);
+            }
+
+            #[cfg(feature = "sqlite")]
+            AnyConnectOptionsKind::Sqlite(o) => {
+                o.pretty_print(pretty_print);
+            }
+
+            #[cfg(feature = "mssql")]
+            AnyConnectOptionsKind::Mssql(o) => {
+                o.pretty_print(pretty_print);
+            }
+        };
+        self
+    }
 }

--- a/sqlx-core/src/connection.rs
+++ b/sqlx-core/src/connection.rs
@@ -136,6 +136,7 @@ pub(crate) struct LogSettings {
     pub(crate) statements_level: LevelFilter,
     pub(crate) slow_statements_level: LevelFilter,
     pub(crate) slow_statements_duration: Duration,
+    pub(crate) pretty_print: bool,
 }
 
 impl Default for LogSettings {
@@ -144,6 +145,7 @@ impl Default for LogSettings {
             statements_level: LevelFilter::Info,
             slow_statements_level: LevelFilter::Warn,
             slow_statements_duration: Duration::from_secs(1),
+            pretty_print: true,
         }
     }
 }
@@ -155,6 +157,10 @@ impl LogSettings {
     pub(crate) fn log_slow_statements(&mut self, level: LevelFilter, duration: Duration) {
         self.slow_statements_level = level;
         self.slow_statements_duration = duration;
+    }
+
+    pub(crate)fn pretty_print(&mut self, pretty_print: bool) {
+        self.pretty_print = pretty_print;
     }
 }
 
@@ -178,4 +184,8 @@ pub trait ConnectOptions: 'static + Send + Sync + FromStr<Err = Error> + Debug +
         self.log_statements(LevelFilter::Off)
             .log_slow_statements(LevelFilter::Off, Duration::default())
     }
+
+    /// Print multi-line SQL queries
+    fn pretty_print(&mut self, pretty_print: bool) -> &mut Self;
+
 }

--- a/sqlx-core/src/logger.rs
+++ b/sqlx-core/src/logger.rs
@@ -43,13 +43,19 @@ impl<'q> QueryLogger<'q> {
             self.settings.statements_level
         };
 
+        let pretty = self.settings.pretty_print;
+
         if let Some(lvl) = lvl
             .to_level()
             .filter(|lvl| log::log_enabled!(target: "sqlx::query", *lvl))
         {
-            let mut summary = parse_query_summary(&self.sql);
+            let mut summary = if pretty {
+                parse_query_summary(&self.sql)
+            } else {
+                self.sql.to_owned()
+            };
 
-            let sql = if summary != self.sql {
+            let sql = if pretty && summary != self.sql {
                 summary.push_str(" …");
                 format!(
                     "\n\n{}\n",
@@ -128,14 +134,19 @@ impl<'q, O: Debug + Hash + Eq, R: Debug, P: Debug> QueryPlanLogger<'q, O, R, P> 
 
     pub(crate) fn finish(&self) {
         let lvl = self.settings.statements_level;
+        let pretty = self.settings.pretty_print;
 
         if let Some(lvl) = lvl
             .to_level()
             .filter(|lvl| log::log_enabled!(target: "sqlx::explain", *lvl))
         {
-            let mut summary = parse_query_summary(&self.sql);
+            let mut summary = if pretty {
+                parse_query_summary(&self.sql)
+            } else {
+                self.sql.to_string()
+            };
 
-            let sql = if summary != self.sql {
+            let sql = if pretty && summary != self.sql {
                 summary.push_str(" …");
                 format!(
                     "\n\n{}\n",

--- a/sqlx-core/src/mssql/options/connect.rs
+++ b/sqlx-core/src/mssql/options/connect.rs
@@ -24,4 +24,9 @@ impl ConnectOptions for MssqlConnectOptions {
         self.log_settings.log_slow_statements(level, duration);
         self
     }
+
+    fn pretty_print(&mut self, pretty_print: bool) -> &mut Self {
+        self.log_settings.pretty_print(pretty_print);
+        self
+    }
 }

--- a/sqlx-core/src/mysql/options/connect.rs
+++ b/sqlx-core/src/mysql/options/connect.rs
@@ -71,4 +71,9 @@ impl ConnectOptions for MySqlConnectOptions {
         self.log_settings.log_slow_statements(level, duration);
         self
     }
+
+    fn pretty_print(&mut self, pretty_print: bool) -> &mut Self {
+        self.log_settings.pretty_print(pretty_print);
+        self
+    }
 }

--- a/sqlx-core/src/postgres/options/connect.rs
+++ b/sqlx-core/src/postgres/options/connect.rs
@@ -24,4 +24,9 @@ impl ConnectOptions for PgConnectOptions {
         self.log_settings.log_slow_statements(level, duration);
         self
     }
+
+    fn pretty_print(&mut self, pretty_print: bool) -> &mut Self {
+        self.log_settings.pretty_print(pretty_print);
+        self
+    }
 }

--- a/sqlx-core/src/sqlite/options/connect.rs
+++ b/sqlx-core/src/sqlite/options/connect.rs
@@ -41,6 +41,11 @@ impl ConnectOptions for SqliteConnectOptions {
         self.log_settings.log_slow_statements(level, duration);
         self
     }
+
+    fn pretty_print(&mut self, pretty_print: bool) -> &mut Self {
+        self.log_settings.pretty_print(pretty_print);
+        self
+    }
 }
 
 impl SqliteConnectOptions {


### PR DESCRIPTION
At https://github.com/ethereum/kzg-ceremony-sequencer we use a log format where each line corresponds to a single log message + span data. This allows for easy grepping for `userIds`/`traceIds` in server logs in cases where we don't have proper infrastructure to handle JSON logs.

We can't always guarantee that there won't be a newline in SQL queries but at the very least we can disable SQL formatting to prevent introduction of new newline characters. This should cover majority of our cases.

This PR adds an option to disable SQL formatting (and it respects current defaults).