### PR TITLE
feat: add migration_table name option

### DIFF
--- a/sqlx-cli/src/database.rs
+++ b/sqlx-cli/src/database.rs
@@ -43,14 +43,15 @@ pub async fn reset(
     migration_source: &str,
     connect_opts: &ConnectOpts,
     confirm: bool,
+    migration_table: Option<String>
 ) -> anyhow::Result<()> {
     drop(connect_opts, confirm).await?;
-    setup(migration_source, connect_opts).await
+    setup(migration_source, connect_opts, migration_table).await
 }
 
-pub async fn setup(migration_source: &str, connect_opts: &ConnectOpts) -> anyhow::Result<()> {
+pub async fn setup(migration_source: &str, connect_opts: &ConnectOpts, migration_table: Option<String>) -> anyhow::Result<()> {
     create(connect_opts).await?;
-    migrate::run(migration_source, connect_opts, false, false, None).await
+    migrate::run(migration_source, connect_opts, false, false, None, migration_table).await
 }
 
 fn ask_to_continue(connect_opts: &ConnectOpts) -> bool {

--- a/sqlx-cli/src/lib.rs
+++ b/sqlx-cli/src/lib.rs
@@ -36,6 +36,7 @@ pub async fn run(opt: Opt) -> Result<()> {
                 ignore_missing,
                 connect_opts,
                 target_version,
+                migration_table,
             } => {
                 migrate::run(
                     &source,
@@ -43,6 +44,7 @@ pub async fn run(opt: Opt) -> Result<()> {
                     dry_run,
                     *ignore_missing,
                     target_version,
+                    migration_table,
                 )
                 .await?
             }
@@ -52,6 +54,7 @@ pub async fn run(opt: Opt) -> Result<()> {
                 ignore_missing,
                 connect_opts,
                 target_version,
+                migration_table,
             } => {
                 migrate::revert(
                     &source,
@@ -59,13 +62,15 @@ pub async fn run(opt: Opt) -> Result<()> {
                     dry_run,
                     *ignore_missing,
                     target_version,
+                    migration_table,
                 )
                 .await?
             }
             MigrateCommand::Info {
                 source,
                 connect_opts,
-            } => migrate::info(&source, &connect_opts).await?,
+                migration_table,
+            } => migrate::info(&source, &connect_opts, migration_table).await?,
             MigrateCommand::BuildScript { source, force } => migrate::build_script(&source, force)?,
         },
 
@@ -79,11 +84,13 @@ pub async fn run(opt: Opt) -> Result<()> {
                 confirmation,
                 source,
                 connect_opts,
-            } => database::reset(&source, &connect_opts, !confirmation.yes).await?,
+                migration_table,
+            } => database::reset(&source, &connect_opts, !confirmation.yes, migration_table).await?,
             DatabaseCommand::Setup {
                 source,
                 connect_opts,
-            } => database::setup(&source, &connect_opts).await?,
+                migration_table,
+            } => database::setup(&source, &connect_opts, migration_table).await?,
         },
 
         Command::Prepare {

--- a/sqlx-cli/src/opt.rs
+++ b/sqlx-cli/src/opt.rs
@@ -88,6 +88,9 @@ pub enum DatabaseCommand {
 
         #[clap(flatten)]
         connect_opts: ConnectOpts,
+
+        #[clap(long)]
+        migration_table: Option<String>,
     },
 
     /// Creates the database specified in your DATABASE_URL and runs any pending migrations.
@@ -97,6 +100,9 @@ pub enum DatabaseCommand {
 
         #[clap(flatten)]
         connect_opts: ConnectOpts,
+
+        #[clap(long)]
+        migration_table: Option<String>
     },
 }
 
@@ -164,6 +170,9 @@ pub enum MigrateCommand {
         /// pending migrations. If already at the target version, then no-op.
         #[clap(long)]
         target_version: Option<i64>,
+
+        #[arg(long)]
+        migration_table: Option<String>
     },
 
     /// Revert the latest migration with a down file.
