### PR TITLE
Fix broken doc link in sqlx::migrate!

### DIFF
--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -721,7 +721,7 @@ macro_rules! query_file_scalar_unchecked (
     )
 );
 
-/// Embeds migrations into the binary by expanding to a static instance of [Migrator][crate::migrate::Migrator].
+/// Embeds migrations into the binary.
 ///
 /// ```rust,ignore
 /// sqlx::migrate!("db/migrations")


### PR DESCRIPTION
Target is doc(hidden) so the referring text was simply removed.

https://docs.rs/sqlx/0.7.3/sqlx/macro.migrate.html