### PR TITLE
Correct mention of the `tls-native-tls` in the documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,14 +134,14 @@ For the previous stable release, 0.6.3, see [the previous version of this docume
 # tokio (no TLS)
 sqlx = { version = "0.7", features = [ "runtime-tokio" ] }
 # tokio + native-tls
-sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-native" ] }
+sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-native-tls" ] }
 # tokio + rustls
 sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-rustls" ] }
 
 # async-std (no TLS)
 sqlx = { version = "0.7", features = [ "runtime-async-std" ] }
 # async-std + native-tls
-sqlx = { version = "0.7", features = [ "runtime-async-std", "tls-native" ] }
+sqlx = { version = "0.7", features = [ "runtime-async-std", "tls-native-tls" ] }
 # async-std + rustls
 sqlx = { version = "0.7", features = [ "runtime-async-std", "tls-rustls" ] }
 ```
@@ -168,7 +168,7 @@ be removed in the future.
 
     - Actix-web is fully compatible with Tokio and so a separate runtime feature is no longer needed.
 
--   `tls-native`: Use the `native-tls` TLS backend (OpenSSL on *nix, SChannel on Windows, Secure Transport on macOS).
+-   `tls-native-tls`: Use the `native-tls` TLS backend (OpenSSL on *nix, SChannel on Windows, Secure Transport on macOS).
 
 -   `tls-rustls`: Use the `rustls` TLS backend (cross-platform backend, only supports TLS 1.2 and 1.3).
 

--- a/src/lib.md
+++ b/src/lib.md
@@ -30,16 +30,16 @@ internal management tasks.
 For securely communicating with SQL servers over an untrusted network connection such as the internet, 
 you can enable Transport Layer Security (TLS) by enabling one of the following features:
 
-* `tls-native`: Enables the [`native-tls`] backend which uses the OS-native TLS capabilities:
+* `tls-native-tls`: Enables the [`native-tls`] backend which uses the OS-native TLS capabilities:
   * SecureTransport on macOS.
   * SChannel on Windows.
   * OpenSSL on all other platforms.
 * `tls-rustls`: Enables the [RusTLS] backend, a crossplatform TLS library.
   * Only supports TLS revisions 1.2 and 1.3. 
   * If you get `HandshakeFailure` errors when using this feature, it likely means your database server does not support 
-    these newer revisions. This might be resolved by enabling or switching to the `tls-native` feature.
+    these newer revisions. This might be resolved by enabling or switching to the `tls-native-tls` feature.
     
-If more than one TLS feature is enabled, the `tls-native` feature takes precedent so that it is only necessary to enable
+If more than one TLS feature is enabled, the `tls-native-tls` feature takes precedent so that it is only necessary to enable
 it to see if it resolves the `HandshakeFailure` error without disabling `tls-rustls`.
 
 Consult the user manual for your database to find the TLS versions it supports.


### PR DESCRIPTION
The feature is called `tls-native-tls`, not `tls-native`:

https://github.com/launchbadge/sqlx/blob/258eacafd9567df89f862cfbad3e8b9d69c22610/Cargo.toml#L77

So all the existing documentation is wrong.

I'd personally probably prefer `tls-native` as a feature name, but I wasn't sure if it's a good move to just change the name of that feature, so I decided to PR the docs change first. :)