@@ -186,6 +195,9 @@ pub enum MigrateCommand {
         /// at the target version, then no-op.
         #[clap(long)]
         target_version: Option<i64>,
+
+        #[arg(long)]
+        migration_table: Option<String>
     },
 
     /// List all available migrations.
@@ -195,6 +207,9 @@ pub enum MigrateCommand {
 
         #[clap(flatten)]
         connect_opts: ConnectOpts,
+
+        #[arg(long)]
+        migration_table: Option<String>
     },
 
     /// Generate a `build.rs` to trigger recompilation when a new migration is added.

--- a/sqlx-core/src/any/migrate.rs
+++ b/sqlx-core/src/any/migrate.rs
@@ -35,18 +35,18 @@ impl MigrateDatabase for Any {
 }
 
 impl Migrate for AnyConnection {
-    fn ensure_migrations_table(&mut self) -> BoxFuture<'_, Result<(), MigrateError>> {
-        Box::pin(async { self.get_migrate()?.ensure_migrations_table().await })
+    fn ensure_migrations_table<'a>(&mut self, migration_table: String) -> BoxFuture<'_, Result<(), MigrateError>> {
+        Box::pin(async { self.get_migrate()?.ensure_migrations_table(migration_table).await })
     }
 
-    fn dirty_version(&mut self) -> BoxFuture<'_, Result<Option<i64>, MigrateError>> {
-        Box::pin(async { self.get_migrate()?.dirty_version().await })
+    fn dirty_version(&mut self, migration_table: String) -> BoxFuture<'_, Result<Option<i64>, MigrateError>> {
+        Box::pin(async { self.get_migrate()?.dirty_version(migration_table).await })
     }
 
     fn list_applied_migrations(
-        &mut self,
+        &mut self, migration_table: String
     ) -> BoxFuture<'_, Result<Vec<AppliedMigration>, MigrateError>> {
-        Box::pin(async { self.get_migrate()?.list_applied_migrations().await })
+        Box::pin(async { self.get_migrate()?.list_applied_migrations(migration_table).await })
     }
 
     fn lock(&mut self) -> BoxFuture<'_, Result<(), MigrateError>> {
@@ -60,14 +60,16 @@ impl Migrate for AnyConnection {
     fn apply<'e: 'm, 'm>(
         &'e mut self,
         migration: &'m Migration,
+        migration_table: String,
     ) -> BoxFuture<'m, Result<Duration, MigrateError>> {
-        Box::pin(async { self.get_migrate()?.apply(migration).await })
+        Box::pin(async { self.get_migrate()?.apply(migration, migration_table).await })
     }
 
     fn revert<'e: 'm, 'm>(
         &'e mut self,
         migration: &'m Migration,
+        migration_table: String,
     ) -> BoxFuture<'m, Result<Duration, MigrateError>> {
-        Box::pin(async { self.get_migrate()?.revert(migration).await })
+        Box::pin(async { self.get_migrate()?.revert(migration, migration_table).await })
     }
 }

--- a/sqlx-core/src/migrate/error.rs
+++ b/sqlx-core/src/migrate/error.rs
@@ -30,7 +30,7 @@ pub enum MigrateError {
 
     // NOTE: this will only happen with a database that does not have transactional DDL (.e.g, MySQL or Oracle)
     #[error(
-        "migration {0} is partially applied; fix and remove row from `_sqlx_migrations` table"
+        "migration {0} is partially applied; fix and remove row from the migrations table"
     )]
     Dirty(i64),
 }

