### PR TITLE
ReadMe Grammer/Mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ SQLx is an async, pure Rust<sub>†</sub> SQL crate featuring compile-time check
 we could be pure Rust for SQLite is by porting _all_ of SQLite to Rust).
 
 †† SQLx uses `#![forbid(unsafe_code)]` unless the `sqlite` feature is enabled. As the SQLite driver interacts
-with C, those interactions are `unsafe`.
+with C, these interactions are considered `unsafe`.
 
 </small></small>
 


### PR DESCRIPTION
It reads wrong, "those" is used when refering to something far away. The drivers unsafe interactions are of its own not a "side effect" (far away)
