### PR TITLE
derive FromRow: sqlx(default) for all fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-std",
@@ -3096,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-cli"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3122,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "ahash 0.8.3",
  "async-io",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3319,7 +3319,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-std",
  "dotenvy",
@@ -3344,7 +3344,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "atoi",
  "base64 0.21.0",
@@ -3389,7 +3389,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "atoi",
  "base64 0.21.0",
@@ -3435,7 +3435,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "atoi",
  "chrono",

--- a/sqlx-core/src/from_row.rs
+++ b/sqlx-core/src/from_row.rs
@@ -91,6 +91,20 @@ use crate::{error::Error, row::Row};
 /// will set the value of the field `location` to the default value of `Option<String>`,
 /// which is `None`.
 ///
+/// Moreover, if all field types have an implementation for [`Default`], you can use the `default``
+/// attribute at the struct level rather than each single field.
+/// For example:
+///
+/// ```rust, ignore
+/// #[derive(sqlx::FromRow)]
+/// #[sqlx(default)]
+/// struct Options {
+///     option_a: Option<i32>,
+///     option_b: Option<String>,
+///     option_c: Option<bool>,
+/// }
+/// ```
+///
 /// ### `flatten`
 ///
 /// If you want to handle a field that implements [`FromRow`],

--- a/sqlx-core/src/from_row.rs
+++ b/sqlx-core/src/from_row.rs
@@ -91,12 +91,13 @@ use crate::{error::Error, row::Row};
 /// will set the value of the field `location` to the default value of `Option<String>`,
 /// which is `None`.
 ///
-/// Moreover, if all field types have an implementation for [`Default`], you can use the `default``
-/// attribute at the struct level rather than each single field.
+/// Moreover, if the struct has an implementation for [`Default`], you can use the `default``
+/// attribute at the struct level rather than for each single field. This way the default
+/// value of each attribute is optained from the particular `Default` implementation.
 /// For example:
 ///
 /// ```rust, ignore
-/// #[derive(sqlx::FromRow)]
+/// #[derive(Default, sqlx::FromRow)]
 /// #[sqlx(default)]
 /// struct Options {
 ///     option_a: Option<i32>,

--- a/sqlx-core/src/from_row.rs
+++ b/sqlx-core/src/from_row.rs
@@ -92,8 +92,8 @@ use crate::{error::Error, row::Row};
 /// which is `None`.
 ///
 /// Moreover, if the struct has an implementation for [`Default`], you can use the `default``
-/// attribute at the struct level rather than for each single field. This way the default
-/// value of each attribute is optained from the particular `Default` implementation.
+/// attribute at the struct level rather than for each single field. If a field does not appear in the result,
+/// its value is taken from the `Default` implementation for the struct.
 /// For example:
 ///
 /// ```rust, ignore

--- a/sqlx-core/src/from_row.rs
+++ b/sqlx-core/src/from_row.rs
@@ -106,11 +106,11 @@ use crate::{error::Error, row::Row};
 /// }
 /// ```
 ///
-/// For a derived `Default` implementation this effectively populates each missing field 
+/// For a derived `Default` implementation this effectively populates each missing field
 /// with `Default::default()`, but a manual `Default` implementation can provide
 /// different placeholder values, if applicable.
 ///
-/// This is similar to how `#[serde(default)]` behaves. 
+/// This is similar to how `#[serde(default)]` behaves.
 /// ### `flatten`
 ///
 /// If you want to handle a field that implements [`FromRow`],

--- a/sqlx-core/src/from_row.rs
+++ b/sqlx-core/src/from_row.rs
@@ -106,6 +106,11 @@ use crate::{error::Error, row::Row};
 /// }
 /// ```
 ///
+/// For a derived `Default` implementation this effectively populates each missing field 
+/// with `Default::default()`, but a manual `Default` implementation can provide
+/// different placeholder values, if applicable.
+///
+/// This is similar to how `#[serde(default)]` behaves. 
 /// ### `flatten`
 ///
 /// If you want to handle a field that implements [`FromRow`],

--- a/sqlx-macros-core/src/derives/attributes.rs
+++ b/sqlx-macros-core/src/derives/attributes.rs
@@ -57,6 +57,7 @@ pub struct SqlxContainerAttributes {
     pub rename_all: Option<RenameAll>,
     pub repr: Option<Ident>,
     pub no_pg_array: bool,
+    pub default: bool,
 }
 
 pub struct SqlxChildAttributes {
@@ -74,6 +75,7 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
     let mut type_name = None;
     let mut rename_all = None;
     let mut no_pg_array = None;
+    let mut default = None;
 
     for attr in input
         .iter()
@@ -129,6 +131,10 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
                                 )
                             }
 
+                            Meta::Path(p) if p.is_ident("default") => {
+                                try_set!(default, true, value)
+                            }
+
                             u => fail!(u, "unexpected attribute"),
                         },
                         u => fail!(u, "unexpected attribute"),
@@ -156,6 +162,7 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
         type_name,
         rename_all,
         no_pg_array: no_pg_array.unwrap_or(false),
+        default: default.unwrap_or(false),
     })
 }
 

