### PR TITLE
`time`: Assume UTC when decoding a DATETIME column in sqlite

### DIFF
--- a/sqlx-sqlite/src/types/time.rs
+++ b/sqlx-sqlite/src/types/time.rs
@@ -145,6 +145,10 @@ fn decode_offset_datetime_from_text(value: &str) -> Option<OffsetDateTime> {
         return Some(dt);
     }
 
+    if let Some(dt) = decode_datetime_from_text(value) {
+        return Some(dt.assume_utc());
+    }
+
     None
 }
 


### PR DESCRIPTION
Sqlite's DATETIME column can have a default value set by CURRENT_TIMESTAMP which is then a string expressed from UTC in the following format: "YYYY-MM-DD HH:MM:SS". Unfortunately, this can't be properly decoded as a time::OffsetDateTime as the TZ info is missing. This PR proposes to assume UTC in such a case.

Related issue #2288.