### PR TITLE
MySQL: Remove collation compatibility check for strings

### DIFF
--- a/sqlx-mysql/src/protocol/text/column.rs
+++ b/sqlx-mysql/src/protocol/text/column.rs
@@ -112,6 +112,7 @@ pub(crate) struct ColumnDefinition {
     table: Bytes,
     alias: Bytes,
     name: Bytes,
+    #[allow(unused)]
     pub(crate) collation: u16,
     pub(crate) max_size: u32,
     pub(crate) r#type: ColumnType,
@@ -165,13 +166,8 @@ impl Decode<'_, Capabilities> for ColumnDefinition {
 }
 
 impl ColumnType {
-    pub(crate) fn name(
-        self,
-        collation: u16,
-        flags: ColumnFlags,
-        max_size: Option<u32>,
-    ) -> &'static str {
-        let is_binary = collation == 63;
+    pub(crate) fn name(self, flags: ColumnFlags, max_size: Option<u32>) -> &'static str {
+        let is_binary = flags.contains(ColumnFlags::BINARY);
         let is_unsigned = flags.contains(ColumnFlags::UNSIGNED);
         let is_enum = flags.contains(ColumnFlags::ENUM);
 

--- a/sqlx-mysql/src/protocol/text/column.rs
+++ b/sqlx-mysql/src/protocol/text/column.rs
@@ -112,7 +112,7 @@ pub(crate) struct ColumnDefinition {
     table: Bytes,
     alias: Bytes,
     name: Bytes,
-    pub(crate) char_set: u16,
+    pub(crate) collation: u16,
     pub(crate) max_size: u32,
     pub(crate) r#type: ColumnType,
     pub(crate) flags: ColumnFlags,
@@ -142,7 +142,7 @@ impl Decode<'_, Capabilities> for ColumnDefinition {
         let alias = buf.get_bytes_lenenc();
         let name = buf.get_bytes_lenenc();
         let _next_len = buf.get_uint_lenenc(); // always 0x0c
-        let char_set = buf.get_u16_le();
+        let collation = buf.get_u16_le();
         let max_size = buf.get_u32_le();
         let type_id = buf.get_u8();
         let flags = buf.get_u16_le();
@@ -155,7 +155,7 @@ impl Decode<'_, Capabilities> for ColumnDefinition {
             table,
             alias,
             name,
-            char_set,
+            collation,
             max_size,
             r#type: ColumnType::try_from_u16(type_id)?,
             flags: ColumnFlags::from_bits_truncate(flags),
@@ -167,11 +167,11 @@ impl Decode<'_, Capabilities> for ColumnDefinition {
 impl ColumnType {
     pub(crate) fn name(
         self,
-        char_set: u16,
+        collation: u16,
         flags: ColumnFlags,
         max_size: Option<u32>,
     ) -> &'static str {
-        let is_binary = char_set == 63;
+        let is_binary = collation == 63;
         let is_unsigned = flags.contains(ColumnFlags::UNSIGNED);
         let is_enum = flags.contains(ColumnFlags::ENUM);
 

--- a/sqlx-mysql/src/type_info.rs
+++ b/sqlx-mysql/src/type_info.rs
@@ -10,7 +10,7 @@ use crate::protocol::text::{ColumnDefinition, ColumnFlags, ColumnType};
 pub struct MySqlTypeInfo {
     pub(crate) r#type: ColumnType,
     pub(crate) flags: ColumnFlags,
-    pub(crate) char_set: u16,
+    pub(crate) collation: u16,
 
     // [max_size] for integer types, this is (M) in BIT(M) or TINYINT(M)
     #[cfg_attr(feature = "offline", serde(default))]
@@ -22,7 +22,7 @@ impl MySqlTypeInfo {
         Self {
             r#type: ty,
             flags: ColumnFlags::BINARY,
-            char_set: 63,
+            collation: 63,
             max_size: None,
         }
     }
@@ -32,7 +32,7 @@ impl MySqlTypeInfo {
         Self {
             r#type: ColumnType::Enum,
             flags: ColumnFlags::BINARY,
-            char_set: 63,
+            collation: 63,
             max_size: None,
         }
     }
@@ -55,7 +55,7 @@ impl MySqlTypeInfo {
         Self {
             r#type: column.r#type,
             flags: column.flags,
-            char_set: column.char_set,
+            collation: column.collation,
             max_size: Some(column.max_size),
         }
     }
@@ -73,7 +73,7 @@ impl TypeInfo for MySqlTypeInfo {
     }
 
     fn name(&self) -> &str {
-        self.r#type.name(self.char_set, self.flags, self.max_size)
+        self.r#type.name(self.collation, self.flags, self.max_size)
     }
 }
 
@@ -102,7 +102,7 @@ impl PartialEq<MySqlTypeInfo> for MySqlTypeInfo {
             | ColumnType::String
             | ColumnType::VarString
             | ColumnType::Enum => {
-                return self.char_set == other.char_set;
+                return self.collation == other.collation;
             }
 
             _ => {}

--- a/sqlx-mysql/src/type_info.rs
+++ b/sqlx-mysql/src/type_info.rs
@@ -10,7 +10,6 @@ use crate::protocol::text::{ColumnDefinition, ColumnFlags, ColumnType};
 pub struct MySqlTypeInfo {
     pub(crate) r#type: ColumnType,
     pub(crate) flags: ColumnFlags,
-    pub(crate) collation: u16,
 
     // [max_size] for integer types, this is (M) in BIT(M) or TINYINT(M)
     #[cfg_attr(feature = "offline", serde(default))]
@@ -22,7 +21,6 @@ impl MySqlTypeInfo {
         Self {
             r#type: ty,
             flags: ColumnFlags::BINARY,
-            collation: 63,
             max_size: None,
         }
     }
@@ -32,7 +30,6 @@ impl MySqlTypeInfo {
         Self {
             r#type: ColumnType::Enum,
             flags: ColumnFlags::BINARY,
-            collation: 63,
             max_size: None,
         }
     }
@@ -55,7 +52,6 @@ impl MySqlTypeInfo {
         Self {
             r#type: column.r#type,
             flags: column.flags,
-            collation: column.collation,
             max_size: Some(column.max_size),
         }
     }
@@ -73,7 +69,7 @@ impl TypeInfo for MySqlTypeInfo {
     }
 
     fn name(&self) -> &str {
-        self.r#type.name(self.collation, self.flags, self.max_size)
+        self.r#type.name(self.flags, self.max_size)
     }
 }
 
@@ -102,9 +98,8 @@ impl PartialEq<MySqlTypeInfo> for MySqlTypeInfo {
             | ColumnType::String
             | ColumnType::VarString
             | ColumnType::Enum => {
-                return self.collation == other.collation;
+                return self.flags == other.flags;
             }
-
             _ => {}
         }
 

--- a/sqlx-mysql/src/types/bool.rs
+++ b/sqlx-mysql/src/types/bool.rs
@@ -12,7 +12,6 @@ impl Type<MySql> for bool {
         // MySQL has no actual `BOOLEAN` type, the type is an alias of `TINYINT(1)`
         MySqlTypeInfo {
             flags: ColumnFlags::BINARY | ColumnFlags::UNSIGNED,
-            collation: 63,
             max_size: Some(1),
             r#type: ColumnType::Tiny,
         }

--- a/sqlx-mysql/src/types/bool.rs
+++ b/sqlx-mysql/src/types/bool.rs
@@ -12,7 +12,7 @@ impl Type<MySql> for bool {
         // MySQL has no actual `BOOLEAN` type, the type is an alias of `TINYINT(1)`
         MySqlTypeInfo {
             flags: ColumnFlags::BINARY | ColumnFlags::UNSIGNED,
-            char_set: 63,
+            collation: 63,
             max_size: Some(1),
             r#type: ColumnType::Tiny,
         }

--- a/sqlx-mysql/src/types/str.rs
+++ b/sqlx-mysql/src/types/str.rs
@@ -7,18 +7,10 @@ use crate::types::Type;
 use crate::{MySql, MySqlTypeInfo, MySqlValueRef};
 use std::borrow::Cow;
 
-const COLLATE_UTF8_GENERAL_CI: u16 = 33;
-const COLLATE_UTF8_UNICODE_CI: u16 = 192;
-const COLLATE_UTF8MB4_UNICODE_CI: u16 = 224;
-const COLLATE_UTF8MB4_BIN: u16 = 46;
-const COLLATE_UTF8MB4_GENERAL_CI: u16 = 45;
-const COLLATE_UTF8MB4_0900_AI_CI: u16 = 255;
-
 impl Type<MySql> for str {
     fn type_info() -> MySqlTypeInfo {
         MySqlTypeInfo {
-            r#type: ColumnType::VarString,         // VARCHAR
-            collation: COLLATE_UTF8MB4_UNICODE_CI, // utf8mb4_unicode_ci
+            r#type: ColumnType::VarString, // VARCHAR
             flags: ColumnFlags::empty(),
             max_size: None,
         }
@@ -36,15 +28,7 @@ impl Type<MySql> for str {
                 | ColumnType::String
                 | ColumnType::VarString
                 | ColumnType::Enum
-        ) && matches!(
-            ty.collation,
-            COLLATE_UTF8MB4_UNICODE_CI
-                | COLLATE_UTF8_UNICODE_CI
-                | COLLATE_UTF8_GENERAL_CI
-                | COLLATE_UTF8MB4_BIN
-                | COLLATE_UTF8MB4_GENERAL_CI
-                | COLLATE_UTF8MB4_0900_AI_CI
-        )
+        ) && !ty.flags.contains(ColumnFlags::BINARY)
     }
 }
 

--- a/sqlx-mysql/src/types/str.rs
+++ b/sqlx-mysql/src/types/str.rs
@@ -17,8 +17,8 @@ const COLLATE_UTF8MB4_0900_AI_CI: u16 = 255;
 impl Type<MySql> for str {
     fn type_info() -> MySqlTypeInfo {
         MySqlTypeInfo {
-            r#type: ColumnType::VarString,        // VARCHAR
-            char_set: COLLATE_UTF8MB4_UNICODE_CI, // utf8mb4_unicode_ci
+            r#type: ColumnType::VarString,         // VARCHAR
+            collation: COLLATE_UTF8MB4_UNICODE_CI, // utf8mb4_unicode_ci
             flags: ColumnFlags::empty(),
             max_size: None,
         }
@@ -37,7 +37,7 @@ impl Type<MySql> for str {
                 | ColumnType::VarString
                 | ColumnType::Enum
         ) && matches!(
-            ty.char_set,
+            ty.collation,
             COLLATE_UTF8MB4_UNICODE_CI
                 | COLLATE_UTF8_UNICODE_CI
                 | COLLATE_UTF8_GENERAL_CI

--- a/sqlx-mysql/src/types/uint.rs
+++ b/sqlx-mysql/src/types/uint.rs
@@ -10,7 +10,7 @@ fn uint_type_info(ty: ColumnType) -> MySqlTypeInfo {
     MySqlTypeInfo {
         r#type: ty,
         flags: ColumnFlags::BINARY | ColumnFlags::UNSIGNED,
-        char_set: 63,
+        collation: 63,
         max_size: None,
     }
 }

--- a/sqlx-mysql/src/types/uint.rs
+++ b/sqlx-mysql/src/types/uint.rs
@@ -10,7 +10,6 @@ fn uint_type_info(ty: ColumnType) -> MySqlTypeInfo {
     MySqlTypeInfo {
         r#type: ty,
         flags: ColumnFlags::BINARY | ColumnFlags::UNSIGNED,
-        collation: 63,
         max_size: None,
     }
 }


### PR DESCRIPTION
Compatibility check in`<str as sqlx::Type<sqlx::MySql>>::compatible(tv)` for collation is not necessary because collation does not affect to output string.

RELATE: #1241