### PR TITLE
U256 support for NUMERIC type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +407,12 @@ name = "bumpalo"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "byteorder"
@@ -716,6 +734,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,6 +985,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethbloom"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "uint",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,6 +1057,18 @@ dependencies = [
  "libc",
  "redox_syscall",
  "windows-sys",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand 0.8.5",
+ "rustc-hex",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1071,6 +1134,12 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1416,6 +1485,44 @@ name = "if_chain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
+
+[[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "indexmap"
@@ -1898,6 +2005,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
+name = "parity-scale-codec"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366e44391a8af4cfd6002ef6ba072bae071a96aafca98d7d448a34c5dca38b6a"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9299338969a3d2f491d65f140b00ddec470858402f888af98e8642fb5e8965cd"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,6 +2254,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "primitive-types"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "uint",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
+dependencies = [
+ "once_cell",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,6 +2327,12 @@ checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "radix_trie"
@@ -2362,6 +2525,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
 name = "rsa"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2391,6 +2564,12 @@ dependencies = [
  "num-traits",
  "serde",
 ]
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
@@ -2798,6 +2977,7 @@ dependencies = [
  "dotenvy",
  "either",
  "encoding_rs",
+ "ethereum-types",
  "event-listener",
  "flume",
  "futures-channel",
@@ -2986,6 +3166,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "str-buf"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3059,6 +3245,12 @@ name = "sync_wrapper"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempdir"
@@ -3173,6 +3365,15 @@ name = "time-macros"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
 
 [[package]]
 name = "tinytemplate"
@@ -3378,6 +3579,18 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -3747,6 +3960,15 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ all-databases = ["mysql", "sqlite", "postgres", "mssql", "any"]
 all-types = [
     "bigdecimal",
     "decimal",
+    "u256",
     "json",
     "time",
     "chrono",
@@ -114,6 +115,7 @@ mssql = ["sqlx-core/mssql", "sqlx-macros/mssql"]
 # types
 bigdecimal = ["sqlx-core/bigdecimal", "sqlx-macros/bigdecimal"]
 decimal = ["sqlx-core/decimal", "sqlx-macros/decimal"]
+u256 = ["sqlx-core/u256", "sqlx-macros/u256"]
 chrono = ["sqlx-core/chrono", "sqlx-macros/chrono"]
 ipnetwork = ["sqlx-core/ipnetwork", "sqlx-macros/ipnetwork"]
 mac_address = ["sqlx-core/mac_address", "sqlx-macros/mac_address"]

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ sqlx = { version = "0.6", features = [ "runtime-async-std-native-tls" ] }
 
 -   `decimal`: Add support for `NUMERIC` using the `rust_decimal` crate.
 
+-   `u256`: Add support for `NUMERIC` using the `ethereum-types` crate.
+
 -   `ipnetwork`: Add support for `INET` and `CIDR` (in postgres) using the `ipnetwork` crate.
 
 -   `json`: Add support for `JSON` and `JSONB` (in postgres) using the `serde_json` crate.

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -63,7 +63,7 @@ all-types = [
 ]
 bigdecimal = ["bigdecimal_", "num-bigint"]
 decimal = ["rust_decimal", "num-bigint"]
-u256 = ["ethereum_types"]
+u256 = ["ethereum-types"]
 json = ["serde", "serde_json"]
 
 # runtimes

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -54,6 +54,7 @@ all-types = [
     "time",
     "bigdecimal",
     "decimal",
+    "u256",
     "ipnetwork",
     "mac_address",
     "json",
@@ -62,6 +63,7 @@ all-types = [
 ]
 bigdecimal = ["bigdecimal_", "num-bigint"]
 decimal = ["rust_decimal", "num-bigint"]
+u256 = ["ethereum_types"]
 json = ["serde", "serde_json"]
 
 # runtimes
@@ -110,6 +112,7 @@ sqlx-rt = { path = "../sqlx-rt", version = "0.6.2" }
 base64 = { version = "0.13.0", default-features = false, optional = true, features = ["std"] }
 bigdecimal_ = { version = "0.3.0", optional = true, package = "bigdecimal" }
 rust_decimal = { version = "1.19.0", optional = true }
+ethereum-types = { version = "0.14.1", optional = true }
 bit-vec = { version = "0.6.3", optional = true }
 bitflags = { version = "1.3.2", default-features = false }
 bytes = "1.1.0"

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -63,7 +63,7 @@ all-types = [
 ]
 bigdecimal = ["bigdecimal_", "num-bigint"]
 decimal = ["rust_decimal", "num-bigint"]
-u256 = ["ethereum-types"]
+u256 = ["ethereum-types", "bigdecimal"]
 json = ["serde", "serde_json"]
 
 # runtimes

--- a/sqlx-core/src/postgres/types/mod.rs
+++ b/sqlx-core/src/postgres/types/mod.rs
@@ -31,7 +31,7 @@
 //! | Rust type                             | Postgres type(s)                                        |
 //! |---------------------------------------|------------------------------------------------------|
 //! | `rust_decimal::Decimal`               | NUMERIC                                              |
-//! 
+//!
 //! ### [`u256`](https://crates.io/crates/ethereum-types)
 //! Requires the `u256` Cargo feature flag.
 //!

--- a/sqlx-core/src/postgres/types/mod.rs
+++ b/sqlx-core/src/postgres/types/mod.rs
@@ -31,6 +31,13 @@
 //! | Rust type                             | Postgres type(s)                                        |
 //! |---------------------------------------|------------------------------------------------------|
 //! | `rust_decimal::Decimal`               | NUMERIC                                              |
+//! 
+//! ### [`u256`](https://crates.io/crates/ethereum-types)
+//! Requires the `u256` Cargo feature flag.
+//!
+//! | Rust type                             | Postgres type(s)                                        |
+//! |---------------------------------------|------------------------------------------------------|
+//! | `ethereum_types::U256`                | NUMERIC                                              |
 //!
 //! ### [`chrono`](https://crates.io/crates/chrono)
 //!
@@ -191,11 +198,14 @@ mod time_tz;
 #[cfg(feature = "bigdecimal")]
 mod bigdecimal;
 
-#[cfg(any(feature = "bigdecimal", feature = "decimal"))]
+#[cfg(any(feature = "bigdecimal", feature = "decimal", feature = "u256"))]
 mod numeric;
 
 #[cfg(feature = "decimal")]
 mod decimal;
+
+#[cfg(feature = "u256")]
+mod u256;
 
 #[cfg(feature = "chrono")]
 mod chrono;

--- a/sqlx-core/src/postgres/types/range.rs
+++ b/sqlx-core/src/postgres/types/range.rs
@@ -155,6 +155,17 @@ impl Type<Postgres> for PgRange<rust_decimal::Decimal> {
     }
 }
 
+#[cfg(feature = "u256")]
+impl Type<Postgres> for PgRange<ethereum_types::U256> {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::NUM_RANGE
+    }
+
+    fn compatible(ty: &PgTypeInfo) -> bool {
+        range_compatible::<ethereum_types::U256>(ty)
+    }
+}
+
 #[cfg(feature = "chrono")]
 impl Type<Postgres> for PgRange<chrono::NaiveDate> {
     fn type_info() -> PgTypeInfo {
@@ -242,6 +253,13 @@ impl PgHasArrayType for PgRange<bigdecimal::BigDecimal> {
 
 #[cfg(feature = "decimal")]
 impl PgHasArrayType for PgRange<rust_decimal::Decimal> {
+    fn array_type_info() -> PgTypeInfo {
+        PgTypeInfo::NUM_RANGE_ARRAY
+    }
+}
+
+#[cfg(feature = "u256")]
+impl PgHasArrayType for PgRange<ethereum_types::U256> {
     fn array_type_info() -> PgTypeInfo {
         PgTypeInfo::NUM_RANGE_ARRAY
     }

--- a/sqlx-core/src/postgres/types/u256.rs
+++ b/sqlx-core/src/postgres/types/u256.rs
@@ -1,0 +1,94 @@
+use core::num;
+use std::cmp;
+use std::str::FromStr;
+
+use bigdecimal::BigDecimal;
+use ethereum_types::U256;
+use num_bigint::{BigInt, Sign};
+
+use crate::decode::Decode;
+use crate::encode::{Encode, IsNull};
+use crate::error::BoxDynError;
+use crate::postgres::types::numeric::{PgNumeric, PgNumericSign};
+use crate::postgres::{
+    PgArgumentBuffer, PgHasArrayType, PgTypeInfo, PgValueFormat, PgValueRef, Postgres,
+};
+use crate::types::Type;
+
+impl Type<Postgres> for U256 {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::NUMERIC
+    }
+}
+
+impl PgHasArrayType for U256 {
+    fn array_type_info() -> PgTypeInfo {
+        PgTypeInfo::NUMERIC_ARRAY
+    }
+}
+
+impl TryFrom<PgNumeric> for U256 {
+    type Error = BoxDynError;
+
+    fn try_from(numeric: PgNumeric) -> Result<Self, BoxDynError> {
+        let bigdecimal =
+            BigDecimal::try_from(numeric).expect("U256 failed to convert NUMERIC to BigDecimal");
+
+        if bigdecimal.sign() == Sign::Minus {
+            return Err("U256 is unsigned".into());
+        }
+        if bigdecimal.digits() > 0 {
+            return Err("U256 doesn't support decimal digits".into());
+        }
+
+        let u256 =
+            U256::from_dec_str(&bigdecimal.to_string()).expect("U256 failed from BigDecimal");
+
+        Ok(u256)
+    }
+}
+
+impl TryFrom<&'_ U256> for PgNumeric {
+    type Error = BoxDynError;
+
+    fn try_from(u256: &U256) -> Result<Self, BoxDynError> {
+        let bigdecimal =
+            BigDecimal::from_str(&u256.to_string()).expect("U256 failed to convert to BigDecimal");
+        let numeric = PgNumeric::try_from(&bigdecimal)
+            .expect("U256 failed to convert BigDecimal to PgNumeric");
+
+        Ok(numeric)
+    }
+}
+
+/// ### Panics
+/// If this `U256` cannot be represented by `PgNumeric`.
+impl Encode<'_, Postgres> for U256 {
+    fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> IsNull {
+        PgNumeric::try_from(self)
+            .expect("Failed to convert U256 to PgNumeric")
+            .encode(buf);
+
+        IsNull::No
+    }
+
+    fn size_hint(&self) -> usize {
+        // We use the same formula as the BigDecimal specific size_hint function.
+        let bigdecimal =
+            BigDecimal::from_str(&self.to_string()).expect("U256 failed to convert to BigDecimal");
+
+        8 + (bigdecimal.digits() / 4 + 1) as usize * 2
+    }
+}
+
+impl Decode<'_, Postgres> for U256 {
+    fn decode(value: PgValueRef<'_>) -> Result<Self, BoxDynError> {
+        match value.format() {
+            PgValueFormat::Binary => PgNumeric::decode(value.as_bytes()?)?.try_into(),
+            PgValueFormat::Text => Ok(U256::from_dec_str(
+                &value.as_str()?.parse::<BigDecimal>()?.to_string()
+            )
+            .expect("U256 failed from BigDecimal")),
+        }
+    }
+}

--- a/sqlx-core/src/postgres/types/u256.rs
+++ b/sqlx-core/src/postgres/types/u256.rs
@@ -86,7 +86,7 @@ impl Decode<'_, Postgres> for U256 {
         match value.format() {
             PgValueFormat::Binary => PgNumeric::decode(value.as_bytes()?)?.try_into(),
             PgValueFormat::Text => Ok(U256::from_dec_str(
-                &value.as_str()?.parse::<BigDecimal>()?.to_string()
+                &value.as_str()?.parse::<BigDecimal>()?.to_string(),
             )
             .expect("U256 failed from BigDecimal")),
         }

--- a/sqlx-core/src/postgres/types/u256.rs
+++ b/sqlx-core/src/postgres/types/u256.rs
@@ -1,15 +1,13 @@
-use core::num;
-use std::cmp;
 use std::str::FromStr;
 
 use bigdecimal::BigDecimal;
 use ethereum_types::U256;
-use num_bigint::{BigInt, Sign};
+use num_bigint::Sign;
 
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
 use crate::error::BoxDynError;
-use crate::postgres::types::numeric::{PgNumeric, PgNumericSign};
+use crate::postgres::types::numeric::PgNumeric;
 use crate::postgres::{
     PgArgumentBuffer, PgHasArrayType, PgTypeInfo, PgValueFormat, PgValueRef, Postgres,
 };

--- a/sqlx-core/src/types/mod.rs
+++ b/sqlx-core/src/types/mod.rs
@@ -68,6 +68,11 @@ pub use bigdecimal::BigDecimal;
 #[doc(no_inline)]
 pub use rust_decimal::Decimal;
 
+#[cfg(feature = "u256")]
+#[cfg_attr(docsrs, doc(cfg(feature = "u256")))]
+#[doc(no_inline)]
+pub use ethereum_types::U256;
+
 #[cfg(feature = "ipnetwork")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ipnetwork")))]
 pub mod ipnetwork {

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -59,6 +59,7 @@ mssql = ["sqlx-core/mssql"]
 
 # type
 bigdecimal = ["sqlx-core/bigdecimal"]
+u256 = ["sqlx-core/u256"]
 decimal = ["sqlx-core/decimal"]
 chrono = ["sqlx-core/chrono"]
 time = ["sqlx-core/time"]

--- a/sqlx-macros/src/database/postgres.rs
+++ b/sqlx-macros/src/database/postgres.rs
@@ -62,6 +62,9 @@ impl_database_ext! {
         #[cfg(feature = "decimal")]
         sqlx::types::Decimal,
 
+        #[cfg(feature = "u256")]
+        sqlx::types::U256,
+
         #[cfg(feature = "ipnetwork")]
         sqlx::types::ipnetwork::IpNetwork,
 
@@ -121,6 +124,9 @@ impl_database_ext! {
         #[cfg(feature = "decimal")]
         Vec<sqlx::types::Decimal> | &[sqlx::types::Decimal],
 
+        #[cfg(feature = "u256")]
+        Vec<sqlx::types::U256> | &[sqlx::types::U256],
+
         #[cfg(feature = "ipnetwork")]
         Vec<sqlx::types::ipnetwork::IpNetwork> | &[sqlx::types::ipnetwork::IpNetwork],
 
@@ -140,6 +146,9 @@ impl_database_ext! {
 
         #[cfg(feature = "decimal")]
         sqlx::postgres::types::PgRange<sqlx::types::Decimal>,
+
+        #[cfg(feature = "u256")]
+        sqlx::postgres::types::PgRange<sqlx::types::U256>,
 
         #[cfg(feature = "chrono")]
         sqlx::postgres::types::PgRange<sqlx::types::chrono::NaiveDate>,
@@ -172,6 +181,10 @@ impl_database_ext! {
         #[cfg(feature = "decimal")]
         Vec<sqlx::postgres::types::PgRange<sqlx::types::Decimal>> |
             &[sqlx::postgres::types::PgRange<sqlx::types::Decimal>],
+
+        #[cfg(feature = "u256")]
+        Vec<sqlx::postgres::types::PgRange<sqlx::types::U256>> |
+            &[sqlx::postgres::types::PgRange<sqlx::types::U256>],
 
         #[cfg(feature = "chrono")]
         Vec<sqlx::postgres::types::PgRange<sqlx::types::chrono::NaiveDate>> |


### PR DESCRIPTION
This PR adds support for U256 for NUMERICs in PGSQL. The PRed implementation uses BigDecimal under the hood and constructs the U256 from it.