### PR TITLE
Add support for Boxed / Arced string and array.

### DIFF
--- a/sqlx-core/src/types/arced.rs
+++ b/sqlx-core/src/types/arced.rs
@@ -1,0 +1,70 @@
+use crate::{
+    database::{Database, HasArguments, HasValueRef},
+    decode::Decode,
+    encode::{Encode, IsNull},
+    error::BoxDynError,
+    types::Type,
+};
+use std::sync::Arc;
+
+impl<DB> Type<DB> for Arc<str>
+where
+    DB: Database,
+    str: Type<DB>,
+{
+    fn type_info() -> DB::TypeInfo {
+        <str as Type<DB>>::type_info()
+    }
+}
+
+impl<DB> Decode<'_, DB> for Arc<str>
+where
+    DB: Database,
+    for<'any> &'any str: Decode<'any, DB>,
+{
+    fn decode(value: <DB as HasValueRef<'_>>::ValueRef) -> Result<Self, BoxDynError> {
+        <&'_ str as Decode<'_, DB>>::decode(value).map(Arc::from)
+    }
+}
+
+impl<'q, DB> Encode<'q, DB> for Arc<str>
+where
+    DB: Database,
+    for<'any> &'any str: Encode<'q, DB>,
+{
+    fn encode_by_ref(&self, buf: &mut <DB as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
+        self.as_ref().encode_by_ref(buf)
+    }
+}
+
+impl<DB, T> Type<DB> for Arc<[T]>
+where
+    DB: Database,
+    [T]: Type<DB>,
+{
+    fn type_info() -> DB::TypeInfo {
+        <[T] as Type<DB>>::type_info()
+    }
+}
+
+impl<'q, DB, T> Decode<'q, DB> for Arc<[T]>
+where
+    Vec<T>: Decode<'q, DB>,
+    T: Decode<'q, DB>,
+    DB: Database,
+{
+    fn decode(value: <DB as HasValueRef<'q>>::ValueRef) -> Result<Self, BoxDynError> {
+        <Vec<T> as Decode<'q, DB>>::decode(value).map(Arc::from)
+    }
+}
+
+impl<'q, DB, T> Encode<'q, DB> for Arc<[T]>
+where
+    for<'any> &'any [T]: Encode<'q, DB>,
+    T: Encode<'q, DB>,
+    DB: Database,
+{
+    fn encode_by_ref(&self, buf: &mut <DB as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
+        self.as_ref().encode_by_ref(buf)
+    }
+}

