### PR TITLE
Added `migrate fresh --force` command to cli

### DIFF
--- a/sqlx-cli/src/lib.rs
+++ b/sqlx-cli/src/lib.rs
@@ -43,6 +43,11 @@ pub async fn run(opt: Opt) -> Result<()> {
                 connect_opts,
             } => migrate::info(&source, &connect_opts).await?,
             MigrateCommand::BuildScript { source, force } => migrate::build_script(&source, force)?,
+            MigrateCommand::Fresh {
+                source,
+                force,
+                connect_opts,
+            } => migrate::fresh(&source, &connect_opts, force).await?,
         },
 
         Command::Database(database) => match database.command {

--- a/sqlx-cli/src/migrate.rs
+++ b/sqlx-cli/src/migrate.rs
@@ -339,3 +339,27 @@ fn main() {{
 
     Ok(())
 }
+
+pub async fn fresh(
+    migration_source: &str,
+    connect_opts: &ConnectOpts,
+    force: bool,
+) -> anyhow::Result<()> {
+    let mut conn = crate::connect(connect_opts).await?;
+
+    if !force {
+        bail!(MigrateError::MustForce);
+    }
+
+    conn.reset()
+        .await?;
+
+    run(
+        migration_source,
+        connect_opts,
+        false,
+        true
+    ).await?;
+
+    Ok(())
+}

--- a/sqlx-cli/src/opt.rs
+++ b/sqlx-cli/src/opt.rs
@@ -169,6 +169,19 @@ pub enum MigrateCommand {
         #[clap(long)]
         force: bool,
     },
+
+    /// Delete all database tables & re-run migrations
+    Fresh {
+        #[clap(flatten)]
+        source: Source,
+
+        /// List all the migrations to be run without applying
+        #[clap(long)]
+        force: bool,
+
+        #[clap(flatten)]
+        connect_opts: ConnectOpts,
+    },
 }
 
 /// Argument for the migration scripts source.

--- a/sqlx-cli/src/opt.rs
+++ b/sqlx-cli/src/opt.rs
@@ -170,12 +170,12 @@ pub enum MigrateCommand {
         force: bool,
     },
 
-    /// Delete all database tables & re-run migrations
+    /// Delete all database tables & re-run migrations.
     Fresh {
         #[clap(flatten)]
         source: Source,
 
-        /// List all the migrations to be run without applying
+        /// Force the command to run.
         #[clap(long)]
         force: bool,
 

--- a/sqlx-core/src/any/migrate.rs
+++ b/sqlx-core/src/any/migrate.rs
@@ -70,4 +70,8 @@ impl Migrate for AnyConnection {
     ) -> BoxFuture<'m, Result<Duration, MigrateError>> {
         Box::pin(async { self.get_migrate()?.revert(migration).await })
     }
+
+    fn reset<'e>(&'e mut self) -> BoxFuture<'e, Result<Duration, MigrateError>> {
+        Box::pin(async { self.get_migrate()?.reset().await })
+    }
 }

--- a/sqlx-core/src/migrate/error.rs
+++ b/sqlx-core/src/migrate/error.rs
@@ -23,4 +23,7 @@ pub enum MigrateError {
         "migration {0} is partially applied; fix and remove row from `_sqlx_migrations` table"
     )]
     Dirty(i64),
+
+    #[error("destructive command: you must use '--force'")]
+    MustForce,
 }

--- a/sqlx-core/src/migrate/migrate.rs
+++ b/sqlx-core/src/migrate/migrate.rs
@@ -43,7 +43,7 @@ pub trait Migrate {
 
     // run SQL from migration in a DDL transaction
     // insert new row to [_migrations] table on completion (success or failure)
-    // returns the time taking to run the migration SQL
+    // returns the time taken to run the migration SQL
     fn apply<'e: 'm, 'm>(
         &'e mut self,
         migration: &'m Migration,
@@ -51,9 +51,13 @@ pub trait Migrate {
 
     // run a revert SQL from migration in a DDL transaction
     // deletes the row in [_migrations] table with specified migration version on completion (success or failure)
-    // returns the time taking to run the migration SQL
+    // returns the time taken to run the migration SQL
     fn revert<'e: 'm, 'm>(
         &'e mut self,
         migration: &'m Migration,
     ) -> BoxFuture<'m, Result<Duration, MigrateError>>;
+
+    // run SQL to drop all tables in the configured database
+    // returns the time taken to run the SQL
+    fn reset<'e>(&'e mut self) -> BoxFuture<'e, Result<Duration, MigrateError>>;
 }


### PR DESCRIPTION
Hi,

While learning Rust + SQLx I thought it would be really nice to be able to clear the database and run all migrations again. I usually work on Laravel (php) applications where we have the `artisan migrate:fresh` command.

I've added the `migrate fresh` command to the CLI which will drop all tables and run the migrations. To run it you need to use the `--force` param to prevent people from dropping their database tables in production.

I've tested the MySQL implementation. If there's interest in merging this pull request I'll test the Postgres & Sqlite drivers and write the required tests.

P.S: I'm very new to Rust so some of the code might be abit spaghetti-like.