### PR TITLE
fix duplicate "`" in FromRow "default" attribute doc comment

### DIFF
--- a/sqlx-core/src/from_row.rs
+++ b/sqlx-core/src/from_row.rs
@@ -91,7 +91,7 @@ use crate::{error::Error, row::Row};
 /// will set the value of the field `location` to the default value of `Option<String>`,
 /// which is `None`.
 ///
-/// Moreover, if the struct has an implementation for [`Default`], you can use the `default``
+/// Moreover, if the struct has an implementation for [`Default`], you can use the `default`
 /// attribute at the struct level rather than for each single field. If a field does not appear in the result,
 /// its value is taken from the `Default` implementation for the struct.
 /// For example:


### PR DESCRIPTION
Fix a tiny doc error:
https://docs.rs/sqlx/latest/sqlx/trait.FromRow.html#default

<img width="957" alt="image" src="https://github.com/launchbadge/sqlx/assets/562720/dd153eed-af8a-4cf5-aaab-7b07eb432fac">
