### PR TITLE
Automatically infer migration type

### DIFF
--- a/sqlx-cli/README.md
+++ b/sqlx-cli/README.md
@@ -72,7 +72,7 @@ sqlx migrate info --source ../relative/migrations
 
 ### Reverting Migrations
 
-If you would like to create _reversible_ migrations with corresponding "up" and "down" scripts, you use the `-r` flag when creating new migrations:
+If you would like to create _reversible_ migrations with corresponding "up" and "down" scripts, you use the `-r` flag when creating the first migration:
 
 ```bash
 $ sqlx migrate add -r <name>
@@ -94,14 +94,12 @@ $ sqlx migrate revert
 Applied 20211001154420/revert <name>
 ```
 
-**Note**: attempting to mix "simple" migrations with reversible migrations with result in an error.
+**Note**: All the subsequent migrations will be reversible as well.
 
 ```bash
 $ sqlx migrate add <name1>
-Creating migrations/20211001154420_<name>.sql
-
-$ sqlx migrate add -r <name2>
-error: cannot mix reversible migrations with simple migrations. All migrations should be reversible or simple migrations
+Creating migrations/20211001154420_<name>.up.sql
+Creating migrations/20211001154420_<name>.down.sql
 ```
 
 ### Enable building in "offline mode" with `query!()`

--- a/sqlx-core/src/migrate/error.rs
+++ b/sqlx-core/src/migrate/error.rs
@@ -24,6 +24,7 @@ pub enum MigrateError {
     #[error("migration {0} is newer than the latest applied migration {1}")]
     VersionTooNew(i64, i64),
 
+    #[deprecated = "migration types are now inferred"]
     #[error("cannot mix reversible migrations with simple migrations. All migrations should be reversible or simple migrations")]
     InvalidMixReversibleAndSimple,
 

--- a/sqlx-core/src/migrate/migration_type.rs
+++ b/sqlx-core/src/migrate/migration_type.rs
@@ -1,3 +1,5 @@
+use super::Migrator;
+
 /// Migration Type represents the type of migration
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum MigrationType {
@@ -69,6 +71,19 @@ impl MigrationType {
             MigrationType::Simple => "-- Add migration script here\n",
             MigrationType::ReversibleUp => "-- Add up migration script here\n",
             MigrationType::ReversibleDown => "-- Add down migration script here\n",
+        }
+    }
+
+    pub fn infer(migrator: &Migrator, reversible: bool) -> MigrationType {
+        match migrator.iter().next() {
+            Some(first_migration) => first_migration.migration_type,
+            None => {
+                if reversible {
+                    MigrationType::ReversibleUp
+                } else {
+                    MigrationType::Simple
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Since sqlx requires all migrations to be of the same type (simple or reversible), it makes sense to automatically set the type of newly generated migration to be the same as the last one if it exists.