### PR TITLE
Add context to confusing sqlx prepare parse error

### DIFF
--- a/sqlx-cli/src/prepare.rs
+++ b/sqlx-cli/src/prepare.rs
@@ -118,7 +118,9 @@ hint: This command only works in the manifest directory of a Cargo package."#
 
     let output_str =
         std::str::from_utf8(&output.stdout).context("Invalid `cargo metadata` output")?;
-    let metadata: Metadata = output_str.parse()?;
+    let metadata: Metadata = output_str.parse().context(
+        "Issue parsing `cargo metadata` output - consider manually running it to check for issues",
+    )?;
 
     // try removing the target/sqlx directory before running, as stale files
     // have repeatedly caused issues in the past.


### PR DESCRIPTION
Previously, if `cargo metadata` failed to run, `cargo sqlx prepare` would output a cryptic `error: EOF while parsing a value at line 1 column 0` as reported in #2218 

This PR aims to clear up any confusion about the source of the error by changing the message to. `error: Issue parsing 'cargo metadata' output - consider manually running it to check for issues`