### PR TITLE
Remove sealed trait comments from documentation

### DIFF
--- a/sqlx-core/src/column.rs
+++ b/sqlx-core/src/column.rs
@@ -28,8 +28,6 @@ pub trait Column: 'static + Send + Sync + Debug {
 /// This trait is implemented for strings which are used to look up a column by name, and for
 /// `usize` which is used as a positional index into the row.
 ///
-/// This trait is sealed and cannot be implemented for types outside of SQLx.
-///
 /// [`Row`]: crate::row::Row
 /// [`Statement`]: crate::statement::Statement
 /// [`get`]: crate::row::Row::get

--- a/sqlx-core/src/row.rs
+++ b/sqlx-core/src/row.rs
@@ -9,8 +9,6 @@ use crate::value::ValueRef;
 
 /// Represents a single row from the database.
 ///
-/// This trait is sealed and cannot be implemented for types outside of SQLx.
-///
 /// [`FromRow`]: crate::row::FromRow
 /// [`Query::fetch`]: crate::query::Query::fetch
 pub trait Row: Unpin + Send + Sync + 'static {


### PR DESCRIPTION
The `Row` and `ColumnIndex` traits used to be sealed, but that is not the case anymore. This PR removes the obsolete comments from the traits docs.