### PR TITLE
binding to an unused variable to avoid immediately dropping the value

### DIFF
--- a/sqlx-core/src/sqlite/statement/unlock_notify.rs
+++ b/sqlx-core/src/sqlite/statement/unlock_notify.rs
@@ -48,7 +48,7 @@ impl Notify {
     }
 
     fn wait(&self) {
-        let _ = self
+        let _ignore = self
             .condvar
             .wait_while(self.mutex.lock().unwrap(), |fired| !*fired)
             .unwrap();


### PR DESCRIPTION
closes #2198