### PR TITLE
Impl `AsMut` for advisory lock types (#2520)

### DIFF
--- a/sqlx-core/src/transaction.rs
+++ b/sqlx-core/src/transaction.rs
@@ -197,6 +197,16 @@ where
     }
 }
 
+// Implement `AsMut<DB::Connection>` so `Transaction` can be given to a
+// `PgAdvisoryLockGuard`.
+//
+// See: https://github.com/launchbadge/sqlx/issues/2520
+impl<'c, DB: Database> AsMut<DB::Connection> for Transaction<'c, DB> {
+    fn as_mut(&mut self) -> &mut DB::Connection {
+        &mut self.connection
+    }
+}
+
 impl<'c, 't, DB: Database> crate::acquire::Acquire<'t> for &'t mut Transaction<'c, DB> {
     type Database = DB;
 

--- a/sqlx-postgres/src/connection/mod.rs
+++ b/sqlx-postgres/src/connection/mod.rs
@@ -213,3 +213,13 @@ impl Connection for PgConnection {
         !self.stream.write_buffer().is_empty()
     }
 }
+
+// Implement `AsMut<Self>` so that `PgConnection` can be wrapped in
+// a `PgAdvisoryLockGuard`.
+//
+// See: https://github.com/launchbadge/sqlx/issues/2520
+impl AsMut<PgConnection> for PgConnection {
+    fn as_mut(&mut self) -> &mut PgConnection {
+        self
+    }
+}


### PR DESCRIPTION
The documentation for `PgAdvisoryLockGuard` lists a set of types that should be able to be passed to it, but when actually trying to do so, compilation would fail due to missing `AsMut` trait implementations for those types. This commit adds the missing `AsMut` impls so that `Transaction` and `PgConnection` can be used as type parameters to `PgAdvisoryLockGuard`, as expected.

For reference: https://github.com/launchbadge/sqlx/issues/2520