--- a/sqlx-core/src/migrate/migrate.rs
+++ b/sqlx-core/src/migrate/migrate.rs
@@ -21,15 +21,15 @@ pub trait MigrateDatabase {
 pub trait Migrate {
     // ensure migrations table exists
     // will create or migrate it if needed
-    fn ensure_migrations_table(&mut self) -> BoxFuture<'_, Result<(), MigrateError>>;
+    fn ensure_migrations_table(&mut self, migration_table: String) -> BoxFuture<'_, Result<(), MigrateError>>;
 
     // Return the version on which the database is dirty or None otherwise.
     // "dirty" means there is a partially applied migration that failed.
-    fn dirty_version(&mut self) -> BoxFuture<'_, Result<Option<i64>, MigrateError>>;
+    fn dirty_version(&mut self, migration_table: String) -> BoxFuture<'_, Result<Option<i64>, MigrateError>>;
 
     // Return the ordered list of applied migrations
     fn list_applied_migrations(
-        &mut self,
+        &mut self, migration_table: String
     ) -> BoxFuture<'_, Result<Vec<AppliedMigration>, MigrateError>>;
 
     // Should acquire a database lock so that only one migration process
@@ -47,6 +47,7 @@ pub trait Migrate {
     fn apply<'e: 'm, 'm>(
         &'e mut self,
         migration: &'m Migration,
+        migration_table: String,
     ) -> BoxFuture<'m, Result<Duration, MigrateError>>;
 
     // run a revert SQL from migration in a DDL transaction
@@ -55,5 +56,6 @@ pub trait Migrate {
     fn revert<'e: 'm, 'm>(
         &'e mut self,
         migration: &'m Migration,
+        migration_table: String,
     ) -> BoxFuture<'m, Result<Duration, MigrateError>>;
 }

--- a/sqlx-core/src/migrate/mod.rs
+++ b/sqlx-core/src/migrate/mod.rs
@@ -12,3 +12,5 @@ pub use migration::{AppliedMigration, Migration};
 pub use migration_type::MigrationType;
 pub use migrator::Migrator;
 pub use source::MigrationSource;
+
+pub const DEFAULT_MIGRATION_TABLE: &str = "_sqlx_migrations";

--- a/sqlx-core/src/migrate/source.rs
+++ b/sqlx-core/src/migrate/source.rs
@@ -18,8 +18,8 @@ use std::path::{Path, PathBuf};
 /// You can create a new empty migration script using sqlx-cli:
 /// `sqlx migrate add <DESCRIPTION>`.
 ///
-/// Note that migrations for each database are tracked using the
-/// `_sqlx_migrations` table (stored in the database). If a migration's hash
+/// Note that migrations for each database are tracked using a
+/// migrations table stored in the database. If a migration's hash
 /// changes and it has already been run, this will cause an error.
 pub trait MigrationSource<'s>: Debug {
     fn resolve(self) -> BoxFuture<'s, Result<Vec<Migration>, BoxDynError>>;

--- a/sqlx-macros-core/src/migrate.rs
+++ b/sqlx-macros-core/src/migrate.rs
@@ -150,6 +150,7 @@ pub(crate) fn expand_migrator(path: &Path) -> crate::Result<TokenStream> {
             ]),
             ignore_missing: false,
             locking: true,
+            migration_table: None,
         }
     })
 }

