### PR TITLE
fix: Make rust_decimal and bigdecimal decoding more lenient

### DIFF
--- a/sqlx-mysql/src/types/bigdecimal.rs
+++ b/sqlx-mysql/src/types/bigdecimal.rs
@@ -12,6 +12,10 @@ impl Type<MySql> for BigDecimal {
     fn type_info() -> MySqlTypeInfo {
         MySqlTypeInfo::binary(ColumnType::NewDecimal)
     }
+
+    fn compatible(ty: &MySqlTypeInfo) -> bool {
+        matches!(ty.r#type, ColumnType::Decimal | ColumnType::NewDecimal)
+    }
 }
 
 impl Encode<'_, MySql> for BigDecimal {

--- a/sqlx-mysql/src/types/rust_decimal.rs
+++ b/sqlx-mysql/src/types/rust_decimal.rs
@@ -12,6 +12,10 @@ impl Type<MySql> for Decimal {
     fn type_info() -> MySqlTypeInfo {
         MySqlTypeInfo::binary(ColumnType::NewDecimal)
     }
+
+    fn compatible(ty: &MySqlTypeInfo) -> bool {
+        matches!(ty.r#type, ColumnType::Decimal | ColumnType::NewDecimal)
+    }
 }
 
 impl Encode<'_, MySql> for Decimal {


### PR DESCRIPTION
fixes https://github.com/readysettech/readyset/issues/143

When using readyset as a caching proxy - readyset returns a decimal with the following type info `MySqlTypeInfo { type: Decimal, flags: ColumnFlags(0x0), char_set: 33, max_size: Some(1024) }`

Currently rust_decimal and bigdecimal expect an exact match for the type info `MySqlTypeInfo { type: NewDecimal, flags: ColumnFlags(BINARY), char_set: 63, max_size: None }`

Therefore the following error  occurs when readyset sends a valid decimal type

```
    error occurred while decoding column "price": mismatched types; Rust type `core::option::Option<rust_decimal::decimal::Decimal>` (as SQL type `DECIMAL`) is not compatible with SQL type `DECIMAL`
```

This patch makes the `Type<MySql> for Decimal` more lenient by matching `MySqlTypeInfo` that has ColumType::Decimal |  ColumnType::NewDecimal to be parsed by both rust_decimal and bigdecimal types