### PR TITLE
fix(postgres): fix buffer management in PgCopyIn::read_from

### DIFF
--- a/sqlx-core/src/net/socket/buffered.rs
+++ b/sqlx-core/src/net/socket/buffered.rs
@@ -151,7 +151,7 @@ impl WriteBuffer {
             self.buf.truncate(self.bytes_written);
             self.buf.extend_from_slice(slice);
         }
-
+        self.advance(slice.len());
         self.sanity_check();
     }
 

--- a/sqlx-postgres/src/copy.rs
+++ b/sqlx-postgres/src/copy.rs
@@ -229,7 +229,7 @@ impl<C: DerefMut<Target = PgConnection>> PgCopyIn<C> {
             let buf = conn.stream.write_buffer_mut();
 
             // CopyData format code and reserved space for length
-            buf.put_slice(b"d\0\0\0\0");
+            buf.put_slice(b"d\0\0\0\x04");
 
             let read = match () {
                 // Tokio lets us read into the buffer without zeroing first


### PR DESCRIPTION
fixes #2614 

This pull request addresses the issue with the `put_slice` function does not advance the `bytes_written` variable, and that an empty `CopyData` packet is sent with the correct length.
