### PR TITLE
Fix migration for files with no number befor _

### DIFF
--- a/sqlx-macros-core/src/migrate.rs
+++ b/sqlx-macros-core/src/migrate.rs
@@ -93,7 +93,13 @@ pub(crate) fn expand_migrator(path: &Path) -> crate::Result<TokenStream> {
             continue;
         }
 
-        let version: i64 = parts[0].parse()?;
+        let version = match parts[0].parse::<i64>() {
+            Ok(v) => v,
+            Err(_) => {
+                // not of the format: <VERSION>_<DESCRIPTION>.sql; ignore
+                continue;
+            }
+        };
 
         let migration_type = MigrationType::from_filename(parts[1]);
         // remove the `.sql` and replace `_` with ` `


### PR DESCRIPTION
Hello,
As a noob, I lost a few hours of my life with this cryptic error message

```rust
#[cfg(test)]
mod tests {
    use sqlx::SqlitePool;

    use super::*;
 
    #[sqlx::test]
    async fn auth_test(pool: SqlitePool) -> sqlx::Result<()> {
    ...
    }
}
```

```

error: macros that expand to items must be delimited with braces or followed by a semicolon
   --> src/app_tokens.rs:128:5
    |
128 |     #[sqlx::test]
    |     ^^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `sqlx::test` (in Nightly builds, run with -Z macro-backtrace for more info)

error: invalid digit found in string
   --> src/app_tokens.rs:128:5
    |
128 |     #[sqlx::test]
    |     ^^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `sqlx::test` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This error was result of wrong naming in my migration file. I copied file app_user.sql into the migrations dir.
After some digging, I make this small pr. 

Thanks.
