### PR TITLE
Fix for Issue #2549 - cannot use feature "rust_decimal" without also using "bigdecimal"

### DIFF
--- a/sqlx-macros-core/src/database/postgres.rs
+++ b/sqlx-macros-core/src/database/postgres.rs
@@ -59,7 +59,7 @@ impl_database_ext! {
         #[cfg(feature = "bigdecimal")]
         sqlx::types::BigDecimal,
 
-        #[cfg(feature = "decimal")]
+        #[cfg(feature = "rust_decimal")]
         sqlx::types::Decimal,
 
         #[cfg(feature = "ipnetwork")]
@@ -118,7 +118,7 @@ impl_database_ext! {
         #[cfg(feature = "bigdecimal")]
         Vec<sqlx::types::BigDecimal> | &[sqlx::types::BigDecimal],
 
-        #[cfg(feature = "decimal")]
+        #[cfg(feature = "rust_decimal")]
         Vec<sqlx::types::Decimal> | &[sqlx::types::Decimal],
 
         #[cfg(feature = "ipnetwork")]
@@ -138,7 +138,7 @@ impl_database_ext! {
         #[cfg(feature = "bigdecimal")]
         sqlx::postgres::types::PgRange<sqlx::types::BigDecimal>,
 
-        #[cfg(feature = "decimal")]
+        #[cfg(feature = "rust_decimal")]
         sqlx::postgres::types::PgRange<sqlx::types::Decimal>,
 
         #[cfg(feature = "chrono")]

--- a/sqlx-postgres/Cargo.toml
+++ b/sqlx-postgres/Cargo.toml
@@ -16,7 +16,7 @@ migrate = ["sqlx-core/migrate"]
 offline = ["sqlx-core/offline"]
 
 # Type integration features which require additional dependencies
-rust_decimal = ["dep:rust_decimal"]
+rust_decimal = ["dep:rust_decimal", "dep:num-bigint"]
 bigdecimal = ["dep:bigdecimal", "dep:num-bigint"]
 
 [dependencies]

--- a/sqlx-postgres/src/types/mod.rs
+++ b/sqlx-postgres/src/types/mod.rs
@@ -196,7 +196,7 @@ mod time_tz;
 #[cfg(feature = "bigdecimal")]
 mod bigdecimal;
 
-#[cfg(any(feature = "bigdecimal", feature = "decimal"))]
+#[cfg(any(feature = "bigdecimal", feature = "rust_decimal"))]
 mod numeric;
 
 #[cfg(feature = "rust_decimal")]

--- a/sqlx-postgres/src/types/money.rs
+++ b/sqlx-postgres/src/types/money.rs
@@ -81,7 +81,7 @@ impl PgMoney {
     /// See the type-level docs for an explanation of `locale_frac_digits`.
     ///
     /// [`Decimal`]: crate::types::Decimal
-    #[cfg(feature = "decimal")]
+    #[cfg(feature = "rust_decimal")]
     pub fn to_decimal(self, locale_frac_digits: u32) -> rust_decimal::Decimal {
         rust_decimal::Decimal::new(self.0, locale_frac_digits)
     }
@@ -94,7 +94,7 @@ impl PgMoney {
     /// If the value is larger than 63 bits it will be truncated.
     ///
     /// [`Decimal`]: crate::types::Decimal
-    #[cfg(feature = "decimal")]
+    #[cfg(feature = "rust_decimal")]
     pub fn from_decimal(mut decimal: rust_decimal::Decimal, locale_frac_digits: u32) -> Self {
         // this is all we need to convert to our expected locale's `frac_digits`
         decimal.rescale(locale_frac_digits);
@@ -316,7 +316,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "decimal")]
+    #[cfg(feature = "rust_decimal")]
     fn conversion_to_decimal_works() {
         assert_eq!(
             rust_decimal::Decimal::new(12345, 2),
@@ -325,7 +325,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "decimal")]
+    #[cfg(feature = "rust_decimal")]
     fn conversion_from_decimal_works() {
         assert_eq!(
             PgMoney(12345),

--- a/sqlx-postgres/src/types/range.rs
+++ b/sqlx-postgres/src/types/range.rs
@@ -143,7 +143,7 @@ impl Type<Postgres> for PgRange<bigdecimal::BigDecimal> {
     }
 }
 
-#[cfg(feature = "decimal")]
+#[cfg(feature = "rust_decimal")]
 impl Type<Postgres> for PgRange<rust_decimal::Decimal> {
     fn type_info() -> PgTypeInfo {
         PgTypeInfo::NUM_RANGE


### PR DESCRIPTION
Fix for [this issue](https://github.com/launchbadge/sqlx/issues/2549).

When trying to use the (newly renamed) `rust_decimal` feature in version 7.0.0, compiling fails because there is a missing dependency on `num-bigint` and numerous places in the code where the previous feature name of `decimal` was not updated to the new name of `rust_decimal`. 

Even if one includes the `bigdecimal` feature when using the current code on `main`, `rust_decimal` functionality is not restored (although it is then possible to compile) because the macros still return `BigDecimal` for all `NUMERIC` Postgres types.

This small patch fixes those issues and restores `rust_decimal` functionality.