### PR TITLE
fix(mysql): Close prepared statement if persistence is disabled

### DIFF
--- a/tests/mysql/mysql.rs
+++ b/tests/mysql/mysql.rs
@@ -238,6 +238,57 @@ async fn it_caches_statements() -> anyhow::Result<()> {
 }
 
 #[sqlx_macros::test]
+async fn it_closes_statements_with_persistent_disabled() -> anyhow::Result<()> {
+    let mut conn = new::<MySql>().await?;
+
+    let old_statement_count = select_statement_count(&mut conn).await.unwrap_or_default();
+
+    for i in 0..2 {
+        let row = sqlx::query("SELECT ? AS val")
+            .bind(i)
+            .persistent(false)
+            .fetch_one(&mut conn)
+            .await?;
+
+        let val: i32 = row.get("val");
+
+        assert_eq!(i, val);
+    }
+
+    let new_statement_count = select_statement_count(&mut conn).await.unwrap_or_default();
+
+    assert_eq!(old_statement_count, new_statement_count);
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
+async fn it_closes_statements_with_cache_disabled() -> anyhow::Result<()> {
+    setup_if_needed();
+
+    let mut url = url::Url::parse(&env::var("DATABASE_URL")?)?;
+    url.query_pairs_mut()
+        .append_pair("statement-cache-capacity", "0");
+
+    let mut conn = MySqlConnection::connect(url.as_ref()).await?;
+
+    let old_statement_count = select_statement_count(&mut conn).await.unwrap_or_default();
+
+    for index in 1..=10_i32 {
+        let _ = sqlx::query("SELECT ?")
+            .bind(index)
+            .execute(&mut conn)
+            .await?;
+    }
+
+    let new_statement_count = select_statement_count(&mut conn).await.unwrap_or_default();
+
+    assert_eq!(old_statement_count, new_statement_count);
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
 async fn it_can_bind_null_and_non_null_issue_540() -> anyhow::Result<()> {
     let mut conn = new::<MySql>().await?;
 
@@ -509,4 +560,19 @@ async fn test_shrink_buffers() -> anyhow::Result<()> {
     assert_eq!(ret, 12345678i64);
 
     Ok(())
+}
+
+async fn select_statement_count(conn: &mut MySqlConnection) -> Result<i64, sqlx::Error> {
+    // Fails if performance schema does not exist
+    sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM performance_schema.threads AS t
+        INNER JOIN performance_schema.prepared_statements_instances AS psi
+            ON psi.OWNER_THREAD_ID = t.THREAD_ID 
+        WHERE t.processlist_id = CONNECTION_ID()
+        "#,
+    )
+    .fetch_one(conn)
+    .await
 }


### PR DESCRIPTION
This pull request fixes an issue that prepared statements are not closed if persistence or statement cache are disabled.


### How to reproduce this issue

```rust
use sqlx::{Connection, MySqlConnection, Row};

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let url = std::env::var("DATABASE_URL")?;
    let mut connection = MySqlConnection::connect(&url).await?;

    for i in 0..10 {
        let _ = sqlx::query("SELECT ? AS val")
            .bind(i)
            .persistent(false)
            .fetch_one(&mut connection)
            .await?;
    }

    let rows = sqlx::query(
        r#"
        SELECT 
              psi.STATEMENT_ID
            , psi.SQL_TEXT
        FROM performance_schema.threads AS t
        INNER JOIN performance_schema.prepared_statements_instances AS psi
            ON psi.OWNER_THREAD_ID = t.THREAD_ID 
        WHERE t.processlist_id = CONNECTION_ID()
        "#,
    )
    .fetch_all(&mut connection)
    .await?;

    for row in rows {
        let id: u64 = row.try_get("STATEMENT_ID")?;
        let sql: String = row.try_get("SQL_TEXT")?;

        println!("ID: {id}; SQL: {sql}");
    }

    Ok(())
}
```

#### Output:
```
ID: 1; SQL: SELECT ? AS val
ID: 3; SQL: SELECT ? AS val
ID: 5; SQL: SELECT ? AS val
ID: 7; SQL: SELECT ? AS val
ID: 9; SQL: SELECT ? AS val
ID: 11; SQL: SELECT ? AS val
ID: 13; SQL: SELECT ? AS val
ID: 15; SQL: SELECT ? AS val
ID: 17; SQL: SELECT ? AS val
ID: 19; SQL: SELECT ? AS val
ID: 21; SQL: SELECT
              psi.STATEMENT_ID
            , psi.SQL_TEXT
        FROM performance_schema.threads AS t
        INNER JOIN performance_schema.prepared_statements_instances AS psi
            ON psi.OWNER_THREAD_ID = t.THREAD_ID
        WHERE t.processlist_id = CONNECTION_ID()
```
I only expect the last statement in the output.


### Info
SQLx version: 0.7.3
Database server: MySQL 8.0.33