### PR TITLE
Is tests/x.py maintained? And I tried fix it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ target/
 # Shared-memory and WAL files created by SQLite.
 *-shm
 *-wal
+
+# Integration testing extension library for SQLite.
+ipaddr.dylib
+ipaddr.so

--- a/tests/docker.py
+++ b/tests/docker.py
@@ -2,6 +2,7 @@ import subprocess
 import sys
 import time
 from os import path
+import shutil
 
 # base dir of sqlx workspace
 dir_workspace = path.dirname(path.dirname(path.realpath(__file__)))
@@ -13,8 +14,12 @@ dir_tests = path.join(dir_workspace, "tests")
 # start database server and return a URL to use to connect
 def start_database(driver, database, cwd):
     if driver == "sqlite":
+        database = path.join(cwd, database)
+        (base_path, ext) = path.splitext(database)
+        new_database = f"{base_path}.test{ext}"
+        shutil.copy(database, new_database)
         # short-circuit for sqlite
-        return f"sqlite://{path.join(cwd, database)}"
+        return f"sqlite://{path.join(cwd, new_database)}"
 
     res = subprocess.run(
         ["docker-compose", "up", "-d", driver],

--- a/tests/sqlite/.gitignore
+++ b/tests/sqlite/.gitignore
@@ -1,2 +1,2 @@
-sqlite.db
+sqlite.test.db
 

--- a/tests/sqlite/any.rs
+++ b/tests/sqlite/any.rs
@@ -6,8 +6,7 @@ async fn it_encodes_bool_with_any() -> anyhow::Result<()> {
     sqlx::any::install_default_drivers();
     let mut conn = new::<Any>().await?;
 
-    let res = sqlx::query("INSERT INTO accounts VALUES (?, ?, ?)")
-        .bind(87)
+    let res = sqlx::query("INSERT INTO accounts (name, is_active) VALUES (?, ?)")
         .bind("Harrison Ford")
         .bind(true)
         .execute(&mut conn)

--- a/tests/x.py
+++ b/tests/x.py
@@ -79,6 +79,12 @@ def run(command, comment=None, env=None, service=None, tag=None, args=None, data
                 environ["RUSTFLAGS"] += " --cfg sqlite_ipaddr"
             else:
                 environ["RUSTFLAGS"] = "--cfg sqlite_ipaddr"
+            if platform.system() == "Linux":
+                if os.environ.get("LD_LIBRARY_PATH"):
+                    environ["LD_LIBRARY_PATH"]= os.environ.get("LD_LIBRARY_PATH") + ":"+ os.getcwd()
+                else:
+                    environ["LD_LIBRARY_PATH"]=os.getcwd()
+
 
     if service is not None:
         database_url = start_database(service, database="sqlite/sqlite.db" if service == "sqlite" else "sqlx", cwd=dir_tests)
@@ -110,7 +116,7 @@ def run(command, comment=None, env=None, service=None, tag=None, args=None, data
             *command.split(" "),
             *command_args
         ],
-        env=dict(**os.environ, **environ),
+        env=dict(list(os.environ.items()) + list(environ.items())),
         cwd=cwd,
     )
 

--- a/tests/x.py
+++ b/tests/x.py
@@ -207,12 +207,15 @@ for runtime in ["async-std", "tokio"]:
         #
 
         for version in ["8", "5_7"]:
-            run(
-                f"cargo test --no-default-features --features any,mysql,macros,_unstable-all-types,runtime-{runtime},tls-{tls}",
-                comment=f"test mysql {version}",
-                service=f"mysql_{version}",
-                tag=f"mysql_{version}" if runtime == "async-std" else f"mysql_{version}_{runtime}",
-            )
+            # Since docker mysql 5.7 using yaSSL(It only supports TLSv1.1), avoid running when using rustls.
+            # https://github.com/docker-library/mysql/issues/567
+            if not(version == "5_7" and tls == "rustls"):
+                run(
+                    f"cargo test --no-default-features --features any,mysql,macros,_unstable-all-types,runtime-{runtime},tls-{tls}",
+                    comment=f"test mysql {version}",
+                    service=f"mysql_{version}",
+                    tag=f"mysql_{version}" if runtime == "async-std" else f"mysql_{version}_{runtime}",
+                )
 
             ## +client-ssl
             if tls != "none" and not(version == "5_7" and tls == "rustls"):


### PR DESCRIPTION
Hello!
I found some bugs in `tests/x.py`.
Is it maintained?
Also, I tried fix it and made some small improvements.
Please use this if you like.

Here's contents of fixing and improvements.

### 1. Added ipaddr extension library to gitignore.(improve)
In Macos and Linux, download ipaddr binary when running `tests/x.py`.
However, they are targeting git modifications and it takes time and effort to remove them from the commit target.
So I added to gitignore ipaddr library files.

### 2. Added current directory to `LD_LIBRARY_PATH` environment variable.(fix)
In Linux, shared libraries in the current directory are not loaded, so add the current directory to the LD_LIBRARY_PATH environment variable.

### 3. Removed specific primary key in insert when testing sqlite.(fix)
In sqlite it_encodes_bool_with_any, originally it was inserted by specifying the primary key.
However, Since it_encodes_bool_with_any is executed for each test cases, it is conflicted.
So I removed specific primary key in insert.
From a testing perspective, it was to check whether bool encoding and AnyQueryResult worked, so I decided there was no problem.

### 4. Copy the db file to new testing db file when run sqlite testing.(improve)
After executed `tests/x.py`, the `tests/sqlite/sqlite.db` is modified and it is targeted git modifications.
It also takes time and effort to prevent this from being commited.
So I modified run function in `tests/x.py` to copy db file for each test cases when sqlite testing and changed sqlite.db to sqlite.test.db in gitignore file.

### 5. Avoid running test when cases are mysql5.7 and rustls.(fix)
Since [docker mysql 5.7 limitation](https://github.com/docker-library/mysql/issues/567), TLSv1.2 is not supported and rustls only supports TLSv1.2 and above, I modified `tests/x.py` to avoid running test when cases are mysql5.7 and rutls.