### PR TITLE
core,macros: allow buildtime bindings for SQLite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,8 @@ _rt-tokio = []
 any = ["sqlx-core/any", "sqlx-mysql?/any", "sqlx-postgres?/any", "sqlx-sqlite?/any"]
 postgres = ["sqlx-postgres", "sqlx-macros?/postgres"]
 mysql = ["sqlx-mysql", "sqlx-macros?/mysql"]
-sqlite = ["sqlx-sqlite", "sqlx-macros?/sqlite"]
+sqlite-nonbundled = ["sqlx-sqlite", "sqlx-macros?/sqlite"]
+sqlite = ["sqlite-nonbundled", "sqlx-sqlite/bundled"]
 
 # types
 json = ["sqlx-macros?/json", "sqlx-mysql?/json", "sqlx-postgres?/json", "sqlx-sqlite?/json"]

--- a/sqlx-sqlite/Cargo.toml
+++ b/sqlx-sqlite/Cargo.toml
@@ -15,6 +15,7 @@ any = ["sqlx-core/any"]
 json = ["sqlx-core/json", "serde"]
 offline = ["sqlx-core/offline", "serde"]
 migrate = ["sqlx-core/migrate"]
+bundled = ["libsqlite3-sys/bundled"]
 
 chrono = ["dep:chrono", "bitflags"]
 regexp = ["dep:regex"]
@@ -52,7 +53,6 @@ default-features = false
 features = [
     "pkg-config",
     "vcpkg",
-    "bundled",
     "unlock_notify"
 ]
 


### PR DESCRIPTION
Before this patch, libsqlite3-sys crate was always used with its "bundled" feature, which makes it impossible to build bindings and link with a custom version of the libsqlite3 library. This patch adds a "sqlite-nonbundled" feature which does not enforce `libsqlite3-sys/bundled`, allowing the users to provide their own paths for binding and linking, as well as other custom features of libsqlite3-sys, like buildtime_bindgen (also added to sqlx-sqlite's Cargo.toml).

The snippet below works as expected after the patch:
```
SQLITE3_LIB_DIR=~/repo/libsql/.libs \
    SQLITE3_INCLUDE_DIR=~/repo/libsql/ \
    cargo build -F sqlite-nonbundled,libsqlite3-sys/buildtime_bindgen
```

For backward compatibility purposes, the existing sqlite feature still defaults to using bundled SQLite.