### PR TITLE
fix(postgres): PgHasArrayType is not implemented for Vec<i64>

### DIFF
--- a/sqlx-macros-core/src/derives/type.rs
+++ b/sqlx-macros-core/src/derives/type.rs
@@ -77,7 +77,7 @@ fn expand_derive_has_sql_type_transparent(
             .push(parse_quote!(#ty: ::sqlx::postgres::PgHasArrayType));
         let (array_impl_generics, _, array_where_clause) = array_generics.split_for_impl();
 
-        let mut tokens = quote!(
+        return Ok(quote!(
             #[automatically_derived]
             impl #impl_generics ::sqlx::Type< DB > for #ident #ty_generics #where_clause {
                 fn type_info() -> DB::TypeInfo {
@@ -88,21 +88,15 @@ fn expand_derive_has_sql_type_transparent(
                     <#ty as ::sqlx::Type<DB>>::compatible(ty)
                 }
             }
-        );
-
-        if cfg!(feature = "postgres") {
-            tokens.extend(quote!(
-                #[automatically_derived]
-                impl #array_impl_generics ::sqlx::postgres::PgHasArrayType for #ident #ty_generics
-                #array_where_clause {
-                    fn array_type_info() -> ::sqlx::postgres::PgTypeInfo {
-                        <#ty as ::sqlx::postgres::PgHasArrayType>::array_type_info()
-                    }
+            #[automatically_derived]
+            #[cfg(feature = "postgres")]
+            impl #array_impl_generics ::sqlx::postgres::PgHasArrayType for #ident #ty_generics
+            #array_where_clause {
+                fn array_type_info() -> ::sqlx::postgres::PgTypeInfo {
+                    <#ty as ::sqlx::postgres::PgHasArrayType>::array_type_info()
                 }
-            ));
-        }
-
-        return Ok(tokens);
+            }
+        ));
     }
 
     let mut tts = TokenStream::new();


### PR DESCRIPTION
caused by #2086
closes #2611

## context
seems like #2086 fixed issue described by @Wopple by making that block of code unreachable. Not as it was stated in
> Problem: PgHasArrayType was checking the application's postgres feature
> Solution: only check the library's postgres feature

## rationale for reverting that change
after checking https://doc.rust-lang.org/std/macro.cfg.html
> `cfg!`, unlike `#[cfg]`, does not remove any code and only evaluates
> to true or false. For example, all blocks in an if/else expression
> need to be valid when `cfg!` is used for the condition, regardless of
> what `cfg!` is evaluating.

so to my understanding it would be `true` anyway in @Woople scenario