### PR TITLE
Add postgres support for specifying schema when defining enum type

### DIFF
--- a/sqlx-core/src/type_info.rs
+++ b/sqlx-core/src/type_info.rs
@@ -14,3 +14,13 @@ pub trait TypeInfo: Debug + Display + Clone + PartialEq<Self> + Send + Sync {
         false
     }
 }
+
+pub fn get_type_name(type_name: &str, schema_name: Option<&str>) -> String {
+    let mut val = String::new();
+    if let Some(schema_str) = schema_name {
+        val.push_str(schema_str);
+        val.push('.');
+    }
+    val.push_str(type_name);
+    val
+}

--- a/sqlx-macros-core/src/derives/attributes.rs
+++ b/sqlx-macros-core/src/derives/attributes.rs
@@ -1,5 +1,6 @@
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
+use sqlx_core::type_info::get_type_name;
 use syn::{
     punctuated::Punctuated, spanned::Spanned, token::Comma, Attribute, DeriveInput, Field, Lit,
     Meta, MetaNameValue, NestedMeta, Type, Variant,
@@ -34,10 +35,15 @@ pub struct TypeName {
 }
 
 impl TypeName {
-    pub fn get(&self) -> TokenStream {
-        let val = &self.val;
+    pub fn get(&self, schema_name: Option<&str>) -> TokenStream {
+        let val = get_type_name(&self.val, schema_name);
         quote! { #val }
     }
+}
+
+pub struct SchemaName {
+    pub val: String,
+    pub span: Span,
 }
 
 #[derive(Copy, Clone)]
@@ -54,6 +60,7 @@ pub enum RenameAll {
 pub struct SqlxContainerAttributes {
     pub transparent: bool,
     pub type_name: Option<TypeName>,
+    pub schema_name: Option<SchemaName>,
     pub rename_all: Option<RenameAll>,
     pub repr: Option<Ident>,
     pub no_pg_array: bool,
@@ -72,6 +79,7 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
     let mut transparent = None;
     let mut repr = None;
     let mut type_name = None;
+    let mut schema_name = None;
     let mut rename_all = None;
     let mut no_pg_array = None;
 
@@ -129,6 +137,21 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
                                 )
                             }
 
+                            Meta::NameValue(MetaNameValue {
+                                path,
+                                lit: Lit::Str(val),
+                                ..
+                            }) if path.is_ident("schema") => {
+                                try_set!(
+                                    schema_name,
+                                    SchemaName {
+                                        val: val.value(),
+                                        span: value.span(),
+                                    },
+                                    value
+                                )
+                            }
+
                             u => fail!(u, "unexpected attribute"),
                         },
                         u => fail!(u, "unexpected attribute"),
@@ -154,6 +177,7 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
         transparent: transparent.unwrap_or(false),
         repr,
         type_name,
+        schema_name,
         rename_all,
         no_pg_array: no_pg_array.unwrap_or(false),
     })

--- a/sqlx-macros-core/src/derives/type.rs
+++ b/sqlx-macros-core/src/derives/type.rs
@@ -187,6 +187,10 @@ fn expand_derive_has_sql_type_strong_enum(
                 fn type_info() -> ::sqlx::postgres::PgTypeInfo {
                     ::sqlx::postgres::PgTypeInfo::with_name(#ty_name)
                 }
+
+                fn compatible(ty: &::sqlx::postgres::PgTypeInfo) -> ::std::primitive::bool {
+                    matches!(*ty.kind(), ::sqlx::postgres::PgTypeKind::Enum(_))
+                }
             }
         ));
     }


### PR DESCRIPTION
Reopening #2183 after rebase

> Hello!
>
>Since we also ran into the need for specifying the schema name when defining a postgres enum to avoid collision when the enum types name appears in multiple schemas (https://github.com/launchbadge/sqlx/issues/1171), here is an attempt to implement this feature.

>This PR contains the following changes:
>
>    -  extending the enum type macro to accept a schema attribute
>    -  update postgres implementation to treat the enum types name as schema.enum_name when schema is specified
>    -  when querying the type info by type id from the pg_catalog, the schema's name + the count of type that have the same name as the type that is being queried are joined to the fetched data. In case there are multiple types with the same name, use the schema.enum_name format (unless the schema is the default public schema, in that case we just use the enum name)
>    -  when querying the type by name and if the schema attribute is provided, include it in the fetch query so that only the desired type gets returned.
>    -  add a test for an enum type defined with an already existing name color_upper but in a different schema test which verified that there is no collision with these 2 enums
>
>This is a quite minimalistic implementation, therefore it's possible that some things are missing (some edge cases that need to be covered/tested, better code design, ...), if so, let me know and I'll be happy to add the requested changes.