### PR TITLE
fix(sqlite/any): encode bool as integer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,6 +212,11 @@ path = "tests/sqlite/sqlite.rs"
 required-features = ["sqlite"]
 
 [[test]]
+name = "sqlite-any"
+path = "tests/sqlite/any.rs"
+required-features = ["sqlite"]
+
+[[test]]
 name = "sqlite-types"
 path = "tests/sqlite/types.rs"
 required-features = ["sqlite"]

--- a/sqlx-sqlite/src/any.rs
+++ b/sqlx-sqlite/src/any.rs
@@ -205,6 +205,7 @@ fn map_arguments(args: AnyArguments<'_>) -> SqliteArguments<'_> {
             .into_iter()
             .map(|val| match val {
                 AnyValueKind::Null => SqliteArgumentValue::Null,
+                AnyValueKind::Bool(b) => SqliteArgumentValue::Int(b as i32),
                 AnyValueKind::SmallInt(i) => SqliteArgumentValue::Int(i as i32),
                 AnyValueKind::Integer(i) => SqliteArgumentValue::Int(i),
                 AnyValueKind::BigInt(i) => SqliteArgumentValue::Int64(i),

--- a/tests/sqlite/any.rs
+++ b/tests/sqlite/any.rs
@@ -1,0 +1,19 @@
+use sqlx::{Any, Sqlite};
+use sqlx_test::new;
+
+#[sqlx_macros::test]
+async fn it_encodes_bool_with_any() -> anyhow::Result<()> {
+    sqlx::any::install_default_drivers();
+    let mut conn = new::<Any>().await?;
+
+    let res = sqlx::query("INSERT INTO accounts VALUES (?, ?, ?)")
+        .bind(87)
+        .bind("Harrison Ford")
+        .bind(true)
+        .execute(&mut conn)
+        .await
+        .expect("failed to encode bool");
+    assert_eq!(res.rows_affected(), 1);
+
+    Ok(())
+}


### PR DESCRIPTION
Encodes boolean data types as integers when using the `AnyConnection`. This is a partial fix.
It is still not possible to `query_as::<_, (bool,)>`. `AnyRow` expects the bool type info to be
`BOOLEAN` but SQLite returns `INTEGER`.

An options is to modify the `impl Type<Any> for bool`
https://github.com/launchbadge/sqlx/blob/b5312c3b6f8e34e757d1441216b6b34a18afd14b/sqlx-core/src/any/types/bool.rs#L8-L14
and override the default `compatible` function to accept both `AnyTypeInfo::Bool` and `AnyTypeInfo::Integer`,
but this could lead to unintended problems when using other drivers that have a boolean data type.

*Partially* fixes #2592.