### PR TITLE
Depend on version of async-std with non-private spawn-blocking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ dotenvy = { version = "0.15.0", default-features = false }
 
 # Runtimes
 [workspace.dependencies.async-std]
-version = "1"
+version = "1.12"
 
 [workspace.dependencies.tokio]
 version = "1"
@@ -162,7 +162,7 @@ anyhow = "1.0.52"
 time_ = { version = "0.3.2", package = "time" }
 futures = "0.3.19"
 env_logger = "0.9.0"
-async-std = { version = "1.10.0", features = ["attributes"] }
+async-std = { version = "1.12.0", features = ["attributes"] }
 tokio = { version = "1.15.0", features = ["full"] }
 dotenvy = "0.15.0"
 trybuild = "1.0.53"


### PR DESCRIPTION
I had been running into compilation failures because async-std's `task::spawn_blocking` function was marked as private. Upgrading my project to use async-std 1.12 fixed compilation, but I wondered why sqlx didn't encode this requirement.

The function was stabilized in async-std 1.12 (https://github.com/async-rs/async-std/pull/1017) -- according to what I read, `spawn_blocking` previously required a feature flag. It seems sensible to declare this requirement in sqlx.