### PR TITLE
Add new features runtime-{runtime}-notls to avoid tls dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,18 @@ runtime-tokio-rustls = [
     "_rt-tokio",
 ]
 
+runtime-actix-notls = ["runtime-tokio-notls"]
+runtime-async-std-notls = [
+    "sqlx-core/runtime-async-std-notls",
+    "sqlx-macros/runtime-async-std-notls",
+    "_rt-async-std",
+]
+runtime-tokio-notls = [
+    "sqlx-core/runtime-tokio-notls",
+    "sqlx-macros/runtime-tokio-notls",
+    "_rt-tokio",
+]
+
 # for conditional compilation
 _rt-async-std = []
 _rt-tokio = []

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -93,10 +93,25 @@ runtime-tokio-rustls = [
     "_rt-tokio"
 ]
 
+runtime-actix-notls = ['runtime-tokio-notls']
+runtime-async-std-notls = [
+    "sqlx-rt/runtime-async-std-notls",
+    "sqlx/runtime-async-std-notls",
+    "_tls-notls",
+    "_rt-async-std",
+]
+runtime-tokio-notls = [
+    "sqlx-rt/runtime-tokio-notls",
+    "sqlx/runtime-tokio-notls",
+    "_tls-notls",
+    "_rt-tokio"
+]
+
 # for conditional compilation
 _rt-async-std = []
 _rt-tokio = ["tokio-stream"]
 _tls-native-tls = []
+_tls-notls = []
 _tls-rustls = ["rustls", "rustls-pemfile", "webpki-roots"]
 
 # support offline/decoupled building (enables serialization of `Describe`)

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -44,6 +44,18 @@ runtime-tokio-rustls = [
     "_rt-tokio",
 ]
 
+runtime-actix-notls = ["runtime-tokio-notls"]
+runtime-async-std-notls = [
+    "sqlx-core/runtime-async-std-notls",
+    "sqlx-rt/runtime-async-std-notls",
+    "_rt-async-std",
+]
+runtime-tokio-notls = [
+    "sqlx-core/runtime-tokio-notls",
+    "sqlx-rt/runtime-tokio-notls",
+    "_rt-tokio",
+]
+
 # for conditional compilation
 _rt-async-std = []
 _rt-tokio = []

--- a/sqlx-rt/Cargo.toml
+++ b/sqlx-rt/Cargo.toml
@@ -23,10 +23,15 @@ runtime-actix-rustls = ["runtime-tokio-rustls"]
 runtime-async-std-rustls = ["_rt-async-std", "_tls-rustls", "futures-rustls"]
 runtime-tokio-rustls = ["_rt-tokio", "_tls-rustls", "tokio-rustls"]
 
+runtime-actix-notls = ["runtime-tokio-notls"]
+runtime-async-std-notls = ["_rt-async-std", "_tls-notls"]
+runtime-tokio-notls = ["_rt-tokio", "_tls-notls"]
+
 # Not used directly and not re-exported from sqlx
 _rt-async-std = ["async-std"]
 _rt-tokio = ["tokio", "once_cell"]
 _tls-native-tls = ["native-tls"]
+_tls-notls = []
 _tls-rustls = []
 
 [dependencies]

--- a/sqlx-rt/src/lib.rs
+++ b/sqlx-rt/src/lib.rs
@@ -7,11 +7,15 @@
     feature = "runtime-actix-rustls",
     feature = "runtime-async-std-rustls",
     feature = "runtime-tokio-rustls",
+    feature = "runtime-actix-notls",
+    feature = "runtime-async-std-notls",
+    feature = "runtime-tokio-notls",
 )))]
 compile_error!(
     "one of the features ['runtime-actix-native-tls', 'runtime-async-std-native-tls', \
      'runtime-tokio-native-tls', 'runtime-actix-rustls', 'runtime-async-std-rustls', \
-     'runtime-tokio-rustls'] must be enabled"
+     'runtime-tokio-rustls', 'runtime-actix-notls', 'runtime-async-std-notls', \
+     'runtime-tokio-notls'] must be enabled"
 );
 
 #[cfg(any(
@@ -19,11 +23,14 @@ compile_error!(
     all(feature = "_rt-actix", feature = "_rt-tokio"),
     all(feature = "_rt-async-std", feature = "_rt-tokio"),
     all(feature = "_tls-native-tls", feature = "_tls-rustls"),
+    all(feature = "_tls-native-tls", feature = "_tls-notls"),
+    all(feature = "_tls-rustls", feature = "_tls-notls"),
 ))]
 compile_error!(
     "only one of ['runtime-actix-native-tls', 'runtime-async-std-native-tls', \
      'runtime-tokio-native-tls', 'runtime-actix-rustls', 'runtime-async-std-rustls', \
-     'runtime-tokio-rustls'] can be enabled"
+     'runtime-tokio-rustls', 'runtime-actix-notls', 'runtime-async-std-notls', \
+     'runtime-tokio-notls'] can be enabled"
 );
 
 #[cfg(feature = "_rt-async-std")]


### PR DESCRIPTION
Add new features runtime-{runtime}-notls to avoid tls dependency

Should fix #515 now that rust 1.60 supports optional dependency features