### PR TITLE
Add CLI autocompletion using clap_complete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "3.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2453,6 +2462,7 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "clap",
+ "clap_complete",
  "console",
  "dotenvy",
  "filetime",

--- a/sqlx-cli/Cargo.toml
+++ b/sqlx-cli/Cargo.toml
@@ -34,6 +34,7 @@ sqlx = { workspace = true, default-features = false, features = [
 ] }
 futures = "0.3.19"
 clap = { version = "3.1.0", features = ["derive", "env"] }
+clap_complete = { version = "3.1.0", optional = true }
 chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
 anyhow = "1.0.52"
 url = { version = "2.2.2", default-features = false }
@@ -52,7 +53,7 @@ filetime = "0.2"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 
 [features]
-default = ["postgres", "sqlite", "mysql", "native-tls"]
+default = ["postgres", "sqlite", "mysql", "native-tls", "completions"]
 rustls = ["sqlx/runtime-tokio-rustls"]
 native-tls = ["sqlx/runtime-tokio-native-tls"]
 
@@ -63,3 +64,5 @@ sqlite = ["sqlx/sqlite"]
 
 # workaround for musl + openssl issues
 openssl-vendored = ["openssl/vendored"]
+
+completions = ["dep:clap_complete"]

--- a/sqlx-cli/src/completions.rs
+++ b/sqlx-cli/src/completions.rs
@@ -1,0 +1,10 @@
+use std::io;
+
+use clap::CommandFactory;
+use clap_complete::{generate, Shell};
+
+use crate::opt::Command;
+
+pub fn run(shell: Shell) {
+    generate(shell, &mut Command::command(), "sqlx", &mut io::stdout())
+}

--- a/sqlx-cli/src/lib.rs
+++ b/sqlx-cli/src/lib.rs
@@ -12,6 +12,8 @@ mod database;
 mod metadata;
 // mod migration;
 // mod migrator;
+#[cfg(feature = "completions")]
+mod completions;
 mod migrate;
 mod opt;
 mod prepare;
@@ -68,6 +70,9 @@ pub async fn run(opt: Opt) -> Result<()> {
             connect_opts,
             args,
         } => prepare::run(check, workspace, connect_opts, args).await?,
+
+        #[cfg(feature = "completions")]
+        Command::Completions { shell } => completions::run(shell),
     };
 
     Ok(())

--- a/sqlx-cli/src/opt.rs
+++ b/sqlx-cli/src/opt.rs
@@ -1,6 +1,8 @@
 use std::ops::{Deref, Not};
 
 use clap::{Args, Parser};
+#[cfg(feature = "completions")]
+use clap_complete::Shell;
 
 #[derive(Parser, Debug)]
 #[clap(version, about, author)]
@@ -46,6 +48,10 @@ pub enum Command {
 
     #[clap(alias = "mig")]
     Migrate(MigrateOpt),
+
+    #[cfg(feature = "completions")]
+    /// Generate shell completions for the specified shell
+    Completions { shell: Shell },
 }
 
 /// Group of commands for creating and dropping your database.


### PR DESCRIPTION
I recently started using `sqlx` (and `sqlx-cli`) for a project and
noticed there is no autocompletion.

As it's trivial to add autocompletion to `clap`-based CLIs and I've done
it a bunch of times I would just create a pr.

## How to use it

I added a subcommand named `completions` to generate completions on the
fly. `clap_complete` theoretically also supports generating completions
at compile time, but as `cargo install` doesn't support installing
autocompletion scripts that doesn't really make sense here.

```console
$ sqlx completions bash > path/to/completions
```
`clap_complete` per default supports generating autocompletions for `bash`, `elvish`, `fish`, `powershell`, and `zsh`.

Sadly there is currently no standard way to create completions for
cargo subcommands, so `cargo-sqlx` can't benefit from completions.
