### PR TITLE
Gzp issue 2500

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,9 +95,9 @@ _rt-tokio = []
 
 # database
 any = ["sqlx-core/any", "sqlx-mysql?/any", "sqlx-postgres?/any", "sqlx-sqlite?/any"]
-postgres = ["sqlx-postgres", "sqlx-macros?/postgres"]
-mysql = ["sqlx-mysql", "sqlx-macros?/mysql"]
-sqlite = ["sqlx-sqlite", "sqlx-macros?/sqlite"]
+postgres = ["sqlx-postgres", "sqlx-macros?/postgres", "sqlx-core/postgres"]
+mysql = ["sqlx-mysql", "sqlx-macros?/mysql", "sqlx-core/mysql"]
+sqlite = ["sqlx-sqlite", "sqlx-macros?/sqlite", "sqlx-core/sqlite"]
 
 # types
 json = ["sqlx-macros?/json", "sqlx-mysql?/json", "sqlx-postgres?/json", "sqlx-sqlite?/json"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,9 +95,9 @@ _rt-tokio = []
 
 # database
 any = ["sqlx-core/any", "sqlx-mysql?/any", "sqlx-postgres?/any", "sqlx-sqlite?/any"]
-postgres = ["sqlx-postgres", "sqlx-macros?/postgres", "sqlx-core/postgres"]
-mysql = ["sqlx-mysql", "sqlx-macros?/mysql", "sqlx-core/mysql"]
-sqlite = ["sqlx-sqlite", "sqlx-macros?/sqlite", "sqlx-core/sqlite"]
+postgres = ["sqlx-postgres", "sqlx-macros?/postgres"]
+mysql = ["sqlx-mysql", "sqlx-macros?/mysql"]
+sqlite = ["sqlx-sqlite", "sqlx-macros?/sqlite"]
 
 # types
 json = ["sqlx-macros?/json", "sqlx-mysql?/json", "sqlx-postgres?/json", "sqlx-sqlite?/json"]

--- a/sqlx-core/src/any/connection/mod.rs
+++ b/sqlx-core/src/any/connection/mod.rs
@@ -34,7 +34,7 @@ impl AnyConnection {
 
     pub(crate) fn connect(options: &AnyConnectOptions) -> BoxFuture<'_, crate::Result<Self>> {
         Box::pin(async {
-            let driver = crate::any::driver::from_url(&options.database_url)?;
+            let driver = crate::any::driver::from_str(&options.database_url)?;
             (driver.connect)(options).await
         })
     }

--- a/sqlx-core/src/any/migrate.rs
+++ b/sqlx-core/src/any/migrate.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 impl MigrateDatabase for Any {
     fn create_database(url: &str) -> BoxFuture<'_, Result<(), Error>> {
         Box::pin(async {
-            driver::from_url_str(url)?
+            driver::from_str(url)?
                 .get_migrate_database()?
                 .create_database(url)
                 .await
@@ -17,7 +17,7 @@ impl MigrateDatabase for Any {
 
     fn database_exists(url: &str) -> BoxFuture<'_, Result<bool, Error>> {
         Box::pin(async {
-            driver::from_url_str(url)?
+            driver::from_str(url)?
                 .get_migrate_database()?
                 .database_exists(url)
                 .await
@@ -26,7 +26,7 @@ impl MigrateDatabase for Any {
 
     fn drop_database(url: &str) -> BoxFuture<'_, Result<(), Error>> {
         Box::pin(async {
-            driver::from_url_str(url)?
+            driver::from_str(url)?
                 .get_migrate_database()?
                 .drop_database(url)
                 .await

--- a/sqlx-core/src/any/options.rs
+++ b/sqlx-core/src/any/options.rs
@@ -17,7 +17,7 @@ use url::Url;
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct AnyConnectOptions {
-    pub database_url: Url,
+    pub database_url: String,
     pub log_settings: LogSettings,
 }
 impl FromStr for AnyConnectOptions {
@@ -25,9 +25,7 @@ impl FromStr for AnyConnectOptions {
 
     fn from_str(url: &str) -> Result<Self, Self::Err> {
         Ok(AnyConnectOptions {
-            database_url: url
-                .parse::<Url>()
-                .map_err(|e| Error::Configuration(e.into()))?,
+            database_url: url.to_owned(),
             log_settings: LogSettings::default(),
         })
     }
@@ -38,7 +36,7 @@ impl ConnectOptions for AnyConnectOptions {
 
     fn from_url(url: &Url) -> Result<Self, Error> {
         Ok(AnyConnectOptions {
-            database_url: url.clone(),
+            database_url: url.to_string(),
             log_settings: LogSettings::default(),
         })
     }

--- a/sqlx-mysql/src/any.rs
+++ b/sqlx-mysql/src/any.rs
@@ -11,6 +11,7 @@ use sqlx_core::any::{
     Any, AnyArguments, AnyColumn, AnyConnectOptions, AnyConnectionBackend, AnyQueryResult, AnyRow,
     AnyStatement, AnyTypeInfo, AnyTypeInfoKind,
 };
+use std::str::FromStr;
 use sqlx_core::connection::Connection;
 use sqlx_core::database::Database;
 use sqlx_core::describe::Describe;
@@ -189,7 +190,7 @@ impl<'a> TryFrom<&'a AnyConnectOptions> for MySqlConnectOptions {
     type Error = sqlx_core::Error;
 
     fn try_from(any_opts: &'a AnyConnectOptions) -> Result<Self, Self::Error> {
-        let mut opts = Self::parse_from_url(&any_opts.database_url)?;
+        let mut opts = Self::from_str(&any_opts.database_url)?;
         opts.log_settings = any_opts.log_settings.clone();
         Ok(opts)
     }

--- a/sqlx-postgres/src/any.rs
+++ b/sqlx-postgres/src/any.rs
@@ -1,3 +1,4 @@
+use std::str::FromStr;
 use crate::{
     Either, PgColumn, PgConnectOptions, PgConnection, PgQueryResult, PgRow, PgTransactionManager,
     PgTypeInfo, Postgres,
@@ -223,7 +224,7 @@ impl<'a> TryFrom<&'a AnyConnectOptions> for PgConnectOptions {
     type Error = sqlx_core::Error;
 
     fn try_from(value: &'a AnyConnectOptions) -> Result<Self, Self::Error> {
-        let mut opts = PgConnectOptions::parse_from_url(&value.database_url)?;
+        let mut opts = PgConnectOptions::from_str(&value.database_url)?;
         opts.log_settings = value.log_settings.clone();
         Ok(opts)
     }

--- a/sqlx-sqlite/src/any.rs
+++ b/sqlx-sqlite/src/any.rs
@@ -1,3 +1,4 @@
+use std::str::FromStr;
 use crate::{
     Either, Sqlite, SqliteArgumentValue, SqliteArguments, SqliteColumn, SqliteConnectOptions,
     SqliteConnection, SqliteQueryResult, SqliteRow, SqliteTransactionManager, SqliteTypeInfo,
@@ -12,7 +13,7 @@ use sqlx_core::any::{
 };
 
 use crate::type_info::DataType;
-use sqlx_core::connection::{ConnectOptions, Connection};
+use sqlx_core::connection::Connection;
 use sqlx_core::database::Database;
 use sqlx_core::describe::Describe;
 use sqlx_core::executor::Executor;
@@ -190,7 +191,7 @@ impl<'a> TryFrom<&'a AnyConnectOptions> for SqliteConnectOptions {
     type Error = sqlx_core::Error;
 
     fn try_from(opts: &'a AnyConnectOptions) -> Result<Self, Self::Error> {
-        let mut opts_out = SqliteConnectOptions::from_url(&opts.database_url)?;
+        let mut opts_out = SqliteConnectOptions::from_str(&opts.database_url)?;
         opts_out.log_settings = opts.log_settings.clone();
         Ok(opts_out)
     }

--- a/sqlx-sqlite/src/connection/mod.rs
+++ b/sqlx-sqlite/src/connection/mod.rs
@@ -258,7 +258,7 @@ impl LockedSqliteHandle<'_> {
     /// The progress handler callback must not do anything that will modify the database connection that invoked
     /// the progress handler. Note that sqlite3_prepare_v2() and sqlite3_step() both modify their database connections
     /// in this context.
-    pub fn set_progress_handler<F>(&mut self, num_ops: i32, mut callback: F)
+    pub fn set_progress_handler<F>(&mut self, num_ops: i32, callback: F)
     where
         F: FnMut() -> bool + Send + 'static,
     {


### PR DESCRIPTION
A potential fix for #2500.
AnyConnectOptions stores a raw string and let the driver handle any url conversion.