### PR TITLE
Add From impls for Json

### DIFF
--- a/sqlx-core/src/types/json.rs
+++ b/sqlx-core/src/types/json.rs
@@ -63,12 +63,6 @@ impl<T> From<T> for Json<T> {
     }
 }
 
-impl<T> From<Json<T>> for T {
-    fn from(Json(value): Json<T>) -> Self {
-        value
-    }
-}
-
 impl<T> Deref for Json<T> {
     type Target = T;
 

--- a/sqlx-core/src/types/json.rs
+++ b/sqlx-core/src/types/json.rs
@@ -57,6 +57,18 @@ use crate::types::Type;
 #[serde(transparent)]
 pub struct Json<T: ?Sized>(pub T);
 
+impl<T> From<T> for Json<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
+impl<T> From<Json<T>> for T {
+    fn from(Json(value): Json<T>) -> Self {
+        value
+    }
+}
+
 impl<T> Deref for Json<T> {
     type Target = T;
 


### PR DESCRIPTION
Implements conversion traits between `Json` and its inner value. Useful for generic code. I ran into this today while trying to return an `impl Into<Foo>` using `sqlx::types::Json`.