### PR TITLE
fix: decode postgres time without subsecond

### DIFF
--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -321,7 +321,8 @@ mod time_tests {
 
     test_type!(time_time<Time>(
         Postgres,
-        "TIME '05:10:20.115100'" == time!(5:10:20.115100)
+        "TIME '05:10:20.115100'" == time!(5:10:20.115100),
+        "TIME '05:10:20'" == time!(5:10:20)
     ));
 
     test_type!(time_date_time<PrimitiveDateTime>(


### PR DESCRIPTION
This resolves #2707 

### The cause of the issue
The issue is caused by Postgres.

Specifically, when we select `0:0:0.123` from Postgres, it properly returns `00:00:00.123`.
However, in the case of selecting `0:0:0.0`, it returns `00:00:00`, removing after the `.0`.

This leads to the error `Decode(ParseFromDescription(InvalidLiteral)`, because it does not match the `Time` format.
```
test=# select '0:0:0.0'::time;
   time
----------
 00:00:00
(1 row)

test=# select '0:0:0.123'::time;
     time
--------------
 00:00:00.123
(1 row)
```

To solve this, I implemented the same logic as `datetime`.


