### PR TITLE
Add postgres support for specifying schema when defining enum type

### DIFF
--- a/sqlx-core/src/type_info.rs
+++ b/sqlx-core/src/type_info.rs
@@ -14,3 +14,13 @@ pub trait TypeInfo: Debug + Display + Clone + PartialEq<Self> + Send + Sync {
         false
     }
 }
+
+pub fn get_type_name(type_name: &str, schema_name: Option<&str>) -> String {
+    let mut val = String::new();
+    if let Some(schema_str) = schema_name {
+        val.push_str(schema_str);
+        val.push('.');
+    }
+    val.push_str(type_name);
+    val
+}

--- a/tests/postgres/derives.rs
+++ b/tests/postgres/derives.rs
@@ -73,6 +73,15 @@ enum ColorUpper {
 }
 
 #[derive(PartialEq, Debug, sqlx::Type)]
+#[sqlx(type_name = "color_upper", schema = "test")]
+#[sqlx(rename_all = "UPPERCASE")]
+enum ColorInTestSchema {
+    Yellow,
+    Orange,
+    Pink,
+}
+
+#[derive(PartialEq, Debug, sqlx::Type)]
 #[sqlx(type_name = "color_screaming_snake")]
 #[sqlx(rename_all = "SCREAMING_SNAKE_CASE")]
 enum ColorScreamingSnake {
@@ -161,9 +170,13 @@ async fn test_enum_type() -> anyhow::Result<()> {
 
     conn.execute(
         r#"
+DROP SCHEMA IF EXISTS test CASCADE;
+CREATE SCHEMA test;
+
 DROP TABLE IF EXISTS people;
 
 DROP TYPE IF EXISTS mood CASCADE;
+
 
 CREATE TYPE mood AS ENUM ( 'ok', 'happy', 'sad' );
 
@@ -174,6 +187,7 @@ DROP TYPE IF EXISTS color_screaming_snake CASCADE;
 DROP TYPE IF EXISTS color_kebab_case CASCADE;
 DROP TYPE IF EXISTS color_mixed_case CASCADE;
 DROP TYPE IF EXISTS color_camel_case CASCADE;
+DROP TYPE IF EXISTS test.color_upper CASCADE;
 
 
 CREATE TYPE color_lower AS ENUM ( 'red', 'green', 'blue' );
@@ -183,6 +197,7 @@ CREATE TYPE color_screaming_snake AS ENUM ( 'RED_GREEN', 'BLUE_BLACK' );
 CREATE TYPE color_kebab_case AS ENUM ( 'red-green', 'blue-black' );
 CREATE TYPE color_mixed_case AS ENUM ( 'redGreen', 'blueBlack' );
 CREATE TYPE color_camel_case AS ENUM ( 'RedGreen', 'BlueBlack' );
+CREATE TYPE test.color_upper AS ENUM ( 'YELLOW', 'ORANGE', 'PINK' );
 
 
 CREATE TABLE people (
@@ -345,6 +360,15 @@ SELECT id, mood FROM people WHERE id = $1
 
     assert!(rec.0);
     assert_eq!(rec.1, ColorPascalCase::RedGreen);
+
+    let rec: (bool, ColorInTestSchema) =
+        sqlx::query_as("SELECT $1 = 'YELLOW'::test.color_upper, $1")
+            .bind(&ColorInTestSchema::Yellow)
+            .fetch_one(&mut conn)
+            .await?;
+
+    assert!(rec.0);
+    assert_eq!(rec.1, ColorInTestSchema::Yellow);
 
     Ok(())
 }


### PR DESCRIPTION
Hello!

Since we also ran into the need for specifying the schema name when defining a postgres enum to avoid collision when the enum types name appears in multiple schemas (https://github.com/launchbadge/sqlx/issues/1171), here is an attempt to implement this feature.

This PR contains the following changes:
- extending the enum type macro to accept a `schema` attribute
- update postgres implementation to treat the enum types name as `schema.enum_name` when schema is specified
- when querying the type info by type id from the `pg_catalog`, the schema's name + the count of type that have the same name as the type that is being queried are joined to the fetched data. In case there are multiple types with the same name, use the `schema.enum_name` format (unless the schema is the default `public` schema, in that case we just use the enum name)
- when querying the type by name and if the `schema` attribute is provided, include it in the fetch query so that only the desired type gets returned.
- add a test for an enum type defined with an already existing name `color_upper` but in a different schema `test` which verified that there is no collision with these 2 enums


This is a quite minimalistic implementation, therefore it's possible that some things are missing (some edge cases that need to be covered/tested, better code design, ...), if so, let me know and I'll be happy to add the requested changes.