### PR TITLE
remove &mut PoolConnection from Executor docs

### DIFF
--- a/sqlx-core/src/executor.rs
+++ b/sqlx-core/src/executor.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 /// Implemented for the following:
 ///
 ///  * [`&Pool`](super::pool::Pool)
-///  * [`&mut PoolConnection`](super::pool::PoolConnection)
 ///  * [`&mut Connection`](super::connection::Connection)
 ///
 pub trait Executor<'c>: Send + Debug + Sized {


### PR DESCRIPTION
As per the Changelog for the 0.7.0 release:

> The Executor impls for Transaction and PoolConnection have been deleted because they cannot exist in the new crate architecture without rewriting the Executor trait entirely. 