### PR TITLE
Upgrade to libsqlite-sys 0.25

### DIFF
--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -135,7 +135,7 @@ itoa = "1.0.1"
 ipnetwork = { version = "0.19.0", default-features = false, optional = true }
 mac_address = { version = "1.1.2", default-features = false, optional = true }
 libc = "0.2.112"
-libsqlite3-sys = { version = "0.24.1", optional = true, default-features = false, features = [
+libsqlite3-sys = { version = "0.25", optional = true, default-features = false, features = [
     "pkg-config",
     "vcpkg",
     "bundled",


### PR DESCRIPTION
We're using `sqlx` in an application that also needs to use `libsqlite-sys` version 0.25, via a different dependency. This change makes it possible for us to have both dependencies compiled in at once. Let me know if you have a policy around versioning sqlite. Another option I considered was to loosen the `libsqlite-sys` dependency version specifier to something like `>= 0.24.1, <= 0.25`.