### PR TITLE
Do not panic when `PrepareOk` fails to decode

### DIFF
--- a/sqlx-mysql/src/protocol/statement/prepare_ok.rs
+++ b/sqlx-mysql/src/protocol/statement/prepare_ok.rs
@@ -16,8 +16,14 @@ pub(crate) struct PrepareOk {
 }
 
 impl Decode<'_, Capabilities> for PrepareOk {
-    fn decode_with(mut buf: Bytes, _: Capabilities) -> Result<Self, Error> {
-        let status = buf.get_u8();
+    fn decode_with(buf: Bytes, _: Capabilities) -> Result<Self, Error> {
+        const SIZE: usize = 12;
+
+        let mut slice = buf.get(..SIZE).ok_or_else(|| {
+            err_protocol!("PrepareOk expected 12 bytes but got {} bytes", buf.len())
+        })?;
+
+        let status = slice.get_u8();
         if status != 0x00 {
             return Err(err_protocol!(
                 "expected 0x00 (COM_STMT_PREPARE_OK) but found 0x{:02x}",
@@ -25,13 +31,13 @@ impl Decode<'_, Capabilities> for PrepareOk {
             ));
         }
 
-        let statement_id = buf.get_u32_le();
-        let columns = buf.get_u16_le();
-        let params = buf.get_u16_le();
+        let statement_id = slice.get_u32_le();
+        let columns = slice.get_u16_le();
+        let params = slice.get_u16_le();
 
-        buf.advance(1); // reserved: string<1>
+        slice.advance(1); // reserved: string<1>
 
-        let warnings = buf.get_u16_le();
+        let warnings = slice.get_u16_le();
 
         Ok(Self {
             statement_id,


### PR DESCRIPTION
Fixes #2512

I'm not sure what is the underlying issue that causes it, but it would be preferable to avoid panic if possible.