### PR TITLE
extra_float_digits URL support

### DIFF
--- a/sqlx-postgres/src/options/parse.rs
+++ b/sqlx-postgres/src/options/parse.rs
@@ -85,6 +85,8 @@ impl PgConnectOptions {
 
                 "application_name" => options = options.application_name(&*value),
 
+                "extra_float_digits" => options = options.extra_float_digits(Some(value.parse().map_err(Error::config)?)),
+
                 "options" => {
                     if let Some(options) = options.options.as_mut() {
                         options.push(' ');
@@ -188,6 +190,14 @@ fn it_parses_application_name_correctly_from_parameter() {
     let opts = PgConnectOptions::from_str(url).unwrap();
 
     assert_eq!(Some("some_name"), opts.application_name.as_deref());
+}
+
+#[test]
+fn it_parses_extra_float_digits_correctly_from_parameter() {
+    let url = "postgres:///?extra_float_digits=2";
+    let opts = PgConnectOptions::from_str(url).unwrap();
+
+    assert_eq!(Some("2"), opts.extra_float_digits.as_deref());
 }
 
 #[test]


### PR DESCRIPTION
When attempting to use SQLx 0.7.1 with Redshift, an error is returned upon connection due to `extra_float_digits` defaulting to `3`.  Adding the capability to define this value via a URL parameter removes the need for code changes or work-arounds (e.g. https://github.com/launchbadge/sqlx/issues/801).

```text
Connection Error: error returned from database: 3 is outside the valid range for parameter "extra_float_digits" (-15 .. 2)
```