### PR TITLE
Introduce build_query_scalar for QueryBuilder

### DIFF
--- a/sqlx-core/src/query_builder.rs
+++ b/sqlx-core/src/query_builder.rs
@@ -10,6 +10,7 @@ use crate::encode::Encode;
 use crate::from_row::FromRow;
 use crate::query::Query;
 use crate::query_as::QueryAs;
+use crate::query_scalar::QueryScalar;
 use crate::types::Type;
 use crate::Either;
 
@@ -445,6 +446,30 @@ where
         QueryAs {
             inner: self.build(),
             output: PhantomData,
+        }
+    }
+
+    /// Produce an executable query from this builder.
+    ///
+    /// ### Note: Query is not Checked
+    /// It is your responsibility to ensure that you produce a syntactically correct query here,
+    /// this API has no way to check it for you.
+    ///
+    /// ### Note: Reuse
+    /// You can reuse this builder afterwards to amortize the allocation overhead of the query
+    /// string, however you must call [`.reset()`][Self::reset] first, which returns `Self`
+    /// to the state it was in immediately after [`new()`][Self::new].
+    ///
+    /// Calling any other method but `.reset()` after `.build()` will panic for sanity reasons.
+    pub fn build_query_scalar<'q, T>(
+        &'q mut self,
+    ) -> QueryScalar<'q, DB, T, <DB as HasArguments<'args>>::Arguments>
+    where
+        DB: Database,
+        (T,): for<'r> FromRow<'r, DB::Row>,
+    {
+        QueryScalar {
+            inner: self.build_query_as(),
         }
     }
 

--- a/sqlx-core/src/query_scalar.rs
+++ b/sqlx-core/src/query_scalar.rs
@@ -17,7 +17,7 @@ use crate::types::Type;
 /// Returned from [`query_scalar`].
 #[must_use = "query must be executed to affect database"]
 pub struct QueryScalar<'q, DB: Database, O, A> {
-    inner: QueryAs<'q, DB, (O,), A>,
+    pub(crate) inner: QueryAs<'q, DB, (O,), A>,
 }
 
 impl<'q, DB: Database, O: Send, A: Send> Execute<'q, DB> for QueryScalar<'q, DB, O, A>


### PR DESCRIPTION
This pr try to address #2550 by adding `build_query_scalar` to `QueryBuilder`. 

Closes
https://github.com/launchbadge/sqlx/issues/2539