### PR TITLE
Support `query!` for cargo-free systems

### DIFF
--- a/sqlx-macros-core/src/query/mod.rs
+++ b/sqlx-macros-core/src/query/mod.rs
@@ -166,13 +166,13 @@ pub fn expand_input<'a>(
 
             // Check SQLX_OFFLINE_DIR, then local .sqlx, then workspace .sqlx.
             let dirs = [
-                env("SQLX_OFFLINE_DIR").ok().map(PathBuf::from),
-                Some(METADATA.manifest_dir.join(".sqlx")),
-                Some(METADATA.workspace_root().join(".sqlx")),
+                || env("SQLX_OFFLINE_DIR").ok().map(PathBuf::from),
+                || Some(METADATA.manifest_dir.join(".sqlx")),
+                || Some(METADATA.workspace_root().join(".sqlx")),
             ];
             let Some(data_file_path) = dirs
                 .iter()
-                .filter_map(|path| path.as_ref())
+                .filter_map(|path| path())
                 .map(|path| path.join(&filename))
                 .find(|path| path.exists())
             else {


### PR DESCRIPTION
### Does your PR solve an issue?

Eagerly calling https://github.com/launchbadge/sqlx/blob/929af41745a9434ae83417dcf2571685cecca6f0/sqlx-macros-core/src/query/mod.rs#L80 results in build failure in Bazel builds.

### Delete this text and add "fixes #(issue number)"
