### PR TITLE
Set whoami default-features to false

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3910,10 +3910,6 @@ name = "whoami"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45dbc71f0cdca27dc261a9bd37ddec174e4a0af2b900b890f378460f745426e3"
-dependencies = [
- "wasm-bindgen",
- "web-sys",
-]
 
 [[package]]
 name = "winapi"

--- a/sqlx-mysql/Cargo.toml
+++ b/sqlx-mysql/Cargo.toml
@@ -61,7 +61,7 @@ smallvec = "1.7.0"
 stringprep = "0.1.2"
 thiserror = "1.0.35"
 tracing = { version = "0.1.37", features = ["log"] }
-whoami = "1.2.1"
+whoami = { version = "1.2.1", default-features = false }
 
 serde = { version = "1.0.144", optional = true }
 

--- a/sqlx-postgres/Cargo.toml
+++ b/sqlx-postgres/Cargo.toml
@@ -62,7 +62,7 @@ smallvec = "1.7.0"
 stringprep = "0.1.2"
 thiserror = "1.0.35"
 tracing = { version = "0.1.37", features = ["log"] }
-whoami = "1.2.1"
+whoami = { version = "1.2.1", default-features = false }
 
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = { version = "1.0.85", features = ["raw_value"] }

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -733,7 +733,7 @@ macro_rules! query_file_scalar_unchecked (
 ///
 /// This is because our ability to tell the compiler to watch external files for changes
 /// from a proc-macro is very limited. The compiler by default only re-runs proc macros when
-/// one ore more source files have changed, because normally it shouldn't have to otherwise. SQLx is
+/// one or more source files have changed, because normally it shouldn't have to otherwise. SQLx is
 /// just weird in that external factors can change the output of proc macros, much to the chagrin of
 /// the compiler team and IDE plugin authors.
 ///


### PR DESCRIPTION
Otherwise, whoami pulls in web-sys, wasm-bindgen and a BUNCH of additional dependencies. This is really unnecessary, and if someone has an actual use case where they are attempting to connect to postgres from a browser, well ... they've probably already been pwned by now. If it is deemed necessary, then add an additional activation feature for that specific slew of deps.