### PR TITLE
Bump mariadb CI images + mysql unpin

### DIFF
--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -467,7 +467,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        mariadb: [10_6, 10_3]
+        mariadb: [verylatest, 10_11, 10_4]
         runtime: [async-std, tokio]
         tls: [native-tls, rustls, none]
     needs: check

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -7,11 +7,9 @@ services:
     #
 
     mysql_8:
-        # FIXME: 8.0.28 introduced a regression in our type tests: https://github.com/launchbadge/sqlx/issues/1664
-        # The MySQL devs agreed that it was a regression and that it will be fixed in 8.0.29
-        image: mysql:8.0.27
+        image: mysql:8.0
         volumes:
-            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         ports:
             - 3306
         environment:
@@ -24,9 +22,9 @@ services:
             context: .
             dockerfile: mysql/Dockerfile
             args:
-                IMAGE: mysql:8.0.27
+                IMAGE: mysql:8.0
         volumes:
-            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         ports:
             - 3306
         environment:
@@ -37,7 +35,7 @@ services:
     mysql_5_7:
         image: mysql:5.7
         volumes:
-            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         ports:
             - 3306
         environment:
@@ -52,7 +50,7 @@ services:
             args:
                 IMAGE: mysql:5.7
         volumes:
-            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         ports:
             - 3306
         environment:
@@ -61,19 +59,43 @@ services:
             MYSQL_ALLOW_EMPTY_PASSWORD: 1
 
     #
-    # MariaDB 10.6, 10.5, 10.4, 10.3
+    # MariaDB 10.11, 10.6, 10.5, 10.4
     # https://mariadb.org/about/#maintenance-policy
     #
+
+    mariadb_10_11:
+        image: mariadb:10.11
+        volumes:
+            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
+        ports:
+            - 3306
+        environment:
+            MARIADB_ROOT_PASSWORD: password
+            MARIADB_DATABASE: sqlx
+
+    mariadb_10_11_client_ssl:
+        build:
+            context: .
+            dockerfile: mysql/Dockerfile
+            args:
+                IMAGE: mariadb:10.11
+        volumes:
+            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
+        ports:
+            - 3306
+        environment:
+            MARIADB_DATABASE: sqlx
+            MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 1
 
     mariadb_10_6:
         image: mariadb:10.6
         volumes:
-            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         ports:
             - 3306
         environment:
-            MYSQL_ROOT_PASSWORD: password
-            MYSQL_DATABASE: sqlx
+            MARIADB_ROOT_PASSWORD: password
+            MARIADB_DATABASE: sqlx
 
     mariadb_10_6_client_ssl:
         build:
@@ -82,7 +104,7 @@ services:
             args:
                 IMAGE: mariadb:10.6
         volumes:
-            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         ports:
             - 3306
         environment:
@@ -92,12 +114,12 @@ services:
     mariadb_10_5:
         image: mariadb:10.5
         volumes:
-            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         ports:
             - 3306
         environment:
-            MYSQL_ROOT_PASSWORD: password
-            MYSQL_DATABASE: sqlx
+            MARIADB_ROOT_PASSWORD: password
+            MARIADB_DATABASE: sqlx
 
     mariadb_10_5_client_ssl:
         build:
@@ -106,7 +128,7 @@ services:
             args:
                 IMAGE: mariadb:10.5
         volumes:
-            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         ports:
             - 3306
         environment:
@@ -116,12 +138,12 @@ services:
     mariadb_10_4:
         image: mariadb:10.4
         volumes:
-            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         ports:
             - 3306
         environment:
-            MYSQL_ROOT_PASSWORD: password
-            MYSQL_DATABASE: sqlx
+            MARIADB_ROOT_PASSWORD: password
+            MARIADB_DATABASE: sqlx
 
     mariadb_10_4_client_ssl:
         build:
@@ -130,37 +152,38 @@ services:
             args:
                 IMAGE: mariadb:10.4
         volumes:
-            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         ports:
             - 3306
         environment:
             MARIADB_DATABASE: sqlx
             MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 1
 
-    mariadb_10_3:
-        image: mariadb:10.3
+    # Ensure MariaDB upstream isn't regressing before release
+    # https://mariadb.org/new-service-quay-io-mariadb-foundation-mariadb-devel/
+    mariadb_verylatest:
+        image: quay.io/mariadb-foundation/mariadb-devel:verylatest
         volumes:
-            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         ports:
             - 3306
         environment:
-            MYSQL_ROOT_PASSWORD: password
-            MYSQL_DATABASE: sqlx
+            MARIADB_ROOT_PASSWORD: password
+            MARIADB_DATABASE: sqlx
 
-    mariadb_10_3_client_ssl:
+    mariadb_verylatest_client_ssl:
         build:
             context: .
             dockerfile: mysql/Dockerfile
             args:
-                IMAGE: mariadb:10.3
+                IMAGE: quay.io/mariadb-foundation/mariadb-devel:verylatest
         volumes:
-            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         ports:
             - 3306
         environment:
             MARIADB_DATABASE: sqlx
             MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 1
-
     #
     # PostgreSQL 15.x, 14.x, 13.x, 12.x, 11.x
     # https://www.postgresql.org/support/versioning/
@@ -181,7 +204,7 @@ services:
             POSTGRES_HOST_AUTH_METHOD: scram-sha-256
             POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256
         volumes:
-            - "./postgres/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./postgres/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         # Loading `pg_stat_statements` should serve as a regression test for:
         # https://github.com/launchbadge/sqlx/issues/2622
         command: >
