### PR TITLE
Implement mysql_clear_password

### DIFF
--- a/sqlx-mysql/src/connection/auth.rs
+++ b/sqlx-mysql/src/connection/auth.rs
@@ -27,6 +27,12 @@ impl AuthPlugin {
 
             // https://mariadb.com/kb/en/sha256_password-plugin/
             AuthPlugin::Sha256Password => encrypt_rsa(stream, 0x01, password, nonce).await,
+
+            AuthPlugin::MySqlClearPassword => {
+                let mut pw_bytes = password.as_bytes().to_owned();
+                pw_bytes.push(0); // null terminate
+                Ok(pw_bytes)
+            },
         }
     }
 

--- a/sqlx-mysql/src/connection/auth.rs
+++ b/sqlx-mysql/src/connection/auth.rs
@@ -32,7 +32,7 @@ impl AuthPlugin {
                 let mut pw_bytes = password.as_bytes().to_owned();
                 pw_bytes.push(0); // null terminate
                 Ok(pw_bytes)
-            },
+            }
         }
     }
 

--- a/sqlx-mysql/src/connection/establish.rs
+++ b/sqlx-mysql/src/connection/establish.rs
@@ -134,7 +134,8 @@ impl<'a> DoHandshake<'a> {
                 }
 
                 0xfe => {
-                    let switch: AuthSwitchRequest = packet.decode_with(self.options.enable_cleartext_plugin)?;
+                    let switch: AuthSwitchRequest =
+                        packet.decode_with(self.options.enable_cleartext_plugin)?;
 
                     plugin = Some(switch.plugin);
                     let nonce = switch.data.chain(Bytes::new());

--- a/sqlx-mysql/src/connection/establish.rs
+++ b/sqlx-mysql/src/connection/establish.rs
@@ -11,7 +11,7 @@ use crate::protocol::connect::{
     AuthSwitchRequest, AuthSwitchResponse, Handshake, HandshakeResponse,
 };
 use crate::protocol::Capabilities;
-use crate::{MySqlConnectOptions, MySqlConnection};
+use crate::{MySqlConnectOptions, MySqlConnection, MySqlSslMode};
 
 impl MySqlConnection {
     pub(crate) async fn establish(options: &MySqlConnectOptions) -> Result<Self, Error> {
@@ -48,6 +48,15 @@ impl<'a> DoHandshake<'a> {
             .map(|collation| collation.parse())
             .transpose()?
             .unwrap_or_else(|| charset.default_collation());
+
+        if options.enable_cleartext_plugin
+            && matches!(
+                options.ssl_mode,
+                MySqlSslMode::Disabled | MySqlSslMode::Preferred
+            )
+        {
+            log::warn!("Security warning: sending cleartext passwords without requiring SSL");
+        }
 
         Ok(Self {
             options,

--- a/sqlx-mysql/src/connection/establish.rs
+++ b/sqlx-mysql/src/connection/establish.rs
@@ -134,7 +134,7 @@ impl<'a> DoHandshake<'a> {
                 }
 
                 0xfe => {
-                    let switch: AuthSwitchRequest = packet.decode()?;
+                    let switch: AuthSwitchRequest = packet.decode_with(self.options.enable_cleartext_plugin)?;
 
                     plugin = Some(switch.plugin);
                     let nonce = switch.data.chain(Bytes::new());

--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -68,6 +68,7 @@ pub struct MySqlConnectOptions {
     pub(crate) collation: Option<String>,
     pub(crate) log_settings: LogSettings,
     pub(crate) pipes_as_concat: bool,
+    pub(crate) enable_cleartext_plugin: bool,
 }
 
 impl Default for MySqlConnectOptions {
@@ -95,6 +96,7 @@ impl MySqlConnectOptions {
             statement_cache_capacity: 100,
             log_settings: Default::default(),
             pipes_as_concat: true,
+            enable_cleartext_plugin: false,
         }
     }
 
@@ -256,6 +258,17 @@ impl MySqlConnectOptions {
     /// cases.
     pub fn pipes_as_concat(mut self, flag_val: bool) -> Self {
         self.pipes_as_concat = flag_val;
+        self
+    }
+
+    /// Enables mysql_clear_password plugin support.
+    ///
+    /// Security Note:
+    /// Sending passwords as cleartext may be a security problem in some
+    /// configurations. Please consider using TLS or encrypted tunnels for
+    /// server connection.
+    pub fn enable_cleartext_plugin(mut self, flag_val: bool) -> Self {
+        self.enable_cleartext_plugin = flag_val;
         self
     }
 }

--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -265,8 +265,12 @@ impl MySqlConnectOptions {
     ///
     /// Security Note:
     /// Sending passwords as cleartext may be a security problem in some
-    /// configurations. Please consider using TLS or encrypted tunnels for
-    /// server connection.
+    /// configurations. Without additional defensive configuration like
+    /// ssl-mode=VERIFY_IDENTITY, an attacker can compromise a router
+    /// and trick the application into divulging its credentials.
+    ///
+    /// It is strongly recommended to set `.ssl_mode` to `Required`,
+    /// `VerifyCa`, or `VerifyIdentity` when enabling cleartext plugin.
     pub fn enable_cleartext_plugin(mut self, flag_val: bool) -> Self {
         self.enable_cleartext_plugin = flag_val;
         self

--- a/sqlx-mysql/src/protocol/auth.rs
+++ b/sqlx-mysql/src/protocol/auth.rs
@@ -7,6 +7,7 @@ pub enum AuthPlugin {
     MySqlNativePassword,
     CachingSha2Password,
     Sha256Password,
+    MySqlClearPassword,
 }
 
 impl AuthPlugin {
@@ -15,6 +16,7 @@ impl AuthPlugin {
             AuthPlugin::MySqlNativePassword => "mysql_native_password",
             AuthPlugin::CachingSha2Password => "caching_sha2_password",
             AuthPlugin::Sha256Password => "sha256_password",
+            AuthPlugin::MySqlClearPassword => "mysql_clear_password",
         }
     }
 }
@@ -27,6 +29,7 @@ impl FromStr for AuthPlugin {
             "mysql_native_password" => Ok(AuthPlugin::MySqlNativePassword),
             "caching_sha2_password" => Ok(AuthPlugin::CachingSha2Password),
             "sha256_password" => Ok(AuthPlugin::Sha256Password),
+            "mysql_clear_password" => Ok(AuthPlugin::MySqlClearPassword),
 
             _ => Err(err_protocol!("unknown authentication plugin: {}", s)),
         }

--- a/sqlx-mysql/src/protocol/connect/auth_switch.rs
+++ b/sqlx-mysql/src/protocol/connect/auth_switch.rs
@@ -80,7 +80,10 @@ fn test_decode_auth_switch_cleartext_disabled() {
 
     let e = AuthSwitchRequest::decode_with(AUTH_SWITCH_CLEARTEXT.into(), false).unwrap_err();
 
-    assert_eq!(e.to_string(), "encountered unexpected or invalid data: mysql_cleartext_plugin disabled");
+    assert_eq!(
+        e.to_string(),
+        "encountered unexpected or invalid data: mysql_cleartext_plugin disabled"
+    );
 }
 
 #[test]

--- a/sqlx-mysql/src/protocol/connect/auth_switch.rs
+++ b/sqlx-mysql/src/protocol/connect/auth_switch.rs
@@ -14,8 +14,8 @@ pub struct AuthSwitchRequest {
     pub data: Bytes,
 }
 
-impl Decode<'_> for AuthSwitchRequest {
-    fn decode_with(mut buf: Bytes, _: ()) -> Result<Self, Error> {
+impl Decode<'_, bool> for AuthSwitchRequest {
+    fn decode_with(mut buf: Bytes, enable_cleartext_plugin: bool) -> Result<Self, Error> {
         let header = buf.get_u8();
         if header != 0xfe {
             return Err(err_protocol!(
@@ -25,6 +25,10 @@ impl Decode<'_> for AuthSwitchRequest {
         }
 
         let plugin = buf.get_str_nul()?.parse()?;
+
+        if matches!(plugin, AuthPlugin::MySqlClearPassword) && !enable_cleartext_plugin {
+            return Err(err_protocol!("mysql_cleartext_plugin disabled"));
+        }
 
         if matches!(plugin, AuthPlugin::MySqlClearPassword) && buf.is_empty() {
             // Contrary to the MySQL protocol, AWS Aurora with IAM sends
@@ -64,17 +68,26 @@ impl Encode<'_, Capabilities> for AuthSwitchResponse {
 fn test_decode_auth_switch_packet_data() {
     const AUTH_SWITCH_NO_DATA: &[u8] = b"\xfecaching_sha2_password\x00abcdefghijabcdefghij\x00";
 
-    let p = AuthSwitchRequest::decode_with(AUTH_SWITCH_NO_DATA.into(), ()).unwrap();
+    let p = AuthSwitchRequest::decode_with(AUTH_SWITCH_NO_DATA.into(), true).unwrap();
 
     assert!(matches!(p.plugin, AuthPlugin::CachingSha2Password));
     assert_eq!(p.data, &b"abcdefghijabcdefghij"[..]);
 }
 
 #[test]
+fn test_decode_auth_switch_cleartext_disabled() {
+    const AUTH_SWITCH_CLEARTEXT: &[u8] = b"\xfemysql_clear_password\x00abcdefghijabcdefghij\x00";
+
+    let e = AuthSwitchRequest::decode_with(AUTH_SWITCH_CLEARTEXT.into(), false).unwrap_err();
+
+    assert_eq!(e.to_string(), "encountered unexpected or invalid data: mysql_cleartext_plugin disabled");
+}
+
+#[test]
 fn test_decode_auth_switch_packet_no_data() {
     const AUTH_SWITCH_NO_DATA: &[u8] = b"\xfemysql_clear_password\x00";
 
-    let p = AuthSwitchRequest::decode_with(AUTH_SWITCH_NO_DATA.into(), ()).unwrap();
+    let p = AuthSwitchRequest::decode_with(AUTH_SWITCH_NO_DATA.into(), true).unwrap();
 
     assert!(matches!(p.plugin, AuthPlugin::MySqlClearPassword));
     assert_eq!(p.data, Bytes::new());

--- a/sqlx-mysql/src/protocol/connect/auth_switch.rs
+++ b/sqlx-mysql/src/protocol/connect/auth_switch.rs
@@ -30,7 +30,8 @@ impl Decode<'_> for AuthSwitchRequest {
         let data = if buf.len() != 21 {
             if matches!(plugin, AuthPlugin::MySqlClearPassword) {
                 // Contrary to the MySQL protocol, AWS Aurora with IAM sends
-                // no data.
+                // no data. That is fine because the MySQL protocol says to
+                // ignore any data sent.
                 Bytes::new()
             } else {
                 return Err(err_protocol!(


### PR DESCRIPTION
Fixes https://github.com/launchbadge/sqlx/issues/2443 by implementing `AuthPlugin::MySqlClearPassword` as described in [mysql docs](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_authentication_methods_clear_text_password.html) and sufficient to connect to a MySQL server hosted by AWS using [IAM authentication with ephemeral passwords](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Connecting.AWSCLI.html).

For consistency with other clients, like [mysql](https://docs.rs/mysql/latest/mysql/struct.OptsBuilder.html#method.enable_cleartext_plugin), and to avoid accidental security issues, we also add a flag to ConnectionOpts to enable this plugin, as described [here](https://dev.mysql.com/doc/refman/8.0/en/cleartext-pluggable-authentication.html).