### PR TITLE
sqlite date macro support

### DIFF
--- a/sqlx-macros-core/src/database/sqlite.rs
+++ b/sqlx-macros-core/src/database/sqlite.rs
@@ -22,10 +22,10 @@ impl_database_ext! {
         sqlx::types::chrono::DateTime<sqlx::types::chrono::Utc> | sqlx::types::chrono::DateTime<_>,
 
         #[cfg(feature = "time")]
-        sqlx::types::time::PrimitiveDateTime,
+        sqlx::types::time::OffsetDateTime,
 
         #[cfg(feature = "time")]
-        sqlx::types::time::OffsetDateTime,
+        sqlx::types::time::PrimitiveDateTime,
 
         #[cfg(feature = "time")]
         sqlx::types::time::Date,

--- a/sqlx-macros-core/src/database/sqlite.rs
+++ b/sqlx-macros-core/src/database/sqlite.rs
@@ -14,7 +14,7 @@ impl_database_ext! {
 
         #[cfg(feature = "chrono")]
         sqlx::types::chrono::NaiveDate,
-            
+
         #[cfg(feature = "chrono")]
         sqlx::types::chrono::NaiveDateTime,
 

--- a/sqlx-macros-core/src/database/sqlite.rs
+++ b/sqlx-macros-core/src/database/sqlite.rs
@@ -24,6 +24,9 @@ impl_database_ext! {
         #[cfg(feature = "time")]
         sqlx::types::time::OffsetDateTime,
 
+        #[cfg(feature = "time")]
+        sqlx::types::time::Date,
+
         #[cfg(feature = "uuid")]
         sqlx::types::Uuid,
     },

--- a/sqlx-macros-core/src/database/sqlite.rs
+++ b/sqlx-macros-core/src/database/sqlite.rs
@@ -13,6 +13,9 @@ impl_database_ext! {
         Vec<u8>,
 
         #[cfg(feature = "chrono")]
+        sqlx::types::chrono::NaiveDate,
+            
+        #[cfg(feature = "chrono")]
         sqlx::types::chrono::NaiveDateTime,
 
         #[cfg(feature = "chrono")]


### PR DESCRIPTION
Adds DATE pseudo-type support for sqlite into the macros for both `chrono` and `time`.

Just adding the few lines mentioned in https://github.com/launchbadge/sqlx/issues/2026#issuecomment-1212482339.

I'm aware sqlite has no actual support for the types and simply treats them as strings, however given we already kinda support it in sqlx I figured it may as well be integrated.