### PR TITLE
fix(macros): only enable chrono when time is disabled

### DIFF
--- a/sqlx-macros-core/src/database/postgres.rs
+++ b/sqlx-macros-core/src/database/postgres.rs
@@ -26,19 +26,19 @@ impl_database_ext! {
         #[cfg(feature = "uuid")]
         sqlx::types::Uuid,
 
-        #[cfg(feature = "chrono")]
+        #[cfg(all(feature = "chrono", not(feature = "time")))]
         sqlx::types::chrono::NaiveTime,
 
-        #[cfg(feature = "chrono")]
+        #[cfg(all(feature = "chrono", not(feature = "time")))]
         sqlx::types::chrono::NaiveDate,
 
-        #[cfg(feature = "chrono")]
+        #[cfg(all(feature = "chrono", not(feature = "time")))]
         sqlx::types::chrono::NaiveDateTime,
 
-        #[cfg(feature = "chrono")]
+        #[cfg(all(feature = "chrono", not(feature = "time")))]
         sqlx::types::chrono::DateTime<sqlx::types::chrono::Utc> | sqlx::types::chrono::DateTime<_>,
 
-        #[cfg(feature = "chrono")]
+        #[cfg(all(feature = "chrono", not(feature = "time")))]
         sqlx::postgres::types::PgTimeTz<sqlx::types::chrono::NaiveTime, sqlx::types::chrono::FixedOffset>,
 
         #[cfg(feature = "time")]
@@ -91,16 +91,16 @@ impl_database_ext! {
         #[cfg(feature = "uuid")]
         Vec<sqlx::types::Uuid> | &[sqlx::types::Uuid],
 
-        #[cfg(feature = "chrono")]
+        #[cfg(all(feature = "chrono", not(feature = "time")))]
         Vec<sqlx::types::chrono::NaiveTime> | &[sqlx::types::chrono::NaiveTime],
 
-        #[cfg(feature = "chrono")]
+        #[cfg(all(feature = "chrono", not(feature = "time")))]
         Vec<sqlx::types::chrono::NaiveDate> | &[sqlx::types::chrono::NaiveDate],
 
-        #[cfg(feature = "chrono")]
+        #[cfg(all(feature = "chrono", not(feature = "time")))]
         Vec<sqlx::types::chrono::NaiveDateTime> | &[sqlx::types::chrono::NaiveDateTime],
 
-        #[cfg(feature = "chrono")]
+        #[cfg(all(feature = "chrono", not(feature = "time")))]
         Vec<sqlx::types::chrono::DateTime<sqlx::types::chrono::Utc>> | &[sqlx::types::chrono::DateTime<_>],
 
         #[cfg(feature = "time")]
@@ -141,13 +141,13 @@ impl_database_ext! {
         #[cfg(feature = "rust_decimal")]
         sqlx::postgres::types::PgRange<sqlx::types::Decimal>,
 
-        #[cfg(feature = "chrono")]
+        #[cfg(all(feature = "chrono", not(feature = "time")))]
         sqlx::postgres::types::PgRange<sqlx::types::chrono::NaiveDate>,
 
-        #[cfg(feature = "chrono")]
+        #[cfg(all(feature = "chrono", not(feature = "time")))]
         sqlx::postgres::types::PgRange<sqlx::types::chrono::NaiveDateTime>,
 
-        #[cfg(feature = "chrono")]
+        #[cfg(all(feature = "chrono", not(feature = "time")))]
         sqlx::postgres::types::PgRange<sqlx::types::chrono::DateTime<sqlx::types::chrono::Utc>> |
             sqlx::postgres::types::PgRange<sqlx::types::chrono::DateTime<_>>,
 
@@ -173,19 +173,19 @@ impl_database_ext! {
         Vec<sqlx::postgres::types::PgRange<sqlx::types::Decimal>> |
             &[sqlx::postgres::types::PgRange<sqlx::types::Decimal>],
 
-        #[cfg(feature = "chrono")]
+        #[cfg(all(feature = "chrono", not(feature = "time")))]
         Vec<sqlx::postgres::types::PgRange<sqlx::types::chrono::NaiveDate>> |
             &[sqlx::postgres::types::PgRange<sqlx::types::chrono::NaiveDate>],
 
-        #[cfg(feature = "chrono")]
+        #[cfg(all(feature = "chrono", not(feature = "time")))]
         Vec<sqlx::postgres::types::PgRange<sqlx::types::chrono::NaiveDateTime>> |
             &[sqlx::postgres::types::PgRange<sqlx::types::chrono::NaiveDateTime>],
 
-        #[cfg(feature = "chrono")]
+        #[cfg(all(feature = "chrono", not(feature = "time")))]
         Vec<sqlx::postgres::types::PgRange<sqlx::types::chrono::DateTime<sqlx::types::chrono::Utc>>> |
             Vec<sqlx::postgres::types::PgRange<sqlx::types::chrono::DateTime<_>>>,
 
-        #[cfg(feature = "chrono")]
+        #[cfg(all(feature = "chrono", not(feature = "time")))]
         &[sqlx::postgres::types::PgRange<sqlx::types::chrono::DateTime<sqlx::types::chrono::Utc>>] |
             &[sqlx::postgres::types::PgRange<sqlx::types::chrono::DateTime<_>>],
 

--- a/sqlx-macros-core/src/database/sqlite.rs
+++ b/sqlx-macros-core/src/database/sqlite.rs
@@ -12,13 +12,13 @@ impl_database_ext! {
         String,
         Vec<u8>,
 
-        #[cfg(feature = "chrono")]
+        #[cfg(all(feature = "chrono", not(feature = "time")))]
         sqlx::types::chrono::NaiveDate,
 
-        #[cfg(feature = "chrono")]
+        #[cfg(all(feature = "chrono", not(feature = "time")))]
         sqlx::types::chrono::NaiveDateTime,
 
-        #[cfg(feature = "chrono")]
+        #[cfg(all(feature = "chrono", not(feature = "time")))]
         sqlx::types::chrono::DateTime<sqlx::types::chrono::Utc> | sqlx::types::chrono::DateTime<_>,
 
         #[cfg(feature = "time")]


### PR DESCRIPTION
Replicates the same approach done by the MySQL compatibility layer and only enables `chrono` types
if `time` is disabled.

I expect this to close #2689.