### PR TITLE
Bump mac_address to 1.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "mac_address"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d1bc1084549d60725ccc53a2bfa07f67fe4689fda07b05a36531f2988104a"
+checksum = "4863ee94f19ed315bf3bc00299338d857d4b5bc856af375cc97d237382ad3856"
 dependencies = [
  "nix",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ bigdecimal = "0.3.0"
 bit-vec = "0.6.3"
 chrono = { version = "0.4.22", default-features = false }
 ipnetwork = "0.20.0"
-mac_address = "1.1.3"
+mac_address = "1.1.5"
 rust_decimal = "1.26.1"
 time = { version = "0.3.14", features = ["formatting", "parsing", "macros"] }
 uuid = "1.1.2"


### PR DESCRIPTION
Hi, `mac_address` maintainer here. This bumps the version of `mac_address` to 1.1.5 (which I just published) which includes an important fix for 32-bit Windows targets which would trigger a panic on nightly due to some unfortunate Windows ABI issues where Rust and the WinAPI don't agree on a struct's alignment. This is very unlikely to affect the vast majority of people using `sqlx`, so I don't think any kind of backport is necessary for pre-0.7 releases, but I wanted to make sure that you folks had the latest version going forward.

If you have any questions or comments let me know!