### PR TITLE
fix: re-add offline flag to sqlx crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = ["any", "macros", "migrate", "json"]
 macros = ["sqlx-macros"]
 migrate = ["sqlx-core/migrate", "sqlx-macros?/migrate", "sqlx-mysql?/migrate", "sqlx-postgres?/migrate", "sqlx-sqlite?/migrate"]
+offline = ["sqlx-core/offline"]
 
 # intended mainly for CI and docs
 all-databases = ["mysql", "sqlite", "postgres", "any"]


### PR DESCRIPTION
I think this got accidentally dropped in the big refactor, unless there’s some reason I’m missing why use of the `offline` flag should require a direct `sqlx-core` dependency.