--- a/sqlx-macros-core/src/derives/row.rs
+++ b/sqlx-macros-core/src/derives/row.rs
@@ -65,6 +65,17 @@ fn expand_derive_from_row_struct(
 
     let container_attributes = parse_container_attributes(&input.attrs)?;
 
+    let default_instance: Option<Stmt>;
+
+    if container_attributes.default {
+        predicates.push(parse_quote!(#ident: ::std::default::Default));
+        default_instance = Some(parse_quote!(
+            let __default = #ident::default();
+        ));
+    } else {
+        default_instance = None;
+    }
+
     let reads: Vec<Stmt> = fields
         .iter()
         .filter_map(|field| -> Option<Stmt> {
@@ -141,13 +152,20 @@ fn expand_derive_from_row_struct(
                 },
             };
 
-            if attributes.default || container_attributes.default {
+            if attributes.default {
                 Some(parse_quote!(let #id: #ty = #expr.or_else(|e| match e {
                 ::sqlx::Error::ColumnNotFound(_) => {
                     ::std::result::Result::Ok(Default::default())
                 },
                 e => ::std::result::Result::Err(e)
             })?;))
+            } else if container_attributes.default {
+                Some(parse_quote!(let #id: #ty = #expr.or_else(|e| match e {
+                    ::sqlx::Error::ColumnNotFound(_) => {
+                        ::std::result::Result::Ok(__default.#id)
+                    },
+                    e => ::std::result::Result::Err(e)
+                })?;))
             } else {
                 Some(parse_quote!(
                     let #id: #ty = #expr?;
@@ -164,6 +182,8 @@ fn expand_derive_from_row_struct(
         #[automatically_derived]
         impl #impl_generics ::sqlx::FromRow<#lifetime, R> for #ident #ty_generics #where_clause {
             fn from_row(row: &#lifetime R) -> ::sqlx::Result<Self> {
+                #default_instance
+
                 #(#reads)*
 
                 ::std::result::Result::Ok(#ident {

--- a/sqlx-macros-core/src/derives/row.rs
+++ b/sqlx-macros-core/src/derives/row.rs
@@ -141,7 +141,7 @@ fn expand_derive_from_row_struct(
                 },
             };
 
-            if attributes.default {
+            if attributes.default || container_attributes.default {
                 Some(parse_quote!(let #id: #ty = #expr.or_else(|e| match e {
                 ::sqlx::Error::ColumnNotFound(_) => {
                     ::std::result::Result::Ok(Default::default())

--- a/tests/postgres/derives.rs
+++ b/tests/postgres/derives.rs
@@ -627,7 +627,7 @@ async fn test_struct_default() -> anyhow::Result<()> {
     #[derive(Debug, sqlx::FromRow)]
     #[sqlx(default)]
     struct HasDefault {
-        value: Option<i32>,
+        not_default: Option<i32>,
         default_a: Option<String>,
         default_b: Option<i32>,
     }
@@ -639,7 +639,7 @@ async fn test_struct_default() -> anyhow::Result<()> {
         .await?;
     println!("{has_default:?}");
 
-    assert_eq!(has_default.value, Some(1));
+    assert_eq!(has_default.not_default, Some(1));
     assert_eq!(has_default.default_a, None);
     assert_eq!(has_default.default_b, None);
 

--- a/tests/postgres/derives.rs
+++ b/tests/postgres/derives.rs
@@ -632,6 +632,16 @@ async fn test_struct_default() -> anyhow::Result<()> {
         default_b: Option<i32>,
     }
 
+    impl Default for HasDefault {
+        fn default() -> HasDefault {
+            HasDefault {
+                not_default: None,
+                default_a: None,
+                default_b: Some(0),
+            }
+        }
+    }
+
     let mut conn = new::<Postgres>().await?;
 
     let has_default: HasDefault = sqlx::query_as(r#"SELECT 1 AS not_default"#)
@@ -641,7 +651,7 @@ async fn test_struct_default() -> anyhow::Result<()> {
 
     assert_eq!(has_default.not_default, Some(1));
     assert_eq!(has_default.default_a, None);
-    assert_eq!(has_default.default_b, None);
+    assert_eq!(has_default.default_b, Some(0));
 
     Ok(())
 }

--- a/tests/postgres/derives.rs
+++ b/tests/postgres/derives.rs
@@ -623,6 +623,31 @@ async fn test_default() -> anyhow::Result<()> {
 
 #[cfg(feature = "macros")]
 #[sqlx_macros::test]
+async fn test_struct_default() -> anyhow::Result<()> {
+    #[derive(Debug, sqlx::FromRow)]
+    #[sqlx(default)]
+    struct HasDefault {
+        value: Option<i32>,
+        default_a: Option<String>,
+        default_b: Option<i32>,
+    }
+
+    let mut conn = new::<Postgres>().await?;
+
+    let has_default: HasDefault = sqlx::query_as(r#"SELECT 1 AS not_default"#)
+        .fetch_one(&mut conn)
+        .await?;
+    println!("{has_default:?}");
+
+    assert_eq!(has_default.value, Some(1));
+    assert_eq!(has_default.default_a, None);
+    assert_eq!(has_default.default_b, None);
+
+    Ok(())
+}
+
+#[cfg(feature = "macros")]
+#[sqlx_macros::test]
 async fn test_flatten() -> anyhow::Result<()> {
     #[derive(Debug, Default, sqlx::FromRow)]
     struct AccountDefault {


### PR DESCRIPTION
This commit adds `sqlx(default)` as a struct attribute when deriving `FromRow` - imitating the similar behaviour of `serde(default)`. E.g. the following two definitions are equivalent:

```rust
#[derive(sqlx::FromRow)]
#[sqlx(default)]
struct Options {
    option_a: Option<String>,
    option_b: Option<i32>,
}
```

derives the same `FromRow` implementation as

```rust
#[derive(sqlx::FromRow)]
struct Options {
    #[sqlx(default)]
    option_a: Option<String>,
    #[sqlx(default)]
    option_b: Option<i32>,
}
```
