### PR TITLE
Fix syntax error in MySQL testing

### DIFF
--- a/sqlx-mysql/src/testing/mod.rs
+++ b/sqlx-mysql/src/testing/mod.rs
@@ -178,7 +178,7 @@ async fn test_context(args: &TestArgs) -> Result<TestContext<MySql>, Error> {
 async fn do_cleanup(conn: &mut MySqlConnection, created_before: Duration) -> Result<usize, Error> {
     let delete_db_ids: Vec<u64> = query_scalar(
         "select db_id from _sqlx_test_databases \
-            where created_at < (cast(from_unixtime($1) as timestamp))",
+            where created_at < (cast(from_unixtime($1) as datetime))",
     )
     .bind(&created_before.as_secs())
     .fetch_all(&mut *conn)


### PR DESCRIPTION
Cleanup fails with a syntax error:

```
failed to connect to setup test database: Database(MySqlDatabaseError { code: Some("42000"), number: 1064, message: "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'timestamp))' at line 1" })
```