### PR TITLE
Constrain cyclic associated types to themselves

### DIFF
--- a/sqlx-core/src/column.rs
+++ b/sqlx-core/src/column.rs
@@ -4,7 +4,7 @@ use crate::error::Error;
 use std::fmt::Debug;
 
 pub trait Column: 'static + Send + Sync + Debug {
-    type Database: Database;
+    type Database: Database<Column = Self>;
 
     /// Gets the column ordinal.
     ///

--- a/sqlx-core/src/connection.rs
+++ b/sqlx-core/src/connection.rs
@@ -11,7 +11,7 @@ use url::Url;
 
 /// Represents a single database connection.
 pub trait Connection: Send {
-    type Database: Database;
+    type Database: Database<Connection = Self>;
 
     type Options: ConnectOptions<Connection = Self>;
 
@@ -184,7 +184,7 @@ impl LogSettings {
 }
 
 pub trait ConnectOptions: 'static + Send + Sync + FromStr<Err = Error> + Debug + Clone {
-    type Connection: Connection + ?Sized;
+    type Connection: Connection<Options = Self> + ?Sized;
 
     /// Parse the `ConnectOptions` from a URL.
     fn from_url(url: &Url) -> Result<Self, Error>;

--- a/sqlx-core/src/row.rs
+++ b/sqlx-core/src/row.rs
@@ -14,7 +14,7 @@ use crate::value::ValueRef;
 /// [`FromRow`]: crate::row::FromRow
 /// [`Query::fetch`]: crate::query::Query::fetch
 pub trait Row: Unpin + Send + Sync + 'static {
-    type Database: Database;
+    type Database: Database<Row = Self>;
 
     /// Returns `true` if this row has no columns.
     #[inline]

--- a/sqlx-core/src/value.rs
+++ b/sqlx-core/src/value.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 
 /// An owned value from the database.
 pub trait Value {
-    type Database: Database;
+    type Database: Database<Value = Self>;
 
     /// Get this value as a reference.
     fn as_ref(&self) -> <Self::Database as HasValueRef<'_>>::ValueRef;


### PR DESCRIPTION
The `Database` trait's associated types are constrained using `Connection<Database = Self>` but this constraint is not specified for the reverse `Database<Connection = Self>`. This causes issues when wrapping or "extending" sqlx traits since as far as rust's type system is concerned `Self::Connection::Database::Connection != Self::Connection`. 

Consider the following example: 

```rust
type DatabaseTypeOf<T> = <<T as ConnectOptions>::Connection as Connection>::Database;

pub trait OptionWrapper {
    type Pool: Pool;
    async fn connect(self) -> Self::Pool;
}

impl <T> OptionWrapper for T
where
    T: ConnectOptions,
    for<'a> &'a mut T::Connection: Executor<'a, Database = DatabaseTypeOf<T>>,
{
    type Client = Pool<DatabaseTypeOf<T>>;

    async fn connect(self) -> Self::Pool {
        Pool::connect_with(self).await.unwrap()
        //    ^^^^^^^^^^^^^^^^^^ expected associated type, found type parameter `T`
        // type mismatch resolving `<<<<T as ConnectOptions>::Connection as Connection>::Database as Database>::Connection as Connection>::Options == T`
    }
}
```
----

This PR adds bounds such that cyclic associated types are equal to themselves.
```
<T as Connection>::Database as Database>::Connection == T
<T as ConnectOptions>::Connection as Connection>::Options == T
<T as Row>::Database as Database>::Row == T
<T as Column>::Database as Database>::Column == T
<T as Value>::Database as Database>::Value == T
```