### PR TITLE
Added support for locale more locales.

### DIFF
--- a/sqlx-core/src/mssql/protocol/type_info.rs
+++ b/sqlx-core/src/mssql/protocol/type_info.rs
@@ -119,6 +119,7 @@ impl TypeInfo {
                     // which is known as Latin 1.
                     0x0409 => encoding_rs::WINDOWS_1252,
                     0x0424 => encoding_rs::ISO_8859_2,
+                    0x040C => encoding_rs::ISO_8859_16,
 
                     locale => {
                         return Err(err_protocol!("unsupported locale 0x{:04X?}", locale));

--- a/sqlx-core/src/mssql/protocol/type_info.rs
+++ b/sqlx-core/src/mssql/protocol/type_info.rs
@@ -118,9 +118,10 @@ impl TypeInfo {
                     // This is the Western encoding for Windows. It is an extension of ISO-8859-1,
                     // which is known as Latin 1.
                     0x0409 => encoding_rs::WINDOWS_1252,
+                    0x0424 => encoding_rs::ISO_8859_2,
 
                     locale => {
-                        return Err(err_protocol!("unsupported locale 0x{:?}", locale));
+                        return Err(err_protocol!("unsupported locale 0x{:04X?}", locale));
                     }
                 })
             }


### PR DESCRIPTION
Fixed print `unsupported locale 0x{}`. It was in decimal, prepended by `0x`. It's hexadecimal now.

If we want to do further locale matching, we could use [this table](https://learn.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-ver16#Server-level-collations).

Could close the following issues once the table is implemented:
- #2161 
- #796
- #416 