### PR TITLE
Add impl for `Type`, `Decode`, and `Encode` for `Box<str>` and `Box<[u8]>`

### DIFF
--- a/sqlx-mysql/src/types/bytes.rs
+++ b/sqlx-mysql/src/types/bytes.rs
@@ -40,6 +40,28 @@ impl<'r> Decode<'r, MySql> for &'r [u8] {
     }
 }
 
+impl Type<MySql> for Box<[u8]> {
+    fn type_info() -> MySqlTypeInfo {
+        <&[u8] as Type<MySql>>::type_info()
+    }
+
+    fn compatible(ty: &MySqlTypeInfo) -> bool {
+        <&[u8] as Type<MySql>>::compatible(ty)
+    }
+}
+
+impl Encode<'_, MySql> for Box<[u8]> {
+    fn encode_by_ref(&self, buf: &mut Vec<u8>) -> IsNull {
+        <&[u8] as Encode<MySql>>::encode(self.as_ref(), buf)
+    }
+}
+
+impl<'r> Decode<'r, MySql> for Box<[u8]> {
+    fn decode(value: MySqlValueRef<'r>) -> Result<Self, BoxDynError> {
+        <&[u8] as Decode<MySql>>::decode(value).map(Box::from)
+    }
+}
+
 impl Type<MySql> for Vec<u8> {
     fn type_info() -> MySqlTypeInfo {
         <[u8] as Type<MySql>>::type_info()

--- a/sqlx-mysql/src/types/str.rs
+++ b/sqlx-mysql/src/types/str.rs
@@ -62,6 +62,28 @@ impl<'r> Decode<'r, MySql> for &'r str {
     }
 }
 
+impl Type<MySql> for Box<str> {
+    fn type_info() -> MySqlTypeInfo {
+        <&str as Type<MySql>>::type_info()
+    }
+
+    fn compatible(ty: &MySqlTypeInfo) -> bool {
+        <&str as Type<MySql>>::compatible(ty)
+    }
+}
+
+impl Encode<'_, MySql> for Box<str> {
+    fn encode_by_ref(&self, buf: &mut Vec<u8>) -> IsNull {
+        <&str as Encode<MySql>>::encode(&**self, buf)
+    }
+}
+
+impl<'r> Decode<'r, MySql> for Box<str> {
+    fn decode(value: MySqlValueRef<'r>) -> Result<Self, BoxDynError> {
+        <&str as Decode<MySql>>::decode(value).map(Box::from)
+    }
+}
+
 impl Type<MySql> for String {
     fn type_info() -> MySqlTypeInfo {
         <str as Type<MySql>>::type_info()

--- a/sqlx-postgres/src/types/bytes.rs
+++ b/sqlx-postgres/src/types/bytes.rs
@@ -22,6 +22,12 @@ impl<const N: usize> PgHasArrayType for &'_ [u8; N] {
     }
 }
 
+impl PgHasArrayType for Box<[u8]> {
+    fn array_type_info() -> PgTypeInfo {
+        <[&[u8]] as Type<Postgres>>::type_info()
+    }
+}
+
 impl PgHasArrayType for Vec<u8> {
     fn array_type_info() -> PgTypeInfo {
         <[&[u8]] as Type<Postgres>>::type_info()
@@ -39,6 +45,12 @@ impl Encode<'_, Postgres> for &'_ [u8] {
         buf.extend_from_slice(self);
 
         IsNull::No
+    }
+}
+
+impl Encode<'_, Postgres> for Box<[u8]> {
+    fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> IsNull {
+        <&[u8] as Encode<Postgres>>::encode(self.as_ref(), buf)
     }
 }
 
@@ -72,6 +84,15 @@ fn text_hex_decode_input(value: PgValueRef<'_>) -> Result<&[u8], BoxDynError> {
         .strip_prefix(b"\\x")
         .ok_or("text does not start with \\x")
         .map_err(Into::into)
+}
+
+impl Decode<'_, Postgres> for Box<[u8]> {
+    fn decode(value: PgValueRef<'_>) -> Result<Self, BoxDynError> {
+        Ok(match value.format() {
+            PgValueFormat::Binary => Box::from(value.as_bytes()?),
+            PgValueFormat::Text => Box::from(hex::decode(text_hex_decode_input(value)?)?),
+        })
+    }
 }
 
 impl Decode<'_, Postgres> for Vec<u8> {

--- a/sqlx-postgres/src/types/str.rs
+++ b/sqlx-postgres/src/types/str.rs
@@ -33,6 +33,16 @@ impl Type<Postgres> for Cow<'_, str> {
     }
 }
 
