### PR TITLE
add support for scoped lifetimes in transaction callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,6 +2224,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-futures"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1473e24c637950c9bd38763220bea91ec3e095a89f672bbd7a10d03e77ba467"
+dependencies = [
+ "cfg-if",
+ "pin-utils",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2513,6 +2523,7 @@ dependencies = [
  "rust_decimal",
  "rustls",
  "rustls-pemfile",
+ "scoped-futures",
  "serde",
  "serde_json",
  "sha1",

--- a/examples/postgres/transaction/Cargo.toml
+++ b/examples/postgres/transaction/Cargo.toml
@@ -7,4 +7,4 @@ workspace = "../../../"
 [dependencies]
 sqlx = { path = "../../../", features = [ "postgres", "runtime-tokio-native-tls" ] }
 futures = "0.3.1"
-tokio = { version = "1.20.0", features = ["macros"]}
+tokio = { version = "1.20.0", features = ["macros", "rt-multi-thread"]}

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -77,6 +77,7 @@ once_cell = "1.9.0"
 percent-encoding = "2.1.0"
 regex = { version = "1.5.5", optional = true }
 rsa = { version = "0.8.0", optional = true }
+scoped-futures = { version = "0.1.3", features = ["std"] }
 serde = { version = "1.0.132", features = ["derive", "rc"], optional = true }
 serde_json = { version = "1.0.73", features = ["raw_value"], optional = true }
 sha1 = { version = "0.10.1", default-features = false, optional = true }

--- a/sqlx-core/src/connection.rs
+++ b/sqlx-core/src/connection.rs
@@ -73,7 +73,9 @@ pub trait Connection: Send {
         callback: F,
     ) -> BoxFuture<'fut, Result<R, E>>
     where
-        for<'c> F: FnOnce(&'c mut Transaction<'a, Self::Database>) -> ScopedBoxFuture<'b, 'c, Result<R, E>>
+        for<'c> F: FnOnce(
+                &'c mut Transaction<'fut, Self::Database>,
+            ) -> ScopedBoxFuture<'b, 'c, Result<R, E>>
             + 'b
             + Send
             + Sync,


### PR DESCRIPTION
Hi there! This revision changes the callback parameter `F` in the `Connection::transaction` method to allow F to have a scoped lifetime associated with it that is shorter than `'static` but longer than the hrtb attached to the callback's connection pararmeter. I'm coming from mostly using diesel so I'm not sure if there's a demand for this feature in sqlx but it seems useful. I merged a similar change in the diesel-async project [here](https://github.com/weiznich/diesel_async/pull/38).

As mentioned in that revision, the main downside of introducing this change would be the breaking change on application code calling `Connection::transaction` if they pass a callback that is boxed using `FutureExt::boxed` because now they would need to use `ScopedFutureExt::scope_boxed` or `Box::pinned`.