### PR TITLE
Chore: Fix few build warnings, and make CI fail on warn

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -33,6 +33,8 @@ jobs:
             --release
             --no-default-features
             --features mysql,postgres,sqlite
+        env:
+          RUSTFLAGS: -D warnings
 
       - uses: actions/upload-artifact@v3
         with:
@@ -157,10 +159,9 @@ jobs:
       # so we only check that it compiles.
       - name: Chat (Check)
         uses: actions-rs/cargo@v1
-        env:
         with:
           command: check
-          args: -p sqlx-example-postgres-check
+          args: -p sqlx-example-postgres-chat
 
       - name: Files (Setup)
         working-directory: examples/postgres/files

--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -55,6 +55,8 @@ jobs:
             --manifest-path sqlx-core/Cargo.toml
             --no-default-features
             --features json,offline,migrate,_rt-${{ matrix.runtime }},_tls-${{ matrix.tls }}
+        env:
+          RUSTFLAGS: -D warnings
 
       - uses: actions-rs/cargo@v1
         with:
@@ -62,6 +64,8 @@ jobs:
           args: >
             --no-default-features
             --features all-databases,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }},macros
+        env:
+          RUSTFLAGS: -D warnings
 
   test:
     name: Unit Test
@@ -189,7 +193,7 @@ jobs:
         env:
           SQLX_OFFLINE: true
           SQLX_OFFLINE_DIR: .sqlx
-          RUSTFLAGS: --cfg sqlite_ipaddr
+          RUSTFLAGS: -D warnings --cfg sqlite_ipaddr
           LD_LIBRARY_PATH: /tmp/sqlite3-lib
 
       # Test macros in offline mode (still needs DATABASE_URL to run)
@@ -233,7 +237,7 @@ jobs:
         env:
           # FIXME: needed to disable `ltree` tests in Postgres 9.6
           # but `PgLTree` should just fall back to text format
-          RUSTFLAGS: --cfg postgres_${{ matrix.postgres }}
+          RUSTFLAGS: -D warnings --cfg postgres_${{ matrix.postgres }}
         with:
           command: build
           args: >
@@ -289,7 +293,7 @@ jobs:
           SQLX_OFFLINE_DIR: .sqlx
           # FIXME: needed to disable `ltree` tests in Postgres 9.6
           # but `PgLTree` should just fall back to text format
-          RUSTFLAGS: --cfg postgres_${{ matrix.postgres }}
+          RUSTFLAGS: -D warnings --cfg postgres_${{ matrix.postgres }}
 
       # Test macros in offline mode (still needs DATABASE_URL to run)
       - uses: actions-rs/cargo@v1
@@ -399,7 +403,7 @@ jobs:
         env:
           SQLX_OFFLINE: true
           SQLX_OFFLINE_DIR: .sqlx
-          RUSTFLAGS: --cfg mysql_${{ matrix.mysql }}
+          RUSTFLAGS: -D warnings --cfg mysql_${{ matrix.mysql }}
 
       # Test macros in offline mode (still needs DATABASE_URL to run)
       # MySQL 5.7 supports TLS but not TLSv1.3 as required by RusTLS.
@@ -495,7 +499,7 @@ jobs:
         env:
           SQLX_OFFLINE: true
           SQLX_OFFLINE_DIR: .sqlx
-          RUSTFLAGS: --cfg mariadb_${{ matrix.mariadb }}
+          RUSTFLAGS: -D warnings --cfg mariadb_${{ matrix.mariadb }}
 
       # Test macros in offline mode (still needs DATABASE_URL to run)
       - uses: actions-rs/cargo@v1

--- a/sqlx-macros-core/src/database/mod.rs
+++ b/sqlx-macros-core/src/database/mod.rs
@@ -39,10 +39,12 @@ pub trait DatabaseExt: Database {
     fn describe_blocking(query: &str, database_url: &str) -> sqlx_core::Result<Describe<Self>>;
 }
 
+#[allow(dead_code)]
 pub struct CachingDescribeBlocking<DB: DatabaseExt> {
     connections: Lazy<Mutex<HashMap<String, DB::Connection>>>,
 }
 
+#[allow(dead_code)]
 impl<DB: DatabaseExt> CachingDescribeBlocking<DB> {
     pub const fn new() -> Self {
         CachingDescribeBlocking {

--- a/sqlx-macros-core/src/test_attr.rs
+++ b/sqlx-macros-core/src/test_attr.rs
@@ -1,15 +1,16 @@
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::TokenStream;
 use quote::quote;
-use syn::LitStr;
 
+#[cfg(feature = "migrate")]
 struct Args {
-    fixtures: Vec<LitStr>,
+    fixtures: Vec<syn::LitStr>,
     migrations: MigrationsOpt,
 }
 
+#[cfg(feature = "migrate")]
 enum MigrationsOpt {
     InferredPath,
-    ExplicitPath(LitStr),
+    ExplicitPath(syn::LitStr),
     ExplicitMigrator(syn::Path),
     Disabled,
 }
@@ -89,7 +90,8 @@ fn expand_advanced(args: syn::AttributeArgs, input: syn::ItemFn) -> crate::Resul
             quote! { args.migrator(&#migrator); }
         }
         MigrationsOpt::InferredPath if !inputs.is_empty() => {
-            let migrations_path = crate::common::resolve_path("./migrations", Span::call_site())?;
+            let migrations_path =
+                crate::common::resolve_path("./migrations", proc_macro2::Span::call_site())?;
 
             if migrations_path.is_dir() {
                 let migrator = crate::migrate::expand_migrator(&migrations_path)?;

--- a/sqlx-sqlite/src/connection/mod.rs
+++ b/sqlx-sqlite/src/connection/mod.rs
@@ -258,7 +258,7 @@ impl LockedSqliteHandle<'_> {
     /// The progress handler callback must not do anything that will modify the database connection that invoked
     /// the progress handler. Note that sqlite3_prepare_v2() and sqlite3_step() both modify their database connections
     /// in this context.
-    pub fn set_progress_handler<F>(&mut self, num_ops: i32, mut callback: F)
+    pub fn set_progress_handler<F>(&mut self, num_ops: i32, callback: F)
     where
         F: FnMut() -> bool + Send + 'static,
     {


### PR DESCRIPTION
Fix a few warnings and make it so that all `cargo build` and `cargo check` in CI generate errors if they encounter warnings.  This will ensure cleaner code, and won't hide warnings (they tend to hide if CI doesn't show them as failures)

This PR also fixes example CI - `Chat (Check)` had a yaml error and misnamed target.

Note that `cargo test` still generates a lot of warnings, but they don't trigger build failure