### PR TITLE
Make PgListener recover from UnexpectedEof

### DIFF
--- a/sqlx-postgres/src/listener.rs
+++ b/sqlx-postgres/src/listener.rs
@@ -262,7 +262,10 @@ impl PgListener {
 
                 // The connection is dead, ensure that it is dropped,
                 // update self state, and loop to try again.
-                Err(Error::Io(err)) if err.kind() == io::ErrorKind::ConnectionAborted => {
+                Err(Error::Io(err))
+                    if (err.kind() == io::ErrorKind::ConnectionAborted
+                        || err.kind() == io::ErrorKind::UnexpectedEof) =>
+                {
                     self.buffer_tx = self.connection().await?.stream.notifications.take();
                     self.connection = None;
 


### PR DESCRIPTION
This is often encountered when the host the db is on is restarted. For example, a reboot of AWS Aurora cauases this. If we don't handle this properly the PgListeners are stuck in an erroring state, even when the DB is back online. By catching it here, we will reconnect when it is (eventually) back online.