### PR TITLE
Expose pipes_as_concat in the database URL

### DIFF
--- a/sqlx-mysql/src/options/parse.rs
+++ b/sqlx-mysql/src/options/parse.rs
@@ -72,6 +72,10 @@ impl MySqlConnectOptions {
                     options = options.socket(&*value);
                 }
 
+                "pipes_as_concat" => {
+                    options = options.pipes_as_concat(value.parse().map_err(Error::config)?);
+                }
+
                 _ => {}
             }
         }


### PR DESCRIPTION
The option to set `pipes_as_concat` is currently not exposed in the MySQL database URL parsing function.
Because some sqlx features like `cargo build` support and `cargo sqlx` can only be configured through a database URL this makes it impossible to work with some databases that don't support `PIPES_AS_CONCAT`.
This adds the ability to set the flag through the database URL, which makes it possible to work with those databases.