@@ -200,7 +223,7 @@ services:
             POSTGRES_HOST_AUTH_METHOD: trust
             POSTGRES_INITDB_ARGS: --auth-host=trust
         volumes:
-            - "./postgres/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./postgres/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         command: >
             -c ssl=on -c ssl_cert_file=/var/lib/postgresql/server.crt -c ssl_key_file=/var/lib/postgresql/server.key -c ssl_ca_file=/var/lib/postgresql/ca.crt -c hba_file=/var/lib/postgresql/pg_hba.conf
 
@@ -219,7 +242,7 @@ services:
             POSTGRES_HOST_AUTH_METHOD: scram-sha-256
             POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256
         volumes:
-            - "./postgres/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./postgres/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         command: >
             -c ssl=on -c ssl_cert_file=/var/lib/postgresql/server.crt -c ssl_key_file=/var/lib/postgresql/server.key
 
@@ -236,7 +259,7 @@ services:
             POSTGRES_HOST_AUTH_METHOD: trust
             POSTGRES_INITDB_ARGS: --auth-host=trust
         volumes:
-            - "./postgres/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./postgres/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         command: >
             -c ssl=on -c ssl_cert_file=/var/lib/postgresql/server.crt -c ssl_key_file=/var/lib/postgresql/server.key -c ssl_ca_file=/var/lib/postgresql/ca.crt -c hba_file=/var/lib/postgresql/pg_hba.conf
 
@@ -255,7 +278,7 @@ services:
             POSTGRES_HOST_AUTH_METHOD: scram-sha-256
             POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256
         volumes:
-            - "./postgres/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./postgres/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         command: >
             -c ssl=on -c ssl_cert_file=/var/lib/postgresql/server.crt -c ssl_key_file=/var/lib/postgresql/server.key
 
@@ -272,7 +295,7 @@ services:
             POSTGRES_HOST_AUTH_METHOD: trust
             POSTGRES_INITDB_ARGS: --auth-host=trust
         volumes:
-            - "./postgres/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./postgres/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         command: >
             -c ssl=on -c ssl_cert_file=/var/lib/postgresql/server.crt -c ssl_key_file=/var/lib/postgresql/server.key -c ssl_ca_file=/var/lib/postgresql/ca.crt -c hba_file=/var/lib/postgresql/pg_hba.conf
 
@@ -291,7 +314,7 @@ services:
             POSTGRES_HOST_AUTH_METHOD: scram-sha-256
             POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256
         volumes:
-            - "./postgres/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./postgres/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         command: >
             -c ssl=on -c ssl_cert_file=/var/lib/postgresql/server.crt -c ssl_key_file=/var/lib/postgresql/server.key
 
@@ -308,7 +331,7 @@ services:
             POSTGRES_HOST_AUTH_METHOD: trust
             POSTGRES_INITDB_ARGS: --auth-host=trust
         volumes:
-            - "./postgres/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./postgres/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         command: >
             -c ssl=on -c ssl_cert_file=/var/lib/postgresql/server.crt -c ssl_key_file=/var/lib/postgresql/server.key -c ssl_ca_file=/var/lib/postgresql/ca.crt -c hba_file=/var/lib/postgresql/pg_hba.conf
 
@@ -327,7 +350,7 @@ services:
             POSTGRES_HOST_AUTH_METHOD: scram-sha-256
             POSTGRES_INITDB_ARGS: --auth-host=scram-sha-256
         volumes:
-            - "./postgres/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./postgres/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         command: >
             -c ssl=on -c ssl_cert_file=/var/lib/postgresql/server.crt -c ssl_key_file=/var/lib/postgresql/server.key
 
@@ -344,6 +367,6 @@ services:
             POSTGRES_HOST_AUTH_METHOD: trust
             POSTGRES_INITDB_ARGS: --auth-host=trust
         volumes:
-            - "./postgres/setup.sql:/docker-entrypoint-initdb.d/setup.sql"
+            - "./postgres/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         command: >
             -c ssl=on -c ssl_cert_file=/var/lib/postgresql/server.crt -c ssl_key_file=/var/lib/postgresql/server.key -c ssl_ca_file=/var/lib/postgresql/ca.crt -c hba_file=/var/lib/postgresql/pg_hba.conf

--- a/tests/x.py
+++ b/tests/x.py
@@ -222,7 +222,7 @@ for runtime in ["async-std", "tokio"]:
         # mariadb
         #
 
-        for version in ["10_6", "10_5", "10_4", "10_3"]:
+        for version in ["verylatest", "10_11", "10_6", "10_5", "10_4"]:
             run(
                 f"cargo test --no-default-features --features any,mysql,macros,_unstable-all-types,runtime-{runtime},tls-{tls}",
                 comment=f"test mariadb {version}",


### PR DESCRIPTION
With MariaDB 10.3 EOL it seems prudent to include the latest 10.11 LTS release in the CI tests.

To catch #1664 sort of issues prior to release, add a container image test for mariadb that contains the finished pre-release code changes (and container changes) to ensure that compatibility is maintianed. When server code hits the branch associated with this tag it is considered finished by its server developers and has passes CI so no regressions are expected, but it wouldn't hurt to have CI in other systems testing it too.

Since MySQL has fixed the regression that caused #1664 this puts it back to their 8.0 release tag.

Append the :z tag to the docker compose volume mounts so on selinux systems enough permissions occur for the volume to be able to read the volume contents.