### PR TITLE
Closes #2719 by bumping bigdecimal version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ sqlx = { version = "=0.7.1", path = ".", default-features = false }
 
 # Common type integrations shared by multiple driver crates.
 # These are optional unless enabled in a workspace crate.
-bigdecimal = "0.3.0"
+bigdecimal = "0.4.0"
 bit-vec = "0.6.3"
 chrono = { version = "0.4.22", default-features = false }
 ipnetwork = "0.20.0"


### PR DESCRIPTION
This PR bumps the `bigdecimal` version to enable using the latest `bigdecimal` crate version solving #2719.