### PR TITLE
fix(#2407): respect the HaltIfNull opcode when determining nullability

### DIFF
--- a/sqlx-sqlite/src/connection/explain.rs
+++ b/sqlx-sqlite/src/connection/explain.rs
@@ -125,6 +125,7 @@ const OP_CONCAT: &str = "Concat";
 const OP_OFFSET_LIMIT: &str = "OffsetLimit";
 const OP_RESULT_ROW: &str = "ResultRow";
 const OP_HALT: &str = "Halt";
+const OP_HALT_IF_NULL: &str = "HaltIfNull";
 
 const MAX_LOOP_COUNT: u8 = 2;
 
@@ -940,6 +941,16 @@ pub(super) fn explain(
                 OP_VARIABLE => {
                     // r[p2] = <value of variable>
                     state.r.insert(p2, RegDataType::Single(ColumnType::null()));
+                }
+
+                // if there is a value in p3, and the query passes, then
+                // we know that it is not nullable
+                OP_HALT_IF_NULL => {
+                    if let Some(RegDataType::Single(ColumnType::Single { nullable, .. })) =
+                        state.r.get_mut(&p3)
+                    {
+                        *nullable = Some(false);
+                    }
                 }
 
                 OP_FUNCTION => {

--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -251,6 +251,22 @@ async fn it_describes_insert_with_returning() -> anyhow::Result<()> {
 }
 
 #[sqlx_macros::test]
+async fn it_describes_bound_columns_non_null() -> anyhow::Result<()> {
+    let mut conn = new::<Sqlite>().await?;
+    let d = conn
+        .describe("INSERT INTO tweet (id, text) VALUES ($1, $2) returning *")
+        .await?;
+
+    assert_eq!(d.columns().len(), 4);
+    assert_eq!(d.column(0).type_info().name(), "INTEGER");
+    assert_eq!(d.nullable(0), Some(false));
+    assert_eq!(d.column(1).type_info().name(), "TEXT");
+    assert_eq!(d.nullable(1), Some(false));
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
 async fn it_describes_update_with_returning() -> anyhow::Result<()> {
     let mut conn = new::<Sqlite>().await?;
 


### PR DESCRIPTION
This closes https://github.com/launchbadge/sqlx/issues/2407

The issue describes the situation. The HaltIfNull opcode was not being respected, causing the macro to spit out optionals for types that could never be null.

This PR fixes it :)