### PR TITLE
derived Hash trait for PgInterval

### DIFF
--- a/sqlx-postgres/src/types/interval.rs
+++ b/sqlx-postgres/src/types/interval.rs
@@ -10,7 +10,7 @@ use crate::{PgArgumentBuffer, PgHasArrayType, PgTypeInfo, PgValueFormat, PgValue
 
 // `PgInterval` is available for direct access to the INTERVAL type
 
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, Hash)]
 pub struct PgInterval {
     pub months: i32,
     pub days: i32,


### PR DESCRIPTION
First of all, thank you for all the hard work you put into this library.

This is required for [these changes](https://github.com/SeaQL/sea-query/pull/709) in SeaQuery to work.