### PR TITLE
Removed `Send` trait bound from argument binding

### DIFF
--- a/sqlx-core/src/any/arguments.rs
+++ b/sqlx-core/src/any/arguments.rs
@@ -18,7 +18,7 @@ impl<'q> Arguments<'q> for AnyArguments<'q> {
 
     fn add<T>(&mut self, value: T)
     where
-        T: 'q + Send + Encode<'q, Self::Database> + Type<Self::Database>,
+        T: 'q + Encode<'q, Self::Database> + Type<Self::Database>,
     {
         let _ = value.encode(&mut self.values);
     }

--- a/sqlx-core/src/arguments.rs
+++ b/sqlx-core/src/arguments.rs
@@ -16,7 +16,7 @@ pub trait Arguments<'q>: Send + Sized + Default {
     /// Add the value to the end of the arguments.
     fn add<T>(&mut self, value: T)
     where
-        T: 'q + Send + Encode<'q, Self::Database> + Type<Self::Database>;
+        T: 'q + Encode<'q, Self::Database> + Type<Self::Database>;
 
     fn format_placeholder<W: Write>(&self, writer: &mut W) -> fmt::Result {
         writer.write_str("?")

--- a/sqlx-core/src/query.rs
+++ b/sqlx-core/src/query.rs
@@ -76,7 +76,7 @@ impl<'q, DB: Database> Query<'q, DB, <DB as HasArguments<'q>>::Arguments> {
     ///
     /// There is no validation that the value is of the type expected by the query. Most SQL
     /// flavors will perform type coercion (Postgres will return a database error).
-    pub fn bind<T: 'q + Send + Encode<'q, DB> + Type<DB>>(mut self, value: T) -> Self {
+    pub fn bind<T: 'q + Encode<'q, DB> + Type<DB>>(mut self, value: T) -> Self {
         if let Some(arguments) = &mut self.arguments {
             arguments.add(value);
         }

--- a/sqlx-core/src/query_as.rs
+++ b/sqlx-core/src/query_as.rs
@@ -51,7 +51,7 @@ impl<'q, DB: Database, O> QueryAs<'q, DB, O, <DB as HasArguments<'q>>::Arguments
     /// Bind a value for use with this SQL query.
     ///
     /// See [`Query::bind`](Query::bind).
-    pub fn bind<T: 'q + Send + Encode<'q, DB> + Type<DB>>(mut self, value: T) -> Self {
+    pub fn bind<T: 'q + Encode<'q, DB> + Type<DB>>(mut self, value: T) -> Self {
         self.inner = self.inner.bind(value);
         self
     }

--- a/sqlx-core/src/query_builder.rs
+++ b/sqlx-core/src/query_builder.rs
@@ -147,7 +147,7 @@ where
     /// [postgres-limit-issue]: https://github.com/launchbadge/sqlx/issues/671#issuecomment-687043510
     pub fn push_bind<T>(&mut self, value: T) -> &mut Self
     where
-        T: 'args + Encode<'args, DB> + Send + Type<DB>,
+        T: 'args + Encode<'args, DB> + Type<DB>,
     {
         self.sanity_check();
 
@@ -569,7 +569,7 @@ where
     /// See [`QueryBuilder::push_bind()`] for details.
     pub fn push_bind<T>(&mut self, value: T) -> &mut Self
     where
-        T: 'args + Encode<'args, DB> + Send + Type<DB>,
+        T: 'args + Encode<'args, DB> + Type<DB>,
     {
         if self.push_separator {
             self.query_builder.push(&self.separator);
@@ -587,7 +587,7 @@ where
     /// Simply calls [`QueryBuilder::push_bind()`] directly.
     pub fn push_bind_unseparated<T>(&mut self, value: T) -> &mut Self
     where
-        T: 'args + Encode<'args, DB> + Send + Type<DB>,
+        T: 'args + Encode<'args, DB> + Type<DB>,
     {
         self.query_builder.push_bind(value);
         self

--- a/sqlx-core/src/query_scalar.rs
+++ b/sqlx-core/src/query_scalar.rs
@@ -48,7 +48,7 @@ impl<'q, DB: Database, O> QueryScalar<'q, DB, O, <DB as HasArguments<'q>>::Argum
     /// Bind a value for use with this SQL query.
     ///
     /// See [`Query::bind`](crate::query::Query::bind).
-    pub fn bind<T: 'q + Send + Encode<'q, DB> + Type<DB>>(mut self, value: T) -> Self {
+    pub fn bind<T: 'q + Encode<'q, DB> + Type<DB>>(mut self, value: T) -> Self {
         self.inner = self.inner.bind(value);
         self
     }


### PR DESCRIPTION
Initial PR that removes all the `Send` trait bounds from various argument binding methods. While the argument buffer makes sense to be `Send` as it might be passed around, arguments passed in are immediately encoded away, so it does not seem to be required for them to be `Send`.

The PR could be expanded to add an `Encode` impl for `std::fmt::Arguments` (the initial motivation for removing the bounds) and even make the `Text` adapter rely on it when getting encoded.

Fixes #2959 
