### PR TITLE
feat: enable fuzzing sqlx-based postgresql backends

### DIFF
--- a/sqlx-core/src/testing/mod.rs
+++ b/sqlx-core/src/testing/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::future::Future;
 use std::time::Duration;
 
@@ -52,6 +53,7 @@ pub struct TestArgs {
     pub test_path: &'static str,
     pub migrator: Option<&'static Migrator>,
     pub fixtures: &'static [TestFixture],
+    pub args: HashMap<String, String>,
 }
 
 pub trait TestFn {
@@ -144,6 +146,7 @@ impl TestArgs {
             test_path,
             migrator: None,
             fixtures: &[],
+            args: HashMap::new(),
         }
     }
 
@@ -153,6 +156,13 @@ impl TestArgs {
 
     pub fn fixtures(&mut self, fixtures: &'static [TestFixture]) {
         self.fixtures = fixtures;
+    }
+
+    pub fn arg(&mut self, key: String, value: String) {
+        assert!(
+            self.args.insert(key, value).is_none(),
+            "set argument multiple times"
+        );
     }
 }
 
@@ -168,7 +178,7 @@ impl<T, E> TestTermination for Result<T, E> {
     }
 }
 
-fn run_test_with_pool<DB, F, Fut>(args: TestArgs, test_fn: F) -> Fut::Output
+pub fn run_test_with_pool<DB, F, Fut>(args: TestArgs, test_fn: F) -> Fut::Output
 where
     DB: TestSupport,
     DB::Connection: Migrate,
@@ -198,7 +208,7 @@ where
     })
 }
 
-fn run_test<DB, F, Fut>(args: TestArgs, test_fn: F) -> Fut::Output
+pub fn run_test<DB, F, Fut>(args: TestArgs, test_fn: F) -> Fut::Output
 where
     DB: TestSupport,
     DB::Connection: Migrate,

--- a/sqlx-postgres/src/testing/mod.rs
+++ b/sqlx-postgres/src/testing/mod.rs
@@ -161,8 +161,16 @@ async fn test_context(args: &TestArgs) -> Result<TestContext<Postgres>, Error> {
     .fetch_one(&mut *conn)
     .await?;
 
-    conn.execute(&format!("create database {new_db_name:?}")[..])
-        .await?;
+    conn.execute(
+        &format!(
+            "create database {new_db_name:?} {}",
+            args.args
+                .get("tablespace")
+                .map(|t| format!("with tablespace = {t:?}"))
+                .unwrap_or_else(String::new)
+        )[..],
+    )
+    .await?;
 
     Ok(TestContext {
         pool_opts: PoolOptions::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,11 @@ pub use sqlx_macros::test;
 #[cfg(feature = "migrate")]
 pub use sqlx_core::testing;
 
+#[cfg(feature = "migrate")]
+pub mod test {
+    pub use sqlx_core::testing::{run_test, run_test_with_pool, TestArgs};
+}
+
 #[doc(hidden)]
 pub use sqlx_core::rt::test_block_on;
 


### PR DESCRIPTION
This PR contains changes I wanted to be able to fuzz [my application](https://github.com/Ekleog/risuto)'s sqlx PostgreSQL backend. Considering the complexity of the queries involved, fuzzing definitely makes sense there. I'm actually sending this PR, hoping for it to land so that I could use it in [a new project](https://github.com/Ekleog/crdb) that also has maybe even worse queries.

The changes made in this PR are:
- Making `run_test` and `run_test_with_pool` public. This makes it possible to use the sqlx testing infrastructure without using `#[sqlx::test]`. This is required for fuzzing, in order to put the test inside `bolero::check!().for_each(|| { ...})` or `fuzz_target!`. Without this, writing a fuzzer requires a custom re-implementation of the sqlx fuzzing infrastructure (see an example of such a reimplementation [here](https://github.com/Ekleog/risuto/blob/main/risuto-server/src/fuzz.rs#L66))
- Allowing the user of these functions to set a custom tablespace for the test database. While not strictly necessary for fuzzing, it helps setting the tablespace on a ramdisk, which should avoid burning through the disk with all the disk operations that'd be performed by fuzzing. Given sqlx deletes its databases just after the test, it should not be a big deal from the postgresql side of things

WDYT of these changes? :)