### PR TITLE
new type support in query_as

### DIFF
--- a/sqlx-macros-core/src/query/output.rs
+++ b/sqlx-macros-core/src/query/output.rs
@@ -144,7 +144,7 @@ pub fn quote_query_as<DB: DatabaseExt>(
                     // binding to a `let` avoids confusing errors about
                     // "try expression alternatives have incompatible types"
                     // it doesn't seem to hurt inference in the other branches
-                    let #var_name = row.try_get_unchecked::<#type_, _>(#i)?;
+                    let #var_name = row.try_get_unchecked::<#type_, _>(#i)?.into();
                 },
                 // type was overridden to be a wildcard so we fallback to the runtime check
                 (true, ColumnType::Wildcard) => quote! ( let #var_name = row.try_get(#i)?; ),

--- a/sqlx-postgres/Cargo.toml
+++ b/sqlx-postgres/Cargo.toml
@@ -16,7 +16,8 @@ migrate = ["sqlx-core/migrate"]
 offline = ["sqlx-core/offline"]
 
 # Type integration features which require additional dependencies
-rust_decimal = ["dep:rust_decimal", "dep:num-bigint"]
+rust_decimal = ["dep:rust_decimal"]
+bigdecimal = ["dep:bigdecimal", "dep:num-bigint"]
 
 [dependencies]
 # Futures crates


### PR DESCRIPTION
fixes https://github.com/launchbadge/sqlx/issues/2173


```rs
use sqlx::PgPool;


struct Wrap(bigdecimal::BigDecimal);

impl From<bigdecimal::BigDecimal> for Wrap {
    fn from(x: bigdecimal::BigDecimal) -> Self {
        Wrap(x)
    }
}

impl From<Wrap> for bigdecimal::BigDecimal {
    fn from(x: Wrap) -> Self {
        x.0
    }
}

struct Data {
    pub amount: Wrap,
}


#[tokio::main]
async fn main() {
    let db = PgPool::connect("postgres://postgres:mysecretpassword@localhost:5432/teststore").await.unwrap();

    sqlx::query_as!(Data, "select amount from test").fetch_one(&db).await.unwrap();
    // previously it will expand like this:
     {
         {
             #[allow(clippy::all)] {
                 use ::sqlx::Arguments   as _;
                 let query_args = <sqlx::postgres::Postgres as ::sqlx::database::HasArguments>::Arguments::default();
                 ::sqlx::query_with::<sqlx::postgres::Postgres, _>("select amount from test", query_args).try_map(|row: sqlx::postgres::PgRow| {
                     use ::sqlx::Row   as _;
                     let sqlx_query_as_amount = row.try_get_unchecked::<sqlx::types::BigDecimal, _>(0usize)?;
                     Ok(Data { r#amount: sqlx_query_as_amount })
                 })
             }
         }
     }
```

     now it will expand like this:

```rs
let sqlx_query_as_amount = row.try_get_unchecked::<sqlx::types::BigDecimal, _>(0usize)?.into(); <-----  

```
 This change shouldn't break anything, because `From<T>` is implemented for `T`.

Maybe we can also use `From` for binded arguments in `sqlx::query`

example:
```rs
let t = "string";
sqlx::query!("select $1",  t)
```
Here we can use `t.into()` internally, but it can break inference