### PR TITLE
Exposing the Oid of PostgreSQL types

### DIFF
--- a/sqlx-postgres/src/type_info.rs
+++ b/sqlx-postgres/src/type_info.rs
@@ -166,8 +166,22 @@ impl PgTypeInfo {
         self.0.kind()
     }
 
-    /// Returns the OID for this type, if any.
-    pub fn try_oid(&self) -> Option<Oid> {
+    /// Returns the OID for this type, if available.
+    ///
+    /// The OID may not be available if SQLx only knows the type by name.
+    /// It will have to be resolved by a `PgConnection` at runtime which 
+    /// will yield a new and semantically distinct `TypeInfo` instance.
+    ///
+    /// This method does not perform any such lookup.
+    ///
+    /// ### Note
+    /// With the exception of [the default `pg_type` catalog][pg_type], type OIDs are *not* stable in PostgreSQL.
+    /// If a type is added by an extension, its OID will be assigned when the `CREATE EXTENSION` statement is executed,
+    /// and so can change depending on what extensions are installed and in what order, as well as the exact
+    /// version of PostgreSQL.
+    ///
+    /// [pg_type]: https://github.com/postgres/postgres/blob/master/src/include/catalog/pg_type.dat
+    pub fn oid(&self) -> Option<Oid> {
         self.0.try_oid()
     }
 

--- a/sqlx-postgres/src/type_info.rs
+++ b/sqlx-postgres/src/type_info.rs
@@ -166,6 +166,11 @@ impl PgTypeInfo {
         self.0.kind()
     }
 
+    /// Returns the OID for this type.
+    pub fn oid(&self) -> Oid {
+        self.0.oid()
+    }
+
     #[doc(hidden)]
     pub fn __type_feature_gate(&self) -> Option<&'static str> {
         if [

--- a/sqlx-postgres/src/type_info.rs
+++ b/sqlx-postgres/src/type_info.rs
@@ -166,9 +166,9 @@ impl PgTypeInfo {
         self.0.kind()
     }
 
-    /// Returns the OID for this type.
-    pub fn oid(&self) -> Oid {
-        self.0.oid()
+    /// Returns the OID for this type, if any.
+    pub fn try_oid(&self) -> Option<Oid> {
+        self.0.try_oid()
     }
 
     #[doc(hidden)]

--- a/sqlx-postgres/src/type_info.rs
+++ b/sqlx-postgres/src/type_info.rs
@@ -169,7 +169,7 @@ impl PgTypeInfo {
     /// Returns the OID for this type, if available.
     ///
     /// The OID may not be available if SQLx only knows the type by name.
-    /// It will have to be resolved by a `PgConnection` at runtime which 
+    /// It will have to be resolved by a `PgConnection` at runtime which
     /// will yield a new and semantically distinct `TypeInfo` instance.
     ///
     /// This method does not perform any such lookup.


### PR DESCRIPTION
This PR closes #1111 and supersedes #2146. It adds a function to retrieve OIDs, which is very useful in very dynamic schemas, such as DBMSs or when you want to provide a more low-level interface to the DB.

This function is a non-panicking alternative to `.oid()`.