### PR TITLE
Added support fetching (pg) enums that are not in the public schema

### DIFF
--- a/sqlx-postgres/src/connection/describe.rs
+++ b/sqlx-postgres/src/connection/describe.rs
@@ -228,7 +228,7 @@ impl PgConnection {
                 }
 
                 (Ok(TypType::Enum), Ok(TypCategory::Enum)) => {
-                    self.fetch_enum_by_oid(oid, namespaced_name).await
+                    self.fetch_enum_by_oid(oid, name).await
                 }
 
                 (Ok(TypType::Composite), Ok(TypCategory::Composite)) => {

--- a/sqlx-postgres/src/connection/describe.rs
+++ b/sqlx-postgres/src/connection/describe.rs
@@ -185,10 +185,10 @@ impl PgConnection {
 
     fn fetch_type_by_oid(&mut self, oid: Oid) -> BoxFuture<'_, Result<PgTypeInfo, Error>> {
         Box::pin(async move {
-            let (name, typ_type, category, relation_id, element, base_type, namespace): (String, i8, i8, Oid, Oid, Oid, String) = query_as(
+            let (name, typ_type, category, relation_id, element, base_type): (String, i8, i8, Oid, Oid, Oid) = query_as(
                 r#"
                     SELECT
-                        t.typname, t.typtype, t.typcategory, t.typrelid, t.typelem, t.typbasetype, n.nspname
+                        n.nspname || '.' || t.typname, t.typtype, t.typcategory, t.typrelid, t.typelem, t.typbasetype
                     FROM
                         pg_catalog.pg_type t
                     LEFT JOIN
@@ -198,8 +198,6 @@ impl PgConnection {
                 .bind(oid)
                 .fetch_one(&mut *self)
                 .await?;
-
-            let namespaced_name = namespace + "." + &name;
 
             let typ_type = TypType::try_from(typ_type as u8);
             let category = TypCategory::try_from(category as u8);

--- a/sqlx-postgres/src/connection/describe.rs
+++ b/sqlx-postgres/src/connection/describe.rs
@@ -193,11 +193,12 @@ impl PgConnection {
                         pg_catalog.pg_type t
                     LEFT JOIN
                         pg_catalog.pg_namespace n ON t.typnamespace = n.oid
-                    WHERE t.oid = $1"#,
+                    WHERE t.oid = $1
+                    "#,
             )
-                .bind(oid)
-                .fetch_one(&mut *self)
-                .await?;
+            .bind(oid)
+            .fetch_one(&mut *self)
+            .await?;
 
             let typ_type = TypType::try_from(typ_type as u8);
             let category = TypCategory::try_from(category as u8);

--- a/tests/postgres/describe.rs
+++ b/tests/postgres/describe.rs
@@ -52,7 +52,7 @@ async fn it_describes_enum() -> anyhow::Result<()> {
 
     let ty = d.columns()[0].type_info();
 
-    assert_eq!(ty.name(), "status");
+    assert_eq!(ty.name(), "public.status");
 
     assert_eq!(
         format!("{:?}", ty.kind()),
@@ -84,7 +84,7 @@ async fn it_describes_composite() -> anyhow::Result<()> {
 
     let ty = d.columns()[0].type_info();
 
-    assert_eq!(ty.name(), "inventory_item");
+    assert_eq!(ty.name(), "public.inventory_item");
 
     assert_eq!(
         format!("{:?}", ty.kind()),


### PR DESCRIPTION
### Does your PR solve an issue?

This PR allow fetching postgres enums which are not in a public schema.

This has already been fixed in both these places https://github.com/launchbadge/sqlx/pull/2638 and https://github.com/launchbadge/sqlx/pull/2791, but this PR extracts the schema-type qualification patch.