### PR TITLE
Allow ignoring attributes for deriving FromRow

### DIFF
--- a/sqlx-macros-core/src/derives/attributes.rs
+++ b/sqlx-macros-core/src/derives/attributes.rs
@@ -63,6 +63,7 @@ pub struct SqlxChildAttributes {
     pub default: bool,
     pub flatten: bool,
     pub try_from: Option<Type>,
+    pub skip: bool,
 }
 
 pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContainerAttributes> {
@@ -155,6 +156,7 @@ pub fn parse_child_attributes(input: &[Attribute]) -> syn::Result<SqlxChildAttri
     let mut default = false;
     let mut try_from = None;
     let mut flatten = false;
+    let mut skip: bool = false;
 
     for attr in input.iter().filter(|a| a.path.is_ident("sqlx")) {
         let meta = attr
@@ -177,6 +179,7 @@ pub fn parse_child_attributes(input: &[Attribute]) -> syn::Result<SqlxChildAttri
                         }) if path.is_ident("try_from") => try_set!(try_from, val.parse()?, value),
                         Meta::Path(path) if path.is_ident("default") => default = true,
                         Meta::Path(path) if path.is_ident("flatten") => flatten = true,
+                        Meta::Path(path) if path.is_ident("skip") => skip = true,
                         u => fail!(u, "unexpected attribute"),
                     },
                     u => fail!(u, "unexpected attribute"),
@@ -190,6 +193,7 @@ pub fn parse_child_attributes(input: &[Attribute]) -> syn::Result<SqlxChildAttri
         default,
         flatten,
         try_from,
+        skip,
     })
 }
 

--- a/sqlx-macros-core/src/derives/row.rs
+++ b/sqlx-macros-core/src/derives/row.rs
@@ -72,6 +72,12 @@ fn expand_derive_from_row_struct(
             let attributes = parse_child_attributes(&field.attrs).unwrap();
             let ty = &field.ty;
 
+            if attributes.skip {
+                return Some(parse_quote!(
+                    let #id: #ty = Default::default();
+                ));
+            }
+
             let expr: Expr = match (attributes.flatten, attributes.try_from) {
                 (true, None) => {
                     predicates.push(parse_quote!(#ty: ::sqlx::FromRow<#lifetime, R>));

--- a/tests/postgres/derives.rs
+++ b/tests/postgres/derives.rs
@@ -615,7 +615,6 @@ async fn test_flatten() -> anyhow::Result<()> {
     Ok(())
 }
 
-
 #[cfg(feature = "macros")]
 #[sqlx_macros::test]
 async fn test_skip() -> anyhow::Result<()> {
@@ -633,11 +632,9 @@ async fn test_skip() -> anyhow::Result<()> {
 
     let mut conn = new::<Postgres>().await?;
 
-    let account: AccountKeyword = sqlx::query_as(
-        r#"SELECT * from (VALUES (1)) accounts("id")"#,
-    )
-    .fetch_one(&mut conn)
-    .await?;
+    let account: AccountKeyword = sqlx::query_as(r#"SELECT * from (VALUES (1)) accounts("id")"#)
+        .fetch_one(&mut conn)
+        .await?;
     println!("{:?}", account);
 
     assert_eq!(1, account.id);

--- a/tests/postgres/derives.rs
+++ b/tests/postgres/derives.rs
@@ -614,3 +614,34 @@ async fn test_flatten() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+
+#[cfg(feature = "macros")]
+#[sqlx_macros::test]
+async fn test_skip() -> anyhow::Result<()> {
+    #[derive(Debug, Default, sqlx::FromRow)]
+    struct AccountDefault {
+        default: Option<i32>,
+    }
+
+    #[derive(Debug, sqlx::FromRow)]
+    struct AccountKeyword {
+        id: i32,
+        #[sqlx(skip)]
+        default: AccountDefault,
+    }
+
+    let mut conn = new::<Postgres>().await?;
+
+    let account: AccountKeyword = sqlx::query_as(
+        r#"SELECT * from (VALUES (1)) accounts("id")"#,
+    )
+    .fetch_one(&mut conn)
+    .await?;
+    println!("{:?}", account);
+
+    assert_eq!(1, account.id);
+    assert_eq!(None, account.default.default);
+
+    Ok(())
+}


### PR DESCRIPTION
This pull request adds a new attribute flag `skip` for deriving `FromRow` (similar to `serde`'s `skip`). It allows to add additional fields to a `struct` which will be filled with `Default::default()`.