### PR TITLE
Add additional info regarding using Transaction and PoolConnection as…

### DIFF
--- a/sqlx-core/src/executor.rs
+++ b/sqlx-core/src/executor.rs
@@ -23,6 +23,14 @@ use std::fmt::Debug;
 ///  * [`&mut PoolConnection`](super::pool::PoolConnection)
 ///  * [`&mut Connection`](super::connection::Connection)
 ///
+/// The [`Executor`](crate::Executor) impls for [`Transaction`](crate::Transaction)
+/// and [`PoolConnection`](crate::pool::PoolConnection) have been deleted because they
+/// cannot exist in the new crate architecture without rewriting the Executor trait entirely.
+/// To fix this breakage, simply add a dereference where an impl [`Executor`](crate::Executor) is expected, as
+/// they both dereference to the inner connection type which will still implement it:
+/// * `&mut transaction` -> `&mut *transaction`
+/// * `&mut connection` -> `&mut *connection`
+///
 pub trait Executor<'c>: Send + Debug + Sized {
     type Database: Database;
 


### PR DESCRIPTION
I got a little confused when I couldn't use `&mut transaction` for `query.execute()`, turns out the API has slightly changed and it's documented in the [changelog](https://github.com/launchbadge/sqlx/blob/main/CHANGELOG.md#070---2023-06-30). Mentioning it in the doc might help newbies like myself.

I'm not very familiar with Rust or sqlx, would need some help with the wording. (Perhaps this should live in `query!`'s docs?)