### PR TITLE
Allow External Users to Define Custom Sqlite Types

### DIFF
--- a/sqlx-sqlite/src/lib.rs
+++ b/sqlx-sqlite/src/lib.rs
@@ -43,7 +43,7 @@ pub use query_result::SqliteQueryResult;
 pub use row::SqliteRow;
 pub use statement::SqliteStatement;
 pub use transaction::SqliteTransactionManager;
-pub use type_info::SqliteTypeInfo;
+pub use type_info::{SqliteTypeInfo, DataType as SqliteType};
 pub use value::{SqliteValue, SqliteValueRef};
 
 use crate::connection::establish::EstablishParams;

--- a/sqlx-sqlite/src/type_info.rs
+++ b/sqlx-sqlite/src/type_info.rs
@@ -10,7 +10,7 @@ pub(crate) use sqlx_core::type_info::*;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "offline", derive(serde::Serialize, serde::Deserialize))]
-pub(crate) enum DataType {
+pub enum DataType {
     Null,
     Int,
     Float,
@@ -32,7 +32,7 @@ pub(crate) enum DataType {
 /// Type information for a SQLite type.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "offline", derive(serde::Serialize, serde::Deserialize))]
-pub struct SqliteTypeInfo(pub(crate) DataType);
+pub struct SqliteTypeInfo(pub DataType);
 
 impl Display for SqliteTypeInfo {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {

--- a/sqlx-sqlite/src/value.rs
+++ b/sqlx-sqlite/src/value.rs
@@ -23,35 +23,35 @@ enum SqliteValueData<'r> {
 pub struct SqliteValueRef<'r>(SqliteValueData<'r>);
 
 impl<'r> SqliteValueRef<'r> {
-    pub(crate) fn value(value: &'r SqliteValue) -> Self {
+    pub fn value(value: &'r SqliteValue) -> Self {
         Self(SqliteValueData::Value(value))
     }
 
-    pub(super) fn int(&self) -> i32 {
+    pub fn int(&self) -> i32 {
         match self.0 {
             SqliteValueData::Value(v) => v.int(),
         }
     }
 
-    pub(super) fn int64(&self) -> i64 {
+    pub fn int64(&self) -> i64 {
         match self.0 {
             SqliteValueData::Value(v) => v.int64(),
         }
     }
 
-    pub(super) fn double(&self) -> f64 {
+    pub fn double(&self) -> f64 {
         match self.0 {
             SqliteValueData::Value(v) => v.double(),
         }
     }
 
-    pub(super) fn blob(&self) -> &'r [u8] {
+    pub fn blob(&self) -> &'r [u8] {
         match self.0 {
             SqliteValueData::Value(v) => v.blob(),
         }
     }
 
-    pub(super) fn text(&self) -> Result<&'r str, BoxDynError> {
+    pub fn text(&self) -> Result<&'r str, BoxDynError> {
         match self.0 {
             SqliteValueData::Value(v) => v.text(),
         }


### PR DESCRIPTION
I opened Issue #2814 earlier about this issue. Currently the postgres crate exposes the equivalent types that I've made available here. Without these there isn't a way to create custom implementations of the `sqlx::Type` trait when using a custom implementation of `sqlx::Encode` and `sqlx::Decode`.

I renamed the DataType in the exports to match the Pg version for consistency.