### PR TITLE
Clarify where optional features should be enabled

### DIFF
--- a/sqlx-macros-core/src/query/args.rs
+++ b/sqlx-macros-core/src/query/args.rs
@@ -60,7 +60,7 @@ pub fn quote_args<DB: DatabaseExt>(
                                 .ok_or_else(|| {
                                     if let Some(feature_gate) = <DB as DatabaseExt>::get_feature_gate(&param_ty) {
                                         format!(
-                                            "optional feature `{}` required for type {} of param #{}",
+                                            "optional sqlx feature `{}` required for type {} of param #{}",
                                             feature_gate,
                                             param_ty,
                                             i + 1,

--- a/sqlx-macros-core/src/query/output.rs
+++ b/sqlx-macros-core/src/query/output.rs
@@ -227,7 +227,7 @@ fn get_column_type<DB: DatabaseExt>(i: usize, column: &DB::Column) -> TokenStrea
             let message =
                 if let Some(feature_gate) = <DB as DatabaseExt>::get_feature_gate(&type_info) {
                     format!(
-                        "optional feature `{feat}` required for type {ty} of {col}",
+                        "optional sqlx feature `{feat}` required for type {ty} of {col}",
                         ty = &type_info,
                         feat = feature_gate,
                         col = DisplayColumn {

--- a/tests/ui/mysql/gated/chrono.stderr
+++ b/tests/ui/mysql/gated/chrono.stderr
@@ -1,4 +1,4 @@
-error: optional feature `chrono` required for type DATE of column #1 ("date")
+error: optional sqlx feature `chrono` required for type DATE of column #1 ("date")
  --> $DIR/chrono.rs:2:13
   |
 2 |     let _ = sqlx::query!("select CONVERT(now(), DATE) date");
@@ -6,7 +6,7 @@ error: optional feature `chrono` required for type DATE of column #1 ("date")
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: optional feature `chrono` required for type TIME of column #1 ("time")
+error: optional sqlx feature `chrono` required for type TIME of column #1 ("time")
  --> $DIR/chrono.rs:4:13
   |
 4 |     let _ = sqlx::query!("select CONVERT(now(), TIME) time");
@@ -14,7 +14,7 @@ error: optional feature `chrono` required for type TIME of column #1 ("time")
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: optional feature `chrono` required for type DATETIME of column #1 ("datetime")
+error: optional sqlx feature `chrono` required for type DATETIME of column #1 ("datetime")
  --> $DIR/chrono.rs:6:13
   |
 6 |     let _ = sqlx::query!("select CONVERT(now(), DATETIME) datetime");

--- a/tests/ui/postgres/gated/chrono.stderr
+++ b/tests/ui/postgres/gated/chrono.stderr
@@ -1,4 +1,4 @@
-error: optional feature `time` required for type DATE of column #1 ("now")
+error: optional sqlx feature `time` required for type DATE of column #1 ("now")
  --> $DIR/chrono.rs:2:13
   |
 2 |     let _ = sqlx::query!("select now()::date");
@@ -6,7 +6,7 @@ error: optional feature `time` required for type DATE of column #1 ("now")
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: optional feature `time` required for type TIME of column #1 ("now")
+error: optional sqlx feature `time` required for type TIME of column #1 ("now")
  --> $DIR/chrono.rs:4:13
   |
 4 |     let _ = sqlx::query!("select now()::time");
@@ -14,7 +14,7 @@ error: optional feature `time` required for type TIME of column #1 ("now")
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: optional feature `time` required for type TIMESTAMP of column #1 ("now")
+error: optional sqlx feature `time` required for type TIMESTAMP of column #1 ("now")
  --> $DIR/chrono.rs:6:13
   |
 6 |     let _ = sqlx::query!("select now()::timestamp");
@@ -22,7 +22,7 @@ error: optional feature `time` required for type TIMESTAMP of column #1 ("now")
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: optional feature `time` required for type TIMESTAMPTZ of column #1 ("now")
+error: optional sqlx feature `time` required for type TIMESTAMPTZ of column #1 ("now")
  --> $DIR/chrono.rs:8:13
   |
 8 |     let _ = sqlx::query!("select now()::timestamptz");
@@ -30,7 +30,7 @@ error: optional feature `time` required for type TIMESTAMPTZ of column #1 ("now"
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: optional feature `time` required for type DATE of param #1
+error: optional sqlx feature `time` required for type DATE of param #1
   --> $DIR/chrono.rs:10:13
    |
 10 |     let _ = sqlx::query!("select $1::date", ());
@@ -38,7 +38,7 @@ error: optional feature `time` required for type DATE of param #1
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: optional feature `time` required for type TIME of param #1
+error: optional sqlx feature `time` required for type TIME of param #1
   --> $DIR/chrono.rs:12:13
    |
 12 |     let _ = sqlx::query!("select $1::time", ());
@@ -46,7 +46,7 @@ error: optional feature `time` required for type TIME of param #1
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: optional feature `time` required for type TIMESTAMP of param #1
+error: optional sqlx feature `time` required for type TIMESTAMP of param #1
   --> $DIR/chrono.rs:14:13
    |
 14 |     let _ = sqlx::query!("select $1::timestamp", ());
@@ -54,7 +54,7 @@ error: optional feature `time` required for type TIMESTAMP of param #1
    |
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: optional feature `time` required for type TIMESTAMPTZ of param #1
+error: optional sqlx feature `time` required for type TIMESTAMPTZ of param #1
   --> $DIR/chrono.rs:16:13
    |
 16 |     let _ = sqlx::query!("select $1::timestamptz", ());

--- a/tests/ui/postgres/gated/ipnetwork.stderr
+++ b/tests/ui/postgres/gated/ipnetwork.stderr
@@ -1,4 +1,4 @@
-error: optional feature `ipnetwork` required for type INET of column #1 ("inet")
+error: optional sqlx feature `ipnetwork` required for type INET of column #1 ("inet")
  --> $DIR/ipnetwork.rs:2:13
   |
 2 |     let _ = sqlx::query!("select '127.0.0.1'::inet");
@@ -6,7 +6,7 @@ error: optional feature `ipnetwork` required for type INET of column #1 ("inet")
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: optional feature `ipnetwork` required for type CIDR of column #1 ("cidr")
+error: optional sqlx feature `ipnetwork` required for type CIDR of column #1 ("cidr")
  --> $DIR/ipnetwork.rs:4:13
   |
 4 |     let _ = sqlx::query!("select '2001:4f8:3:ba::/64'::cidr");
@@ -14,7 +14,7 @@ error: optional feature `ipnetwork` required for type CIDR of column #1 ("cidr")
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: optional feature `ipnetwork` required for type INET of param #1
+error: optional sqlx feature `ipnetwork` required for type INET of param #1
  --> $DIR/ipnetwork.rs:6:13
   |
 6 |     let _ = sqlx::query!("select $1::inet", ());
@@ -22,7 +22,7 @@ error: optional feature `ipnetwork` required for type INET of param #1
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: optional feature `ipnetwork` required for type CIDR of param #1
+error: optional sqlx feature `ipnetwork` required for type CIDR of param #1
  --> $DIR/ipnetwork.rs:8:13
   |
 8 |     let _ = sqlx::query!("select $1::cidr", ());

--- a/tests/ui/postgres/gated/uuid.stderr
+++ b/tests/ui/postgres/gated/uuid.stderr
@@ -1,4 +1,4 @@
-error: optional feature `uuid` required for type UUID of column #1 ("uuid")
+error: optional sqlx feature `uuid` required for type UUID of column #1 ("uuid")
  --> $DIR/uuid.rs:2:13
   |
 2 |     let _ = sqlx::query!("select 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'::uuid");
@@ -6,7 +6,7 @@ error: optional feature `uuid` required for type UUID of column #1 ("uuid")
   |
   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: optional feature `uuid` required for type UUID of param #1
+error: optional sqlx feature `uuid` required for type UUID of param #1
  --> $DIR/uuid.rs:3:13
   |
 3 |     let _ = sqlx::query!("select $1::uuid", ());


### PR DESCRIPTION
sqlx can give errors like the following:

    optional feature `time` required for type TIMESTAMP of param #1

From this error message it is not clear where this feature should be enabled. I initially thought it is some feature that should be enabled in Postgres. People on Stackoverflow [are also confused](https://stackoverflow.com/questions/75376803/rust-actix-web-sqlx-optional-feature-time-required-for-type-timestamptz-of-col) by this error message.

This PR changes this error message to:

    optional sqlx feature `time` required for type TIMESTAMP of param #1
