### PR TITLE
fix: drop old time 0.1.44 dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,11 +428,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
- "time 0.1.44",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -1051,7 +1048,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -1361,7 +1358,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.36.1",
 ]
 
@@ -2303,7 +2300,7 @@ dependencies = [
  "sqlx-sqlite",
  "sqlx-test",
  "tempdir",
- "time 0.3.19",
+ "time",
  "tokio",
  "trybuild",
  "url",
@@ -2387,7 +2384,7 @@ dependencies = [
  "sqlformat",
  "sqlx",
  "thiserror",
- "time 0.3.19",
+ "time",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2472,7 +2469,7 @@ dependencies = [
  "sqlx-core",
  "stringprep",
  "thiserror",
- "time 0.3.19",
+ "time",
  "tracing",
  "uuid",
  "whoami",
@@ -2517,7 +2514,7 @@ dependencies = [
  "sqlx-core",
  "stringprep",
  "thiserror",
- "time 0.3.19",
+ "time",
  "tracing",
  "uuid",
  "whoami",
@@ -2543,7 +2540,7 @@ dependencies = [
  "serde",
  "sqlx",
  "sqlx-core",
- "time 0.3.19",
+ "time",
  "tracing",
  "url",
  "uuid",
@@ -2667,17 +2664,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -2924,12 +2910,6 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ sqlx = { version = "=0.7.0-alpha.1", path = "." }
 # These are optional unless enabled in a workspace crate.
 bigdecimal = "0.3.0"
 bit-vec = "0.6.3"
-chrono = "0.4.22"
+chrono = { version = "0.4.22", default-features = false }
 ipnetwork = "0.20.0"
 mac_address = "1.1.3"
 rust_decimal = "1.26.1"


### PR DESCRIPTION
chrono 0.4's default features include the `oldtime` feature which pulls in time 0.1.44. This is an unmaintained version with soundness issues (time-rs/time#293) and is rarely needed. If downstream users require this dependency, they can enable the feature themselves.