### PR TITLE
Update extra_float_digits default to 2 instead of 3

### DIFF
--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -165,7 +165,7 @@ impl PgConnectOptions {
                 .unwrap_or_default(),
             statement_cache_capacity: 100,
             application_name: var("PGAPPNAME").ok(),
-            extra_float_digits: Some("3".into()),
+            extra_float_digits: Some("2".into()),
             log_settings: Default::default(),
             options: var("PGOPTIONS").ok(),
         }


### PR DESCRIPTION
Update `extra_float_digits` to default to `2` instead of `3` to address https://github.com/launchbadge/sqlx/issues/801 following the advice provided in https://github.com/launchbadge/sqlx/pull/2708.