### PR TITLE
fix(postgres): avoid unnecessary flush in PgCopyIn::read_from

### DIFF
--- a/sqlx-postgres/src/copy.rs
+++ b/sqlx-postgres/src/copy.rs
@@ -221,10 +221,6 @@ impl<C: DerefMut<Target = PgConnection>> PgCopyIn<C> {
         }
 
         let conn: &mut PgConnection = self.conn.as_deref_mut().expect("copy_from: conn taken");
-
-        // flush any existing messages in the buffer and clear it
-        conn.stream.flush().await?;
-
         loop {
             let buf = conn.stream.write_buffer_mut();
 


### PR DESCRIPTION
This pull request addresses a potential hang in `PgCopyIn::read_from` caused by `conn.stream.flush().await?;`. The flush call appears to be unnecessary at this point, as the write buffer has already been flushed in `PgCopyIn::begin`.