### PR TITLE
Bump libsqlite3-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,9 +1546,9 @@ checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.24.2"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
+checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ rand_xoshiro = "0.6.0"
 hex = "0.4.3"
 tempdir = "0.3.7"
 # Needed to test SQLCipher
-libsqlite3-sys = { version = "0.24", features = ["bundled-sqlcipher"] }
+libsqlite3-sys = { version = "0.25", features = ["bundled-sqlcipher"] }
 
 #
 # Any

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -135,7 +135,7 @@ itoa = "1.0.1"
 ipnetwork = { version = "0.19.0", default-features = false, optional = true }
 mac_address = { version = "1.1.2", default-features = false, optional = true }
 libc = "0.2.112"
-libsqlite3-sys = { version = "0.24.1", optional = true, default-features = false, features = [
+libsqlite3-sys = { version = "0.25.2", optional = true, default-features = false, features = [
     "pkg-config",
     "vcpkg",
     "bundled",

--- a/sqlx-core/src/sqlite/statement/unlock_notify.rs
+++ b/sqlx-core/src/sqlite/statement/unlock_notify.rs
@@ -48,10 +48,11 @@ impl Notify {
     }
 
     fn wait(&self) {
-        let _ = self
-            .condvar
-            .wait_while(self.mutex.lock().unwrap(), |fired| !*fired)
-            .unwrap();
+        drop(
+            self.condvar
+                .wait_while(self.mutex.lock().unwrap(), |fired| !*fired)
+                .unwrap(),
+        );
     }
 
     fn fire(&self) {


### PR DESCRIPTION
Bumps libsqlite3-sys to v0.25.2 (which bumps sqlite to [3.40.1](https://www.sqlite.org/releaselog/3_40_1.html)).

This seems to fix some random glitches that we've been experiencing when running our integration test suite so it would be great to have this merged soon.

I've also included @tyrelr's #2228 because it wouldn't compile without it. 