### PR TITLE
Support for setting client certificate and key from bytes

### DIFF
--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -221,9 +221,9 @@ impl MySqlConnectOptions {
     /// # use sqlx_core::mysql::{MySqlSslMode, MySqlConnectOptions};
     /// let options = MySqlConnectOptions::new()
     ///     .ssl_mode(MySqlSslMode::VerifyCa)
-    ///     .ssl_client_cert_from_bytes(vec![]);
+    ///     .ssl_client_cert_from_pem(vec![]);
     /// ```
-    pub fn ssl_client_cert_from_bytes(mut self, cert: impl AsRef<[u8]>) -> Self {
+    pub fn ssl_client_cert_from_pem(mut self, cert: impl AsRef<[u8]>) -> Self {
         self.ssl_client_cert = Some(CertificateInput::Inline(cert.as_ref().to_vec()));
         self
     }
@@ -251,9 +251,9 @@ impl MySqlConnectOptions {
     /// # use sqlx_core::mysql::{MySqlSslMode, MySqlConnectOptions};
     /// let options = MySqlConnectOptions::new()
     ///     .ssl_mode(MySqlSslMode::VerifyCa)
-    ///     .ssl_client_key_from_bytes(vec![]);
+    ///     .ssl_client_key_from_pem(vec![]);
     /// ```
-    pub fn ssl_client_key_from_bytes(mut self, key: impl AsRef<[u8]>) -> Self {
+    pub fn ssl_client_key_from_pem(mut self, key: impl AsRef<[u8]>) -> Self {
         self.ssl_client_key = Some(CertificateInput::Inline(key.as_ref().to_vec()));
         self
     }

--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -213,15 +213,25 @@ impl MySqlConnectOptions {
         self
     }
 
-    /// Sets the SSL client certificate from a byte slice.
+    /// Sets the SSL client certificate as a PEM-encoded byte slice.
+    ///
+    /// This should be an ASCII-encoded blob that starts with `-----BEGIN CERTIFICATE-----`.
     ///
     /// # Example
+    /// Note: embedding SSL certificates and keys in the binary is not advised.
+    /// This is for illustration purposes only. 
     ///
     /// ```rust
     /// # use sqlx_core::mysql::{MySqlSslMode, MySqlConnectOptions};
+    ///
+    /// const CERT: &[u8] = b"\ 
+    /// -----BEGIN CERTIFICATE-----
+    /// <Certificate data here.>
+    /// -----END CERTIFICATE-----";
+    ///
     /// let options = MySqlConnectOptions::new()
     ///     .ssl_mode(MySqlSslMode::VerifyCa)
-    ///     .ssl_client_cert_from_pem(vec![]);
+    ///     .ssl_client_cert_from_pem(CERT);
     /// ```
     pub fn ssl_client_cert_from_pem(mut self, cert: impl AsRef<[u8]>) -> Self {
         self.ssl_client_cert = Some(CertificateInput::Inline(cert.as_ref().to_vec()));
@@ -243,15 +253,25 @@ impl MySqlConnectOptions {
         self
     }
 
-    /// Sets the SSL client key from a byte slice.
+    /// Sets the SSL client key as a PEM-encoded byte slice.
+    ///
+    /// This should be an ASCII-encoded blob that starts with `-----BEGIN PRIVATE KEY-----`.
     ///
     /// # Example
+    /// Note: embedding SSL certificates and keys in the binary is not advised.
+    /// This is for illustration purposes only. 
     ///
     /// ```rust
     /// # use sqlx_core::mysql::{MySqlSslMode, MySqlConnectOptions};
+    ///
+    /// const KEY: &[u8] = b"\ 
+    /// -----BEGIN PRIVATE KEY-----
+    /// <Private key data here.>
+    /// -----END PRIVATE KEY-----";
+    ///
     /// let options = MySqlConnectOptions::new()
     ///     .ssl_mode(MySqlSslMode::VerifyCa)
-    ///     .ssl_client_key_from_pem(vec![]);
+    ///     .ssl_client_key_from_pem(KEY);
     /// ```
     pub fn ssl_client_key_from_pem(mut self, key: impl AsRef<[u8]>) -> Self {
         self.ssl_client_key = Some(CertificateInput::Inline(key.as_ref().to_vec()));

--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -219,12 +219,12 @@ impl MySqlConnectOptions {
     ///
     /// # Example
     /// Note: embedding SSL certificates and keys in the binary is not advised.
-    /// This is for illustration purposes only. 
+    /// This is for illustration purposes only.
     ///
     /// ```rust
     /// # use sqlx_core::mysql::{MySqlSslMode, MySqlConnectOptions};
     ///
-    /// const CERT: &[u8] = b"\ 
+    /// const CERT: &[u8] = b"\
     /// -----BEGIN CERTIFICATE-----
     /// <Certificate data here.>
     /// -----END CERTIFICATE-----";
@@ -259,12 +259,12 @@ impl MySqlConnectOptions {
     ///
     /// # Example
     /// Note: embedding SSL certificates and keys in the binary is not advised.
-    /// This is for illustration purposes only. 
+    /// This is for illustration purposes only.
     ///
     /// ```rust
     /// # use sqlx_core::mysql::{MySqlSslMode, MySqlConnectOptions};
     ///
-    /// const KEY: &[u8] = b"\ 
+    /// const KEY: &[u8] = b"\
     /// -----BEGIN PRIVATE KEY-----
     /// <Private key data here.>
     /// -----END PRIVATE KEY-----";

--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -213,6 +213,21 @@ impl MySqlConnectOptions {
         self
     }
 
+    /// Sets the SSL client certificate from a byte slice.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use sqlx_core::mysql::{MySqlSslMode, MySqlConnectOptions};
+    /// let options = MySqlConnectOptions::new()
+    ///     .ssl_mode(MySqlSslMode::VerifyCa)
+    ///     .ssl_client_cert_from_bytes(vec![]);
+    /// ```
+    pub fn ssl_client_cert_from_bytes(mut self, cert: impl AsRef<[u8]>) -> Self {
+        self.ssl_client_cert = Some(CertificateInput::Inline(cert.as_ref().to_vec()));
+        self
+    }
+
     /// Sets the name of a file containing SSL client key.
     ///
     /// # Example
@@ -225,6 +240,21 @@ impl MySqlConnectOptions {
     /// ```
     pub fn ssl_client_key(mut self, key: impl AsRef<Path>) -> Self {
         self.ssl_client_key = Some(CertificateInput::File(key.as_ref().to_path_buf()));
+        self
+    }
+
+    /// Sets the SSL client key from a byte slice.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use sqlx_core::mysql::{MySqlSslMode, MySqlConnectOptions};
+    /// let options = MySqlConnectOptions::new()
+    ///     .ssl_mode(MySqlSslMode::VerifyCa)
+    ///     .ssl_client_key_from_bytes(vec![]);
+    /// ```
+    pub fn ssl_client_key_from_bytes(mut self, key: impl AsRef<[u8]>) -> Self {
+        self.ssl_client_key = Some(CertificateInput::Inline(key.as_ref().to_vec()));
         self
     }
 

--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -344,16 +344,26 @@ impl PgConnectOptions {
         self
     }
 
-    /// Sets the SSL client certificate from a byte slice.
+    /// Sets the SSL client certificate as a PEM-encoded byte slice.
+    ///
+    /// This should be an ASCII-encoded blob that starts with `-----BEGIN CERTIFICATE-----`.
     ///
     /// # Example
+    /// Note: embedding SSL certificates and keys in the binary is not advised.
+    /// This is for illustration purposes only. 
     ///
     /// ```rust
     /// # use sqlx_core::postgres::{PgSslMode, PgConnectOptions};
+    ///
+    /// const CERT: &[u8] = b"\ 
+    /// -----BEGIN CERTIFICATE-----
+    /// <Certificate data here.>
+    /// -----END CERTIFICATE-----";
+    ///    
     /// let options = PgConnectOptions::new()
     ///     // Providing a CA certificate with less than VerifyCa is pointless
     ///     .ssl_mode(PgSslMode::VerifyCa)
-    ///     .ssl_client_cert_from_pem(vec![]);
+    ///     .ssl_client_cert_from_pem(CERT);
     /// ```
     pub fn ssl_client_cert_from_pem(mut self, cert: impl AsRef<[u8]>) -> Self {
         self.ssl_client_cert = Some(CertificateInput::Inline(cert.as_ref().to_vec()));
@@ -376,16 +386,26 @@ impl PgConnectOptions {
         self
     }
 
-    /// Sets the SSL client key from a byte slice.
+    /// Sets the SSL client key as a PEM-encoded byte slice.
+    ///
+    /// This should be an ASCII-encoded blob that starts with `-----BEGIN PRIVATE KEY-----`.
     ///
     /// # Example
+    /// Note: embedding SSL certificates and keys in the binary is not advised.
+    /// This is for illustration purposes only. 
     ///
     /// ```rust
     /// # use sqlx_core::postgres::{PgSslMode, PgConnectOptions};
+    ///
+    /// const KEY: &[u8] = b"\ 
+    /// -----BEGIN PRIVATE KEY-----
+    /// <Private key data here.>
+    /// -----END PRIVATE KEY-----";
+    ///
     /// let options = PgConnectOptions::new()
     ///     // Providing a CA certificate with less than VerifyCa is pointless
     ///     .ssl_mode(PgSslMode::VerifyCa)
-    ///     .ssl_client_key_from_pem(vec![]);
+    ///     .ssl_client_key_from_pem(KEY);
     /// ```
     pub fn ssl_client_key_from_pem(mut self, key: impl AsRef<[u8]>) -> Self {
         self.ssl_client_key = Some(CertificateInput::Inline(key.as_ref().to_vec()));

--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -350,12 +350,12 @@ impl PgConnectOptions {
     ///
     /// # Example
     /// Note: embedding SSL certificates and keys in the binary is not advised.
-    /// This is for illustration purposes only. 
+    /// This is for illustration purposes only.
     ///
     /// ```rust
     /// # use sqlx_core::postgres::{PgSslMode, PgConnectOptions};
     ///
-    /// const CERT: &[u8] = b"\ 
+    /// const CERT: &[u8] = b"\
     /// -----BEGIN CERTIFICATE-----
     /// <Certificate data here.>
     /// -----END CERTIFICATE-----";
@@ -392,12 +392,12 @@ impl PgConnectOptions {
     ///
     /// # Example
     /// Note: embedding SSL certificates and keys in the binary is not advised.
-    /// This is for illustration purposes only. 
+    /// This is for illustration purposes only.
     ///
     /// ```rust
     /// # use sqlx_core::postgres::{PgSslMode, PgConnectOptions};
     ///
-    /// const KEY: &[u8] = b"\ 
+    /// const KEY: &[u8] = b"\
     /// -----BEGIN PRIVATE KEY-----
     /// <Private key data here.>
     /// -----END PRIVATE KEY-----";

--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -353,9 +353,9 @@ impl PgConnectOptions {
     /// let options = PgConnectOptions::new()
     ///     // Providing a CA certificate with less than VerifyCa is pointless
     ///     .ssl_mode(PgSslMode::VerifyCa)
-    ///     .ssl_client_cert_from_bytes(vec![]);
+    ///     .ssl_client_cert_from_pem(vec![]);
     /// ```
-    pub fn ssl_client_cert_from_bytes(mut self, cert: impl AsRef<[u8]>) -> Self {
+    pub fn ssl_client_cert_from_pem(mut self, cert: impl AsRef<[u8]>) -> Self {
         self.ssl_client_cert = Some(CertificateInput::Inline(cert.as_ref().to_vec()));
         self
     }
@@ -385,9 +385,9 @@ impl PgConnectOptions {
     /// let options = PgConnectOptions::new()
     ///     // Providing a CA certificate with less than VerifyCa is pointless
     ///     .ssl_mode(PgSslMode::VerifyCa)
-    ///     .ssl_client_key_from_bytes(vec![]);
+    ///     .ssl_client_key_from_pem(vec![]);
     /// ```
-    pub fn ssl_client_key_from_bytes(mut self, key: impl AsRef<[u8]>) -> Self {
+    pub fn ssl_client_key_from_pem(mut self, key: impl AsRef<[u8]>) -> Self {
         self.ssl_client_key = Some(CertificateInput::Inline(key.as_ref().to_vec()));
         self
     }

--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -344,6 +344,22 @@ impl PgConnectOptions {
         self
     }
 
+    /// Sets the SSL client certificate from a byte slice.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use sqlx_core::postgres::{PgSslMode, PgConnectOptions};
+    /// let options = PgConnectOptions::new()
+    ///     // Providing a CA certificate with less than VerifyCa is pointless
+    ///     .ssl_mode(PgSslMode::VerifyCa)
+    ///     .ssl_client_cert_from_bytes(vec![]);
+    /// ```
+    pub fn ssl_client_cert_from_bytes(mut self, cert: impl AsRef<[u8]>) -> Self {
+        self.ssl_client_cert = Some(CertificateInput::Inline(cert.as_ref().to_vec()));
+        self
+    }
+
     /// Sets the name of a file containing SSL client key.
     ///
     /// # Example
@@ -357,6 +373,22 @@ impl PgConnectOptions {
     /// ```
     pub fn ssl_client_key(mut self, key: impl AsRef<Path>) -> Self {
         self.ssl_client_key = Some(CertificateInput::File(key.as_ref().to_path_buf()));
+        self
+    }
+
+    /// Sets the SSL client key from a byte slice.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use sqlx_core::postgres::{PgSslMode, PgConnectOptions};
+    /// let options = PgConnectOptions::new()
+    ///     // Providing a CA certificate with less than VerifyCa is pointless
+    ///     .ssl_mode(PgSslMode::VerifyCa)
+    ///     .ssl_client_key_from_bytes(vec![]);
+    /// ```
+    pub fn ssl_client_key_from_bytes(mut self, key: impl AsRef<[u8]>) -> Self {
+        self.ssl_client_key = Some(CertificateInput::Inline(key.as_ref().to_vec()));
         self
     }
 


### PR DESCRIPTION
This PR adds `ssl_client_cert_from_bytes` and `ssl_client_key_from_bytes` to `MySQL` and `PostgreSQL`.

This will allow slqx to configure tls cert without going through the filesystem. This can be useful in certain scenarios, such as reading certificates from Keychain.