--- a/sqlx-sqlite/src/migrate.rs
+++ b/sqlx-sqlite/src/migrate.rs
@@ -65,12 +65,12 @@ impl MigrateDatabase for Sqlite {
 }
 
 impl Migrate for SqliteConnection {
-    fn ensure_migrations_table(&mut self) -> BoxFuture<'_, Result<(), MigrateError>> {
+    fn ensure_migrations_table(&mut self, migration_table: String) -> BoxFuture<'_, Result<(), MigrateError>> {
         Box::pin(async move {
             // language=SQLite
             self.execute(
-                r#"
-CREATE TABLE IF NOT EXISTS _sqlx_migrations (
+                format!(r#"
+CREATE TABLE IF NOT EXISTS {migration_table} (
     version BIGINT PRIMARY KEY,
     description TEXT NOT NULL,
     installed_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -78,7 +78,7 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
     checksum BLOB NOT NULL,
     execution_time BIGINT NOT NULL
 );
-                "#,
+                "#).as_str(),
             )
             .await?;
 
@@ -86,11 +86,11 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
         })
     }
 
-    fn dirty_version(&mut self) -> BoxFuture<'_, Result<Option<i64>, MigrateError>> {
+    fn dirty_version(&mut self, migration_table: String) -> BoxFuture<'_, Result<Option<i64>, MigrateError>> {
         Box::pin(async move {
             // language=SQLite
             let row: Option<(i64,)> = query_as(
-                "SELECT version FROM _sqlx_migrations WHERE success = false ORDER BY version LIMIT 1",
+                &format!("SELECT version FROM {migration_table} WHERE success = false ORDER BY version LIMIT 1"),
             )
             .fetch_optional(self)
             .await?;
@@ -101,11 +101,12 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
 
     fn list_applied_migrations(
         &mut self,
+        migration_table: String,
     ) -> BoxFuture<'_, Result<Vec<AppliedMigration>, MigrateError>> {
         Box::pin(async move {
             // language=SQLite
             let rows: Vec<(i64, Vec<u8>)> =
-                query_as("SELECT version, checksum FROM _sqlx_migrations ORDER BY version")
+                query_as(&format!("SELECT version, checksum FROM {migration_table} ORDER BY version"))
                     .fetch_all(self)
                     .await?;
 
@@ -132,6 +133,7 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
     fn apply<'e: 'm, 'm>(
         &'e mut self,
         migration: &'m Migration,
+        migration_table: String,
     ) -> BoxFuture<'m, Result<Duration, MigrateError>> {
         Box::pin(async move {
             let mut tx = self.begin().await?;
@@ -146,10 +148,10 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
 
             // language=SQL
             let _ = query(
-                r#"
-    INSERT INTO _sqlx_migrations ( version, description, success, checksum, execution_time )
+                &format!(r#"
+    INSERT INTO {migration_table} ( version, description, success, checksum, execution_time )
     VALUES ( ?1, ?2, TRUE, ?3, -1 )
-                "#,
+                "#),
             )
             .bind(migration.version)
             .bind(&*migration.description)
@@ -167,11 +169,11 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
 
             // language=SQL
             let _ = query(
-                r#"
-    UPDATE _sqlx_migrations
+                &format!(r#"
+    UPDATE {migration_table}
     SET execution_time = ?1
     WHERE version = ?2
-                "#,
+                "#),
             )
             .bind(elapsed.as_nanos() as i64)
             .bind(migration.version)
@@ -185,6 +187,7 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
     fn revert<'e: 'm, 'm>(
         &'e mut self,
         migration: &'m Migration,
+        migration_table: String,
     ) -> BoxFuture<'m, Result<Duration, MigrateError>> {
         Box::pin(async move {
             // Use a single transaction for the actual migration script and the essential bookeeping so we never
@@ -195,7 +198,7 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
             let _ = tx.execute(&*migration.sql).await?;
 
             // language=SQL
-            let _ = query(r#"DELETE FROM _sqlx_migrations WHERE version = ?1"#)
+            let _ = query(&format!(r#"DELETE FROM {migration_table} WHERE version = ?1"#))
                 .bind(migration.version)
                 .execute(&mut *tx)
                 .await?;

--- a/src/macros/test.md
+++ b/src/macros/test.md
@@ -133,6 +133,7 @@ use sqlx::{PgPool, Row};
 #       migrations: Cow::Borrowed(&[]),
 #       ignore_missing: false,
 #       locking: true,
+#       migration_table: None,
 #   };
 # } 
 


### PR DESCRIPTION
Add `migration_table` option to enable sharing a database among multiple apps/clients. It is the responsibility of the user to ensure database permissions for the database role performing the migration is not able affect other co-hosted apps/clients done in separate migration "partitions".

- fixes #1835, fixes #1698, fixes #1356, fixes #946


