### PR TITLE
Enable runtime-tokio feature of sqlx when building sqlx-cli

### DIFF
--- a/sqlx-cli/Cargo.toml
+++ b/sqlx-cli/Cargo.toml
@@ -28,6 +28,7 @@ path = "src/bin/cargo-sqlx.rs"
 dotenvy = "0.15.0"
 tokio = { version = "1.15.0", features = ["macros", "rt", "rt-multi-thread"] }
 sqlx = { workspace = true, default-features = false, features = [
+    "runtime-tokio",
     "migrate",
     "any",
 ] }


### PR DESCRIPTION
Without the `runtime-tokio` feature enabled `sqlx-cli` builds fine but when run prints ```thread 'main' panicked at 'either the `runtime-async-std` or `runtime-tokio` feature must be enabled', /home/paolo/.cargo/git/checkouts/sqlx-f05f33ba4f5c3036/9ac2cb3/sqlx-core/src/net/socket/mod.rs:217:9```