### PR TITLE
Sqlite describe fixes

### DIFF
--- a/sqlx-sqlite/src/connection/explain.rs
+++ b/sqlx-sqlite/src/connection/explain.rs
@@ -19,6 +19,7 @@ const SQLITE_AFF_REAL: u8 = 0x45; /* 'E' */
 const OP_INIT: &str = "Init";
 const OP_GOTO: &str = "Goto";
 const OP_DECR_JUMP_ZERO: &str = "DecrJumpZero";
+const OP_DELETE: &str = "Delete";
 const OP_ELSE_EQ: &str = "ElseEq";
 const OP_EQ: &str = "Eq";
 const OP_END_COROUTINE: &str = "EndCoroutine";
@@ -882,6 +883,15 @@ pub(super) fn explain(
                         }
                     }
                     //Noop if the register p2 isn't a record, or if pointer p1 does not exist
+                }
+
+                OP_DELETE => {
+                    // delete a record from cursor p1
+                    if let Some(CursorDataType::Normal { is_empty, .. }) = state.p.get_mut(&p1) {
+                        if *is_empty == Some(false) {
+                            *is_empty = None; //the cursor might be empty now
+                        }
+                    }
                 }
 
                 OP_OPEN_PSEUDO => {

--- a/sqlx-sqlite/src/connection/explain.rs
+++ b/sqlx-sqlite/src/connection/explain.rs
@@ -507,7 +507,7 @@ pub(super) fn explain(
                         let mut branch_state = state.clone();
                         branch_state.program_i = p2 as usize;
                         if p3 == 0 {
-                            state.r.insert(p1, RegDataType::Int(1));
+                            branch_state.r.insert(p1, RegDataType::Int(1));
                         }
                         states.push(branch_state);
                     }
@@ -527,19 +527,19 @@ pub(super) fn explain(
                     // goto <p2> if r[p1] is true (1) or r[p1] is null and p3 is nonzero
 
                     let might_branch = match state.r.get(&p1) {
-                        Some(RegDataType::Int(r_p1)) => *r_p1 != 0,
+                        Some(RegDataType::Int(r_p1)) => *r_p1 >= 1,
                         _ => true,
                     };
 
                     let might_not_branch = match state.r.get(&p1) {
-                        Some(RegDataType::Int(r_p1)) => *r_p1 == 0,
+                        Some(RegDataType::Int(r_p1)) => *r_p1 < 1,
                         _ => true,
                     };
 
                     if might_branch {
                         let mut branch_state = state.clone();
                         branch_state.program_i = p2 as usize;
-                        if let Some(RegDataType::Int(r_p1)) = state.r.get_mut(&p1) {
+                        if let Some(RegDataType::Int(r_p1)) = branch_state.r.get_mut(&p1) {
                             *r_p1 -= 1;
                         }
                         states.push(branch_state);

--- a/sqlx-sqlite/src/connection/explain.rs
+++ b/sqlx-sqlite/src/connection/explain.rs
@@ -460,12 +460,19 @@ pub(super) fn explain(
                     continue;
                 }
 
+                OP_GO_SUB => {
+                    // store current instruction in r[p1], goto <p2>
+                    state.r.insert(p1, RegDataType::Int(state.program_i as i64));
+                    state.program_i = p2 as usize;
+                    continue;
+                }
+
                 OP_DECR_JUMP_ZERO | OP_ELSE_EQ | OP_EQ | OP_FILTER | OP_FK_IF_ZERO | OP_FOUND
-                | OP_GE | OP_GO_SUB | OP_GT | OP_IDX_GE | OP_IDX_GT | OP_IDX_LE | OP_IDX_LT
-                | OP_IF | OP_IF_NO_HOPE | OP_IF_NOT | OP_IF_NOT_OPEN | OP_IF_NOT_ZERO
-                | OP_IF_NULL_ROW | OP_IF_POS | OP_IF_SMALLER | OP_INCR_VACUUM | OP_IS_NULL
-                | OP_IS_NULL_OR_TYPE | OP_MUST_BE_INT | OP_LE | OP_LT | OP_NE | OP_NEXT
-                | OP_NO_CONFLICT | OP_NOT_EXISTS | OP_NOT_NULL | OP_ONCE | OP_PREV | OP_PROGRAM
+                | OP_GE | OP_GT | OP_IDX_GE | OP_IDX_GT | OP_IDX_LE | OP_IDX_LT | OP_IF
+                | OP_IF_NO_HOPE | OP_IF_NOT | OP_IF_NOT_OPEN | OP_IF_NOT_ZERO | OP_IF_NULL_ROW
+                | OP_IF_POS | OP_IF_SMALLER | OP_INCR_VACUUM | OP_IS_NULL | OP_IS_NULL_OR_TYPE
+                | OP_MUST_BE_INT | OP_LE | OP_LT | OP_NE | OP_NEXT | OP_NO_CONFLICT
+                | OP_NOT_EXISTS | OP_NOT_NULL | OP_ONCE | OP_PREV | OP_PROGRAM
                 | OP_ROW_SET_READ | OP_ROW_SET_TEST | OP_SEEK_GE | OP_SEEK_GT | OP_SEEK_LE
                 | OP_SEEK_LT | OP_SEEK_ROW_ID | OP_SEEK_SCAN | OP_SEQUENCE_TEST
                 | OP_SORTER_NEXT | OP_V_FILTER | OP_V_NEXT => {

--- a/sqlx-sqlite/src/connection/explain.rs
+++ b/sqlx-sqlite/src/connection/explain.rs
@@ -795,6 +795,36 @@ pub(super) fn explain(
                                 }),
                             );
                         }
+                        "date(-1)" | "time(-1)" | "datetime(-1)" | "strftime(-1)" => {
+                            // date|time|datetime|strftime(...) -> TEXT
+                            state.r.insert(
+                                p3,
+                                RegDataType::Single(ColumnType::Single {
+                                    datatype: DataType::Text,
+                                    nullable: Some(p2 != 0), //never a null result if no argument provided
+                                }),
+                            );
+                        }
+                        "julianday(-1)" => {
+                            // julianday(...) -> REAL
+                            state.r.insert(
+                                p3,
+                                RegDataType::Single(ColumnType::Single {
+                                    datatype: DataType::Float,
+                                    nullable: Some(p2 != 0), //never a null result if no argument provided
+                                }),
+                            );
+                        }
+                        "unixepoch(-1)" => {
+                            // unixepoch(p2...) -> INTEGER
+                            state.r.insert(
+                                p3,
+                                RegDataType::Single(ColumnType::Single {
+                                    datatype: DataType::Int64,
+                                    nullable: Some(p2 != 0), //never a null result if no argument provided
+                                }),
+                            );
+                        }
 
                         _ => logger.add_unknown_operation(&program[state.program_i]),
                     }

--- a/sqlx-sqlite/src/connection/explain.rs
+++ b/sqlx-sqlite/src/connection/explain.rs
@@ -1014,6 +1014,20 @@ pub(super) fn explain(
                                 nullable: Some(false),
                             }),
                         );