--- a/sqlx-core/src/types/boxed.rs
+++ b/sqlx-core/src/types/boxed.rs
@@ -1,3 +1,4 @@
+use crate::any::Any;
 use crate::{
     database::{Database, HasArguments, HasValueRef},
     decode::Decode,

--- a/sqlx-core/src/types/boxed.rs
+++ b/sqlx-core/src/types/boxed.rs
@@ -1,4 +1,3 @@
-use crate::any::Any;
 use crate::{
     database::{Database, HasArguments, HasValueRef},
     decode::Decode,

--- a/sqlx-core/src/types/boxed.rs
+++ b/sqlx-core/src/types/boxed.rs
@@ -1,0 +1,70 @@
+use crate::{
+    database::{Database, HasArguments, HasValueRef},
+    decode::Decode,
+    encode::{Encode, IsNull},
+    error::BoxDynError,
+    types::Type,
+};
+
+impl<DB> Type<DB> for Box<str>
+where
+    DB: Database,
+    str: Type<DB>,
+{
+    fn type_info() -> DB::TypeInfo {
+        <str as Type<DB>>::type_info()
+    }
+}
+
+impl<DB> Decode<'_, DB> for Box<str>
+where
+    DB: Database,
+    for<'any> &'any str: Decode<'any, DB>,
+{
+    fn decode(value: <DB as HasValueRef<'_>>::ValueRef) -> Result<Self, BoxDynError> {
+        // FIXME: Replace on <String as Decode<'_, DB>>::decode(value).map(String::into_boxed_str)?
+        <&'_ str as Decode<'_, DB>>::decode(value).map(Box::from)
+    }
+}
+
+impl<'q, DB> Encode<'q, DB> for Box<str>
+where
+    DB: Database,
+    for<'any> &'any str: Encode<'q, DB>,
+{
+    fn encode_by_ref(&self, buf: &mut <DB as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
+        self.as_ref().encode_by_ref(buf)
+    }
+}
+
+impl<DB, T> Type<DB> for Box<[T]>
+where
+    DB: Database,
+    [T]: Type<DB>,
+{
+    fn type_info() -> DB::TypeInfo {
+        <[T] as Type<DB>>::type_info()
+    }
+}
+
+impl<'q, DB, T> Decode<'q, DB> for Box<[T]>
+where
+    Vec<T>: Decode<'q, DB>,
+    T: Decode<'q, DB>,
+    DB: Database,
+{
+    fn decode(value: <DB as HasValueRef<'q>>::ValueRef) -> Result<Self, BoxDynError> {
+        <Vec<T> as Decode<'q, DB>>::decode(value).map(Vec::into_boxed_slice)
+    }
+}
+
+impl<'q, DB, T> Encode<'q, DB> for Box<[T]>
+where
+    for<'any> &'any [T]: Encode<'q, DB>,
+    T: Encode<'q, DB>,
+    DB: Database,
+{
+    fn encode_by_ref(&self, buf: &mut <DB as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
+        self.as_ref().encode_by_ref(buf)
+    }
+}

--- a/sqlx-core/src/types/mod.rs
+++ b/sqlx-core/src/types/mod.rs
@@ -20,6 +20,9 @@
 
 use crate::database::Database;
 
+mod arced;
+mod boxed;
+
 #[cfg(feature = "bstr")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bstr")))]
 pub mod bstr;

--- a/sqlx-postgres/src/types/array.rs
+++ b/sqlx-postgres/src/types/array.rs
@@ -1,5 +1,6 @@
 use sqlx_core::bytes::Buf;
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
@@ -26,6 +27,26 @@ where
 
     fn array_compatible(ty: &PgTypeInfo) -> bool {
         T::array_compatible(ty)
+    }
+}
+
+impl PgHasArrayType for Box<str> {
+    fn array_type_info() -> PgTypeInfo {
+        <&str as PgHasArrayType>::array_type_info()
+    }
+
+    fn array_compatible(ty: &PgTypeInfo) -> bool {
+        <&str as PgHasArrayType>::array_compatible(ty)
+    }
+}
+
+impl PgHasArrayType for Arc<str> {
+    fn array_type_info() -> PgTypeInfo {
+        <&str as PgHasArrayType>::array_type_info()
+    }
+
+    fn array_compatible(ty: &PgTypeInfo) -> bool {
+        <&str as PgHasArrayType>::array_compatible(ty)
     }
 }
 

--- a/tests/mysql/types.rs
+++ b/tests/mysql/types.rs
@@ -2,6 +2,7 @@ extern crate time_ as time;
 
 #[cfg(feature = "decimal")]
 use std::str::FromStr;
+use std::sync::Arc;
 
 use sqlx::mysql::MySql;
 use sqlx::{Executor, Row};
@@ -33,6 +34,20 @@ test_type!(string<String>(MySql,
     "''" == ""
 ));
 
+test_type!(boxed_str<Box<str>>(MySql,
+    "'helloworld'"
+        == Box::<str>::from("helloworld"),
+    "''"
+        == Box::<str>::from("")
+));
+
+test_type!(arced_str<Arc<str>>(MySql,
+    "'helloworld'"
+        == Arc::<str>::from("helloworld"),
+    "''"
+        == Arc::<str>::from("")
+));
+
 test_type!(bytes<Vec<u8>>(MySql,
     "X'DEADBEEF'"
         == vec![0xDE_u8, 0xAD, 0xBE, 0xEF],
@@ -40,6 +55,24 @@ test_type!(bytes<Vec<u8>>(MySql,
         == Vec::<u8>::new(),
     "X'0000000052'"
         == vec![0_u8, 0, 0, 0, 0x52]
+));
+
+test_type!(boxed_array<Box<[u8]>>(MySql,
+    "X'DEADBEEF'"
+        == Box::<[u8]>::from([0xDE_u8, 0xAD, 0xBE, 0xEF]),
+    "X''"
+        == Box::<[u8]>::from([]),
+    "X'0000000052'"
+        == Box::<[u8]>::from([0_u8, 0, 0, 0, 0x52])
+));
+
+test_type!(arced_array<Arc<[u8]>>(MySql,
+    "X'DEADBEEF'"
+        == Arc::<[u8]>::from([0xDE_u8, 0xAD, 0xBE, 0xEF].as_slice()),
+    "X''"
+        == Arc::<[u8]>::from([].as_slice()),
+    "X'0000000052'"
+        == Arc::<[u8]>::from([0_u8, 0, 0, 0, 0x52].as_slice())
 ));
 
 #[cfg(feature = "uuid")]

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -1,6 +1,7 @@
 extern crate time_ as time;
 
 use std::ops::Bound;
+use std::sync::Arc;
 
 use sqlx::postgres::types::{Oid, PgInterval, PgMoney, PgRange};
 use sqlx::postgres::Postgres;
@@ -71,6 +72,14 @@ test_type!(string<String>(Postgres,
     "'this is foo'" == format!("this is foo"),
 ));
 
+test_type!(boxed_str<Box<str>>(Postgres,
+    "'this is foo'" == Box::<str>::from("this is foo"),
+));
+
+test_type!(arced_str<Arc<str>>(Postgres,
+    "'this is foo'" == Arc::<str>::from("this is foo"),
+));
+
 test_type!(string_vec<Vec<String>>(Postgres,
     "array['one','two','three']::text[]"
         == vec!["one","two","three"],
@@ -80,6 +89,28 @@ test_type!(string_vec<Vec<String>>(Postgres,
 
     "array['Hello, World', '', 'Goodbye']::text[]"
         == vec!["Hello, World", "", "Goodbye"]
+));
+
+test_type!(boxed_str_boxed_array<Box<[Box<str>]>>(Postgres,
+    "array['one','two','three']::text[]"
+        == Box::<[Box::<str>]>::from(["one".into(),"two".into(),"three".into()]),
+
+    "array['', '\"']::text[]"
+        == Box::<[Box::<str>]>::from(["".into(), "\"".into()]),
+
+    "array['Hello, World', '', 'Goodbye']::text[]"
+        == Box::<[Box::<str>]>::from(["Hello, World".into(), "".into(), "Goodbye".into()])
+));
+
+test_type!(arced_str_arced_array<Arc<[Arc<str>]>>(Postgres,
+    "array['one','two','three']::text[]"
+        == Arc::<[Arc::<str>]>::from(["one".into(),"two".into(),"three".into()].as_slice()),
+
+    "array['', '\"']::text[]"
+        == Arc::<[Arc::<str>]>::from(["".into(), "\"".into()].as_slice()),
+
+    "array['Hello, World', '', 'Goodbye']::text[]"
+        == Arc::<[Arc::<str>]>::from(["Hello, World".into(), "".into(), "Goodbye".into()].as_slice())
 ));
 
 test_type!(string_array<[String; 3]>(Postgres,

--- a/tests/sqlite/types.rs
+++ b/tests/sqlite/types.rs
@@ -1,5 +1,7 @@
 extern crate time_ as time;
 
+use std::sync::Arc;
+
 use sqlx::sqlite::{Sqlite, SqliteRow};
 use sqlx_core::row::Row;
 use sqlx_test::new;
@@ -27,6 +29,18 @@ test_type!(str<String>(Sqlite,
     "''" == ""
 ));
 
+/*test_type!(boxed_str<Box<str>>(Sqlite,
+    "'this is foo'" == Box::<str>::from("this is foo"),
+    "cast(x'7468697320006973206E756C2D636F6E7461696E696E67' as text)" == Box::<str>::from("this \0is nul-containing"),
+    "''" == Box::<str>::from("")
+));
+
+test_type!(arced_str<Arc<str>>(Sqlite,
+    "'this is foo'" == Arc::<str>::from("this is foo"),
+    "cast(x'7468697320006973206E756C2D636F6E7461696E696E67' as text)" == Arc::<str>::from("this \0is nul-containing"),
+    "''" == Arc::<str>::from("")
+));*/
+
 test_type!(bytes<Vec<u8>>(Sqlite,
     "X'DEADBEEF'"
         == vec![0xDE_u8, 0xAD, 0xBE, 0xEF],
@@ -35,6 +49,24 @@ test_type!(bytes<Vec<u8>>(Sqlite,
     "X'0000000052'"
         == vec![0_u8, 0, 0, 0, 0x52]
 ));
+
+/*test_type!(boxed_bytes<Box<[u8]>>(Sqlite,
+    "X'DEADBEEF'"
+        == Box::<[u8]>::from([0xDE_u8, 0xAD, 0xBE, 0xEF]),
+    "X''"
+        == Box::<[u8]>::from([]),
+    "X'0000000052'"
+        == Box::<[u8]>::from([0_u8, 0, 0, 0, 0x52])
+));
+
+test_type!(arced_bytes<Arc<[u8]>>(Sqlite,
+    "X'DEADBEEF'"
+        == Arc::<[u8]>::from([0xDE_u8, 0xAD, 0xBE, 0xEF].as_slice()),
+    "X''"
+        == Arc::<[u8]>::from([].as_slice()),
+    "X'0000000052'"
+        == Arc::<[u8]>::from([0_u8, 0, 0, 0, 0x52].as_slice())
+));*/
 
 #[cfg(feature = "json")]
 mod json_tests {


### PR DESCRIPTION
Example:
```rust
use futures_util::StreamExt as _;
use sqlx::{*, postgres::PgArguments};
use std::{sync::Arc, error::Error, pin::pin};

#[derive(FromRow)]
struct Data {
    data0: Box<str>,
    data1: Arc<str>,
    array0: Box<[Box<str>]>,
    array1: Box<[Arc<str>]>,
    array2: Arc<[Box<str>]>,
    array3: Arc<[Arc<str>]>,
}

impl Default for Data {
    fn default() -> Self {
        Self {
            data0: Default::default(),
            data1: Arc::from(""),
            array0: Box::new([]),
            array1: Box::new([]),
            array2: Arc::new([]),
            array3: Arc::new([]),
        }
    }
}

#[tokio::main]
async fn main() -> Result<(), Box<dyn Error>> {
    let pool = PgPool::connect("postgres://localhost:1234").await?;

    let mut args = PgArguments::default();
    args.add(Data::default().data0);
    args.add(Data::default().data1);
    args.add(Data::default().array0);
    args.add(Data::default().array1);
    args.add(Data::default().array2);
    args.add(Data::default().array3);

    query_with("INSERT INTO qwe_table VALUES $1", args)
        .execute(&pool)
        .await?;

    let mut rows = pin!(query_as("SELECT * FROM qwe_table").fetch(&pool));
    while let Option::<Result<Data, _>>::Some(_) = rows.next().await {
        //
    }

    Ok(())
}
```