### PR TITLE
Add `MySqlConnectOptions::get_database()` 

### DIFF
--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -152,6 +152,20 @@ impl MySqlConnectOptions {
         self
     }
 
+    /// Get the current database name.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use sqlx_core::mysql::MySqlConnectOptions;
+    /// let options = MySqlConnectOptions::new()
+    ///     .database("mysqldb");
+    /// assert!(options.get_database().is_some());
+    /// ```
+    pub fn get_database(&self) -> Option<&str> {
+        self.database.as_deref()
+    }
+
     /// Sets whether or with what priority a secure SSL TCP/IP connection will be negotiated
     /// with the server.
     ///


### PR DESCRIPTION
The Postgres implementation has this method. It is also helpful for queries that require the current database name. example:

```sql
SELECT table_name FROM INFORMATION_SCHEMA.TABLES WHERE table_name = ? &&
table_schema = ?;
```

### Does your PR solve an issue?
No
