### PR TITLE
feat: support calling Postgres procedures with the macros

### DIFF
--- a/sqlx-postgres/src/connection/describe.rs
+++ b/sqlx-postgres/src/connection/describe.rs
@@ -449,9 +449,15 @@ WHERE rngtypid = $1
 
         let mut nullables = Vec::new();
 
-        if let Some(outputs) = &explain.plan.output {
+        if let Explain::Plan(
+            plan @ Plan {
+                output: Some(outputs),
+                ..
+            },
+        ) = &explain
+        {
             nullables.resize(outputs.len(), None);
-            visit_plan(&explain.plan, outputs, &mut nullables);
+            visit_plan(&plan, outputs, &mut nullables);
         }
 
         Ok(nullables)
@@ -484,9 +490,13 @@ fn visit_plan(plan: &Plan, outputs: &[String], nullables: &mut Vec<Option<bool>>
 }
 
 #[derive(serde::Deserialize)]
-struct Explain {
-    #[serde(rename = "Plan")]
-    plan: Plan,
+enum Explain {
+    /// {"Plan": ...} -- returned for most statements
+    Plan(Plan),
+    /// The string "Utility Statement" -- returned for
+    /// a CALL statement
+    #[serde(rename = "Utility Statement")]
+    UtilityStatement,
 }
 
 #[derive(serde::Deserialize)]

--- a/tests/postgres/macros.rs
+++ b/tests/postgres/macros.rs
@@ -97,6 +97,19 @@ async fn test_void() -> anyhow::Result<()> {
 }
 
 #[sqlx_macros::test]
+async fn test_call_procedure() -> anyhow::Result<()> {
+    let mut conn = new::<Postgres>().await?;
+
+    let row = sqlx::query!(r#"CALL forty_two(null)"#)
+        .fetch_one(&mut conn)
+        .await?;
+
+    assert_eq!(row.forty_two, Some(42));
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
 async fn test_query_file() -> anyhow::Result<()> {
     let mut conn = new::<Postgres>().await?;
 

--- a/tests/postgres/setup.sql
+++ b/tests/postgres/setup.sql
@@ -41,3 +41,6 @@ CREATE TABLE products (
     name TEXT,
     price NUMERIC CHECK (price > 0)
 );
+
+CREATE OR REPLACE PROCEDURE forty_two(INOUT forty_two INT = NULL)
+    LANGUAGE plpgsql AS 'begin forty_two := 42; end;';


### PR DESCRIPTION
Fixes #1449 (I think). I verified that without the fix, an appropriate invocation to `cargo test` fails, and with the fix included the same invocation to `cargo test` passes.

I used INOUT in setup.sql because older versions of Postgres don't support OUT parameters.