### PR TITLE
Documentation typo: BYTE -> BINARY

### DIFF
--- a/sqlx-mysql/src/types/mod.rs
+++ b/sqlx-mysql/src/types/mod.rs
@@ -61,7 +61,7 @@
 //!
 //! | Rust type                             | MySQL type(s)                                        |
 //! |---------------------------------------|------------------------------------------------------|
-//! | `uuid::Uuid`                          | BYTE(16), VARCHAR, CHAR, TEXT                        |
+//! | `uuid::Uuid`                          | BINARY(16), VARCHAR, CHAR, TEXT                      |
 //! | `uuid::fmt::Hyphenated`               | CHAR(36)                                             |
 //! | `uuid::fmt::Simple`                   | CHAR(32)                                             |
 //!


### PR DESCRIPTION
MySQL does not have a BYTE type.