### PR TITLE
[draft] fix: remove either left value when mysql eof (#2336)

### DIFF
--- a/sqlx-core/src/mysql/connection/executor.rs
+++ b/sqlx-core/src/mysql/connection/executor.rs
@@ -174,10 +174,10 @@ impl MySqlConnection {
                     if packet[0] == 0xfe && packet.len() < 9 {
                         let eof = packet.eof(self.stream.capabilities)?;
 
-                        r#yield!(Either::Left(MySqlQueryResult {
-                            rows_affected: 0,
-                            last_insert_id: 0,
-                        }));
+                        // r#yield!(Either::Left(MySqlQueryResult {
+                        //     rows_affected: 0,
+                        //     last_insert_id: 0,
+                        // }));
 
                         if eof.status.contains(Status::SERVER_MORE_RESULTS_EXISTS) {
                             // more result sets exist, continue to the next one


### PR DESCRIPTION
this PR aim to fix https://github.com/launchbadge/sqlx/issues/2336