### PR TITLE
Remove documentation on offline feature

### DIFF
--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -279,7 +279,7 @@
 /// | `foo!: T` | Forced not-null | Overridden |
 /// | `foo?: T` | Forced nullable | Overridden |
 ///
-/// ## Offline Mode (requires the `offline` feature)
+/// ## Offline Mode
 /// The macros can be configured to not require a live database connection for compilation,
 /// but it requires a couple extra steps:
 ///


### PR DESCRIPTION
I needed offline mode for my application and found the `query` macro documentation, but I spend some time trying to understand where the `offline` feature needed to be enabled. I had to go into the [changelog](https://github.com/launchbadge/sqlx/blob/main/CHANGELOG.md#breaking) to found out it has been removed and is now the default behavior.

This PR just remove the documentation stating it requires the `offline` feature, as this behavior is now unconditionnal.