### PR TITLE
fix(sqlite) Do not drop notify mutex guard until after condvar is triggered

### DIFF
--- a/sqlx-sqlite/src/statement/unlock_notify.rs
+++ b/sqlx-sqlite/src/statement/unlock_notify.rs
@@ -57,7 +57,8 @@ impl Notify {
     }
 
     fn fire(&self) {
-        *self.mutex.lock().unwrap() = true;
+        let mut lock = self.mutex.lock().unwrap();
+        *lock = true;
         self.condvar.notify_one();
     }
 }


### PR DESCRIPTION
I believe this resolves an EXC_BAD_ACCESS error I've been seeing on MacOS under high contention.