### PR TITLE
Implement `Clone` for `PoolOptions` manually (#2548)

### DIFF
--- a/sqlx-core/src/pool/options.rs
+++ b/sqlx-core/src/pool/options.rs
@@ -41,7 +41,6 @@ use std::time::{Duration, Instant};
 /// parameter everywhere, and `Box` is in the prelude so it doesn't need to be manually imported,
 /// so having the closure return `Pin<Box<dyn Future>` directly is the path of least resistance from
 /// the perspectives of both API designer and consumer.
-#[derive(Clone)]
 pub struct PoolOptions<DB: Database> {
     pub(crate) test_before_acquire: bool,
     pub(crate) after_connect: Option<
@@ -82,6 +81,27 @@ pub struct PoolOptions<DB: Database> {
     pub(crate) fair: bool,
 
     pub(crate) parent_pool: Option<Pool<DB>>,
+}
+
+// Manually implement `Clone` to avoid a trait bound issue.
+//
+// See: https://github.com/launchbadge/sqlx/issues/2548
+impl<DB: Database> Clone for PoolOptions<DB> {
+    fn clone(&self) -> Self {
+        PoolOptions {
+            test_before_acquire: self.test_before_acquire,
+            after_connect: self.after_connect.as_ref().map(Arc::clone),
+            before_acquire: self.before_acquire.as_ref().map(Arc::clone),
+            after_release: self.after_release.as_ref().map(Arc::clone),
+            max_connections: self.max_connections,
+            acquire_timeout: self.acquire_timeout,
+            min_connections: self.min_connections,
+            max_lifetime: self.max_lifetime,
+            idle_timeout: self.idle_timeout,
+            fair: self.fair,
+            parent_pool: self.parent_pool.as_ref().map(Pool::clone)
+        }
+    }
 }
 
 /// Metadata for the connection being processed by a [`PoolOptions`] callback.

--- a/sqlx-core/src/pool/options.rs
+++ b/sqlx-core/src/pool/options.rs
@@ -99,7 +99,7 @@ impl<DB: Database> Clone for PoolOptions<DB> {
             max_lifetime: self.max_lifetime,
             idle_timeout: self.idle_timeout,
             fair: self.fair,
-            parent_pool: self.parent_pool.as_ref().map(Pool::clone)
+            parent_pool: self.parent_pool.as_ref().map(Pool::clone),
         }
     }
 }

--- a/sqlx-core/src/pool/options.rs
+++ b/sqlx-core/src/pool/options.rs
@@ -90,9 +90,9 @@ impl<DB: Database> Clone for PoolOptions<DB> {
     fn clone(&self) -> Self {
         PoolOptions {
             test_before_acquire: self.test_before_acquire,
-            after_connect: self.after_connect.as_ref().map(Arc::clone),
-            before_acquire: self.before_acquire.as_ref().map(Arc::clone),
-            after_release: self.after_release.as_ref().map(Arc::clone),
+            after_connect: self.after_connect.clone(),
+            before_acquire: self.before_acquire.clone(),
+            after_release: self.after_release.clone(),
             max_connections: self.max_connections,
             acquire_timeout: self.acquire_timeout,
             min_connections: self.min_connections,


### PR DESCRIPTION
Trying to derive `Clone` automatically for `PoolOptions` results in errors when `clone` is actually called. This is because the derive incorrectly determines that `Clone` is _not_ derivable due to the lack of `Clone` implementation on the `DB: Database` type parameter, even though no value of that type is actually stored in a to-be-cloned position (in fact, it's only used for the `Connection` associated type on the type parameter's `Database` trait impl).

Manually implementing `Clone` side-steps this issue and insures the type is always actually cloneable.

For reference: https://github.com/launchbadge/sqlx/issues/2548