### PR TITLE
PATCH: bump libsqlite3-sys to patched version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,7 +176,7 @@ rand_xoshiro = "0.6.0"
 hex = "0.4.3"
 tempdir = "0.3.7"
 # Needed to test SQLCipher
-libsqlite3-sys = { version = "0.25", features = ["bundled-sqlcipher"] }
+libsqlite3-sys = { version = "0.25.1", features = ["bundled-sqlcipher"] }
 
 #
 # Any


### PR DESCRIPTION
patch for [high severity advisory](https://github.com/advisories/GHSA-jw36-hf63-69r9) in libsqlite3-sys

closes #2388