### PR TITLE
chore: bump syn to 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,10 +488,12 @@ dependencies = [
 
 [[package]]
 name = "bigdecimal"
-version = "0.3.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
+checksum = "9324c8014cd04590682b34f1e9448d38f0674d0f7b2dc553331016ef0e4e9ebc"
 dependencies = [
+ "autocfg",
+ "libm",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -2520,9 +2522,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -3155,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.7.4"
+version = "0.8.0-alpha.0"
 dependencies = [
  "anyhow",
  "async-std",
@@ -3185,7 +3187,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-cli"
-version = "0.7.4"
+version = "0.8.0-alpha.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3211,7 +3213,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.7.4"
+version = "0.8.0-alpha.0"
 dependencies = [
  "ahash 0.8.11",
  "async-io 1.13.0",
@@ -3395,18 +3397,18 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.7.4"
+version = "0.8.0-alpha.0"
 dependencies = [
  "proc-macro2",
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 1.0.109",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.7.4"
+version = "0.8.0-alpha.0"
 dependencies = [
  "async-std",
  "dotenvy",
@@ -3423,7 +3425,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 1.0.109",
+ "syn 2.0.52",
  "tempfile",
  "tokio",
  "url",
@@ -3431,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.7.4"
+version = "0.8.0-alpha.0"
 dependencies = [
  "atoi",
  "base64 0.21.7",
@@ -3476,7 +3478,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.7.4"
+version = "0.8.0-alpha.0"
 dependencies = [
  "atoi",
  "base64 0.21.7",
@@ -3521,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.7.4"
+version = "0.8.0-alpha.0"
 dependencies = [
  "atoi",
  "chrono",

--- a/sqlx-macros-core/Cargo.toml
+++ b/sqlx-macros-core/Cargo.toml
@@ -52,12 +52,11 @@ hex = { version = "0.4.3" }
 heck = { version = "0.4", features = ["unicode"] }
 either = "1.6.1"
 once_cell = "1.9.0"
-proc-macro2 = { version = "1.0.36", default-features = false }
+proc-macro2 = { version = "1.0.79", default-features = false }
 serde = { version = "1.0.132", features = ["derive"] }
 serde_json = { version = "1.0.73" }
 sha2 = { version = "0.10.0" }
-syn = { version = "1.0.84", default-features = false, features = ["full", "derive", "parsing", "printing", "clone-impls"] }
+syn = { version = "2.0.52", default-features = false, features = ["full", "derive", "parsing", "printing", "clone-impls"] }
 tempfile = { version = "3.3.0" }
-quote = { version = "1.0.14", default-features = false }
+quote = { version = "1.0.26", default-features = false }
 url = { version = "2.2.2", default-features = false }
-

--- a/sqlx-macros-core/src/database/mod.rs
+++ b/sqlx-macros-core/src/database/mod.rs
@@ -172,6 +172,7 @@ mod mysql;
 mod sqlite;
 
 mod fake_sqlx {
+    #[cfg(any(feature = "mysql", feature = "postgres", feature = "sqlite"))]
     pub use sqlx_core::*;
 
     #[cfg(feature = "mysql")]

--- a/sqlx-macros-core/src/derives/attributes.rs
+++ b/sqlx-macros-core/src/derives/attributes.rs
@@ -1,8 +1,8 @@
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::{
-    punctuated::Punctuated, spanned::Spanned, token::Comma, Attribute, DeriveInput, Field, Lit,
-    Meta, MetaNameValue, NestedMeta, Type, Variant,
+    punctuated::Punctuated, token::Comma, Attribute, DeriveInput, Field, LitStr, Meta, Token, Type,
+    Variant,
 };
 
 macro_rules! assert_attribute {
@@ -77,82 +77,53 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
     let mut no_pg_array = None;
     let mut default = None;
 
-    for attr in input
-        .iter()
-        .filter(|a| a.path.is_ident("sqlx") || a.path.is_ident("repr"))
-    {
-        let meta = attr
-            .parse_meta()
-            .map_err(|e| syn::Error::new_spanned(attr, e))?;
-        match meta {
-            Meta::List(list) if list.path.is_ident("sqlx") => {
-                for value in list.nested.iter() {
-                    match value {
-                        NestedMeta::Meta(meta) => match meta {
-                            Meta::Path(p) if p.is_ident("transparent") => {
-                                try_set!(transparent, true, value)
-                            }
+    for attr in input {
+        if attr.path().is_ident("sqlx") {
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("transparent") {
+                    try_set!(transparent, true, attr);
+                } else if meta.path.is_ident("no_pg_array") {
+                    try_set!(no_pg_array, true, attr);
+                } else if meta.path.is_ident("default") {
+                    try_set!(default, true, attr);
+                } else if meta.path.is_ident("rename_all") {
+                    meta.input.parse::<Token![=]>()?;
+                    let lit: LitStr = meta.input.parse()?;
 
-                            Meta::Path(p) if p.is_ident("no_pg_array") => {
-                                try_set!(no_pg_array, true, value);
-                            }
+                    let val = match lit.value().as_str() {
+                        "lowercase" => RenameAll::LowerCase,
+                        "snake_case" => RenameAll::SnakeCase,
+                        "UPPERCASE" => RenameAll::UpperCase,
+                        "SCREAMING_SNAKE_CASE" => RenameAll::ScreamingSnakeCase,
+                        "kebab-case" => RenameAll::KebabCase,
+                        "camelCase" => RenameAll::CamelCase,
+                        "PascalCase" => RenameAll::PascalCase,
+                        _ => fail!(lit, "unexpected value for rename_all"),
+                    };
 
-                            Meta::NameValue(MetaNameValue {
-                                path,
-                                lit: Lit::Str(val),
-                                ..
-                            }) if path.is_ident("rename_all") => {
-                                let val = match &*val.value() {
-                                    "lowercase" => RenameAll::LowerCase,
-                                    "snake_case" => RenameAll::SnakeCase,
-                                    "UPPERCASE" => RenameAll::UpperCase,
-                                    "SCREAMING_SNAKE_CASE" => RenameAll::ScreamingSnakeCase,
-                                    "kebab-case" => RenameAll::KebabCase,
-                                    "camelCase" => RenameAll::CamelCase,
-                                    "PascalCase" => RenameAll::PascalCase,
-                                    _ => fail!(meta, "unexpected value for rename_all"),
-                                };
+                    try_set!(rename_all, val, lit)
+                } else if meta.path.is_ident("type_name") {
+                    meta.input.parse::<Token![=]>()?;
+                    let lit: LitStr = meta.input.parse()?;
+                    let name = TypeName {
+                        val: lit.value(),
+                        span: lit.span(),
+                    };
 
-                                try_set!(rename_all, val, value)
-                            }
-
-                            Meta::NameValue(MetaNameValue {
-                                path,
-                                lit: Lit::Str(val),
-                                ..
-                            }) if path.is_ident("type_name") => {
-                                try_set!(
-                                    type_name,
-                                    TypeName {
-                                        val: val.value(),
-                                        span: value.span(),
-                                    },
-                                    value
-                                )
-                            }
-
-                            Meta::Path(p) if p.is_ident("default") => {
-                                try_set!(default, true, value)
-                            }
-
-                            u => fail!(u, "unexpected attribute"),
-                        },
-                        u => fail!(u, "unexpected attribute"),
-                    }
+                    try_set!(type_name, name, lit)
+                } else {
+                    fail!(meta.path, "unexpected attribute")
                 }
+
+                Ok(())
+            })?;
+        } else if attr.path().is_ident("repr") {
+            let list: Punctuated<Meta, Token![,]> =
+                attr.parse_args_with(<Punctuated<Meta, Token![,]>>::parse_terminated)?;
+
+            if let Some(path) = list.iter().find_map(|f| f.require_path_only().ok()) {
+                try_set!(repr, path.get_ident().unwrap().clone(), list);
             }
-            Meta::List(list) if list.path.is_ident("repr") => {
-                if list.nested.len() != 1 {
-                    fail!(&list.nested, "expected one value")
-                }
-                match list.nested.first().unwrap() {
-                    NestedMeta::Meta(Meta::Path(p)) if p.get_ident().is_some() => {
-                        try_set!(repr, p.get_ident().unwrap().clone(), list);
-                    }
-                    u => fail!(u, "unexpected value"),
-                }
-            }
-            _ => {}
         }
     }
 
@@ -174,35 +145,28 @@ pub fn parse_child_attributes(input: &[Attribute]) -> syn::Result<SqlxChildAttri
     let mut skip: bool = false;
     let mut json = false;
 
-    for attr in input.iter().filter(|a| a.path.is_ident("sqlx")) {
-        let meta = attr
-            .parse_meta()
-            .map_err(|e| syn::Error::new_spanned(attr, e))?;
-
-        if let Meta::List(list) = meta {
-            for value in list.nested.iter() {
-                match value {
-                    NestedMeta::Meta(meta) => match meta {
-                        Meta::NameValue(MetaNameValue {
-                            path,
-                            lit: Lit::Str(val),
-                            ..
-                        }) if path.is_ident("rename") => try_set!(rename, val.value(), value),
-                        Meta::NameValue(MetaNameValue {
-                            path,
-                            lit: Lit::Str(val),
-                            ..
-                        }) if path.is_ident("try_from") => try_set!(try_from, val.parse()?, value),
-                        Meta::Path(path) if path.is_ident("default") => default = true,
-                        Meta::Path(path) if path.is_ident("flatten") => flatten = true,
-                        Meta::Path(path) if path.is_ident("skip") => skip = true,
-                        Meta::Path(path) if path.is_ident("json") => json = true,
-                        u => fail!(u, "unexpected attribute"),
-                    },
-                    u => fail!(u, "unexpected attribute"),
-                }
+    for attr in input.iter().filter(|a| a.path().is_ident("sqlx")) {
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("rename") {
+                meta.input.parse::<Token![=]>()?;
+                let val: LitStr = meta.input.parse()?;
+                try_set!(rename, val.value(), val);
+            } else if meta.path.is_ident("try_from") {
+                meta.input.parse::<Token![=]>()?;
+                let val: LitStr = meta.input.parse()?;
+                try_set!(try_from, val.parse()?, val);
+            } else if meta.path.is_ident("default") {
+                default = true;
+            } else if meta.path.is_ident("flatten") {
+                flatten = true;
+            } else if meta.path.is_ident("skip") {
+                skip = true;
+            } else if meta.path.is_ident("json") {
+                json = true;
             }
-        }
+
+            return Ok(());
+        })?;
 
         if json && flatten {
             fail!(

--- a/sqlx-macros-core/src/derives/encode.rs
+++ b/sqlx-macros-core/src/derives/encode.rs
@@ -9,7 +9,7 @@ use syn::punctuated::Punctuated;
 use syn::token::Comma;
 use syn::{
     parse_quote, Data, DataEnum, DataStruct, DeriveInput, Expr, Field, Fields, FieldsNamed,
-    FieldsUnnamed, Lifetime, LifetimeDef, Stmt, Variant,
+    FieldsUnnamed, Lifetime, LifetimeParam, Stmt, Variant,
 };
 
 pub fn expand_derive_encode(input: &DeriveInput) -> syn::Result<TokenStream> {
@@ -66,7 +66,7 @@ fn expand_derive_encode_transparent(
     let mut generics = generics.clone();
     generics
         .params
-        .insert(0, LifetimeDef::new(lifetime.clone()).into());
+        .insert(0, LifetimeParam::new(lifetime.clone()).into());
 
     generics
         .params

--- a/sqlx-macros-core/src/derives/mod.rs
+++ b/sqlx-macros-core/src/derives/mod.rs
@@ -12,7 +12,6 @@ pub use row::expand_derive_from_row;
 use self::attributes::RenameAll;
 use heck::{ToKebabCase, ToLowerCamelCase, ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase};
 use proc_macro2::TokenStream;
-use std::iter::FromIterator;
 use syn::DeriveInput;
 
 pub fn expand_derive_type_encode_decode(input: &DeriveInput) -> syn::Result<TokenStream> {

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -44,5 +44,5 @@ sqlx-core = { workspace = true, features = ["any"] }
 sqlx-macros-core = { workspace = true }
 
 proc-macro2 = { version = "1.0.36", default-features = false }
-syn = { version = "1.0.84", default-features = false, features = ["parsing", "proc-macro"] }
-quote = { version = "1.0.14", default-features = false }
+syn = { version = "2.0.52", default-features = false, features = ["parsing", "proc-macro"] }
+quote = { version = "1.0.26", default-features = false }

--- a/sqlx-macros/src/lib.rs
+++ b/sqlx-macros/src/lib.rs
@@ -79,10 +79,9 @@ pub fn migrate(input: TokenStream) -> TokenStream {
 
 #[proc_macro_attribute]
 pub fn test(args: TokenStream, input: TokenStream) -> TokenStream {
-    let args = syn::parse_macro_input!(args as syn::AttributeArgs);
     let input = syn::parse_macro_input!(input as syn::ItemFn);
 
-    match test_attr::expand(args, input) {
+    match test_attr::expand(args.into(), input) {
         Ok(ts) => ts.into(),
         Err(e) => {
             if let Some(parse_err) = e.downcast_ref::<syn::Error>() {

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -164,10 +164,6 @@
 /// Using `expr as _` simply signals to the macro to not type-check that bind expression,
 /// and then that syntax is stripped from the expression so as to not trigger type errors.
 ///
-/// **NOTE:** type ascription syntax (`expr: _`) is deprecated and will be removed in a
-/// future release. This is due to Rust's [RFC 3307](https://github.com/rust-lang/rfcs/pull/3307)
-/// officially dropping support for the syntax.
-///
 /// ## Type Overrides: Output Columns
 /// Type overrides are also available for output columns, utilizing the SQL standard's support
 /// for arbitrary text in column names:


### PR DESCRIPTION
This PR bumps the `syn` crate to the new major 2.0 version. Following what some of the dependencies
are using as well (`serde 1.0.159`, `futures 0.3.27`, `tokio 1.26.0`).

It seems like now is a good time to bump before the 0.7 release. Some of the breakages include:
* `AttributeArgs` no longer exists, we must `Punctured` directly;
* `NestedMeta` no longer exists.
* `LifetimeDef` is now `LifetimeParam`;
* No more support for type ascription;

The `parse_nested_meta` replaces whatever would be done using `AttributeArgs`.