+                    } else if p4.starts_with("sum(") {
+                        if let Some(r_p2) = state.r.get(&p2) {
+                            let datatype = match r_p2.map_to_datatype() {
+                                DataType::Int64 => DataType::Int64,
+                                DataType::Int => DataType::Int,
+                                DataType::Bool => DataType::Int,
+                                _ => DataType::Float,
+                            };
+                            let nullable = r_p2.map_to_nullable();
+                            state.r.insert(
+                                p3,
+                                RegDataType::Single(ColumnType::Single { datatype, nullable }),
+                            );
+                        }
                     } else if let Some(v) = state.r.get(&p2).cloned() {
                         // r[p3] = AGG ( r[p2] )
                         state.r.insert(p3, v);
@@ -1037,9 +1051,6 @@ pub(super) fn explain(
                                 nullable: Some(false),
                             }),
                         );
-                    } else if let Some(v) = state.r.get(&p2).cloned() {
-                        // r[p3] = AGG ( r[p2] )
-                        state.r.insert(p3, v);
                     }
                 }
 

--- a/sqlx-sqlite/src/connection/explain.rs
+++ b/sqlx-sqlite/src/connection/explain.rs
@@ -470,11 +470,11 @@ pub(super) fn explain(
                 OP_DECR_JUMP_ZERO | OP_ELSE_EQ | OP_EQ | OP_FILTER | OP_FK_IF_ZERO | OP_FOUND
                 | OP_GE | OP_GT | OP_IDX_GE | OP_IDX_GT | OP_IDX_LE | OP_IDX_LT | OP_IF_NO_HOPE
                 | OP_IF_NOT | OP_IF_NOT_OPEN | OP_IF_NOT_ZERO | OP_IF_NULL_ROW | OP_IF_SMALLER
-                | OP_INCR_VACUUM | OP_IS_NULL | OP_IS_NULL_OR_TYPE | OP_MUST_BE_INT | OP_LE
-                | OP_LT | OP_NE | OP_NEXT | OP_NO_CONFLICT | OP_NOT_EXISTS | OP_NOT_NULL
-                | OP_ONCE | OP_PREV | OP_PROGRAM | OP_ROW_SET_READ | OP_ROW_SET_TEST
-                | OP_SEEK_GE | OP_SEEK_GT | OP_SEEK_LE | OP_SEEK_LT | OP_SEEK_ROW_ID
-                | OP_SEEK_SCAN | OP_SEQUENCE_TEST | OP_SORTER_NEXT | OP_V_FILTER | OP_V_NEXT => {
+                | OP_INCR_VACUUM | OP_IS_NULL | OP_IS_NULL_OR_TYPE | OP_LE | OP_LT | OP_NE
+                | OP_NEXT | OP_NO_CONFLICT | OP_NOT_EXISTS | OP_NOT_NULL | OP_ONCE | OP_PREV
+                | OP_PROGRAM | OP_ROW_SET_READ | OP_ROW_SET_TEST | OP_SEEK_GE | OP_SEEK_GT
+                | OP_SEEK_LE | OP_SEEK_LT | OP_SEEK_ROW_ID | OP_SEEK_SCAN | OP_SEQUENCE_TEST
+                | OP_SORTER_NEXT | OP_V_FILTER | OP_V_NEXT => {
                     // goto <p2> or next instruction (depending on actual values)
 
                     let mut branch_state = state.clone();
@@ -484,6 +484,26 @@ pub(super) fn explain(
                     if !visited_branch_state.contains(&bs_hash) {
                         visited_branch_state.insert(bs_hash);
                         states.push(branch_state);
+                    }
+
+                    state.program_i += 1;
+                    continue;
+                }
+
+                OP_MUST_BE_INT => {
+                    // if p1 can be coerced to int, continue
+                    // if p1 cannot be coerced to int, error if p2 == 0, else jump to p2
+
+                    //don't bother checking actual types, just don't branch to instruction 0
+                    if p2 != 0 {
+                        let mut branch_state = state.clone();
+                        branch_state.program_i = p2 as usize;
+
+                        let bs_hash = BranchStateHash::from_query_state(&branch_state);
+                        if !visited_branch_state.contains(&bs_hash) {
+                            visited_branch_state.insert(bs_hash);
+                            states.push(branch_state);
+                        }
                     }
 
                     state.program_i += 1;

--- a/sqlx-sqlite/src/connection/explain.rs
+++ b/sqlx-sqlite/src/connection/explain.rs
@@ -127,15 +127,18 @@ const OP_HALT: &str = "Halt";
 
 const MAX_LOOP_COUNT: u8 = 2;
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-struct ColumnType {
-    pub datatype: DataType,
-    pub nullable: Option<bool>,
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+enum ColumnType {
+    Single {
+        datatype: DataType,
+        nullable: Option<bool>,
+    },
+    Record(Vec<ColumnType>),
 }
 
 impl Default for ColumnType {
     fn default() -> Self {
-        Self {
+        Self::Single {
             datatype: DataType::Null,
             nullable: None,
         }
@@ -144,9 +147,21 @@ impl Default for ColumnType {
 
 impl ColumnType {
     fn null() -> Self {
-        Self {
+        Self::Single {
             datatype: DataType::Null,
             nullable: Some(true),
+        }
+    }
+    fn map_to_datatype(&self) -> DataType {
+        match self {
+            Self::Single { datatype, .. } => datatype.clone(),
+            Self::Record(_) => DataType::Null, //If we're trying to coerce to a regular Datatype, we can assume a Record is invalid for the context
+        }
+    }
+    fn map_to_nullable(&self) -> Option<bool> {
+        match self {
+            Self::Single { nullable, .. } => *nullable,
+            Self::Record(_) => None, //If we're trying to coerce to a regular Datatype, we can assume a Record is invalid for the context
         }
     }
 }
@@ -154,33 +169,26 @@ impl ColumnType {
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 enum RegDataType {
     Single(ColumnType),
-    Record(Vec<ColumnType>),
     Int(i64),
 }
 
 impl RegDataType {
     fn map_to_datatype(&self) -> DataType {
         match self {
-            RegDataType::Single(d) => d.datatype,
-            RegDataType::Record(_) => DataType::Null, //If we're trying to coerce to a regular Datatype, we can assume a Record is invalid for the context
+            RegDataType::Single(d) => d.map_to_datatype(),
             RegDataType::Int(_) => DataType::Int,
         }
     }
     fn map_to_nullable(&self) -> Option<bool> {
         match self {
-            RegDataType::Single(d) => d.nullable,
-            RegDataType::Record(_) => None, //If we're trying to coerce to a regular Datatype, we can assume a Record is invalid for the context
+            RegDataType::Single(d) => d.map_to_nullable(),
             RegDataType::Int(_) => Some(false),
         }
     }
     fn map_to_columntype(&self) -> ColumnType {
         match self {
-            RegDataType::Single(d) => *d,
-            RegDataType::Record(_) => ColumnType {
-                datatype: DataType::Null,
-                nullable: None,
-            }, //If we're trying to coerce to a regular Datatype, we can assume a Record is invalid for the context
-            RegDataType::Int(_) => ColumnType {
+            RegDataType::Single(d) => d.clone(),
+            RegDataType::Int(_) => ColumnType::Single {
                 datatype: DataType::Int,
                 nullable: Some(false),
             },
@@ -202,7 +210,7 @@ impl CursorDataType {
         Self::Normal {
             cols: record
                 .iter()
-                .map(|(&colnum, &datatype)| (colnum, datatype))
+                .map(|(colnum, datatype)| (*colnum, datatype.clone()))
                 .collect(),
             is_empty,
         }
@@ -210,7 +218,7 @@ impl CursorDataType {
 
     fn from_dense_record(record: &Vec<ColumnType>, is_empty: Option<bool>) -> Self {
         Self::Normal {
-            cols: (0..).zip(record.iter().copied()).collect(),
+            cols: (0..).zip(record.iter().cloned()).collect(),
             is_empty,
         }
     }
@@ -225,7 +233,7 @@ impl CursorDataType {
                 rowdata
             }
             Self::Pseudo(i) => match registers.get(i) {
-                Some(RegDataType::Record(r)) => r.clone(),
+                Some(RegDataType::Single(ColumnType::Record(r))) => r.clone(),
                 _ => Vec::new(),
             },
         }
@@ -238,7 +246,9 @@ impl CursorDataType {
         match self {
             Self::Normal { cols, .. } => cols.clone(),
             Self::Pseudo(i) => match registers.get(i) {
-                Some(RegDataType::Record(r)) => (0..).zip(r.iter().copied()).collect(),
+                Some(RegDataType::Single(ColumnType::Record(r))) => {
+                    (0..).zip(r.iter().cloned()).collect()
+                }
                 _ => HashMap::new(),
             },
         }
@@ -313,7 +323,7 @@ fn root_block_columns(
         let row_info = row_info.entry(block).or_default();
         row_info.insert(
             colnum,
-            ColumnType {
+            ColumnType::Single {
                 datatype: datatype.parse().unwrap_or(DataType::Null),
                 nullable: Some(!notnull),
             },
@@ -323,7 +333,7 @@ fn root_block_columns(
         let row_info = row_info.entry(block).or_default();
         row_info.insert(
             colnum,
-            ColumnType {
+            ColumnType::Single {
                 datatype: datatype.parse().unwrap_or(DataType::Null),
                 nullable: Some(!notnull),
             },
@@ -665,7 +675,7 @@ pub(super) fn explain(
                     {
                         if let Some(col) = record.get(&p2) {
                             // insert into p3 the datatype of the col
-                            state.r.insert(p3, RegDataType::Single(*col));
+                            state.r.insert(p3, RegDataType::Single(col.clone()));
                         } else {
                             state
                                 .r
@@ -684,7 +694,7 @@ pub(super) fn explain(
                     //Cursor emulation doesn't sequence value, but it is an int
                     state.r.insert(
                         p2,
-                        RegDataType::Single(ColumnType {
+                        RegDataType::Single(ColumnType::Single {
                             datatype: DataType::Int64,
                             nullable: Some(false),
                         }),
@@ -695,9 +705,13 @@ pub(super) fn explain(
                     //Get entire row from cursor p1, store it into register p2
                     if let Some(record) = state.p.get(&p1) {
                         let rowdata = record.map_to_dense_record(&state.r);
-                        state.r.insert(p2, RegDataType::Record(rowdata));
+                        state
+                            .r
+                            .insert(p2, RegDataType::Single(ColumnType::Record(rowdata)));
                     } else {
-                        state.r.insert(p2, RegDataType::Record(Vec::new()));
+                        state
+                            .r
+                            .insert(p2, RegDataType::Single(ColumnType::Record(Vec::new())));
                     }
                 }
 
@@ -713,16 +727,19 @@ pub(super) fn explain(
                                 .unwrap_or(ColumnType::default()),
                         );
                     }
-                    state.r.insert(p3, RegDataType::Record(record));
+                    state
+                        .r
+                        .insert(p3, RegDataType::Single(ColumnType::Record(record)));
                 }
 
                 OP_INSERT | OP_IDX_INSERT | OP_SORTER_INSERT => {
-                    if let Some(RegDataType::Record(record)) = state.r.get(&p2) {
+                    if let Some(RegDataType::Single(ColumnType::Record(record))) = state.r.get(&p2)
+                    {
                         if let Some(CursorDataType::Normal { cols, is_empty }) =
                             state.p.get_mut(&p1)
                         {
                             // Insert the record into wherever pointer p1 is
-                            *cols = (0..).zip(record.iter().copied()).collect();
+                            *cols = (0..).zip(record.iter().cloned()).collect();
                             *is_empty = Some(false);
                         }
                     }
@@ -784,7 +801,7 @@ pub(super) fn explain(
                             // last_insert_rowid() -> INTEGER
                             state.r.insert(
                                 p3,
-                                RegDataType::Single(ColumnType {
+                                RegDataType::Single(ColumnType::Single {
                                     datatype: DataType::Int64,
                                     nullable: Some(false),
                                 }),
@@ -799,8 +816,13 @@ pub(super) fn explain(
                     // all columns in cursor X are potentially nullable
                     if let Some(CursorDataType::Normal { ref mut cols, .. }) = state.p.get_mut(&p1)
                     {
-                        for ref mut col in cols.values_mut() {
-                            col.nullable = Some(true);
+                        for col in cols.values_mut() {
+                            if let ColumnType::Single {
+                                ref mut nullable, ..
+                            } = col
+                            {
+                                *nullable = Some(true);
+                            }
                         }
                     }
                     //else we don't know about the cursor
@@ -819,7 +841,7 @@ pub(super) fn explain(
                         // count(_) -> INTEGER
                         state.r.insert(
                             p3,
-                            RegDataType::Single(ColumnType {
+                            RegDataType::Single(ColumnType::Single {
                                 datatype: DataType::Int64,
                                 nullable: Some(false),
                             }),
@@ -842,7 +864,7 @@ pub(super) fn explain(
                         // count(_) -> INTEGER
                         state.r.insert(
                             p1,
-                            RegDataType::Single(ColumnType {
+                            RegDataType::Single(ColumnType::Single {
                                 datatype: DataType::Int64,
                                 nullable: Some(false),
                             }),
@@ -856,7 +878,7 @@ pub(super) fn explain(
                 OP_CAST => {
                     // affinity(r[p1])
                     if let Some(v) = state.r.get_mut(&p1) {
-                        *v = RegDataType::Single(ColumnType {
+                        *v = RegDataType::Single(ColumnType::Single {
                             datatype: affinity_to_type(p2 as u8),
                             nullable: v.map_to_nullable(),
                         });
@@ -906,7 +928,7 @@ pub(super) fn explain(
                     // r[p2] = <value of constant>
                     state.r.insert(
                         p2,
-                        RegDataType::Single(ColumnType {
+                        RegDataType::Single(ColumnType::Single {
                             datatype: opcode_to_type(&opcode),
                             nullable: Some(false),
                         }),
@@ -936,7 +958,7 @@ pub(super) fn explain(
                         (Some(a), Some(b)) => {
                             state.r.insert(
                                 p3,
-                                RegDataType::Single(ColumnType {
+                                RegDataType::Single(ColumnType::Single {
                                     datatype: if matches!(a.map_to_datatype(), DataType::Null) {
                                         b.map_to_datatype()
                                     } else {
@@ -955,7 +977,7 @@ pub(super) fn explain(
                         (Some(v), None) => {
                             state.r.insert(
                                 p3,
-                                RegDataType::Single(ColumnType {
+                                RegDataType::Single(ColumnType::Single {
                                     datatype: v.map_to_datatype(),
                                     nullable: None,
                                 }),
@@ -965,7 +987,7 @@ pub(super) fn explain(
                         (None, Some(v)) => {
                             state.r.insert(
                                 p3,
-                                RegDataType::Single(ColumnType {
+                                RegDataType::Single(ColumnType::Single {
                                     datatype: v.map_to_datatype(),
                                     nullable: None,
                                 }),
@@ -980,7 +1002,7 @@ pub(super) fn explain(
                     // r[p2] = if r[p2] < 0 { r[p1] } else if r[p1]<0 { -1 } else { r[p1] + r[p3] }
                     state.r.insert(
                         p2,
-                        RegDataType::Single(ColumnType {
+                        RegDataType::Single(ColumnType::Single {
                             datatype: DataType::Int64,
                             nullable: Some(false),
                         }),
@@ -1160,21 +1182,21 @@ fn test_root_block_columns_has_types() {
     {
         let blocknum = table_block_nums["t"];
         assert_eq!(
-            ColumnType {
+            ColumnType::Single {
                 datatype: DataType::Int64,
                 nullable: Some(true) //sqlite primary key columns are nullable unless declared not null
             },
             root_block_cols[&blocknum][&0]
         );
         assert_eq!(
-            ColumnType {
+            ColumnType::Single {
                 datatype: DataType::Text,
                 nullable: Some(true)
             },
             root_block_cols[&blocknum][&1]
         );
         assert_eq!(
-            ColumnType {
+            ColumnType::Single {
                 datatype: DataType::Text,
                 nullable: Some(false)
             },
@@ -1185,14 +1207,14 @@ fn test_root_block_columns_has_types() {
     {
         let blocknum = table_block_nums["i1"];
         assert_eq!(
-            ColumnType {
+            ColumnType::Single {
                 datatype: DataType::Int64,
                 nullable: Some(true) //sqlite primary key columns are nullable unless declared not null
             },
             root_block_cols[&blocknum][&0]
         );
         assert_eq!(
-            ColumnType {
+            ColumnType::Single {
                 datatype: DataType::Text,
                 nullable: Some(true)
             },
@@ -1203,14 +1225,14 @@ fn test_root_block_columns_has_types() {
     {
         let blocknum = table_block_nums["i2"];
         assert_eq!(
-            ColumnType {
+            ColumnType::Single {
                 datatype: DataType::Int64,
                 nullable: Some(true) //sqlite primary key columns are nullable unless declared not null
             },
             root_block_cols[&blocknum][&0]
         );
         assert_eq!(
-            ColumnType {
+            ColumnType::Single {
                 datatype: DataType::Text,
                 nullable: Some(true)
             },
@@ -1221,21 +1243,21 @@ fn test_root_block_columns_has_types() {
     {
         let blocknum = table_block_nums["t2"];
         assert_eq!(
-            ColumnType {
+            ColumnType::Single {
                 datatype: DataType::Int64,
                 nullable: Some(false)
             },
             root_block_cols[&blocknum][&0]
         );
         assert_eq!(
-            ColumnType {
+            ColumnType::Single {
                 datatype: DataType::Null,
                 nullable: Some(true)
             },
             root_block_cols[&blocknum][&1]
         );
         assert_eq!(
-            ColumnType {
+            ColumnType::Single {
                 datatype: DataType::Null,
                 nullable: Some(false)
             },
@@ -1246,14 +1268,14 @@ fn test_root_block_columns_has_types() {
     {
         let blocknum = table_block_nums["t2i1"];
         assert_eq!(
-            ColumnType {
+            ColumnType::Single {
                 datatype: DataType::Int64,
                 nullable: Some(false)
             },
             root_block_cols[&blocknum][&0]
         );
         assert_eq!(
-            ColumnType {
+            ColumnType::Single {
                 datatype: DataType::Null,
                 nullable: Some(true)
             },
@@ -1264,14 +1286,14 @@ fn test_root_block_columns_has_types() {
     {
         let blocknum = table_block_nums["t2i2"];
         assert_eq!(
-            ColumnType {
+            ColumnType::Single {
                 datatype: DataType::Int64,
                 nullable: Some(false)
             },
             root_block_cols[&blocknum][&0]
         );
         assert_eq!(
-            ColumnType {
+            ColumnType::Single {
                 datatype: DataType::Null,
                 nullable: Some(false)
             },

--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -112,28 +112,28 @@ async fn it_describes_temporary_table() -> anyhow::Result<()> {
     assert_eq!(d.columns().len(), 8);
 
     assert_eq!(d.column(0).type_info().name(), "INTEGER");
-    assert_eq!(d.nullable(0), Some(false));
+    assert_eq!(d.nullable(0), Some(true));
 
-    assert_eq!(d.column(1).type_info().name(), "TEXT");
-    assert_eq!(d.nullable(1), Some(false));
+    assert_eq!(d.column(1).type_info().name(), "REAL");
+    assert_eq!(d.nullable(1), Some(true));
 
-    assert_eq!(d.column(2).type_info().name(), "REAL");
-    assert_eq!(d.nullable(2), Some(false));
+    assert_eq!(d.column(2).type_info().name(), "TEXT");
+    assert_eq!(d.nullable(2), Some(true));
 
     assert_eq!(d.column(3).type_info().name(), "BLOB");
-    assert_eq!(d.nullable(3), Some(false));
+    assert_eq!(d.nullable(3), Some(true));
 
     assert_eq!(d.column(4).type_info().name(), "INTEGER");
-    assert_eq!(d.nullable(4), Some(true));
+    assert_eq!(d.nullable(4), Some(false));
 
-    assert_eq!(d.column(5).type_info().name(), "TEXT");
-    assert_eq!(d.nullable(5), Some(true));
+    assert_eq!(d.column(5).type_info().name(), "REAL");
+    assert_eq!(d.nullable(5), Some(false));
 
-    assert_eq!(d.column(6).type_info().name(), "REAL");
-    assert_eq!(d.nullable(6), Some(true));
+    assert_eq!(d.column(6).type_info().name(), "TEXT");
+    assert_eq!(d.nullable(6), Some(false));
 
     assert_eq!(d.column(7).type_info().name(), "BLOB");
-    assert_eq!(d.nullable(7), Some(true));
+    assert_eq!(d.nullable(7), Some(false));
 
     Ok(())
 }

--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -89,6 +89,56 @@ async fn it_describes_expression() -> anyhow::Result<()> {
 }
 
 #[sqlx_macros::test]
+async fn it_describes_temporary_table() -> anyhow::Result<()> {
+    let mut conn = new::<Sqlite>().await?;
+
+    conn.execute(
+        "CREATE TEMPORARY TABLE IF NOT EXISTS empty_all_types_and_nulls(
+        i1 integer NULL,
+        r1 real NULL,
+        t1 text NULL,
+        b1 blob NULL,
+        i2 INTEGER NOT NULL,
+        r2 REAL NOT NULL,
+        t2 TEXT NOT NULL,
+        b2 BLOB NOT NULL
+        )",
+    )
+    .await?;
+
+    let d = conn
+        .describe("SELECT * FROM empty_all_types_and_nulls")
+        .await?;
+    assert_eq!(d.columns().len(), 8);
+
+    assert_eq!(d.column(0).type_info().name(), "INTEGER");
+    assert_eq!(d.nullable(0), Some(false));
+
+    assert_eq!(d.column(1).type_info().name(), "TEXT");
+    assert_eq!(d.nullable(1), Some(false));
+
+    assert_eq!(d.column(2).type_info().name(), "REAL");
+    assert_eq!(d.nullable(2), Some(false));
+
+    assert_eq!(d.column(3).type_info().name(), "BLOB");
+    assert_eq!(d.nullable(3), Some(false));
+
+    assert_eq!(d.column(4).type_info().name(), "INTEGER");
+    assert_eq!(d.nullable(4), Some(true));
+
+    assert_eq!(d.column(5).type_info().name(), "TEXT");
+    assert_eq!(d.nullable(5), Some(true));
+
+    assert_eq!(d.column(6).type_info().name(), "REAL");
+    assert_eq!(d.nullable(6), Some(true));
+
+    assert_eq!(d.column(7).type_info().name(), "BLOB");
+    assert_eq!(d.nullable(7), Some(true));
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
 async fn it_describes_expression_from_empty_table() -> anyhow::Result<()> {
     let mut conn = new::<Sqlite>().await?;
 

--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -352,6 +352,17 @@ async fn it_describes_left_join() -> anyhow::Result<()> {
 }
 
 #[sqlx_macros::test]
+async fn it_describes_group_by() -> anyhow::Result<()> {
+    let mut conn = new::<Sqlite>().await?;
+
+    let d = conn.describe("select id from accounts group by id").await?;
+    assert_eq!(d.column(0).type_info().name(), "INTEGER");
+    assert_eq!(d.nullable(0), Some(false));
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
 async fn it_describes_literal_subquery() -> anyhow::Result<()> {
     async fn assert_literal_described(
         conn: &mut sqlx::SqliteConnection,

--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -469,3 +469,17 @@ async fn it_describes_union() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+//documents a failure originally found through property testing
+#[sqlx_macros::test]
+async fn it_describes_nested_ordered() -> anyhow::Result<()> {
+    let mut conn = new::<Sqlite>().await?;
+    let info = conn
+        .describe("SELECT true FROM (SELECT true) a ORDER BY true")
+        .await?;
+
+    assert_eq!(info.column(0).type_info().name(), "INTEGER");
+    assert_eq!(info.nullable(0), Some(false));
+
+    Ok(())
+}

--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -568,6 +568,7 @@ async fn it_describes_nested_ordered() -> anyhow::Result<()> {
         "SELECT true FROM (SELECT true) a ORDER BY true",
     )
     .await?;
+
     assert_single_true_column_described(
         &mut conn,
         "
@@ -592,6 +593,8 @@ async fn it_describes_nested_ordered() -> anyhow::Result<()> {
             ORDER BY true ASC NULLS LAST",
     )
     .await?;
+
+    assert_single_true_column_described(&mut conn, "SELECT true LIMIT -1 OFFSET -1").await?;
 
     Ok(())
 }

--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -671,6 +671,14 @@ async fn it_describes_strange_queries() -> anyhow::Result<()> {
     )
     .await?;
 
+    assert_single_column_described(
+        &mut conn,
+        "SELECT SUM(tweet.text) FROM (SELECT NULL FROM accounts_view LIMIT -1 OFFSET 1) CROSS JOIN tweet",
+        "REAL",
+        true, // null if accounts view has fewer rows than the offset
+    )
+    .await?;
+
     Ok(())
 }
 

--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -359,6 +359,12 @@ async fn it_describes_group_by() -> anyhow::Result<()> {
     assert_eq!(d.column(0).type_info().name(), "INTEGER");
     assert_eq!(d.nullable(0), Some(false));
 
+    let d = conn
+        .describe("SELECT name from accounts GROUP BY 1 LIMIT -1 OFFSET 1")
+        .await?;
+    assert_eq!(d.column(0).type_info().name(), "TEXT");
+    assert_eq!(d.nullable(0), Some(false));
+
     Ok(())
 }
 

--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -578,3 +578,128 @@ async fn it_describes_nested_ordered() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[sqlx_macros::test]
+async fn it_describes_func_date() -> anyhow::Result<()> {
+    let mut conn = new::<Sqlite>().await?;
+
+    let query = "SELECT date();";
+    let info = conn.describe(query).await?;
+    assert_eq!(info.column(0).type_info().name(), "TEXT", "{}", query);
+    assert_eq!(info.nullable(0), Some(false), "{}", query);
+
+    let query = "SELECT date('now');";
+    let info = conn.describe(query).await?;
+    assert_eq!(info.column(0).type_info().name(), "TEXT", "{}", query);
+    assert_eq!(info.nullable(0), Some(true), "{}", query); //can't prove that it's not-null yet
+
+    let query = "SELECT date('now', 'start of month');";
+    let info = conn.describe(query).await?;
+    assert_eq!(info.column(0).type_info().name(), "TEXT", "{}", query);
+    assert_eq!(info.nullable(0), Some(true), "{}", query); //can't prove that it's not-null yet
+
+    let query = "SELECT date(:datebind);";
+    let info = conn.describe(query).await?;
+    assert_eq!(info.column(0).type_info().name(), "TEXT", "{}", query);
+    assert_eq!(info.nullable(0), Some(true), "{}", query);
+    Ok(())
+}
+
+#[sqlx_macros::test]
+async fn it_describes_func_time() -> anyhow::Result<()> {
+    let mut conn = new::<Sqlite>().await?;
+
+    let query = "SELECT time();";
+    let info = conn.describe(query).await?;
+    assert_eq!(info.column(0).type_info().name(), "TEXT", "{}", query);
+    assert_eq!(info.nullable(0), Some(false), "{}", query);
+
+    let query = "SELECT time('now');";
+    let info = conn.describe(query).await?;
+    assert_eq!(info.column(0).type_info().name(), "TEXT", "{}", query);
+    assert_eq!(info.nullable(0), Some(true), "{}", query); //can't prove that it's not-null yet
+
+    let query = "SELECT time('now', 'start of month');";
+    let info = conn.describe(query).await?;
+    assert_eq!(info.column(0).type_info().name(), "TEXT", "{}", query);
+    assert_eq!(info.nullable(0), Some(true), "{}", query); //can't prove that it's not-null yet
+
+    let query = "SELECT time(:datebind);";
+    let info = conn.describe(query).await?;
+    assert_eq!(info.column(0).type_info().name(), "TEXT", "{}", query);
+    assert_eq!(info.nullable(0), Some(true), "{}", query);
+    Ok(())
+}
+
+#[sqlx_macros::test]
+async fn it_describes_func_datetime() -> anyhow::Result<()> {
+    let mut conn = new::<Sqlite>().await?;
+
+    let query = "SELECT datetime();";
+    let info = conn.describe(query).await?;
+    assert_eq!(info.column(0).type_info().name(), "TEXT", "{}", query);
+    assert_eq!(info.nullable(0), Some(false), "{}", query);
+
+    let query = "SELECT datetime('now');";
+    let info = conn.describe(query).await?;
+    assert_eq!(info.column(0).type_info().name(), "TEXT", "{}", query);
+    assert_eq!(info.nullable(0), Some(true), "{}", query); //can't prove that it's not-null yet
+
+    let query = "SELECT datetime('now', 'start of month');";
+    let info = conn.describe(query).await?;
+    assert_eq!(info.column(0).type_info().name(), "TEXT", "{}", query);
+    assert_eq!(info.nullable(0), Some(true), "{}", query); //can't prove that it's not-null yet
+
+    let query = "SELECT datetime(:datebind);";
+    let info = conn.describe(query).await?;
+    assert_eq!(info.column(0).type_info().name(), "TEXT", "{}", query);
+    assert_eq!(info.nullable(0), Some(true), "{}", query);
+    Ok(())
+}
+
+#[sqlx_macros::test]
+async fn it_describes_func_julianday() -> anyhow::Result<()> {
+    let mut conn = new::<Sqlite>().await?;
+
+    let query = "SELECT julianday();";
+    let info = conn.describe(query).await?;
+    assert_eq!(info.column(0).type_info().name(), "REAL", "{}", query);
+    assert_eq!(info.nullable(0), Some(false), "{}", query);
+
+    let query = "SELECT julianday('now');";
+    let info = conn.describe(query).await?;
+    assert_eq!(info.column(0).type_info().name(), "REAL", "{}", query);
+    assert_eq!(info.nullable(0), Some(true), "{}", query); //can't prove that it's not-null yet
+
+    let query = "SELECT julianday('now', 'start of month');";
+    let info = conn.describe(query).await?;
+    assert_eq!(info.column(0).type_info().name(), "REAL", "{}", query);
+    assert_eq!(info.nullable(0), Some(true), "{}", query); //can't prove that it's not-null yet
+
+    let query = "SELECT julianday(:datebind);";
+    let info = conn.describe(query).await?;
+    assert_eq!(info.column(0).type_info().name(), "REAL", "{}", query);
+    assert_eq!(info.nullable(0), Some(true), "{}", query);
+    Ok(())
+}
+
+#[sqlx_macros::test]
+async fn it_describes_func_strftime() -> anyhow::Result<()> {
+    let mut conn = new::<Sqlite>().await?;
+
+    let query = "SELECT strftime('%s','now');";
+    let info = conn.describe(query).await?;
+    assert_eq!(info.column(0).type_info().name(), "TEXT", "{}", query);
+    assert_eq!(info.nullable(0), Some(true), "{}", query); //can't prove that it's not-null yet
+
+    let query = "SELECT strftime('%s', 'now', 'start of month');";
+    let info = conn.describe(query).await?;
+    assert_eq!(info.column(0).type_info().name(), "TEXT", "{}", query);
+    assert_eq!(info.nullable(0), Some(true), "{}", query); //can't prove that it's not-null yet
+
+    let query = "SELECT strftime('%s',:datebind);";
+    let info = conn.describe(query).await?;
+    assert_eq!(info.column(0).type_info().name(), "TEXT", "{}", query);
+    assert_eq!(info.nullable(0), Some(true), "{}", query);
+    Ok(())
+}

--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -596,6 +596,12 @@ async fn it_describes_nested_ordered() -> anyhow::Result<()> {
 
     assert_single_true_column_described(&mut conn, "SELECT true LIMIT -1 OFFSET -1").await?;
 
+    assert_single_true_column_described(
+        &mut conn,
+        "SELECT true FROM tweet J LIMIT 10 OFFSET 1000000",
+    )
+    .await?;
+
     Ok(())
 }
 


### PR DESCRIPTION
Add reproducers & fixes for various sqlite describe bugs.
Fixes include:
* fix handling of nested order-by queries
  * handle when sqlite puts a 'record' inside of a blob column
  * handle rewind of an empty table correctly
  * allow opcodes to be evaluated twice per branch path
* fix retrieval of temporary table column signatures
* add basic support for date & time functions
* fix handling of offset clause
  * fix handling of hard-coded large offsets
  * implement IfPos to avoid creating unnecessary branches
* fix handling of group by clause 
  * handle IfNull 
  * handle delete statement when grouping with-clause results