### PR TITLE
feat: add `Connection::shrink_buffers`, `PoolConnection::close`

### DIFF
--- a/sqlx-core/src/any/connection/backend.rs
+++ b/sqlx-core/src/any/connection/backend.rs
@@ -47,6 +47,11 @@ pub trait AnyConnectionBackend: std::any::Any + Debug + Send + 'static {
         Box::pin(async move { Ok(()) })
     }
 
+    /// Forward to [`Connection::shrink_buffers()`].
+    ///
+    /// [`Connection::shrink_buffers()`]: method@crate::connection::Connection::shrink_buffers
+    fn shrink_buffers(&mut self);
+
     #[doc(hidden)]
     fn flush(&mut self) -> BoxFuture<'_, crate::Result<()>>;
 

--- a/sqlx-core/src/any/connection/mod.rs
+++ b/sqlx-core/src/any/connection/mod.rs
@@ -92,6 +92,10 @@ impl Connection for AnyConnection {
         self.backend.clear_cached_statements()
     }
 
+    fn shrink_buffers(&mut self) {
+        self.backend.shrink_buffers()
+    }
+
     #[doc(hidden)]
     fn flush(&mut self) -> BoxFuture<'_, Result<(), Error>> {
         self.backend.flush()

--- a/sqlx-core/src/connection.rs
+++ b/sqlx-core/src/connection.rs
@@ -112,6 +112,20 @@ pub trait Connection: Send {
         Box::pin(async move { Ok(()) })
     }
 
+    /// Restore any buffers in the connection to their default capacity, if possible.
+    ///
+    /// Sending a large query or receiving a resultset with many columns can cause the connection
+    /// to allocate additional buffer space to fit the data which is retained afterwards in
+    /// case it's needed again. This can give the outward appearance of a memory leak, but is
+    /// in fact the intended behavior.
+    ///
+    /// Calling this method tells the connection to release that excess memory if it can,
+    /// though be aware that calling this too often can cause unnecessary thrashing or
+    /// fragmentation in the global allocator. If there's still data in the connection buffers
+    /// (unlikely if the last query was run to completion) then it may need to be moved to
+    /// allow the buffers to shrink.
+    fn shrink_buffers(&mut self);
+
     #[doc(hidden)]
     fn flush(&mut self) -> BoxFuture<'_, Result<(), Error>>;
 

--- a/sqlx-mysql/src/any.rs
+++ b/sqlx-mysql/src/any.rs
@@ -54,6 +54,10 @@ impl AnyConnectionBackend for MySqlConnection {
         MySqlTransactionManager::start_rollback(self)
     }
 
+    fn shrink_buffers(&mut self) {
+        Connection::shrink_buffers(self);
+    }
+
     fn flush(&mut self) -> BoxFuture<'_, sqlx_core::Result<()>> {
         Connection::flush(self)
     }

--- a/sqlx-mysql/src/connection/mod.rs
+++ b/sqlx-mysql/src/connection/mod.rs
@@ -108,4 +108,8 @@ impl Connection for MySqlConnection {
     {
         Transaction::begin(self)
     }
+
+    fn shrink_buffers(&mut self) {
+        self.stream.shrink_buffers();
+    }
 }

--- a/sqlx-postgres/src/any.rs
+++ b/sqlx-postgres/src/any.rs
@@ -57,6 +57,10 @@ impl AnyConnectionBackend for PgConnection {
         PgTransactionManager::start_rollback(self)
     }
 
+    fn shrink_buffers(&mut self) {
+        Connection::shrink_buffers(self);
+    }
+
     fn flush(&mut self) -> BoxFuture<'_, sqlx_core::Result<()>> {
         Connection::flush(self)
     }

--- a/sqlx-postgres/src/connection/mod.rs
+++ b/sqlx-postgres/src/connection/mod.rs
@@ -199,6 +199,10 @@ impl Connection for PgConnection {
         })
     }
 
+    fn shrink_buffers(&mut self) {
+        self.stream.shrink_buffers();
+    }
+
     #[doc(hidden)]
     fn flush(&mut self) -> BoxFuture<'_, Result<(), Error>> {
         self.wait_until_ready().boxed()

--- a/sqlx-sqlite/src/any.rs
+++ b/sqlx-sqlite/src/any.rs
@@ -59,6 +59,10 @@ impl AnyConnectionBackend for SqliteConnection {
         SqliteTransactionManager::start_rollback(self)
     }
 
+    fn shrink_buffers(&mut self) {
+        // NO-OP.
+    }
+
     fn flush(&mut self) -> BoxFuture<'_, sqlx_core::Result<()>> {
         Connection::flush(self)
     }

--- a/sqlx-sqlite/src/connection/mod.rs
+++ b/sqlx-sqlite/src/connection/mod.rs
@@ -157,6 +157,11 @@ impl Connection for SqliteConnection {
         })
     }
 
+    #[inline]
+    fn shrink_buffers(&mut self) {
+        // No-op.
+    }
+
     #[doc(hidden)]
     fn flush(&mut self) -> BoxFuture<'_, Result<(), Error>> {
         // For SQLite, FLUSH does effectively nothing...


### PR DESCRIPTION
BREAKING: adds new required method to `Connection` trait.

closes #2372