### PR TITLE
Use `create_new` instead of `atomic-file-write`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,16 +335,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atomic-write-file"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c232177ba50b16fe7a4588495bd474a62a9e45a8e4ca6fd7d0b7ac29d164631e"
-dependencies = [
- "nix 0.26.4",
- "rand 0.8.5",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1922,7 +1912,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4863ee94f19ed315bf3bc00299338d857d4b5bc856af375cc97d237382ad3856"
 dependencies = [
- "nix 0.23.2",
+ "nix",
  "winapi",
 ]
 
@@ -1953,15 +1943,6 @@ name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
@@ -2073,19 +2054,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset 0.6.5",
-]
-
-[[package]]
-name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.7.1",
- "pin-utils",
 ]
 
 [[package]]
@@ -2906,7 +2874,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix 0.23.2",
+ "nix",
  "radix_trie",
  "scopeguard",
  "smallvec",
@@ -3461,7 +3429,6 @@ name = "sqlx-macros-core"
 version = "0.7.3"
 dependencies = [
  "async-std",
- "atomic-write-file",
  "dotenvy",
  "either",
  "heck 0.4.1",

--- a/sqlx-macros-core/Cargo.toml
+++ b/sqlx-macros-core/Cargo.toml
@@ -48,7 +48,6 @@ tokio = { workspace = true, optional = true }
 
 dotenvy = { workspace = true }
 
-atomic-write-file = { version = "0.1" }
 hex = { version = "0.4.3" }
 heck = { version = "0.4", features = ["unicode"] }
 either = "1.6.1"


### PR DESCRIPTION
This provides the same functionality but without temporary files, platform-specific code, fragility of `O_TMPFILE` support, and an extra dependency.