### PR TITLE
mysql 5.1: authentication with password

### DIFF
--- a/sqlx-core/src/mysql/connection/establish.rs
+++ b/sqlx-core/src/mysql/connection/establish.rs
@@ -20,6 +20,13 @@ impl MySqlConnection {
         let handshake: Handshake = stream.recv_packet().await?.decode()?;
 
         let mut plugin = handshake.auth_plugin;
+
+        // if a auth plugin is not getting recognized but a password was provided,
+        // fallback to mysql native password
+        if plugin.is_none() && options.password.is_some() {
+            plugin = Some(crate::mysql::protocol::auth::AuthPlugin::MySqlNativePassword)
+        }
+
         let mut nonce = handshake.auth_plugin_data;
 
         // FIXME: server version parse is a bit ugly


### PR DESCRIPTION
I'm in the (un)fortunate situation that I need to access a MySQL 5.1 database. On the current `main` branch, I get the following connection error when trying to access the database with a password: `Error: error returned from database: 1045 (28000): Access denied for user 'XYZ'@'192.168.1.1' (using password: NO)`.

I didn't really take a close look at sqlx/mysql but my change did work for me. It seems the mysql server doesn't return a correct or any auth plugin information. It was a quick hack but maybe it helps someone else as well :).

Thanks for sqlx!