### PR TITLE
Use ::std::result::Result::Ok in output.rs

### DIFF
--- a/sqlx-macros-core/src/query/output.rs
+++ b/sqlx-macros-core/src/query/output.rs
@@ -177,7 +177,7 @@ pub fn quote_query_as<DB: DatabaseExt>(
 
             #(#instantiations)*
 
-            Ok(#out_ty { #(#ident: #var_name),* })
+            ::std::result::Result::Ok(#out_ty { #(#ident: #var_name),* })
         })
     }
 }


### PR DESCRIPTION
Since `::std::result::Result::Ok` is not used here, it errs when the `Ok` in global scope is not `::std::result::Result::Ok`, for example when one imports `anyhow::Ok`.

This PR fixes it by using `::std::result::Result::Ok`.