### PR TITLE
Update rustls to 0.21, webpki-roots to 0.23

### DIFF
--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -36,9 +36,9 @@ tokio = { workspace = true, optional = true }
 # TLS
 native-tls = { version = "0.2.10", optional = true }
 
-rustls = { version = "0.20.6", default-features = false, features = ["dangerous_configuration", "tls12"], optional = true }
+rustls = { version = "0.21", default-features = false, features = ["dangerous_configuration", "tls12"], optional = true }
 rustls-pemfile = { version = "1.0", optional = true }
-webpki-roots = { version = "0.22.0", optional = true }
+webpki-roots = { version = "0.23", optional = true }
 
 # Type Integrations
 bit-vec = { workspace = true, optional = true }

--- a/sqlx-core/src/net/tls/tls_rustls.rs
+++ b/sqlx-core/src/net/tls/tls_rustls.rs
@@ -6,7 +6,8 @@ use std::time::SystemTime;
 
 use rustls::{
     client::{ServerCertVerified, ServerCertVerifier, WebPkiVerifier},
-    ClientConfig, ClientConnection, Error as TlsError, OwnedTrustAnchor, RootCertStore, ServerName,
+    CertificateError, ClientConfig, ClientConnection, Error as TlsError, OwnedTrustAnchor,
+    RootCertStore, ServerName,
 };
 
 use crate::error::Error;
@@ -234,8 +235,8 @@ impl ServerCertVerifier for NoHostnameTlsVerifier {
             ocsp_response,
             now,
         ) {
-            Err(TlsError::InvalidCertificateData(reason))
-                if reason.contains("CertNotValidForName") =>
+            Err(TlsError::InvalidCertificate(reason))
+                if reason == CertificateError::NotValidForName =>
             {
                 Ok(ServerCertVerified::assertion())
             }


### PR DESCRIPTION
As in the title. Ideally this would be backported to 0.6. This should solve issues like https://github.com/SergioBenitez/Rocket/issues/2391.