### PR TITLE
Add Simple format for Uuid for MySQL & SQLite.

### DIFF
--- a/sqlx-mysql/src/types/mod.rs
+++ b/sqlx-mysql/src/types/mod.rs
@@ -63,6 +63,7 @@
 //! |---------------------------------------|------------------------------------------------------|
 //! | `uuid::Uuid`                          | BYTE(16), VARCHAR, CHAR, TEXT                        |
 //! | `uuid::fmt::Hyphenated`               | CHAR(36)                                             |
+//! | `uuid::fmt::Simple`                   | CHAR(32)                                             |
 //!
 //! ### [`json`](https://crates.io/crates/serde_json)
 //!

--- a/sqlx-sqlite/src/types/mod.rs
+++ b/sqlx-sqlite/src/types/mod.rs
@@ -62,6 +62,7 @@
 //! |---------------------------------------|------------------------------------------------------|
 //! | `uuid::Uuid`                          | BLOB, TEXT                                           |
 //! | `uuid::fmt::Hyphenated`               | TEXT                                                 |
+//! | `uuid::fmt::Simple`                   | TEXT                                                 |
 //!
 //! ### [`json`](https://crates.io/crates/serde_json)
 //!

--- a/tests/mysql/types.rs
+++ b/tests/mysql/types.rs
@@ -58,6 +58,14 @@ test_type!(uuid_hyphenated<sqlx::types::uuid::fmt::Hyphenated>(MySql,
         == sqlx::types::Uuid::parse_str("00000000-0000-0000-0000-000000000000").unwrap().hyphenated()
 ));
 
+#[cfg(feature = "uuid")]
+test_type!(uuid_simple<sqlx::types::uuid::fmt::Simple>(MySql,
+    "'b731678f636f4135bc6f19440c13bd19'"
+        == sqlx::types::Uuid::parse_str("b731678f636f4135bc6f19440c13bd19").unwrap().simple(),
+    "'00000000000000000000000000000000'"
+        == sqlx::types::Uuid::parse_str("00000000000000000000000000000000").unwrap().simple()
+));
+
 #[cfg(feature = "chrono")]
 mod chrono {
     use super::*;

--- a/tests/sqlite/types.rs
+++ b/tests/sqlite/types.rs
@@ -196,3 +196,11 @@ test_type!(uuid_hyphenated<sqlx::types::uuid::fmt::Hyphenated>(Sqlite,
     "'00000000-0000-0000-0000-000000000000'"
         == sqlx::types::Uuid::parse_str("00000000-0000-0000-0000-000000000000").unwrap().hyphenated()
 ));
+
+#[cfg(feature = "uuid")]
+test_type!(uuid_simple<sqlx::types::uuid::fmt::Simple>(Sqlite,
+    "'b731678f636f4135bc6f19440c13bd19'"
+        == sqlx::types::Uuid::parse_str("b731678f636f4135bc6f19440c13bd19").unwrap().simple(),
+    "'00000000000000000000000000000000'"
+        == sqlx::types::Uuid::parse_str("00000000000000000000000000000000").unwrap().simple()
+));


### PR DESCRIPTION
Copy pasted the implementation for `Hyphenated` and adapt.