### PR TITLE
Remove unused `remove_dir_all` crate from `sqlx-cli`, fixes RUSTSEC-2023-0018

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2620,19 +2620,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "remove_dir_all"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882f368737489ea543bc5c340e6f3d34a28c39980bd9a979e47322b26f60ac40"
-dependencies = [
- "libc",
- "log",
- "num_cpus",
- "rayon",
- "winapi",
-]
-
-[[package]]
 name = "rend"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3127,7 +3114,6 @@ dependencies = [
  "glob",
  "openssl",
  "promptly",
- "remove_dir_all 0.7.0",
  "serde",
  "serde_json",
  "sqlx",
@@ -3578,7 +3564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 dependencies = [
  "rand 0.4.6",
- "remove_dir_all 0.5.3",
+ "remove_dir_all",
 ]
 
 [[package]]
@@ -3591,7 +3577,7 @@ dependencies = [
  "fastrand",
  "libc",
  "redox_syscall",
- "remove_dir_all 0.5.3",
+ "remove_dir_all",
  "winapi",
 ]
 

--- a/sqlx-cli/Cargo.toml
+++ b/sqlx-cli/Cargo.toml
@@ -45,8 +45,6 @@ serde_json = "1.0.73"
 serde = { version = "1.0.132", features = ["derive"] }
 glob = "0.3.0"
 openssl = { version = "0.10.38", optional = true }
-# workaround for https://github.com/rust-lang/rust/issues/29497
-remove_dir_all = "0.7.0"
 cargo_metadata = "0.14"
 filetime = "0.2"
 


### PR DESCRIPTION
Fix https://github.com/launchbadge/sqlx/issues/2755.

NOTES:

- The comment links to [this issue](https://github.com/rust-lang/rust/issues/29497), which relates to Windows. I don't have a Windows host handy to test, but I have seen that the CI covers it.
- Still, I have manually grepped for the three functions implemented by the crate at that version (https://docs.rs/remove_dir_all/0.7.0/remove_dir_all/index.html) and didn't find any reference in `sqlx-cli`.