### PR TITLE
fix: Assign condvar's guard to a temporary variable

### DIFF
--- a/sqlx-core/src/sqlite/statement/unlock_notify.rs
+++ b/sqlx-core/src/sqlite/statement/unlock_notify.rs
@@ -48,7 +48,7 @@ impl Notify {
     }
 
     fn wait(&self) {
-        let _ = self
+        let _dont_drop_early = self
             .condvar
             .wait_while(self.mutex.lock().unwrap(), |fired| !*fired)
             .unwrap();


### PR DESCRIPTION
While trying to compile sqlx-cli with `cargo build --no-default-features --features rustls,postgres,mysql,sqlite` I found the following issue.

```
error: non-binding let on a synchronization lock
  --> sqlx-core/src/sqlite/statement/unlock_notify.rs:51:13
   |
51 |           let _ = self
   |  _____________^___^
   | |             |
   | |             this lock is not assigned to a binding and is immediately dropped
52 | |             .condvar
53 | |             .wait_while(self.mutex.lock().unwrap(), |fired| !*fired)
54 | |             .unwrap();
   | |_____________________^ this binding will immediately drop the value assigned to it
   |
   = note: `#[deny(let_underscore_lock)]` on by default
help: consider binding to an unused variable to avoid immediately dropping the value
   |
51 |         let _unused = self
   |             ~~~~~~~
help: consider immediately dropping the value
   |
51 ~         drop(self
52 |             .condvar
53 |             .wait_while(self.mutex.lock().unwrap(), |fired| !*fired)
54 ~             .unwrap());
   |

error: could not compile `sqlx-core` due to previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `sqlx-core` due to previous error
```
