### PR TITLE
Don't run EXPLAIN nullability analysis on Materialize

### DIFF
--- a/sqlx-postgres/src/connection/describe.rs
+++ b/sqlx-postgres/src/connection/describe.rs
@@ -399,8 +399,10 @@ WHERE rngtypid = $1
             .fetch_all(&mut *self)
             .await?;
 
-        // if it's cockroachdb skip this step #1248
-        if !self.stream.parameter_statuses.contains_key("crdb_version") {
+        // If the server is CockroachDB or Materialize, skip this step (#1248).
+        if !self.stream.parameter_statuses.contains_key("crdb_version")
+            && !self.stream.parameter_statuses.contains_key("mz_version")
+        {
             // patch up our null inference with data from EXPLAIN
             let nullable_patch = self
                 .nullables_from_explain(stmt_id, meta.parameters.len())


### PR DESCRIPTION
Materialize [0] is a PostgreSQL-like database that, similar to CockroachDB, does not support PostgreSQL's `EXPLAIN` output. Extend the fix from PR #1248 to Materialize, too, so that sqlx can still be used with Materialize.

See #1248.

[0]: https://materialize.com