### PR TITLE
Lower default logging level for statements to Debug

### DIFF
--- a/sqlx-core/src/connection.rs
+++ b/sqlx-core/src/connection.rs
@@ -166,7 +166,7 @@ pub struct LogSettings {
 impl Default for LogSettings {
     fn default() -> Self {
         LogSettings {
-            statements_level: LevelFilter::Info,
+            statements_level: LevelFilter::Debug,
             slow_statements_level: LevelFilter::Warn,
             slow_statements_duration: Duration::from_secs(1),
         }


### PR DESCRIPTION
This has been discussed in https://github.com/launchbadge/sqlx/issues/939 and https://github.com/launchbadge/sqlx/issues/942 over the course of two years. https://github.com/launchbadge/sqlx/pull/1371 changed it, but https://github.com/launchbadge/sqlx/pull/1465 reverted it being, I believe, an accident, a side effect of reverting the major change of the pull request.