### PR TITLE
fix: don't use arguments if they are empty when running a query in the postgres driver

### DIFF
--- a/sqlx-postgres/src/arguments.rs
+++ b/sqlx-postgres/src/arguments.rs
@@ -102,6 +102,10 @@ impl PgArguments {
 
         Ok(())
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.types.is_empty()
+    }
 }
 
 impl<'q> Arguments<'q> for PgArguments {

--- a/sqlx-postgres/src/connection/executor.rs
+++ b/sqlx-postgres/src/connection/executor.rs
@@ -206,6 +206,9 @@ impl PgConnection {
 
         let mut metadata: Arc<PgStatementMetadata>;
 
+        // don't use arguments if they are actually empty
+        let arguments = arguments.and_then(|args| if args.is_empty() { None } else { Some(args) });
+
         let format = if let Some(mut arguments) = arguments {
             // prepare the statement if this our first time executing it
             // always return the statement ID here

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -1813,3 +1813,17 @@ async fn test_shrink_buffers() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[sqlx_macros::test]
+async fn it_executes_multiple() -> anyhow::Result<()> {
+    let mut conn = new::<Postgres>().await?;
+
+    sqlx::query("SELECT 1; SELECT 1;")
+        .execute_many(&pool)
+        .await
+        .inspect_err(|err| panic!("{err}"))
+        .count()
+        .await;
+
+    Ok(())
+}


### PR DESCRIPTION
### Does your PR solve an issue?
Kind of:
- https://github.com/launchbadge/sqlx/discussions/2210
- https://github.com/launchbadge/sqlx/discussions/2448

At the moment, this will throw an error with Postgres:

```rust
sqlx::query("SELECT 1; SELECT 1;")
    .execute_many(&pool)
    .await
    .inspect_err(|err| panic!("{err}"))
    .count()
    .await;
```

```
error returned from database: cannot insert multiple commands into a prepared statement
```

Because the query will by default set up empty arguments array and the driver treats the query as if it had arguments.

This on the other hand works fine:

```rust
pool.execute("SELECT 1; SELECT 1;").await.unwrap();
```
In fact, this is why the migrator impl for Postgres doesn't hit this issue.

I've patched the postgres driver to ignore arguments if they are empty, but really it's just a proposal, idk if that's the right solution.
