### PR TITLE
Fix sqlx-cli create, drop, migrate

### DIFF
--- a/sqlx-cli/Cargo.toml
+++ b/sqlx-cli/Cargo.toml
@@ -51,14 +51,14 @@ filetime = "0.2"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 
 [features]
-#default = ["postgres", "sqlite", "mysql", "native-tls"]
+default = ["postgres", "sqlite", "mysql", "native-tls"]
 rustls = ["sqlx/runtime-tokio-rustls"]
 native-tls = ["sqlx/runtime-tokio-native-tls"]
 
 # databases
-#mysql = ["sqlx/mysql"]
-#postgres = ["sqlx/postgres"]
-#sqlite = ["sqlx/sqlite"]
+mysql = ["sqlx/mysql"]
+postgres = ["sqlx/postgres"]
+sqlite = ["sqlx/sqlite"]
 
 # workaround for musl + openssl issues
 openssl-vendored = ["openssl/vendored"]

--- a/sqlx-cli/src/lib.rs
+++ b/sqlx-cli/src/lib.rs
@@ -80,8 +80,6 @@ pub async fn run(opt: Opt) -> Result<()> {
 
 /// Attempt to connect to the database server, retrying up to `ops.connect_timeout`.
 async fn connect(opts: &ConnectOpts) -> sqlx::Result<AnyConnection> {
-    sqlx::any::install_default_drivers();
-
     retry_connect_errors(opts, AnyConnection::connect).await
 }
 
@@ -97,6 +95,8 @@ where
     F: FnMut(&'a str) -> Fut,
     Fut: Future<Output = sqlx::Result<T>> + 'a,
 {
+    sqlx::any::install_default_drivers();
+
     backoff::future::retry(
         backoff::ExponentialBackoffBuilder::new()
             .with_max_elapsed_time(Some(Duration::from_secs(opts.connect_timeout)))

--- a/sqlx-mysql/src/any.rs
+++ b/sqlx-mysql/src/any.rs
@@ -62,6 +62,13 @@ impl AnyConnectionBackend for MySqlConnection {
         Connection::should_flush(self)
     }
 
+    #[cfg(feature = "migrate")]
+    fn as_migrate(
+        &mut self,
+    ) -> sqlx_core::Result<&mut (dyn sqlx_core::migrate::Migrate + Send + 'static)> {
+        Ok(self)
+    }
+
     fn fetch_many<'q>(
         &'q mut self,
         query: &'q str,

--- a/sqlx-postgres/src/any.rs
+++ b/sqlx-postgres/src/any.rs
@@ -65,6 +65,13 @@ impl AnyConnectionBackend for PgConnection {
         Connection::should_flush(self)
     }
 
+    #[cfg(feature = "migrate")]
+    fn as_migrate(
+        &mut self,
+    ) -> sqlx_core::Result<&mut (dyn sqlx_core::migrate::Migrate + Send + 'static)> {
+        Ok(self)
+    }
+
     fn fetch_many<'q>(
         &'q mut self,
         query: &'q str,

--- a/sqlx-sqlite/src/any.rs
+++ b/sqlx-sqlite/src/any.rs
@@ -67,6 +67,13 @@ impl AnyConnectionBackend for SqliteConnection {
         Connection::should_flush(self)
     }
 
+    #[cfg(feature = "migrate")]
+    fn as_migrate(
+        &mut self,
+    ) -> sqlx_core::Result<&mut (dyn sqlx_core::migrate::Migrate + Send + 'static)> {
+        Ok(self)
+    }
+
     fn fetch_many<'q>(
         &'q mut self,
         query: &'q str,


### PR DESCRIPTION
# Description

Fix the `db create`, `db drop`, and `migrate run` commands for `sqlx-cli`. Edit: this is for the latest changes on main for 0.7.

Fixes the following errors running those commands:

> thread 'main' panicked at 'No drivers installed. Please see the documentation in `sqlx::any` for details.', sqlx-core/src/any/driver.rs:143:33

and

> error: while executing migrations: error with configuration: SQLite driver does not support migrations or `migrate` feature was not enabled

### Changes

- Uncomment default and database features for `sqlx-cli`.
- Install database drivers in `sqlx-cli`.
- Implement `AnyConnectionBackend::as_migrate` for databases.

# How to test or review this PR

- Checkout this branch and install `sqlx-cli`.

```sh
cargo install -f --path ./sqlx-cli
```

- Use the SQLite example.

```sh
cd examples/sqlite/todos
export DATABASE_URL="sqlite:${PWD}/todos.db"
```

- Create the DB and run migrations, they should succeed with no errors.

```sh
sqlx db create
sqlx migrate run
```

- Don't forget to reinstall the released `sqlx-cli` 0.6 version locally. 

```sh
cargo install -f sqlx-cli
```