### PR TITLE
Fix comment in `sqlx migrate add` help text

### DIFF
--- a/sqlx-cli/src/opt.rs
+++ b/sqlx-cli/src/opt.rs
@@ -140,7 +140,7 @@ pub enum MigrateCommand {
         #[clap(short, long)]
         timestamp: bool,
 
-        /// If set, use timestamp versioning for the new migration. Conflicts with `--timestamp`.
+        /// If set, use sequential versioning for the new migration. Conflicts with `--timestamp`.
         #[clap(short, long, conflicts_with = "timestamp")]
         sequential: bool,
     },


### PR DESCRIPTION
The old description for the `sequential` flag read "If set, use *timestamp* versioning". I guess this was a simple copy-paste error.