### PR TITLE
chore: add deprecation notice for type ascription use

### DIFF
--- a/sqlx-macros-core/src/lib.rs
+++ b/sqlx-macros-core/src/lib.rs
@@ -19,8 +19,6 @@
     feature(track_path)
 )]
 
-use once_cell::sync::Lazy;
-
 use crate::query::QueryDriver;
 
 pub type Error = Box<dyn std::error::Error>;
@@ -54,6 +52,7 @@ where
 {
     #[cfg(feature = "_rt-tokio")]
     {
+        use once_cell::sync::Lazy;
         use tokio::runtime::{self, Runtime};
 
         // We need a single, persistent Tokio runtime since we're caching connections,

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -43,5 +43,5 @@ sqlx-core = { workspace = true, default-features = false, features = ["any"] }
 sqlx-macros-core = { workspace = true }
 
 proc-macro2 = { version = "1.0.36", default-features = false }
-syn = { version = "1.0.84", default-features = false, features = ["full"] }
+syn = { version = "1.0.84", default-features = false, features = ["parsing", "proc-macro"] }
 quote = { version = "1.0.14", default-features = false }

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -151,9 +151,12 @@
 /// sqlx::query!("select $1::int4 as id", my_int as MyInt4)
 /// ```
 ///
-/// Using `expr as _` or `expr : _` simply signals to the macro to not type-check that bind expression,
-/// and then that syntax is stripped from the expression so as to not trigger type errors
-/// (or an unstable syntax feature in the case of the latter, which is called type ascription).
+/// Using `expr as _` simply signals to the macro to not type-check that bind expression,
+/// and then that syntax is stripped from the expression so as to not trigger type errors.
+///
+/// **NOTE:** type ascription syntax (`expr: _`) is deprecated and will be removed in a
+/// future release. This is due to Rust's [RFC 3307](https://github.com/rust-lang/rfcs/pull/3307)
+/// officially dropping support for the syntax.
 ///
 /// ## Type Overrides: Output Columns
 /// Type overrides are also available for output columns, utilizing the SQL standard's support


### PR DESCRIPTION
Adds a deprecation notice when type ascription pattern is used, preparing grounds for when
we drop support for the pattern, keeping compatibility with Rust's supported syntax, as decided
on [RFC 3307].

This change was created as discussed in #2482.

# Example
The following code uses type ascription for the second argument.
```rust
    let _ = sqlx::query!(
        r#"SELECT $1 as a, $2 as b"#,
        foo_bar as i32,
        (6 + 8): <Foo as Deref>::Target
    );
```
Generating a warning that looks as follows:
```
warning: use of deprecated constant `main::{closure#0}::warning_arg1`: 
                 Type ascription pattern is deprecated, prefer casting
                 Try changing from
                     `(6 + 8) : < Foo as Deref > :: Target`
                 to
                     `(6 + 8) as < Foo as Deref > :: Target`
         
                 See <https://github.com/rust-lang/rfcs/pull/3307> for more information
  --> src/main.rs:16:9
   |
16 |         (6 + 8): <Foo as Deref>::Target
   |         ^^^^^^^
```

[RFC 3307]: https://github.com/rust-lang/rfcs/pull/3307