### PR TITLE
postgres begin cancel safe

### DIFF
--- a/sqlx-postgres/src/transaction.rs
+++ b/sqlx-postgres/src/transaction.rs
@@ -15,10 +15,12 @@ impl TransactionManager for PgTransactionManager {
 
     fn begin(conn: &mut PgConnection) -> BoxFuture<'_, Result<(), Error>> {
         Box::pin(async move {
-            conn.execute(&*begin_ansi_transaction_sql(conn.transaction_depth))
-                .await?;
-
-            conn.transaction_depth += 1;
+            let rollback = Rollback::new(conn);
+            let query = begin_ansi_transaction_sql(rollback.conn.transaction_depth);
+            rollback.conn.queue_simple_query(&query);
+            rollback.conn.transaction_depth += 1;
+            rollback.conn.wait_until_ready().await?;
+            rollback.defuse();
 
             Ok(())
         })
@@ -56,5 +58,30 @@ impl TransactionManager for PgTransactionManager {
 
             conn.transaction_depth -= 1;
         }
+    }
+}
+
+struct Rollback<'c> {
+    conn: &'c mut PgConnection,
+    defuse: bool,
+}
+
+impl Drop for Rollback<'_> {
+    fn drop(&mut self) {
+        if !self.defuse {
+            PgTransactionManager::start_rollback(self.conn)
+        }
+    }
+}
+
+impl<'c> Rollback<'c> {
+    fn new(conn: &'c mut PgConnection) -> Self {
+        Self {
+            conn,
+            defuse: false,
+        }
+    }
+    fn defuse(mut self) {
+        self.defuse = true;
     }
 }


### PR DESCRIPTION
This attempts to make Postgres's begin step more cancel safe than it used to be. 

1. Using execute to perform a `begin` is overkill, so I have switched to using the simple query protocol like sqlx uses in drop-rollback - this is inspired by tokio-postgres.
2. Implement a short lived drop-rollback struct to start the rollback incase of error/panic/cancel during `wait_until_ready`

Because we guarantee to write a BEGIN/SAVEPOINT to the PgStream, any drops will definitely rollback to that point and not to a parent BEGIN. The previous impl could be cancelled at the prepare/bind and not need to be rolled back, so applying this drop guard would not be so safe

cc #2805