### PR TITLE
Add Debug impl for PgRow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1899,9 +1899,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
  "cc",
  "pkg-config",


### PR DESCRIPTION
fixes #150

Adds partial `Debug` impl for `PgRow`. Utilises a mapping between `PgType` variants and types. For the variants for which the mapping is not defined falls back to string or binary representation.