### PR TITLE
chore: Use tracing's fields to get structured logs

### DIFF
--- a/sqlx-core/src/logger.rs
+++ b/sqlx-core/src/logger.rs
@@ -114,12 +114,15 @@ impl<'q> QueryLogger<'q> {
                     String::new()
                 };
 
-                let message = format!(
-                    "{}; rows affected: {}, rows returned: {}, elapsed: {:.3?}{}",
-                    summary, self.rows_affected, self.rows_returned, elapsed, sql
+                private_tracing_dynamic_event!(
+                    target: "sqlx::query",
+                    tracing_level,
+                    summary,
+                    db.statement = sql,
+                    rows_affected = self.rows_affected,
+                    rows_returned= self.rows_returned,
+                    ?elapsed,
                 );
-
-                private_tracing_dynamic_event!(target: "sqlx::query", tracing_level, message);
             }
         }
     }


### PR DESCRIPTION
This also enables on services that can query this data to get useful metrics.
Also note that I chose `db.statement` to having a standard to follow even though this does not use opentelemetry, but the latter can benefit from it [1].

Running the tests with that would log something like this:
```
[2023-02-24T17:14:00Z INFO  sqlx::query] summary="select 1 as \"foo?\"" db.statement="" rows_affected=0 rows_returned=1 elapsed=24.75µs sql=""
[2023-02-24T17:14:00Z INFO  sqlx::query] summary="select 1 as \"foo: …" db.statement="\n\nselect\n  1 as \"foo: MyInt\"\n" rows_affected=0 rows_returned=1 elapsed=44.5µs sql="\n\nselect\n  1 as \"foo: MyInt\"\n"
[2023-02-24T17:14:00Z INFO  sqlx::query] summary="select 1 as \"foo?: …" db.statement="\n\nselect\n  1 as \"foo?: MyInt\"\n" rows_affected=0 rows_returned=1 elapsed=26.208µs sql="\n\nselect\n  1 as \"foo?: MyInt\"\n"
[2023-02-24T17:14:00Z INFO  sqlx::query] summary="select 1 as \"foo!: …" db.statement="\n\nselect\n  1 as \"foo!: MyInt\"\n" rows_affected=0 rows_returned=1 elapsed=22.625µs sql="\n\nselect\n  1 as \"foo!: MyInt\"\n"
```

[1] https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/database/#call-level-attributes
