### PR TITLE
feat(sqlx-core): add table function to database error

### DIFF
--- a/sqlx-core/src/error.rs
+++ b/sqlx-core/src/error.rs
@@ -212,6 +212,14 @@ pub trait DatabaseError: 'static + Send + Sync + StdError {
         None
     }
 
+    /// Returns the name of the table that was affected by the error, if applicable.
+    ///
+    /// ### Note
+    /// Currently only populated by the Postgres driver.
+    fn table(&self) -> Option<&str> {
+        None
+    }
+
     /// Returns the kind of the error, if supported.
     ///
     /// ### Note

--- a/sqlx-postgres/src/error.rs
+++ b/sqlx-postgres/src/error.rs
@@ -204,6 +204,10 @@ impl DatabaseError for PgDatabaseError {
         self.constraint()
     }
 
+    fn table(&self) -> Option<&str> {
+        self.table()
+    }
+
     fn kind(&self) -> ErrorKind {
         match self.code() {
             error_codes::UNIQUE_VIOLATION => ErrorKind::UniqueViolation,


### PR DESCRIPTION
Adds a new `table` function to the `DatabaseError` trait. This change facilitates building
driver-agnostic error handling.

Though only available with the Postgres driver, there's already a `constraint` function that's
also only available through Postgres.

The motivation is partially the same as #2109.