### PR TITLE
Sqlite Describe Bugfixes

### DIFF
--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -67,6 +67,7 @@ const OP_SEEK_LE: &str = "SeekLE";
 const OP_SEEK_LT: &str = "SeekLT";
 const OP_SEEK_ROW_ID: &str = "SeekRowId";
 const OP_SEEK_SCAN: &str = "SeekScan";
+const OP_SEQUENCE: &str = "Sequence";
 const OP_SEQUENCE_TEST: &str = "SequenceTest";
 const OP_SORT: &str = "Sort";
 const OP_SORTER_DATA: &str = "SorterData";
@@ -120,6 +121,7 @@ const OP_MULTIPLY: &str = "Multiply";
 const OP_DIVIDE: &str = "Divide";
 const OP_REMAINDER: &str = "Remainder";
 const OP_CONCAT: &str = "Concat";
+const OP_OFFSET_LIMIT: &str = "OffsetLimit";
 const OP_RESULT_ROW: &str = "ResultRow";
 const OP_HALT: &str = "Halt";
 
@@ -455,7 +457,7 @@ pub(super) fn explain(
                 | OP_GE | OP_GO_SUB | OP_GT | OP_IDX_GE | OP_IDX_GT | OP_IDX_LE | OP_IDX_LT
                 | OP_IF | OP_IF_NO_HOPE | OP_IF_NOT | OP_IF_NOT_OPEN | OP_IF_NOT_ZERO
                 | OP_IF_NULL_ROW | OP_IF_POS | OP_IF_SMALLER | OP_INCR_VACUUM | OP_IS_NULL
-                | OP_IS_NULL_OR_TYPE | OP_LE | OP_LT | OP_MUST_BE_INT | OP_NE | OP_NEXT
+                | OP_IS_NULL_OR_TYPE | OP_MUST_BE_INT | OP_LE | OP_LT | OP_NE | OP_NEXT
                 | OP_NO_CONFLICT | OP_NOT_EXISTS | OP_NOT_NULL | OP_ONCE | OP_PREV | OP_PROGRAM
                 | OP_ROW_SET_READ | OP_ROW_SET_TEST | OP_SEEK_GE | OP_SEEK_GT | OP_SEEK_LE
                 | OP_SEEK_LT | OP_SEEK_ROW_ID | OP_SEEK_SCAN | OP_SEQUENCE_TEST
@@ -470,12 +472,18 @@ pub(super) fn explain(
                         visited_branch_state.insert(bs_hash);
                         states.push(branch_state);
                     }
+
                     state.program_i += 1;
                     continue;
                 }
 
                 OP_REWIND | OP_LAST | OP_SORT | OP_SORTER_SORT => {
-                    // goto <p2> if cursor p1 is empty, else next instruction
+                    // goto <p2> if cursor p1 is empty and p2 != 0, else next instruction
+
+                    if p2 == 0 {
+                        state.program_i += 1;
+                        continue;
+                    }
 
                     if let Some(cursor) = state.p.get(&p1) {
                         if matches!(cursor.is_empty(), None | Some(true)) {
@@ -496,6 +504,8 @@ pub(super) fn explain(
                             //only take this branch if the cursor is non-empty
                             state.program_i += 1;
                             continue;
+                        } else {
+                            break;
                         }
                     }
 
@@ -659,6 +669,19 @@ pub(super) fn explain(
                     }
                 }
 
+                OP_SEQUENCE => {
+                    //Copy sequence number from cursor p1 to register p2, increment cursor p1 sequence number
+
+                    //Cursor emulation doesn't sequence value, but it is an int
+                    state.r.insert(
+                        p2,
+                        RegDataType::Single(ColumnType {
+                            datatype: DataType::Int64,
+                            nullable: Some(false),
+                        }),
+                    );
+                }
+
                 OP_ROW_DATA | OP_SORTER_DATA => {
                     //Get entire row from cursor p1, store it into register p2
                     if let Some(record) = state.p.get(&p1) {
@@ -701,6 +724,7 @@ pub(super) fn explain(
                     // Create a cursor p1 aliasing the record from register p2
                     state.p.insert(p1, CursorDataType::Pseudo(p2));
                 }
+
                 OP_OPEN_READ | OP_OPEN_WRITE => {
                     //Create a new pointer which is referenced by p1, take column metadata from db schema if found
                     if p3 == 0 {
@@ -941,6 +965,17 @@ pub(super) fn explain(
 
                         _ => {}
                     }
+                }
+
+                OP_OFFSET_LIMIT => {
+                    // r[p2] = if r[p2] < 0 { r[p1] } else if r[p1]<0 { -1 } else { r[p1] + r[p3] }
+                    state.r.insert(
+                        p2,
+                        RegDataType::Single(ColumnType {
+                            datatype: DataType::Int64,
+                            nullable: Some(false),
+                        }),
+                    );
                 }
 
                 OP_RESULT_ROW => {

--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -123,6 +123,8 @@ const OP_CONCAT: &str = "Concat";
 const OP_RESULT_ROW: &str = "ResultRow";
 const OP_HALT: &str = "Halt";
 
+const MAX_LOOP_COUNT: u8 = 2;
+
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 struct ColumnType {
     pub datatype: DataType,
@@ -331,7 +333,9 @@ fn root_block_columns(
 
 #[derive(Debug, Clone, PartialEq)]
 struct QueryState {
-    pub visited: Vec<bool>,
+    // The number of times each instruction has been visited
+    pub visited: Vec<u8>,
+    // A log of the order of execution of each instruction
     pub history: Vec<usize>,
     // Registers
     pub r: HashMap<i64, RegDataType>,
@@ -403,7 +407,7 @@ pub(super) fn explain(
         crate::logger::QueryPlanLogger::new(query, &program, conn.log_settings.clone());
 
     let mut states = vec![QueryState {
-        visited: vec![false; program_size],
+        visited: vec![0; program_size],
         history: Vec::new(),
         r: HashMap::with_capacity(6),
         p: HashMap::with_capacity(6),
@@ -417,25 +421,32 @@ pub(super) fn explain(
 
     while let Some(mut state) = states.pop() {
         while state.program_i < program_size {
-            if state.visited[state.program_i] {
-                state.program_i += 1;
+            let (_, ref opcode, p1, p2, p3, ref p4) = program[state.program_i];
+            state.history.push(state.program_i);
+
+            if state.visited[state.program_i] > MAX_LOOP_COUNT {
+                if logger.log_enabled() {
+                    let program_history: Vec<&(i64, String, i64, i64, i64, Vec<u8>)> =
+                        state.history.iter().map(|i| &program[*i]).collect();
+                    logger.add_result((program_history, None));
+                }
+
                 //avoid (infinite) loops by breaking if we ever hit the same instruction twice
                 break;
             }
-            let (_, ref opcode, p1, p2, p3, ref p4) = program[state.program_i];
-            state.history.push(state.program_i);
+
+            state.visited[state.program_i] += 1;
 
             match &**opcode {
                 OP_INIT => {
                     // start at <p2>
-                    state.visited[state.program_i] = true;
                     state.program_i = p2 as usize;
                     continue;
                 }
 
                 OP_GOTO => {
                     // goto <p2>
-                    state.visited[state.program_i] = true;
+
                     state.program_i = p2 as usize;
                     continue;
                 }
@@ -450,7 +461,6 @@ pub(super) fn explain(
                 | OP_SEEK_LT | OP_SEEK_ROW_ID | OP_SEEK_SCAN | OP_SEQUENCE_TEST
                 | OP_SORTER_NEXT | OP_V_FILTER | OP_V_NEXT => {
                     // goto <p2> or next instruction (depending on actual values)
-                    state.visited[state.program_i] = true;
 
                     let mut branch_state = state.clone();
                     branch_state.program_i = p2 as usize;
@@ -460,14 +470,12 @@ pub(super) fn explain(
                         visited_branch_state.insert(bs_hash);
                         states.push(branch_state);
                     }
-
                     state.program_i += 1;
                     continue;
                 }
 
                 OP_REWIND | OP_LAST | OP_SORT | OP_SORTER_SORT => {
                     // goto <p2> if cursor p1 is empty, else next instruction
-                    state.visited[state.program_i] = true;
 
                     if let Some(cursor) = state.p.get(&p1) {
                         if matches!(cursor.is_empty(), None | Some(true)) {
@@ -491,12 +499,18 @@ pub(super) fn explain(
                         }
                     }
 
+                    if logger.log_enabled() {
+                        let program_history: Vec<&(i64, String, i64, i64, i64, Vec<u8>)> =
+                            state.history.iter().map(|i| &program[*i]).collect();
+                        logger.add_result((program_history, None));
+                    }
+
                     break;
                 }
 
                 OP_INIT_COROUTINE => {
                     // goto <p2> or next instruction (depending on actual values)
-                    state.visited[state.program_i] = true;
+
                     state.r.insert(p1, RegDataType::Int(p3));
 
                     if p2 != 0 {
@@ -509,7 +523,7 @@ pub(super) fn explain(
 
                 OP_END_COROUTINE => {
                     // jump to p2 of the yield instruction pointed at by register p1
-                    state.visited[state.program_i] = true;
+
                     if let Some(RegDataType::Int(yield_i)) = state.r.get(&p1) {
                         if let Some((_, yield_op, _, yield_p2, _, _)) =
                             program.get(*yield_i as usize)
@@ -519,31 +533,58 @@ pub(super) fn explain(
                                 state.r.remove(&p1);
                                 continue;
                             } else {
+                                if logger.log_enabled() {
+                                    let program_history: Vec<&(
+                                        i64,
+                                        String,
+                                        i64,
+                                        i64,
+                                        i64,
+                                        Vec<u8>,
+                                    )> = state.history.iter().map(|i| &program[*i]).collect();
+                                    logger.add_result((program_history, None));
+                                }
+
                                 break;
                             }
                         } else {
+                            if logger.log_enabled() {
+                                let program_history: Vec<&(i64, String, i64, i64, i64, Vec<u8>)> =
+                                    state.history.iter().map(|i| &program[*i]).collect();
+                                logger.add_result((program_history, None));
+                            }
                             break;
                         }
                     } else {
+                        if logger.log_enabled() {
+                            let program_history: Vec<&(i64, String, i64, i64, i64, Vec<u8>)> =
+                                state.history.iter().map(|i| &program[*i]).collect();
+                            logger.add_result((program_history, None));
+                        }
                         break;
                     }
                 }
 
                 OP_RETURN => {
                     // jump to the instruction after the instruction pointed at by register p1
-                    state.visited[state.program_i] = true;
+
                     if let Some(RegDataType::Int(return_i)) = state.r.get(&p1) {
                         state.program_i = (*return_i + 1) as usize;
                         state.r.remove(&p1);
                         continue;
                     } else {
+                        if logger.log_enabled() {
+                            let program_history: Vec<&(i64, String, i64, i64, i64, Vec<u8>)> =
+                                state.history.iter().map(|i| &program[*i]).collect();
+                            logger.add_result((program_history, None));
+                        }
                         break;
                     }
                 }
 
                 OP_YIELD => {
                     // jump to p2 of the yield instruction pointed at by register p1, store prior instruction in p1
-                    state.visited[state.program_i] = true;
+
                     if let Some(RegDataType::Int(yield_i)) = state.r.get_mut(&p1) {
                         let program_i: usize = state.program_i;
 
@@ -562,13 +603,17 @@ pub(super) fn explain(
                             continue;
                         }
                     } else {
+                        if logger.log_enabled() {
+                            let program_history: Vec<&(i64, String, i64, i64, i64, Vec<u8>)> =
+                                state.history.iter().map(|i| &program[*i]).collect();
+                            logger.add_result((program_history, None));
+                        }
                         break;
                     }
                 }
 
                 OP_JUMP => {
                     // goto one of <p1>, <p2>, or <p3> based on the result of a prior compare
-                    state.visited[state.program_i] = true;
 
                     let mut branch_state = state.clone();
                     branch_state.program_i = p1 as usize;
@@ -900,7 +945,7 @@ pub(super) fn explain(
 
                 OP_RESULT_ROW => {
                     // output = r[p1 .. p1 + p2]
-                    state.visited[state.program_i] = true;
+
                     state.result = Some(
                         (p1..p1 + p2)
                             .map(|i| {
@@ -919,13 +964,18 @@ pub(super) fn explain(
                     if logger.log_enabled() {
                         let program_history: Vec<&(i64, String, i64, i64, i64, Vec<u8>)> =
                             state.history.iter().map(|i| &program[*i]).collect();
-                        logger.add_result((program_history, state.result.clone()));
+                        logger.add_result((program_history, Some(state.result.clone())));
                     }
 
                     result_states.push(state.clone());
                 }
 
                 OP_HALT => {
+                    if logger.log_enabled() {
+                        let program_history: Vec<&(i64, String, i64, i64, i64, Vec<u8>)> =
+                            state.history.iter().map(|i| &program[*i]).collect();
+                        logger.add_result((program_history, None));
+                    }
                     break;
                 }
 
@@ -936,7 +986,6 @@ pub(super) fn explain(
                 }
             }
 
-            state.visited[state.program_i] = true;
             state.program_i += 1;
         }
     }

--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -289,24 +289,22 @@ fn opcode_to_type(op: &str) -> DataType {
 
 fn root_block_columns(
     conn: &mut ConnectionState,
-) -> Result<HashMap<i64, HashMap<i64, ColumnType>>, Error> {
-    let table_block_columns: Vec<(i64, i64, String, bool)> = execute::iter(
+) -> Result<HashMap<(i64, i64), HashMap<i64, ColumnType>>, Error> {
+    let table_block_columns: Vec<(i64, i64, i64, String, bool)> = execute::iter(
         conn,
-        "SELECT s.rootpage, col.cid as colnum, col.type, col.\"notnull\"
-         FROM (select * from sqlite_temp_schema UNION select * from sqlite_schema) s
+        "SELECT s.dbnum, s.rootpage, col.cid as colnum, col.type, col.\"notnull\"
+         FROM (
+             select 1 dbnum, tss.* from temp.sqlite_schema tss
+             UNION ALL select 0 dbnum, mss.* from main.sqlite_schema mss
+             ) s
          JOIN pragma_table_info(s.name) AS col
-         WHERE s.type = 'table'",
-        None,
-        false,
-    )?
-    .filter_map(|res| res.map(|either| either.right()).transpose())
-    .map(|row| FromRow::from_row(&row?))
-    .collect::<Result<Vec<_>, Error>>()?;
-
-    let index_block_columns: Vec<(i64, i64, String, bool)> = execute::iter(
-        conn,
-        "SELECT s.rootpage, idx.seqno as colnum, col.type, col.\"notnull\"
-         FROM (select * from sqlite_temp_schema UNION select * from sqlite_schema) s
+         WHERE s.type = 'table'
+         UNION ALL
+         SELECT s.dbnum, s.rootpage, idx.seqno as colnum, col.type, col.\"notnull\"
+         FROM (
+             select 1 dbnum, tss.* from temp.sqlite_schema tss
+             UNION ALL select 0 dbnum, mss.* from main.sqlite_schema mss
+             ) s
          JOIN pragma_index_info(s.name) AS idx
          LEFT JOIN pragma_table_info(s.tbl_name) as col
            ON col.cid = idx.cid
@@ -318,19 +316,9 @@ fn root_block_columns(
     .map(|row| FromRow::from_row(&row?))
     .collect::<Result<Vec<_>, Error>>()?;
 
-    let mut row_info: HashMap<i64, HashMap<i64, ColumnType>> = HashMap::new();
-    for (block, colnum, datatype, notnull) in table_block_columns {
-        let row_info = row_info.entry(block).or_default();
-        row_info.insert(
-            colnum,
-            ColumnType::Single {
-                datatype: datatype.parse().unwrap_or(DataType::Null),
-                nullable: Some(!notnull),
-            },
-        );
-    }
-    for (block, colnum, datatype, notnull) in index_block_columns {
-        let row_info = row_info.entry(block).or_default();
+    let mut row_info: HashMap<(i64, i64), HashMap<i64, ColumnType>> = HashMap::new();
+    for (dbnum, block, colnum, datatype, notnull) in table_block_columns {
+        let row_info = row_info.entry((dbnum, block)).or_default();
         row_info.insert(
             colnum,
             ColumnType::Single {
@@ -744,8 +732,8 @@ pub(super) fn explain(
 
                 OP_OPEN_READ | OP_OPEN_WRITE => {
                     //Create a new pointer which is referenced by p1, take column metadata from db schema if found
-                    if p3 == 0 {
-                        if let Some(columns) = root_block_cols.get(&p2) {
+                    if p3 == 0 || p3 == 1 {
+                        if let Some(columns) = root_block_cols.get(&(p3, p2)) {
                             state
                                 .p
                                 .insert(p1, CursorDataType::from_sparse_record(columns, None));
@@ -1158,180 +1146,178 @@ fn test_root_block_columns_has_types() {
     .next()
     .is_some());
 
-    let table_block_nums: HashMap<String, (i64, i64)> = execute::iter(
+    let table_block_nums: HashMap<String, (i64,i64)> = execute::iter(
         &mut conn,
-        r"select name, 0 db_seq, rootpage from main.sqlite_schema
-        UNION ALL select name, 1 db_seq, rootpage from temp.sqlite_schema",
+        r"select name, 0 db_seq, rootpage from main.sqlite_schema UNION ALL select name, 1 db_seq, rootpage from temp.sqlite_schema",
         None,
         false,
     )
     .unwrap()
     .filter_map(|res| res.map(|either| either.right()).transpose())
     .map(|row| FromRow::from_row(row.as_ref().unwrap()))
-    .map(|row| row.map(|(name, seq, block)| (name, (seq, block))))
+    .map(|row| row.map(|(name,seq,block)|(name,(seq,block))))
     .collect::<Result<HashMap<_, _>, Error>>()
     .unwrap();
 
     let root_block_cols = root_block_columns(&mut conn).unwrap();
 
-    //assert_eq!(7, root_block_cols.len());
+    // there should be 7 tables/indexes created explicitly, plus 1 autoindex for t3
+    assert_eq!(8, root_block_cols.len());
 
     //prove that we have some information for each table & index
-    for (name, (seqnum, blocknum)) in dbg!(&table_block_nums) {
+    for (name, db_seq_block) in dbg!(&table_block_nums) {
         assert!(
-            root_block_cols.contains_key(blocknum),
-            "name:{} seq_num:{} key:{}",
-            name,
-            seqnum,
-            blocknum
+            root_block_cols.contains_key(db_seq_block),
+            "{:?}",
+            (name, db_seq_block)
         );
     }
 
     //prove that each block has the correct information
     {
-        let (dbnum, blocknum) = table_block_nums["t"];
+        let table_db_block = table_block_nums["t"];
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Int64,
                 nullable: Some(true) //sqlite primary key columns are nullable unless declared not null
             },
-            root_block_cols[&blocknum][&0]
+            root_block_cols[&table_db_block][&0]
         );
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Text,
                 nullable: Some(true)
             },
-            root_block_cols[&blocknum][&1]
+            root_block_cols[&table_db_block][&1]
         );
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Text,
                 nullable: Some(false)
             },
-            root_block_cols[&blocknum][&2]
+            root_block_cols[&table_db_block][&2]
         );
     }
 
     {
-        let (seqnum, blocknum) = table_block_nums["i1"];
+        let table_db_block = table_block_nums["i1"];
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Int64,
                 nullable: Some(true) //sqlite primary key columns are nullable unless declared not null
             },
-            root_block_cols[&blocknum][&0]
+            root_block_cols[&table_db_block][&0]
         );
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Text,
                 nullable: Some(true)
             },
-            root_block_cols[&blocknum][&1]
+            root_block_cols[&table_db_block][&1]
         );
     }
 
     {
-        let (seqnum, blocknum) = table_block_nums["i2"];
+        let table_db_block = table_block_nums["i2"];
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Int64,
                 nullable: Some(true) //sqlite primary key columns are nullable unless declared not null
             },
-            root_block_cols[&blocknum][&0]
+            root_block_cols[&table_db_block][&0]
         );
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Text,
                 nullable: Some(true)
             },
-            root_block_cols[&blocknum][&1]
+            root_block_cols[&table_db_block][&1]
         );
     }
 
     {
-        let (seqnum, blocknum) = table_block_nums["t2"];
+        let table_db_block = table_block_nums["t2"];
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Int64,
                 nullable: Some(false)
             },
-            root_block_cols[&blocknum][&0]
+            root_block_cols[&table_db_block][&0]
         );
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Null,
                 nullable: Some(true)
             },
-            root_block_cols[&blocknum][&1]
+            root_block_cols[&table_db_block][&1]
         );
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Null,
                 nullable: Some(false)
             },
-            root_block_cols[&blocknum][&2]
+            root_block_cols[&table_db_block][&2]
         );
     }
 
     {
-        let (seqnum, blocknum) = table_block_nums["t2i1"];
+        let table_db_block = table_block_nums["t2i1"];
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Int64,
                 nullable: Some(false)
             },
-            root_block_cols[&blocknum][&0]
+            root_block_cols[&table_db_block][&0]
         );
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Null,
                 nullable: Some(true)
             },
-            root_block_cols[&blocknum][&1]
+            root_block_cols[&table_db_block][&1]
         );
     }
 
     {
-        let (seqnum, blocknum) = table_block_nums["t2i2"];
+        let table_db_block = table_block_nums["t2i2"];
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Int64,
                 nullable: Some(false)
             },
-            root_block_cols[&blocknum][&0]
+            root_block_cols[&table_db_block][&0]
         );
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Null,
                 nullable: Some(false)
             },
-            root_block_cols[&blocknum][&1]
+            root_block_cols[&table_db_block][&1]
         );
     }
 
     {
-        let (seqnum, blocknum) = table_block_nums["t3"];
+        let table_db_block = table_block_nums["t3"];
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Text,
-                nullable: Some(false)
+                nullable: Some(true)
             },
-            root_block_cols[&blocknum][&0]
+            root_block_cols[&table_db_block][&0]
         );
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Float,
                 nullable: Some(false)
             },
-            root_block_cols[&blocknum][&1]
+            root_block_cols[&table_db_block][&1]
         );
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Float,
                 nullable: Some(true)
             },
-            root_block_cols[&blocknum][&2]
+            root_block_cols[&table_db_block][&2]
         );
     }
 }

--- a/sqlx-core/src/sqlite/connection/explain.rs
+++ b/sqlx-core/src/sqlite/connection/explain.rs
@@ -1148,30 +1148,48 @@ fn test_root_block_columns_has_types() {
     .next()
     .is_some());
 
-    let table_block_nums: HashMap<String, i64> = execute::iter(
+    assert!(execute::iter(
         &mut conn,
-        r"select name, rootpage from sqlite_master",
+        r"CREATE TEMPORARY TABLE t3(a TEXT PRIMARY KEY, b REAL NOT NULL, b_null REAL NULL);",
+        None,
+        false
+    )
+    .unwrap()
+    .next()
+    .is_some());
+
+    let table_block_nums: HashMap<String, (i64, i64)> = execute::iter(
+        &mut conn,
+        r"select name, 0 db_seq, rootpage from main.sqlite_schema
+        UNION ALL select name, 1 db_seq, rootpage from temp.sqlite_schema",
         None,
         false,
     )
     .unwrap()
     .filter_map(|res| res.map(|either| either.right()).transpose())
     .map(|row| FromRow::from_row(row.as_ref().unwrap()))
+    .map(|row| row.map(|(name, seq, block)| (name, (seq, block))))
     .collect::<Result<HashMap<_, _>, Error>>()
     .unwrap();
 
     let root_block_cols = root_block_columns(&mut conn).unwrap();
 
-    assert_eq!(6, root_block_cols.len());
+    //assert_eq!(7, root_block_cols.len());
 
     //prove that we have some information for each table & index
-    for blocknum in table_block_nums.values() {
-        assert!(root_block_cols.contains_key(blocknum));
+    for (name, (seqnum, blocknum)) in dbg!(&table_block_nums) {
+        assert!(
+            root_block_cols.contains_key(blocknum),
+            "name:{} seq_num:{} key:{}",
+            name,
+            seqnum,
+            blocknum
+        );
     }
 
     //prove that each block has the correct information
     {
-        let blocknum = table_block_nums["t"];
+        let (dbnum, blocknum) = table_block_nums["t"];
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Int64,
@@ -1196,7 +1214,7 @@ fn test_root_block_columns_has_types() {
     }
 
     {
-        let blocknum = table_block_nums["i1"];
+        let (seqnum, blocknum) = table_block_nums["i1"];
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Int64,
@@ -1214,7 +1232,7 @@ fn test_root_block_columns_has_types() {
     }
 
     {
-        let blocknum = table_block_nums["i2"];
+        let (seqnum, blocknum) = table_block_nums["i2"];
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Int64,
@@ -1232,7 +1250,7 @@ fn test_root_block_columns_has_types() {
     }
 
     {
-        let blocknum = table_block_nums["t2"];
+        let (seqnum, blocknum) = table_block_nums["t2"];
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Int64,
@@ -1257,7 +1275,7 @@ fn test_root_block_columns_has_types() {
     }
 
     {
-        let blocknum = table_block_nums["t2i1"];
+        let (seqnum, blocknum) = table_block_nums["t2i1"];
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Int64,
@@ -1275,7 +1293,7 @@ fn test_root_block_columns_has_types() {
     }
 
     {
-        let blocknum = table_block_nums["t2i2"];
+        let (seqnum, blocknum) = table_block_nums["t2i2"];
         assert_eq!(
             ColumnType::Single {
                 datatype: DataType::Int64,
@@ -1289,6 +1307,31 @@ fn test_root_block_columns_has_types() {
                 nullable: Some(false)
             },
             root_block_cols[&blocknum][&1]
+        );
+    }
+
+    {
+        let (seqnum, blocknum) = table_block_nums["t3"];
+        assert_eq!(
+            ColumnType::Single {
+                datatype: DataType::Text,
+                nullable: Some(false)
+            },
+            root_block_cols[&blocknum][&0]
+        );
+        assert_eq!(
+            ColumnType::Single {
+                datatype: DataType::Float,
+                nullable: Some(false)
+            },
+            root_block_cols[&blocknum][&1]
+        );
+        assert_eq!(
+            ColumnType::Single {
+                datatype: DataType::Float,
+                nullable: Some(true)
+            },
+            root_block_cols[&blocknum][&2]
         );
     }
 }

--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -112,28 +112,28 @@ async fn it_describes_temporary_table() -> anyhow::Result<()> {
     assert_eq!(d.columns().len(), 8);
 
     assert_eq!(d.column(0).type_info().name(), "INTEGER");
-    assert_eq!(d.nullable(0), Some(false));
+    assert_eq!(d.nullable(0), Some(true));
 
-    assert_eq!(d.column(1).type_info().name(), "TEXT");
-    assert_eq!(d.nullable(1), Some(false));
+    assert_eq!(d.column(1).type_info().name(), "REAL");
+    assert_eq!(d.nullable(1), Some(true));
 
-    assert_eq!(d.column(2).type_info().name(), "REAL");
-    assert_eq!(d.nullable(2), Some(false));
+    assert_eq!(d.column(2).type_info().name(), "TEXT");
+    assert_eq!(d.nullable(2), Some(true));
 
     assert_eq!(d.column(3).type_info().name(), "BLOB");
-    assert_eq!(d.nullable(3), Some(false));
+    assert_eq!(d.nullable(3), Some(true));
 
     assert_eq!(d.column(4).type_info().name(), "INTEGER");
-    assert_eq!(d.nullable(4), Some(true));
+    assert_eq!(d.nullable(4), Some(false));
 
-    assert_eq!(d.column(5).type_info().name(), "TEXT");
-    assert_eq!(d.nullable(5), Some(true));
+    assert_eq!(d.column(5).type_info().name(), "REAL");
+    assert_eq!(d.nullable(5), Some(false));
 
-    assert_eq!(d.column(6).type_info().name(), "REAL");
-    assert_eq!(d.nullable(6), Some(true));
+    assert_eq!(d.column(6).type_info().name(), "TEXT");
+    assert_eq!(d.nullable(6), Some(false));
 
     assert_eq!(d.column(7).type_info().name(), "BLOB");
-    assert_eq!(d.nullable(7), Some(true));
+    assert_eq!(d.nullable(7), Some(false));
 
     Ok(())
 }

--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -89,6 +89,56 @@ async fn it_describes_expression() -> anyhow::Result<()> {
 }
 
 #[sqlx_macros::test]
+async fn it_describes_temporary_table() -> anyhow::Result<()> {
+    let mut conn = new::<Sqlite>().await?;
+
+    conn.execute(
+        "CREATE TEMPORARY TABLE IF NOT EXISTS empty_all_types_and_nulls(
+        i1 integer NULL,
+        r1 real NULL,
+        t1 text NULL,
+        b1 blob NULL,
+        i2 INTEGER NOT NULL,
+        r2 REAL NOT NULL,
+        t2 TEXT NOT NULL,
+        b2 BLOB NOT NULL
+        )",
+    )
+    .await?;
+
+    let d = conn
+        .describe("SELECT * FROM empty_all_types_and_nulls")
+        .await?;
+    assert_eq!(d.columns().len(), 8);
+
+    assert_eq!(d.column(0).type_info().name(), "INTEGER");
+    assert_eq!(d.nullable(0), Some(false));
+
+    assert_eq!(d.column(1).type_info().name(), "TEXT");
+    assert_eq!(d.nullable(1), Some(false));
+
+    assert_eq!(d.column(2).type_info().name(), "REAL");
+    assert_eq!(d.nullable(2), Some(false));
+
+    assert_eq!(d.column(3).type_info().name(), "BLOB");
+    assert_eq!(d.nullable(3), Some(false));
+
+    assert_eq!(d.column(4).type_info().name(), "INTEGER");
+    assert_eq!(d.nullable(4), Some(true));
+
+    assert_eq!(d.column(5).type_info().name(), "TEXT");
+    assert_eq!(d.nullable(5), Some(true));
+
+    assert_eq!(d.column(6).type_info().name(), "REAL");
+    assert_eq!(d.nullable(6), Some(true));
+
+    assert_eq!(d.column(7).type_info().name(), "BLOB");
+    assert_eq!(d.nullable(7), Some(true));
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
 async fn it_describes_expression_from_empty_table() -> anyhow::Result<()> {
     let mut conn = new::<Sqlite>().await?;
 

--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -469,3 +469,17 @@ async fn it_describes_union() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+//documents a failure originally found through property testing
+#[sqlx_macros::test]
+async fn it_describes_nested_ordered() -> anyhow::Result<()> {
+    let mut conn = new::<Sqlite>().await?;
+    let info = conn
+        .describe("SELECT true FROM (SELECT true) a ORDER BY true")
+        .await?;
+
+    assert_eq!(info.column(0).type_info().name(), "INTEGER");
+    assert_eq!(info.nullable(0), Some(false));
+
+    Ok(())
+}


### PR DESCRIPTION
Add reproducers & fixes for various sqlite describe bugs .
Fixes include:
* fix handling of nested order-by queries
  * handle when sqlite puts a 'record' inside of a blob column
  * handle rewind of an empty table correctly
* fix retrieval of temporary table column signatures