### PR TITLE
add progress handler support to sqlite

### DIFF
--- a/sqlx-sqlite/src/connection/establish.rs
+++ b/sqlx-sqlite/src/connection/establish.rs
@@ -282,6 +282,7 @@ impl EstablishParams {
             statements: Statements::new(self.statement_cache_capacity),
             transaction_depth: 0,
             log_settings: self.log_settings.clone(),
+            progress_handler_callback: None,
         })
     }
 }

--- a/sqlx-sqlite/src/connection/mod.rs
+++ b/sqlx-sqlite/src/connection/mod.rs
@@ -7,8 +7,8 @@ use sqlx_core::error::Error;
 use sqlx_core::transaction::Transaction;
 use std::cmp::Ordering;
 use std::fmt::{self, Debug, Formatter};
-use std::ptr::NonNull;
 use std::os::raw::{c_int, c_void};
+use std::ptr::NonNull;
 
 use crate::connection::establish::EstablishParams;
 use crate::connection::worker::ConnectionWorker;

--- a/sqlx-sqlite/src/connection/mod.rs
+++ b/sqlx-sqlite/src/connection/mod.rs
@@ -272,6 +272,11 @@ impl LockedSqliteHandle<'_> {
             );
         }
     }
+
+    /// Removes the progress handler on a database connection. The method does nothing if no handler was set.
+    pub fn remove_progress_handler(&mut self) {
+        self.guard.remove_progress_handler();
+    }
 }
 
 impl Drop for ConnectionState {

--- a/sqlx-sqlite/src/connection/mod.rs
+++ b/sqlx-sqlite/src/connection/mod.rs
@@ -54,7 +54,7 @@ pub struct LockedSqliteHandle<'a> {
 }
 
 /// Represents a callback handler that will be shared with the underlying sqlite3 connection.
-pub(crate) struct Handler(NonNull<dyn FnMut() -> bool + Send>);
+pub(crate) struct Handler(NonNull<dyn FnMut() -> bool + Send + 'static>);
 unsafe impl Send for Handler {}
 
 pub(crate) struct ConnectionState {

--- a/tests/sqlite/sqlite.rs
+++ b/tests/sqlite/sqlite.rs
@@ -725,3 +725,19 @@ async fn concurrent_read_and_write() {
     read.await;
     write.await;
 }
+
+#[sqlx_macros::test]
+async fn test_query_with_progress_handler() -> anyhow::Result<()> {
+    let mut conn = new::<Sqlite>().await?;
+    conn.set_progress_handler(1, || false).await;
+
+    match sqlx::query("SELECT 'hello' AS title")
+        .fetch_all(&mut conn)
+        .await
+    {
+        Err(sqlx::Error::Database(err)) => assert_eq!(err.message(), String::from("interrupted")),
+        _ => panic!("expected an interrupt"),
+    }
+
+    Ok(())
+}

--- a/tests/sqlite/sqlite.rs
+++ b/tests/sqlite/sqlite.rs
@@ -729,7 +729,10 @@ async fn concurrent_read_and_write() {
 #[sqlx_macros::test]
 async fn test_query_with_progress_handler() -> anyhow::Result<()> {
     let mut conn = new::<Sqlite>().await?;
-    conn.set_progress_handler(1, || false).await;
+    conn.lock_handle()
+        .await?
+        .set_progress_handler(1, || false)
+        .await;
 
     match sqlx::query("SELECT 'hello' AS title")
         .fetch_all(&mut conn)

--- a/tests/sqlite/sqlite.rs
+++ b/tests/sqlite/sqlite.rs
@@ -729,10 +729,13 @@ async fn concurrent_read_and_write() {
 #[sqlx_macros::test]
 async fn test_query_with_progress_handler() -> anyhow::Result<()> {
     let mut conn = new::<Sqlite>().await?;
-    conn.lock_handle()
-        .await?
-        .set_progress_handler(1, || false)
-        .await;
+
+    // Using this string as a canary to ensure the callback doesn't get called with the wrong data pointer.
+    let state = format!("test");
+    conn.lock_handle().await?.set_progress_handler(1, move || {
+        assert_eq!(state, "test");
+        false
+    });
 
     match sqlx::query("SELECT 'hello' AS title")
         .fetch_all(&mut conn)


### PR DESCRIPTION
**What**
Adds progress handler support to sqlite. The feature is already supported by the sqlite driver. This PR exposes it.