### PR TITLE
Make WeekDay and Month enumerators public for `time` and `chrono` features

### DIFF
--- a/sqlx-core/src/types/mod.rs
+++ b/sqlx-core/src/types/mod.rs
@@ -53,7 +53,7 @@ pub use bit_vec::BitVec;
 #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
 pub mod time {
     #[doc(no_inline)]
-    pub use time::{Date, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
+    pub use time::{Date, Month, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset, Weekday};
 }
 
 #[cfg(feature = "bigdecimal")]

--- a/sqlx-core/src/types/mod.rs
+++ b/sqlx-core/src/types/mod.rs
@@ -40,7 +40,7 @@ pub use uuid::{self, Uuid};
 pub mod chrono {
     #[doc(no_inline)]
     pub use chrono::{
-        DateTime, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc,
+        DateTime, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc, Weekday,
     };
 }
 


### PR DESCRIPTION
Without making `Weekday` and `Month` enumerators public for `time` and `chrono` features, it gets hard to retrieve week information when either a date or a timestamp is saved within a `Postgres` database.

This PR exports:

- `Weekday` and `Month` for `time` crate
- `Weekday` for `chrono` crate 

Thanks in advance for your review! 