### PR TITLE
fix: sqlx::macro db cleanup race condition by adding a margin to current timestamp

### DIFF
--- a/sqlx-mysql/src/testing/mod.rs
+++ b/sqlx-mysql/src/testing/mod.rs
@@ -177,7 +177,7 @@ async fn test_context(args: &TestArgs) -> Result<TestContext<MySql>, Error> {
 
 async fn do_cleanup(conn: &mut MySqlConnection, created_before: Duration) -> Result<usize, Error> {
     // since SystemTime is not monotonic we added a little margin here to avoid race conditions with other threads
-    let created_before_as_secs = created_before.as_secs() - 1;
+    let created_before_as_secs = created_before.as_secs() - 2;
     let delete_db_ids: Vec<u64> = query_scalar(
         "select db_id from _sqlx_test_databases \
             where created_at < from_unixtime(?)",

--- a/sqlx-mysql/src/testing/mod.rs
+++ b/sqlx-mysql/src/testing/mod.rs
@@ -176,11 +176,13 @@ async fn test_context(args: &TestArgs) -> Result<TestContext<MySql>, Error> {
 }
 
 async fn do_cleanup(conn: &mut MySqlConnection, created_before: Duration) -> Result<usize, Error> {
+    // since SystemTime is not monotonic we added a little margin here to avoid race conditions with other threads
+    let created_before_as_secs = created_before.as_secs() - 1;
     let delete_db_ids: Vec<u64> = query_scalar(
         "select db_id from _sqlx_test_databases \
             where created_at < from_unixtime(?)",
     )
-    .bind(&created_before.as_secs())
+    .bind(&created_before_as_secs)
     .fetch_all(&mut *conn)
     .await?;
 

--- a/sqlx-postgres/src/testing/mod.rs
+++ b/sqlx-postgres/src/testing/mod.rs
@@ -184,7 +184,7 @@ async fn test_context(args: &TestArgs) -> Result<TestContext<Postgres>, Error> {
 
 async fn do_cleanup(conn: &mut PgConnection, created_before: Duration) -> Result<usize, Error> {
     // since SystemTime is not monotonic we added a little margin here to avoid race conditions with other threads
-    let created_before = i64::try_from(created_before.as_secs()).unwrap() - 1;
+    let created_before = i64::try_from(created_before.as_secs()).unwrap() - 2;
 
     let delete_db_names: Vec<String> = query_scalar(
         "select db_name from _sqlx_test.databases \

--- a/sqlx-postgres/src/testing/mod.rs
+++ b/sqlx-postgres/src/testing/mod.rs
@@ -183,7 +183,8 @@ async fn test_context(args: &TestArgs) -> Result<TestContext<Postgres>, Error> {
 }
 
 async fn do_cleanup(conn: &mut PgConnection, created_before: Duration) -> Result<usize, Error> {
-    let created_before = i64::try_from(created_before.as_secs()).unwrap();
+    // since SystemTime is not monotonic we added a little margin here to avoid race conditions with other threads
+    let created_before = i64::try_from(created_before.as_secs()).unwrap() - 1;
 
     let delete_db_names: Vec<String> = query_scalar(
         "select db_name from _sqlx_test.databases \


### PR DESCRIPTION
# Issue
As described in https://github.com/launchbadge/sqlx/issues/2631, the #[sqlx::test] macro is occasionally failing to connect to the created database.
- The PR I submitted before, #2635, trying to fix the race condition to ensure the current timestamp was acquired in the proper order didn't cover all the cases
- So I realize that the issue may be that the `SystemTime is not monotonic`, as we can see [from the documentation](https://doc.rust-lang.org/std/time/struct.SystemTime.html):
> Distinct from the [Instant](https://doc.rust-lang.org/std/time/struct.Instant.html) type, this time measurement is not monotonic. This means that you can save a file to the file system, then save another file to the file system, and the second file has a SystemTime measurement earlier than the first. In other words, an operation that happens after another operation in real time may have an earlier SystemTime!

# Solution
- The easiest way to fix this issue was to add a little margin (2 seconds) when comparing the timestamps for cleaning up the old databases.

WDYT of this approach? I'm testing here and it seems to have fixed the issue! The margin doesn't guarantee that the error won't occur again, but it decreases a lot the probability of it happening.