### PR TITLE
fix(prepare): store temporary query files inside the workspace

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -200,11 +200,17 @@ as an ergonomic choice it does _not_ block committing if `cargo sqlx prepare` fa
 
 We're working on a way for the macros to save their data to the filesystem automatically which should be part of SQLx 0.7,
 so your pre-commit hook would then just need to stage the changed files. This can be enabled by creating a directory 
-and setting the `SQLX_OFFLINE_DIR` environment variable to it before compiling, e.g. 
+and setting the `SQLX_OFFLINE_DIR` environment variable to it before compiling. 
+Additionally, if you're not using Cargo or have a nonstandard setup, you may want to set the `SQLX_TMP`
+variable in order to store temporary query files somewhere that isn't picked up by git.
+These files should get cleaned up automatically, but they may not if there's a failure. For example:
 
 ```shell
 $ mkdir .sqlx
 $ export SQLX_OFFLINE_DIR="./.sqlx"`
+$ # Optional and only useful if using a nonstandard setup, ensures temp files won't get picked up by git on failure
+$ mkdir ./my-custom-target/sqlx
+$ export SQLX_TMP="./my-custom-target/sqlx-tmp"
 $ cargo check
 ```
 

--- a/sqlx-macros-core/src/query/data.rs
+++ b/sqlx-macros-core/src/query/data.rs
@@ -157,10 +157,17 @@ where
         }
     }
 
-    pub(super) fn save_in(&self, dir: impl AsRef<Path>) -> crate::Result<()> {
+    pub(super) fn save_in(
+        &self,
+        dir: impl AsRef<Path>,
+        tmp_dir: impl AsRef<Path>,
+    ) -> crate::Result<()> {
         // Output to a temporary file first, then move it atomically to avoid clobbering
         // other invocations trying to write to the same path.
-        let mut tmp_file = tempfile::NamedTempFile::new()
+
+        // Use a temp directory inside the workspace to avoid potential issues
+        // with persisting the file across filesystems.
+        let mut tmp_file = tempfile::NamedTempFile::new_in(tmp_dir)
             .map_err(|err| format!("failed to create query file: {:?}", err))?;
         serde_json::to_writer_pretty(tmp_file.as_file_mut(), self)
             .map_err(|err| format!("failed to serialize query data to file: {:?}", err))?;


### PR DESCRIPTION
Resolves https://github.com/launchbadge/sqlx/issues/2395

Thanks to @cycraig for the advice here: https://github.com/launchbadge/sqlx/issues/2395#issuecomment-1464850928

The PR to implement one file per query: https://github.com/launchbadge/sqlx/pull/2363 implemented logic to write queries to a temp file and then persist them to `SQLX_OFFLINE_DIR` here: https://github.com/launchbadge/sqlx/blob/c03926c74176e80c2f6579e209a924c15494af56/sqlx-macros-core/src/query/data.rs#L163-L170

However, the docs for `NamedTempFile::persist` mention the following:

```
Note: Temporary files cannot be persisted across filesystems.
```

On Linux, the `/tmp` directory is commonly mounted as `tmpfs` which means the call to `tmp_file.persist` will result in the following error: `failed to move query file: PersistError(Os { code: 18, kind: CrossesDevices, message: "Invalid cross-device link" })`.

To prevent this, we can't rely on using the default temp directory. This PR changes the logic to use `NamedTempFile::new_in` to create the temporary files in a new variable called `SQLX_TMP`. When run from `cargo sqlx prepare`, this is set to `$TARGET_DIR/sqlx-tmp`. 

The point of the `SQLX_TMP` variable is to ensure the temporary files are written to a directory that isn't picked up by git. As long as everything completes successfully, this shouldn't really matter as the temp files will get cleaned up automatically on a clean exit. Ideally, we wouldn't need this and could instead just reference the target directory directly, but that would require a call to `cargo metadata` from `sqlx-macros-core`.

I'm not too familiar with this logic so please let me know if there's a better way to handle this. Just thought I'd take a stab at it, thanks!