+impl Type<Postgres> for Box<str> {
+    fn type_info() -> PgTypeInfo {
+        <&str as Type<Postgres>>::type_info()
+    }
+
+    fn compatible(ty: &PgTypeInfo) -> bool {
+        <&str as Type<Postgres>>::compatible(ty)
+    }
+}
+
 impl Type<Postgres> for String {
     fn type_info() -> PgTypeInfo {
         <&str as Type<Postgres>>::type_info()
@@ -54,6 +64,16 @@ impl PgHasArrayType for &'_ str {
 }
 
 impl PgHasArrayType for Cow<'_, str> {
+    fn array_type_info() -> PgTypeInfo {
+        <&str as PgHasArrayType>::array_type_info()
+    }
+
+    fn array_compatible(ty: &PgTypeInfo) -> bool {
+        <&str as PgHasArrayType>::array_compatible(ty)
+    }
+}
+
+impl PgHasArrayType for Box<str> {
     fn array_type_info() -> PgTypeInfo {
         <&str as PgHasArrayType>::array_type_info()
     }
@@ -90,6 +110,12 @@ impl Encode<'_, Postgres> for Cow<'_, str> {
     }
 }
 
+impl Encode<'_, Postgres> for Box<str> {
+    fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> IsNull {
+        <&str as Encode<Postgres>>::encode(&**self, buf)
+    }
+}
+
 impl Encode<'_, Postgres> for String {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> IsNull {
         <&str as Encode<Postgres>>::encode(&**self, buf)
@@ -105,6 +131,12 @@ impl<'r> Decode<'r, Postgres> for &'r str {
 impl<'r> Decode<'r, Postgres> for Cow<'r, str> {
     fn decode(value: PgValueRef<'r>) -> Result<Self, BoxDynError> {
         Ok(Cow::Borrowed(value.as_str()?))
+    }
+}
+
+impl<'r> Decode<'r, Postgres> for Box<str> {
+    fn decode(value: PgValueRef<'r>) -> Result<Self, BoxDynError> {
+        Ok(Box::from(value.as_str()?))
     }
 }
 

--- a/sqlx-sqlite/src/types/bytes.rs
+++ b/sqlx-sqlite/src/types/bytes.rs
@@ -31,6 +31,36 @@ impl<'r> Decode<'r, Sqlite> for &'r [u8] {
     }
 }
 
+impl Type<Sqlite> for Box<[u8]> {
+    fn type_info() -> SqliteTypeInfo {
+        <&[u8] as Type<Sqlite>>::type_info()
+    }
+
+    fn compatible(ty: &SqliteTypeInfo) -> bool {
+        <&[u8] as Type<Sqlite>>::compatible(ty)
+    }
+}
+
+impl Encode<'_, Sqlite> for Box<[u8]> {
+    fn encode(self, args: &mut Vec<SqliteArgumentValue<'_>>) -> IsNull {
+        args.push(SqliteArgumentValue::Blob(Cow::Owned(self.into_vec())));
+
+        IsNull::No
+    }
+
+    fn encode_by_ref(&self, args: &mut Vec<SqliteArgumentValue<'_>>) -> IsNull {
+        args.push(SqliteArgumentValue::Blob(Cow::Owned(self.clone().into_vec())));
+
+        IsNull::No
+    }
+}
+
+impl Decode<'_, Sqlite> for Box<[u8]> {
+    fn decode(value: SqliteValueRef<'_>) -> Result<Self, BoxDynError> {
+        Ok(Box::from(value.blob()))
+    }
+}
+
 impl Type<Sqlite> for Vec<u8> {
     fn type_info() -> SqliteTypeInfo {
         <&[u8] as Type<Sqlite>>::type_info()

--- a/sqlx-sqlite/src/types/str.rs
+++ b/sqlx-sqlite/src/types/str.rs
@@ -27,6 +27,34 @@ impl<'r> Decode<'r, Sqlite> for &'r str {
     }
 }
 
+impl Type<Sqlite> for Box<str> {
+    fn type_info() -> SqliteTypeInfo {
+        <&str as Type<Sqlite>>::type_info()
+    }
+}
+
+impl Encode<'_, Sqlite> for Box<str> {
+    fn encode(self, args: &mut Vec<SqliteArgumentValue<'_>>) -> IsNull {
+        args.push(SqliteArgumentValue::Text(Cow::Owned(self.into_string())));
+
+        IsNull::No
+    }
+
+    fn encode_by_ref(&self, args: &mut Vec<SqliteArgumentValue<'_>>) -> IsNull {
+        args.push(SqliteArgumentValue::Text(Cow::Owned(
+            self.clone().into_string(),
+        )));
+
+        IsNull::No
+    }
+}
+
+impl Decode<'_, Sqlite> for Box<str> {
+    fn decode(value: SqliteValueRef<'_>) -> Result<Self, BoxDynError> {
+        value.text().map(Box::from)
+    }
+}
+
 impl Type<Sqlite> for String {
     fn type_info() -> SqliteTypeInfo {
         <&str as Type<Sqlite>>::type_info()


### PR DESCRIPTION
This added impls for `Type`, `Decode`, and `Encode` for `Box<str>` and `Box<[u8]>`.

Rational is these types are slightly smaller than `String` and `Vec<u8>` if you do not need the ability to grow the capacity of the types.