### PR TITLE
Generic Associated Types in Database, replacing HasValueRef, HasArguments, HasStatement

### DIFF
--- a/sqlx-core/src/any/database.rs
+++ b/sqlx-core/src/any/database.rs
@@ -2,7 +2,7 @@ use crate::any::{
     AnyArgumentBuffer, AnyArguments, AnyColumn, AnyConnection, AnyQueryResult, AnyRow,
     AnyStatement, AnyTransactionManager, AnyTypeInfo, AnyValue, AnyValueRef,
 };
-use crate::database::{Database, HasArguments, HasStatement, HasStatementCache, HasValueRef};
+use crate::database::{Database, HasStatementCache};
 
 /// Opaque database driver. Capable of being used in place of any SQLx database driver. The actual
 /// driver used will be selected at runtime, from the connection url.
@@ -23,29 +23,16 @@ impl Database for Any {
     type TypeInfo = AnyTypeInfo;
 
     type Value = AnyValue;
+    type ValueRef<'r> = AnyValueRef<'r>;
+
+    type Arguments<'q> = AnyArguments<'q>;
+    type ArgumentBuffer<'q> = AnyArgumentBuffer<'q>;
+
+    type Statement<'q> = AnyStatement<'q>;
+
     const NAME: &'static str = "Any";
 
     const URL_SCHEMES: &'static [&'static str] = &[];
-}
-
-impl<'r> HasValueRef<'r> for Any {
-    type Database = Any;
-
-    type ValueRef = AnyValueRef<'r>;
-}
-
-impl<'q> HasStatement<'q> for Any {
-    type Database = Any;
-
-    type Statement = AnyStatement<'q>;
-}
-
-impl<'q> HasArguments<'q> for Any {
-    type Database = Any;
-
-    type Arguments = AnyArguments<'q>;
-
-    type ArgumentBuffer = AnyArgumentBuffer<'q>;
 }
 
 // This _may_ be true, depending on the selected database

--- a/sqlx-core/src/any/row.rs
+++ b/sqlx-core/src/any/row.rs
@@ -1,7 +1,7 @@
 use crate::any::error::mismatched_types;
 use crate::any::{Any, AnyColumn, AnyTypeInfo, AnyTypeInfoKind, AnyValue, AnyValueKind};
 use crate::column::{Column, ColumnIndex};
-use crate::database::{Database, HasValueRef};
+use crate::database::Database;
 use crate::decode::Decode;
 use crate::error::Error;
 use crate::ext::ustr::UStr;
@@ -28,10 +28,7 @@ impl Row for AnyRow {
         &self.columns
     }
 
-    fn try_get_raw<I>(
-        &self,
-        index: I,
-    ) -> Result<<Self::Database as HasValueRef<'_>>::ValueRef, Error>
+    fn try_get_raw<I>(&self, index: I) -> Result<<Self::Database as Database>::ValueRef<'_>, Error>
     where
         I: ColumnIndex<Self>,
     {
@@ -141,7 +138,7 @@ impl AnyRow {
 }
 
 fn decode<'r, DB: Database, T: Decode<'r, DB>>(
-    valueref: <DB as HasValueRef<'r>>::ValueRef,
+    valueref: <DB as Database>::ValueRef<'r>,
 ) -> crate::Result<T> {
     Decode::decode(valueref).map_err(Error::decode)
 }

--- a/sqlx-core/src/any/types/blob.rs
+++ b/sqlx-core/src/any/types/blob.rs
@@ -1,5 +1,5 @@
 use crate::any::{Any, AnyTypeInfo, AnyTypeInfoKind, AnyValueKind};
-use crate::database::{HasArguments, HasValueRef};
+use crate::database::Database;
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
 use crate::error::BoxDynError;
@@ -15,14 +15,14 @@ impl Type<Any> for [u8] {
 }
 
 impl<'q> Encode<'q, Any> for &'q [u8] {
-    fn encode_by_ref(&self, buf: &mut <Any as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
+    fn encode_by_ref(&self, buf: &mut <Any as Database>::ArgumentBuffer<'q>) -> IsNull {
         buf.0.push(AnyValueKind::Blob((*self).into()));
         IsNull::No
     }
 }
 
 impl<'r> Decode<'r, Any> for &'r [u8] {
-    fn decode(value: <Any as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+    fn decode(value: <Any as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
         match value.kind {
             AnyValueKind::Blob(Cow::Borrowed(blob)) => Ok(blob),
             // This shouldn't happen in practice, it means the user got an `AnyValueRef`
@@ -42,14 +42,14 @@ impl Type<Any> for Vec<u8> {
 }
 
 impl<'q> Encode<'q, Any> for Vec<u8> {
-    fn encode_by_ref(&self, buf: &mut <Any as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
+    fn encode_by_ref(&self, buf: &mut <Any as Database>::ArgumentBuffer<'q>) -> IsNull {
         buf.0.push(AnyValueKind::Blob(Cow::Owned(self.clone())));
         IsNull::No
     }
 }
 
 impl<'r> Decode<'r, Any> for Vec<u8> {
-    fn decode(value: <Any as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+    fn decode(value: <Any as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
         match value.kind {
             AnyValueKind::Blob(blob) => Ok(blob.into_owned()),
             other => other.unexpected(),

--- a/sqlx-core/src/any/types/bool.rs
+++ b/sqlx-core/src/any/types/bool.rs
@@ -1,5 +1,5 @@
 use crate::any::{Any, AnyTypeInfo, AnyTypeInfoKind, AnyValueKind};
-use crate::database::{HasArguments, HasValueRef};
+use crate::database::Database;
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
 use crate::error::BoxDynError;
@@ -14,14 +14,14 @@ impl Type<Any> for bool {
 }
 
 impl<'q> Encode<'q, Any> for bool {
-    fn encode_by_ref(&self, buf: &mut <Any as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
+    fn encode_by_ref(&self, buf: &mut <Any as Database>::ArgumentBuffer<'q>) -> IsNull {
         buf.0.push(AnyValueKind::Bool(*self));
         IsNull::No
     }
 }
 
 impl<'r> Decode<'r, Any> for bool {
-    fn decode(value: <Any as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+    fn decode(value: <Any as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
         match value.kind {
             AnyValueKind::Bool(b) => Ok(b),
             other => other.unexpected(),

--- a/sqlx-core/src/any/types/float.rs
+++ b/sqlx-core/src/any/types/float.rs
@@ -1,5 +1,5 @@
 use crate::any::{Any, AnyArgumentBuffer, AnyTypeInfo, AnyTypeInfoKind, AnyValueKind, AnyValueRef};
-use crate::database::{HasArguments, HasValueRef};
+use crate::database::Database;
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
 use crate::error::BoxDynError;
@@ -38,14 +38,14 @@ impl Type<Any> for f64 {
 }
 
 impl<'q> Encode<'q, Any> for f64 {
-    fn encode_by_ref(&self, buf: &mut <Any as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
+    fn encode_by_ref(&self, buf: &mut <Any as Database>::ArgumentBuffer<'q>) -> IsNull {
         buf.0.push(AnyValueKind::Double(*self));
         IsNull::No
     }
 }
 
 impl<'r> Decode<'r, Any> for f64 {
-    fn decode(value: <Any as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+    fn decode(value: <Any as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
         match value.kind {
             // Widening is safe
             AnyValueKind::Real(r) => Ok(r as f64),

--- a/sqlx-core/src/any/types/int.rs
+++ b/sqlx-core/src/any/types/int.rs
@@ -1,5 +1,5 @@
 use crate::any::{Any, AnyTypeInfo, AnyTypeInfoKind, AnyValueKind};
-use crate::database::{HasArguments, HasValueRef};
+use crate::database::Database;
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
 use crate::error::BoxDynError;
@@ -18,14 +18,14 @@ impl Type<Any> for i16 {
 }
 
 impl<'q> Encode<'q, Any> for i16 {
-    fn encode_by_ref(&self, buf: &mut <Any as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
+    fn encode_by_ref(&self, buf: &mut <Any as Database>::ArgumentBuffer<'q>) -> IsNull {
         buf.0.push(AnyValueKind::SmallInt(*self));
         IsNull::No
     }
 }
 
 impl<'r> Decode<'r, Any> for i16 {
-    fn decode(value: <Any as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+    fn decode(value: <Any as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
         value.kind.try_integer()
     }
 }
@@ -43,14 +43,14 @@ impl Type<Any> for i32 {
 }
 
 impl<'q> Encode<'q, Any> for i32 {
-    fn encode_by_ref(&self, buf: &mut <Any as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
+    fn encode_by_ref(&self, buf: &mut <Any as Database>::ArgumentBuffer<'q>) -> IsNull {
         buf.0.push(AnyValueKind::Integer(*self));
         IsNull::No
     }
 }
 
 impl<'r> Decode<'r, Any> for i32 {
-    fn decode(value: <Any as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+    fn decode(value: <Any as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
         value.kind.try_integer()
     }
 }
@@ -68,14 +68,14 @@ impl Type<Any> for i64 {
 }
 
 impl<'q> Encode<'q, Any> for i64 {
-    fn encode_by_ref(&self, buf: &mut <Any as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
+    fn encode_by_ref(&self, buf: &mut <Any as Database>::ArgumentBuffer<'q>) -> IsNull {
         buf.0.push(AnyValueKind::BigInt(*self));
         IsNull::No
     }
 }
 
 impl<'r> Decode<'r, Any> for i64 {
-    fn decode(value: <Any as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+    fn decode(value: <Any as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
         value.kind.try_integer()
     }
 }

--- a/sqlx-core/src/any/types/str.rs
+++ b/sqlx-core/src/any/types/str.rs
@@ -1,6 +1,6 @@
 use crate::any::types::str;
 use crate::any::{Any, AnyTypeInfo, AnyTypeInfoKind, AnyValueKind};
-use crate::database::{HasArguments, HasValueRef};
+use crate::database::Database;
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
 use crate::error::BoxDynError;
@@ -16,7 +16,7 @@ impl Type<Any> for str {
 }
 
 impl<'a> Encode<'a, Any> for &'a str {
-    fn encode(self, buf: &mut <Any as HasArguments<'a>>::ArgumentBuffer) -> IsNull
+    fn encode(self, buf: &mut <Any as Database>::ArgumentBuffer<'a>) -> IsNull
     where
         Self: Sized,
     {
@@ -24,13 +24,13 @@ impl<'a> Encode<'a, Any> for &'a str {
         IsNull::No
     }
 
-    fn encode_by_ref(&self, buf: &mut <Any as HasArguments<'a>>::ArgumentBuffer) -> IsNull {
+    fn encode_by_ref(&self, buf: &mut <Any as Database>::ArgumentBuffer<'a>) -> IsNull {
         (*self).encode(buf)
     }
 }
 
 impl<'a> Decode<'a, Any> for &'a str {
-    fn decode(value: <Any as HasValueRef<'a>>::ValueRef) -> Result<Self, BoxDynError> {
+    fn decode(value: <Any as Database>::ValueRef<'a>) -> Result<Self, BoxDynError> {
         match value.kind {
             AnyValueKind::Text(Cow::Borrowed(text)) => Ok(text),
             // This shouldn't happen in practice, it means the user got an `AnyValueRef`
@@ -50,14 +50,14 @@ impl Type<Any> for String {
 }
 
 impl<'q> Encode<'q, Any> for String {
-    fn encode_by_ref(&self, buf: &mut <Any as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
+    fn encode_by_ref(&self, buf: &mut <Any as Database>::ArgumentBuffer<'q>) -> IsNull {
         buf.0.push(AnyValueKind::Text(Cow::Owned(self.clone())));
         IsNull::No
     }
 }
 
 impl<'r> Decode<'r, Any> for String {
-    fn decode(value: <Any as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+    fn decode(value: <Any as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
         match value.kind {
             AnyValueKind::Text(text) => Ok(text.into_owned()),
             other => other.unexpected(),

--- a/sqlx-core/src/any/value.rs
+++ b/sqlx-core/src/any/value.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use crate::any::{Any, AnyTypeInfo, AnyTypeInfoKind};
-use crate::database::{Database, HasValueRef};
+use crate::database::Database;
 use crate::error::BoxDynError;
 use crate::types::Type;
 use crate::value::{Value, ValueRef};
@@ -71,7 +71,7 @@ pub struct AnyValueRef<'a> {
 impl Value for AnyValue {
     type Database = Any;
 
-    fn as_ref(&self) -> <Self::Database as HasValueRef<'_>>::ValueRef {
+    fn as_ref(&self) -> <Self::Database as Database>::ValueRef<'_> {
         AnyValueRef {
             kind: match &self.kind {
                 AnyValueKind::Null => AnyValueKind::Null,

--- a/sqlx-core/src/arguments.rs
+++ b/sqlx-core/src/arguments.rs
@@ -1,6 +1,6 @@
 //! Types and traits for passing arguments to SQL queries.
 
-use crate::database::{Database, HasArguments};
+use crate::database::Database;
 use crate::encode::Encode;
 use crate::types::Type;
 use std::fmt::{self, Write};
@@ -23,8 +23,8 @@ pub trait Arguments<'q>: Send + Sized + Default {
     }
 }
 
-pub trait IntoArguments<'q, DB: HasArguments<'q>>: Sized + Send {
-    fn into_arguments(self) -> <DB as HasArguments<'q>>::Arguments;
+pub trait IntoArguments<'q, DB: Database>: Sized + Send {
+    fn into_arguments(self) -> <DB as Database>::Arguments<'q>;
 }
 
 // NOTE: required due to lack of lazy normalization
@@ -45,10 +45,10 @@ macro_rules! impl_into_arguments_for_arguments {
 }
 
 /// used by the query macros to prevent supernumerary `.bind()` calls
-pub struct ImmutableArguments<'q, DB: HasArguments<'q>>(pub <DB as HasArguments<'q>>::Arguments);
+pub struct ImmutableArguments<'q, DB: Database>(pub <DB as Database>::Arguments<'q>);
 
-impl<'q, DB: HasArguments<'q>> IntoArguments<'q, DB> for ImmutableArguments<'q, DB> {
-    fn into_arguments(self) -> <DB as HasArguments<'q>>::Arguments {
+impl<'q, DB: Database> IntoArguments<'q, DB> for ImmutableArguments<'q, DB> {
+    fn into_arguments(self) -> <DB as Database>::Arguments<'q> {
         self.0
     }
 }

--- a/sqlx-core/src/database.rs
+++ b/sqlx-core/src/database.rs
@@ -69,15 +69,7 @@ use crate::value::{Value, ValueRef};
 ///
 /// This trait encapsulates a complete set of traits that implement a driver for a
 /// specific database (e.g., MySQL, PostgreSQL).
-pub trait Database:
-    'static
-    + Sized
-    + Send
-    + Debug
-    + for<'r> HasValueRef<'r, Database = Self>
-    + for<'q> HasArguments<'q, Database = Self>
-    + for<'q> HasStatement<'q, Database = Self>
-{
+pub trait Database: 'static + Sized + Send + Debug {
     /// The concrete `Connection` implementation for this database.
     type Connection: Connection<Database = Self>;
 
@@ -99,61 +91,23 @@ pub trait Database:
     /// The concrete type used to hold an owned copy of the not-yet-decoded value that was
     /// received from the database.
     type Value: Value<Database = Self> + 'static;
+    /// The concrete type used to hold a reference to the not-yet-decoded value that has just been
+    /// received from the database.
+    type ValueRef<'r>: ValueRef<'r, Database = Self>;
+
+    /// The concrete `Arguments` implementation for this database.
+    type Arguments<'q>: Arguments<'q, Database = Self>;
+    /// The concrete type used as a buffer for arguments while encoding.
+    type ArgumentBuffer<'q>;
+
+    /// The concrete `Statement` implementation for this database.
+    type Statement<'q>: Statement<'q, Database = Self>;
 
     /// The display name for this database driver.
     const NAME: &'static str;
 
     /// The schemes for database URLs that should match this driver.
     const URL_SCHEMES: &'static [&'static str];
-}
-
-/// Associate [`Database`] with a [`ValueRef`](crate::value::ValueRef) of a generic lifetime.
-///
-/// ---
-///
-/// The upcoming Rust feature, [Generic Associated Types], should obviate
-/// the need for this trait.
-///
-/// [Generic Associated Types]: https://github.com/rust-lang/rust/issues/44265
-pub trait HasValueRef<'r> {
-    type Database: Database;
-
-    /// The concrete type used to hold a reference to the not-yet-decoded value that has just been
-    /// received from the database.
-    type ValueRef: ValueRef<'r, Database = Self::Database>;
-}
-
-/// Associate [`Database`] with an [`Arguments`](crate::arguments::Arguments) of a generic lifetime.
-///
-/// ---
-///
-/// The upcoming Rust feature, [Generic Associated Types], should obviate
-/// the need for this trait.
-///
-/// [Generic Associated Types]: https://github.com/rust-lang/rust/issues/44265
-pub trait HasArguments<'q> {
-    type Database: Database;
-
-    /// The concrete `Arguments` implementation for this database.
-    type Arguments: Arguments<'q, Database = Self::Database>;
-
-    /// The concrete type used as a buffer for arguments while encoding.
-    type ArgumentBuffer;
-}
-
-/// Associate [`Database`] with a [`Statement`](crate::statement::Statement) of a generic lifetime.
-///
-/// ---
-///
-/// The upcoming Rust feature, [Generic Associated Types], should obviate
-/// the need for this trait.
-///
-/// [Generic Associated Types]: https://github.com/rust-lang/rust/issues/44265
-pub trait HasStatement<'q> {
-    type Database: Database;
-
-    /// The concrete `Statement` implementation for this database.
-    type Statement: Statement<'q, Database = Self::Database>;
 }
 
 /// A [`Database`] that maintains a client-side cache of prepared statements.

--- a/sqlx-core/src/decode.rs
+++ b/sqlx-core/src/decode.rs
@@ -1,6 +1,6 @@
 //! Provides [`Decode`] for decoding values from the database.
 
-use crate::database::{Database, HasValueRef};
+use crate::database::Database;
 use crate::error::BoxDynError;
 
 use crate::value::ValueRef;
@@ -14,10 +14,10 @@ use crate::value::ValueRef;
 ///
 /// The following showcases how to implement `Decode` to be generic over [`Database`]. The
 /// implementation can be marginally simpler if you remove the `DB` type parameter and explicitly
-/// use the concrete [`ValueRef`](HasValueRef::ValueRef) and [`TypeInfo`](Database::TypeInfo) types.
+/// use the concrete [`ValueRef`](Database::ValueRef) and [`TypeInfo`](Database::TypeInfo) types.
 ///
 /// ```rust
-/// # use sqlx_core::database::{Database, HasValueRef};
+/// # use sqlx_core::database::{Database};
 /// # use sqlx_core::decode::Decode;
 /// # use sqlx_core::types::Type;
 /// # use std::error::Error;
@@ -42,7 +42,7 @@ use crate::value::ValueRef;
 ///     &'r str: Decode<'r, DB>
 /// {
 ///     fn decode(
-///         value: <DB as HasValueRef<'r>>::ValueRef,
+///         value: <DB as Database>::ValueRef<'r>,
 ///     ) -> Result<MyType, Box<dyn Error + 'static + Send + Sync>> {
 ///         // the interface of ValueRef is largely unstable at the moment
 ///         // so this is not directly implementable
@@ -60,7 +60,7 @@ use crate::value::ValueRef;
 /// ```
 pub trait Decode<'r, DB: Database>: Sized {
     /// Decode a new value of this type using a raw value from the database.
-    fn decode(value: <DB as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError>;
+    fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError>;
 }
 
 // implement `Decode` for Option<T> for all SQL types
@@ -69,7 +69,7 @@ where
     DB: Database,
     T: Decode<'r, DB>,
 {
-    fn decode(value: <DB as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+    fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
         if value.is_null() {
             Ok(None)
         } else {

--- a/sqlx-core/src/pool/executor.rs
+++ b/sqlx-core/src/pool/executor.rs
@@ -3,7 +3,7 @@ use futures_core::future::BoxFuture;
 use futures_core::stream::BoxStream;
 use futures_util::TryStreamExt;
 
-use crate::database::{Database, HasStatement};
+use crate::database::Database;
 use crate::describe::Describe;
 use crate::error::Error;
 use crate::executor::{Execute, Executor};
@@ -52,7 +52,7 @@ where
         self,
         sql: &'q str,
         parameters: &'e [<Self::Database as Database>::TypeInfo],
-    ) -> BoxFuture<'e, Result<<Self::Database as HasStatement<'q>>::Statement, Error>> {
+    ) -> BoxFuture<'e, Result<<Self::Database as Database>::Statement<'q>, Error>> {
         let pool = self.clone();
 
         Box::pin(async move { pool.acquire().await?.prepare_with(sql, parameters).await })
@@ -117,7 +117,7 @@ where
 //         parameters: &'e [<DB as crate::database::Database>::TypeInfo],
 //     ) -> futures_core::future::BoxFuture<
 //         'e,
-//         Result<<DB as crate::database::HasStatement<'q>>::Statement, crate::error::Error>,
+//         Result<<DB as crate::database::Database>::Statement<'q>, crate::error::Error>,
 //     >
 //     where
 //         'c: 'e,

--- a/sqlx-core/src/query.rs
+++ b/sqlx-core/src/query.rs
@@ -5,7 +5,7 @@ use futures_core::stream::BoxStream;
 use futures_util::{future, StreamExt, TryFutureExt, TryStreamExt};
 
 use crate::arguments::{Arguments, IntoArguments};
-use crate::database::{Database, HasArguments, HasStatement, HasStatementCache};
+use crate::database::{Database, HasStatementCache};
 use crate::encode::Encode;
 use crate::error::Error;
 use crate::executor::{Execute, Executor};
@@ -15,7 +15,7 @@ use crate::types::Type;
 /// A single SQL query as a prepared statement. Returned by [`query()`].
 #[must_use = "query must be executed to affect database"]
 pub struct Query<'q, DB: Database, A> {
-    pub(crate) statement: Either<&'q str, &'q <DB as HasStatement<'q>>::Statement>,
+    pub(crate) statement: Either<&'q str, &'q DB::Statement<'q>>,
     pub(crate) arguments: Option<A>,
     pub(crate) database: PhantomData<DB>,
     pub(crate) persistent: bool,
@@ -51,7 +51,7 @@ where
         }
     }
 
-    fn statement(&self) -> Option<&<DB as HasStatement<'q>>::Statement> {
+    fn statement(&self) -> Option<&DB::Statement<'q>> {
         match self.statement {
             Either::Right(ref statement) => Some(&statement),
             Either::Left(_) => None,
@@ -59,7 +59,7 @@ where
     }
 
     #[inline]
-    fn take_arguments(&mut self) -> Option<<DB as HasArguments<'q>>::Arguments> {
+    fn take_arguments(&mut self) -> Option<<DB as Database>::Arguments<'q>> {
         self.arguments.take().map(IntoArguments::into_arguments)
     }
 
@@ -69,7 +69,7 @@ where
     }
 }
 
-impl<'q, DB: Database> Query<'q, DB, <DB as HasArguments<'q>>::Arguments> {
+impl<'q, DB: Database> Query<'q, DB, <DB as Database>::Arguments<'q>> {
     /// Bind a value for use with this SQL query.
     ///
     /// If the number of times this is called does not match the number of bind parameters that
@@ -275,12 +275,12 @@ where
     }
 
     #[inline]
-    fn statement(&self) -> Option<&<DB as HasStatement<'q>>::Statement> {
+    fn statement(&self) -> Option<&DB::Statement<'q>> {
         self.inner.statement()
     }
 
     #[inline]
-    fn take_arguments(&mut self) -> Option<<DB as HasArguments<'q>>::Arguments> {
+    fn take_arguments(&mut self) -> Option<<DB as Database>::Arguments<'q>> {
         self.inner.take_arguments()
     }
 
@@ -465,8 +465,8 @@ where
 
 /// Execute a single SQL query as a prepared statement (explicitly created).
 pub fn query_statement<'q, DB>(
-    statement: &'q <DB as HasStatement<'q>>::Statement,
-) -> Query<'q, DB, <DB as HasArguments<'_>>::Arguments>
+    statement: &'q DB::Statement<'q>,
+) -> Query<'q, DB, <DB as Database>::Arguments<'_>>
 where
     DB: Database,
 {
@@ -480,7 +480,7 @@ where
 
 /// Execute a single SQL query as a prepared statement (explicitly created), with the given arguments.
 pub fn query_statement_with<'q, DB, A>(
-    statement: &'q <DB as HasStatement<'q>>::Statement,
+    statement: &'q DB::Statement<'q>,
     arguments: A,
 ) -> Query<'q, DB, A>
 where
@@ -618,7 +618,7 @@ where
 ///
 /// As an additional benefit, query parameters are usually sent in a compact binary encoding instead of a human-readable
 /// text encoding, which saves bandwidth.
-pub fn query<DB>(sql: &str) -> Query<'_, DB, <DB as HasArguments<'_>>::Arguments>
+pub fn query<DB>(sql: &str) -> Query<'_, DB, <DB as Database>::Arguments<'_>>
 where
     DB: Database,
 {

--- a/sqlx-core/src/query.rs
+++ b/sqlx-core/src/query.rs
@@ -525,6 +525,7 @@ where
 /// // where `conn` is `PgConnection` or `MySqlConnection`
 /// // or some other type that implements `Executor`.
 /// let results = sqlx::query(&query).fetch_all(&mut conn).await?;
+/// # Ok(())
 /// # }
 /// ```
 ///

--- a/sqlx-core/src/query_as.rs
+++ b/sqlx-core/src/query_as.rs
@@ -5,7 +5,7 @@ use futures_core::stream::BoxStream;
 use futures_util::{StreamExt, TryStreamExt};
 
 use crate::arguments::IntoArguments;
-use crate::database::{Database, HasArguments, HasStatement, HasStatementCache};
+use crate::database::{Database, HasStatementCache};
 use crate::encode::Encode;
 use crate::error::Error;
 use crate::executor::{Execute, Executor};
@@ -32,12 +32,12 @@ where
     }
 
     #[inline]
-    fn statement(&self) -> Option<&<DB as HasStatement<'q>>::Statement> {
+    fn statement(&self) -> Option<&DB::Statement<'q>> {
         self.inner.statement()
     }
 
     #[inline]
-    fn take_arguments(&mut self) -> Option<<DB as HasArguments<'q>>::Arguments> {
+    fn take_arguments(&mut self) -> Option<<DB as Database>::Arguments<'q>> {
         self.inner.take_arguments()
     }
 
@@ -47,7 +47,7 @@ where
     }
 }
 
-impl<'q, DB: Database, O> QueryAs<'q, DB, O, <DB as HasArguments<'q>>::Arguments> {
+impl<'q, DB: Database, O> QueryAs<'q, DB, O, <DB as Database>::Arguments<'q>> {
     /// Bind a value for use with this SQL query.
     ///
     /// See [`Query::bind`](Query::bind).
@@ -339,7 +339,7 @@ where
 ///
 /// ```
 #[inline]
-pub fn query_as<'q, DB, O>(sql: &'q str) -> QueryAs<'q, DB, O, <DB as HasArguments<'q>>::Arguments>
+pub fn query_as<'q, DB, O>(sql: &'q str) -> QueryAs<'q, DB, O, <DB as Database>::Arguments<'q>>
 where
     DB: Database,
     O: for<'r> FromRow<'r, DB::Row>,
@@ -371,8 +371,8 @@ where
 
 // Make a SQL query from a statement, that is mapped to a concrete type.
 pub fn query_statement_as<'q, DB, O>(
-    statement: &'q <DB as HasStatement<'q>>::Statement,
-) -> QueryAs<'q, DB, O, <DB as HasArguments<'_>>::Arguments>
+    statement: &'q DB::Statement<'q>,
+) -> QueryAs<'q, DB, O, <DB as Database>::Arguments<'_>>
 where
     DB: Database,
     O: for<'r> FromRow<'r, DB::Row>,
@@ -385,7 +385,7 @@ where
 
 // Make a SQL query from a statement, with the given arguments, that is mapped to a concrete type.
 pub fn query_statement_as_with<'q, DB, O, A>(
-    statement: &'q <DB as HasStatement<'q>>::Statement,
+    statement: &'q DB::Statement<'q>,
     arguments: A,
 ) -> QueryAs<'q, DB, O, A>
 where

--- a/sqlx-core/src/query_builder.rs
+++ b/sqlx-core/src/query_builder.rs
@@ -5,7 +5,7 @@ use std::fmt::Write;
 use std::marker::PhantomData;
 
 use crate::arguments::{Arguments, IntoArguments};
-use crate::database::{Database, HasArguments};
+use crate::database::Database;
 use crate::encode::Encode;
 use crate::from_row::FromRow;
 use crate::query::Query;
@@ -27,7 +27,7 @@ where
 {
     query: String,
     init_len: usize,
-    arguments: Option<<DB as HasArguments<'args>>::Arguments>,
+    arguments: Option<<DB as Database>::Arguments<'args>>,
 }
 
 impl<'args, DB: Database> Default for QueryBuilder<'args, DB> {
@@ -49,7 +49,7 @@ where
     /// Start building a query with an initial SQL fragment, which may be an empty string.
     pub fn new(init: impl Into<String>) -> Self
     where
-        <DB as HasArguments<'args>>::Arguments: Default,
+        <DB as Database>::Arguments<'args>: Default,
     {
         let init = init.into();
 
@@ -445,7 +445,7 @@ where
     /// to the state it was in immediately after [`new()`][Self::new].
     ///
     /// Calling any other method but `.reset()` after `.build()` will panic for sanity reasons.
-    pub fn build(&mut self) -> Query<'_, DB, <DB as HasArguments<'args>>::Arguments> {
+    pub fn build(&mut self) -> Query<'_, DB, <DB as Database>::Arguments<'args>> {
         self.sanity_check();
 
         Query {
@@ -470,7 +470,7 @@ where
     /// Calling any other method but `.reset()` after `.build()` will panic for sanity reasons.
     pub fn build_query_as<'q, T: FromRow<'q, DB::Row>>(
         &'q mut self,
-    ) -> QueryAs<'q, DB, T, <DB as HasArguments<'args>>::Arguments> {
+    ) -> QueryAs<'q, DB, T, <DB as Database>::Arguments<'args>> {
         QueryAs {
             inner: self.build(),
             output: PhantomData,
@@ -491,7 +491,7 @@ where
     /// Calling any other method but `.reset()` after `.build()` will panic for sanity reasons.
     pub fn build_query_scalar<'q, T>(
         &'q mut self,
-    ) -> QueryScalar<'q, DB, T, <DB as HasArguments<'args>>::Arguments>
+    ) -> QueryScalar<'q, DB, T, <DB as Database>::Arguments<'args>>
     where
         DB: Database,
         (T,): for<'r> FromRow<'r, DB::Row>,

--- a/sqlx-core/src/query_scalar.rs
+++ b/sqlx-core/src/query_scalar.rs
@@ -3,7 +3,7 @@ use futures_core::stream::BoxStream;
 use futures_util::{StreamExt, TryFutureExt, TryStreamExt};
 
 use crate::arguments::IntoArguments;
-use crate::database::{Database, HasArguments, HasStatement, HasStatementCache};
+use crate::database::{Database, HasStatementCache};
 use crate::encode::Encode;
 use crate::error::Error;
 use crate::executor::{Execute, Executor};
@@ -29,12 +29,12 @@ where
         self.inner.sql()
     }
 
-    fn statement(&self) -> Option<&<DB as HasStatement<'q>>::Statement> {
+    fn statement(&self) -> Option<&DB::Statement<'q>> {
         self.inner.statement()
     }
 
     #[inline]
-    fn take_arguments(&mut self) -> Option<<DB as HasArguments<'q>>::Arguments> {
+    fn take_arguments(&mut self) -> Option<<DB as Database>::Arguments<'q>> {
         self.inner.take_arguments()
     }
 
@@ -44,7 +44,7 @@ where
     }
 }
 
-impl<'q, DB: Database, O> QueryScalar<'q, DB, O, <DB as HasArguments<'q>>::Arguments> {
+impl<'q, DB: Database, O> QueryScalar<'q, DB, O, <DB as Database>::Arguments<'q>> {
     /// Bind a value for use with this SQL query.
     ///
     /// See [`Query::bind`](crate::query::Query::bind).
@@ -320,7 +320,7 @@ where
 #[inline]
 pub fn query_scalar<'q, DB, O>(
     sql: &'q str,
-) -> QueryScalar<'q, DB, O, <DB as HasArguments<'q>>::Arguments>
+) -> QueryScalar<'q, DB, O, <DB as Database>::Arguments<'q>>
 where
     DB: Database,
     (O,): for<'r> FromRow<'r, DB::Row>,
@@ -350,8 +350,8 @@ where
 
 // Make a SQL query from a statement, that is mapped to a concrete value.
 pub fn query_statement_scalar<'q, DB, O>(
-    statement: &'q <DB as HasStatement<'q>>::Statement,
-) -> QueryScalar<'q, DB, O, <DB as HasArguments<'_>>::Arguments>
+    statement: &'q DB::Statement<'q>,
+) -> QueryScalar<'q, DB, O, <DB as Database>::Arguments<'_>>
 where
     DB: Database,
     (O,): for<'r> FromRow<'r, DB::Row>,
@@ -363,7 +363,7 @@ where
 
 // Make a SQL query from a statement, with the given arguments, that is mapped to a concrete value.
 pub fn query_statement_scalar_with<'q, DB, O, A>(
-    statement: &'q <DB as HasStatement<'q>>::Statement,
+    statement: &'q DB::Statement<'q>,
     arguments: A,
 ) -> QueryScalar<'q, DB, O, A>
 where

--- a/sqlx-core/src/raw_sql.rs
+++ b/sqlx-core/src/raw_sql.rs
@@ -1,8 +1,9 @@
-use crate::database::{Database, HasArguments, HasStatement};
-use crate::executor::{Execute, Executor};
-use crate::Error;
 use either::Either;
 use futures_core::stream::BoxStream;
+
+use crate::database::Database;
+use crate::executor::{Execute, Executor};
+use crate::Error;
 
 // AUTHOR'S NOTE: I was just going to call this API `sql()` and `Sql`, respectively,
 // but realized that would be extremely annoying to deal with as a SQLite user
@@ -121,11 +122,11 @@ impl<'q, DB: Database> Execute<'q, DB> for RawSql<'q> {
         self.0
     }
 
-    fn statement(&self) -> Option<&<DB as HasStatement<'q>>::Statement> {
+    fn statement(&self) -> Option<&<DB as Database>::Statement<'q>> {
         None
     }
 
-    fn take_arguments(&mut self) -> Option<<DB as HasArguments<'q>>::Arguments> {
+    fn take_arguments(&mut self) -> Option<<DB as Database>::Arguments<'q>> {
         None
     }
 

--- a/sqlx-core/src/row.rs
+++ b/sqlx-core/src/row.rs
@@ -1,5 +1,5 @@
 use crate::column::ColumnIndex;
-use crate::database::{Database, HasValueRef};
+use crate::database::Database;
 use crate::decode::Decode;
 use crate::error::{mismatched_types, Error};
 
@@ -171,10 +171,7 @@ pub trait Row: Unpin + Send + Sync + 'static {
     /// [`ColumnNotFound`]: Error::ColumnNotFound
     /// [`ColumnIndexOutOfBounds`]: Error::ColumnIndexOutOfBounds
     ///
-    fn try_get_raw<I>(
-        &self,
-        index: I,
-    ) -> Result<<Self::Database as HasValueRef<'_>>::ValueRef, Error>
+    fn try_get_raw<I>(&self, index: I) -> Result<<Self::Database as Database>::ValueRef<'_>, Error>
     where
         I: ColumnIndex<Self>;
 }

--- a/sqlx-core/src/statement.rs
+++ b/sqlx-core/src/statement.rs
@@ -1,6 +1,6 @@
 use crate::arguments::IntoArguments;
 use crate::column::ColumnIndex;
-use crate::database::{Database, HasArguments, HasStatement};
+use crate::database::Database;
 use crate::error::Error;
 use crate::from_row::FromRow;
 use crate::query::Query;
@@ -21,7 +21,7 @@ pub trait Statement<'q>: Send + Sync {
 
     /// Creates an owned statement from this statement reference. This copies
     /// the original SQL text.
-    fn to_owned(&self) -> <Self::Database as HasStatement<'static>>::Statement;
+    fn to_owned(&self) -> <Self::Database as Database>::Statement<'static>;
 
     /// Get the original SQL text used to create this statement.
     fn sql(&self) -> &str;
@@ -59,7 +59,7 @@ pub trait Statement<'q>: Send + Sync {
         Ok(&self.columns()[index.index(self)?])
     }
 
-    fn query(&self) -> Query<'_, Self::Database, <Self::Database as HasArguments<'_>>::Arguments>;
+    fn query(&self) -> Query<'_, Self::Database, <Self::Database as Database>::Arguments<'_>>;
 
     fn query_with<'s, A>(&'s self, arguments: A) -> Query<'s, Self::Database, A>
     where
@@ -67,7 +67,7 @@ pub trait Statement<'q>: Send + Sync {
 
     fn query_as<O>(
         &self,
-    ) -> QueryAs<'_, Self::Database, O, <Self::Database as HasArguments<'_>>::Arguments>
+    ) -> QueryAs<'_, Self::Database, O, <Self::Database as Database>::Arguments<'_>>
     where
         O: for<'r> FromRow<'r, <Self::Database as Database>::Row>;
 
@@ -78,7 +78,7 @@ pub trait Statement<'q>: Send + Sync {
 
     fn query_scalar<O>(
         &self,
-    ) -> QueryScalar<'_, Self::Database, O, <Self::Database as HasArguments<'_>>::Arguments>
+    ) -> QueryScalar<'_, Self::Database, O, <Self::Database as Database>::Arguments<'_>>
     where
         (O,): for<'r> FromRow<'r, <Self::Database as Database>::Row>;
 
@@ -111,7 +111,7 @@ macro_rules! impl_statement_query {
             '_,
             Self::Database,
             O,
-            <Self::Database as $crate::database::HasArguments<'_>>::Arguments,
+            <Self::Database as $crate::database::Database>::Arguments<'_>,
         >
         where
             O: for<'r> $crate::from_row::FromRow<
@@ -144,7 +144,7 @@ macro_rules! impl_statement_query {
             '_,
             Self::Database,
             O,
-            <Self::Database as $crate::database::HasArguments<'_>>::Arguments,
+            <Self::Database as $crate::database::Database>::Arguments<'_>,
         >
         where
             (O,): for<'r> $crate::from_row::FromRow<

--- a/sqlx-core/src/testing/fixtures.rs
+++ b/sqlx-core/src/testing/fixtures.rs
@@ -1,6 +1,6 @@
 //! TODO: automatic test fixture capture
 
-use crate::database::{Database, HasArguments};
+use crate::database::Database;
 
 use crate::query_builder::QueryBuilder;
 
@@ -111,7 +111,7 @@ impl<DB: Database> FixtureSnapshot<DB> {
 /// which appends to an internal string.
 impl<DB: Database> ToString for Fixture<DB>
 where
-    for<'a> <DB as HasArguments<'a>>::Arguments: Default,
+    for<'a> <DB as Database>::Arguments<'a>: Default,
 {
     fn to_string(&self) -> String {
         let mut query = QueryBuilder::<DB>::new("");

--- a/sqlx-core/src/transaction.rs
+++ b/sqlx-core/src/transaction.rs
@@ -140,7 +140,7 @@ where
 //     ) -> futures_core::future::BoxFuture<
 //         'e,
 //         Result<
-//             <Self::Database as crate::database::HasStatement<'q>>::Statement,
+//             <Self::Database as crate::database::Database>::Statement<'q>,
 //             crate::error::Error,
 //         >,
 //     >

--- a/sqlx-core/src/types/bstr.rs
+++ b/sqlx-core/src/types/bstr.rs
@@ -1,5 +1,5 @@
 /// Conversions between `bstr` types and SQL types.
-use crate::database::{Database, HasArguments, HasValueRef};
+use crate::database::Database;
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
 use crate::error::BoxDynError;
@@ -27,7 +27,7 @@ where
     DB: Database,
     Vec<u8>: Decode<'r, DB>,
 {
-    fn decode(value: <DB as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+    fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
         <Vec<u8> as Decode<DB>>::decode(value).map(BString::from)
     }
 }
@@ -37,7 +37,7 @@ where
     DB: Database,
     &'q [u8]: Encode<'q, DB>,
 {
-    fn encode_by_ref(&self, buf: &mut <DB as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
+    fn encode_by_ref(&self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> IsNull {
         <&[u8] as Encode<DB>>::encode(self.as_bytes(), buf)
     }
 }
@@ -47,7 +47,7 @@ where
     DB: Database,
     Vec<u8>: Encode<'q, DB>,
 {
-    fn encode_by_ref(&self, buf: &mut <DB as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
+    fn encode_by_ref(&self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> IsNull {
         <Vec<u8> as Encode<DB>>::encode(self.as_bytes().to_vec(), buf)
     }
 }

--- a/sqlx-core/src/types/json.rs
+++ b/sqlx-core/src/types/json.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 pub use serde_json::value::RawValue as JsonRawValue;
 pub use serde_json::Value as JsonValue;
 
-use crate::database::{Database, HasArguments, HasValueRef};
+use crate::database::Database;
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
 use crate::error::BoxDynError;
@@ -141,7 +141,7 @@ where
     for<'a> Json<&'a Self>: Encode<'q, DB>,
     DB: Database,
 {
-    fn encode_by_ref(&self, buf: &mut <DB as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
+    fn encode_by_ref(&self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> IsNull {
         <Json<&Self> as Encode<'q, DB>>::encode(Json(self), buf)
     }
 }
@@ -151,7 +151,7 @@ where
     Json<Self>: Decode<'r, DB>,
     DB: Database,
 {
-    fn decode(value: <DB as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+    fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
         <Json<Self> as Decode<DB>>::decode(value).map(|item| item.0)
     }
 }
@@ -177,7 +177,7 @@ where
     Json<Self>: Decode<'r, DB>,
     DB: Database,
 {
-    fn decode(value: <DB as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+    fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
         <Json<Self> as Decode<DB>>::decode(value).map(|item| item.0)
     }
 }

--- a/sqlx-core/src/types/text.rs
+++ b/sqlx-core/src/types/text.rs
@@ -115,7 +115,7 @@ where
     String: Encode<'q, DB>,
     DB: Database,
 {
-    fn encode_by_ref(&self, buf: &mut <DB as HasArguments<'q>>::ArgumentBuffer) -> IsNull {
+    fn encode_by_ref(&self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> IsNull {
         self.0.to_string().encode(buf)
     }
 }
@@ -127,7 +127,7 @@ where
     &'r str: Decode<'r, DB>,
     DB: Database,
 {
-    fn decode(value: <DB as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+    fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
         Ok(Text(<&'r str as Decode<'r, DB>>::decode(value)?.parse()?))
     }
 }

--- a/sqlx-core/src/value.rs
+++ b/sqlx-core/src/value.rs
@@ -1,4 +1,4 @@
-use crate::database::{Database, HasValueRef};
+use crate::database::Database;
 use crate::decode::Decode;
 use crate::error::{mismatched_types, Error};
 use crate::type_info::TypeInfo;
@@ -10,7 +10,7 @@ pub trait Value {
     type Database: Database;
 
     /// Get this value as a reference.
-    fn as_ref(&self) -> <Self::Database as HasValueRef<'_>>::ValueRef;
+    fn as_ref(&self) -> <Self::Database as Database>::ValueRef<'_>;
 
     /// Get the type information for this value.
     fn type_info(&self) -> Cow<'_, <Self::Database as Database>::TypeInfo>;

--- a/sqlx-macros-core/src/derives/decode.rs
+++ b/sqlx-macros-core/src/derives/decode.rs
@@ -76,7 +76,7 @@ fn expand_derive_decode_transparent(
         #[automatically_derived]
         impl #impl_generics ::sqlx::decode::Decode<'r, DB> for #ident #ty_generics #where_clause {
             fn decode(
-                value: <DB as ::sqlx::database::HasValueRef<'r>>::ValueRef,
+                value: <DB as ::sqlx::database::Database>::ValueRef<'r>,
             ) -> ::std::result::Result<
                 Self,
                 ::std::boxed::Box<
@@ -118,7 +118,7 @@ fn expand_derive_decode_weak_enum(
             #repr: ::sqlx::decode::Decode<'r, DB>,
         {
             fn decode(
-                value: <DB as ::sqlx::database::HasValueRef<'r>>::ValueRef,
+                value: <DB as ::sqlx::database::Database>::ValueRef<'r>,
             ) -> ::std::result::Result<
                 Self,
                 ::std::boxed::Box<

--- a/sqlx-macros-core/src/derives/encode.rs
+++ b/sqlx-macros-core/src/derives/encode.rs
@@ -84,7 +84,7 @@ fn expand_derive_encode_transparent(
         {
             fn encode_by_ref(
                 &self,
-                buf: &mut <DB as ::sqlx::database::HasArguments<#lifetime>>::ArgumentBuffer,
+                buf: &mut <DB as ::sqlx::database::Database>::ArgumentBuffer<#lifetime>,
             ) -> ::sqlx::encode::IsNull {
                 <#ty as ::sqlx::encode::Encode<#lifetime, DB>>::encode_by_ref(&self.0, buf)
             }
@@ -123,7 +123,7 @@ fn expand_derive_encode_weak_enum(
         {
             fn encode_by_ref(
                 &self,
-                buf: &mut <DB as ::sqlx::database::HasArguments<'q>>::ArgumentBuffer,
+                buf: &mut <DB as ::sqlx::database::Database>::ArgumentBuffer<'q>,
             ) -> ::sqlx::encode::IsNull {
                 let value = match self {
                     #(#values)*
@@ -173,7 +173,7 @@ fn expand_derive_encode_strong_enum(
         {
             fn encode_by_ref(
                 &self,
-                buf: &mut <DB as ::sqlx::database::HasArguments<'q>>::ArgumentBuffer,
+                buf: &mut <DB as ::sqlx::database::Database>::ArgumentBuffer<'q>,
             ) -> ::sqlx::encode::IsNull {
                 let val = match self {
                     #(#value_arms)*

--- a/sqlx-macros-core/src/query/args.rs
+++ b/sqlx-macros-core/src/query/args.rs
@@ -17,7 +17,7 @@ pub fn quote_args<DB: DatabaseExt>(
 
     if input.arg_exprs.is_empty() {
         return Ok(quote! {
-            let query_args = <#db_path as ::sqlx::database::HasArguments>::Arguments::default();
+            let query_args = <#db_path as ::sqlx::database::Database>::Arguments::<'_>::default();
         });
     }
 
@@ -104,7 +104,7 @@ pub fn quote_args<DB: DatabaseExt>(
 
         #args_check
 
-        let mut query_args = <#db_path as ::sqlx::database::HasArguments>::Arguments::default();
+        let mut query_args = <#db_path as ::sqlx::database::Database>::Arguments::<'_>::default();
         query_args.reserve(
             #args_count,
             0 #(+ ::sqlx::encode::Encode::<#db_path>::size_hint(#arg_name))*

--- a/sqlx-mysql/src/database.rs
+++ b/sqlx-mysql/src/database.rs
@@ -3,9 +3,7 @@ use crate::{
     MySqlArguments, MySqlColumn, MySqlConnection, MySqlQueryResult, MySqlRow, MySqlStatement,
     MySqlTransactionManager, MySqlTypeInfo,
 };
-pub(crate) use sqlx_core::database::{
-    Database, HasArguments, HasStatement, HasStatementCache, HasValueRef,
-};
+pub(crate) use sqlx_core::database::{Database, HasStatementCache};
 
 /// MySQL database driver.
 #[derive(Debug)]
@@ -25,30 +23,16 @@ impl Database for MySql {
     type TypeInfo = MySqlTypeInfo;
 
     type Value = MySqlValue;
+    type ValueRef<'r> = MySqlValueRef<'r>;
+
+    type Arguments<'q> = MySqlArguments;
+    type ArgumentBuffer<'q> = Vec<u8>;
+
+    type Statement<'q> = MySqlStatement<'q>;
 
     const NAME: &'static str = "MySQL";
 
     const URL_SCHEMES: &'static [&'static str] = &["mysql", "mariadb"];
-}
-
-impl<'r> HasValueRef<'r> for MySql {
-    type Database = MySql;
-
-    type ValueRef = MySqlValueRef<'r>;
-}
-
-impl HasArguments<'_> for MySql {
-    type Database = MySql;
-
-    type Arguments = MySqlArguments;
-
-    type ArgumentBuffer = Vec<u8>;
-}
-
-impl<'q> HasStatement<'q> for MySql {
-    type Database = MySql;
-
-    type Statement = MySqlStatement<'q>;
 }
 
 impl HasStatementCache for MySql {}

--- a/sqlx-postgres/src/database.rs
+++ b/sqlx-postgres/src/database.rs
@@ -5,9 +5,7 @@ use crate::{
     PgTypeInfo,
 };
 
-pub(crate) use sqlx_core::database::{
-    Database, HasArguments, HasStatement, HasStatementCache, HasValueRef,
-};
+pub(crate) use sqlx_core::database::{Database, HasStatementCache};
 
 /// PostgreSQL database driver.
 #[derive(Debug)]
@@ -27,30 +25,16 @@ impl Database for Postgres {
     type TypeInfo = PgTypeInfo;
 
     type Value = PgValue;
+    type ValueRef<'r> = PgValueRef<'r>;
+
+    type Arguments<'q> = PgArguments;
+    type ArgumentBuffer<'q> = PgArgumentBuffer;
+
+    type Statement<'q> = PgStatement<'q>;
 
     const NAME: &'static str = "PostgreSQL";
 
     const URL_SCHEMES: &'static [&'static str] = &["postgres", "postgresql"];
-}
-
-impl<'r> HasValueRef<'r> for Postgres {
-    type Database = Postgres;
-
-    type ValueRef = PgValueRef<'r>;
-}
-
-impl HasArguments<'_> for Postgres {
-    type Database = Postgres;
-
-    type Arguments = PgArguments;
-
-    type ArgumentBuffer = PgArgumentBuffer;
-}
-
-impl<'q> HasStatement<'q> for Postgres {
-    type Database = Postgres;
-
-    type Statement = PgStatement<'q>;
 }
 
 impl HasStatementCache for Postgres {}

--- a/sqlx-sqlite/src/database.rs
+++ b/sqlx-sqlite/src/database.rs
@@ -1,6 +1,4 @@
-pub(crate) use sqlx_core::database::{
-    Database, HasArguments, HasStatement, HasStatementCache, HasValueRef,
-};
+pub(crate) use sqlx_core::database::{Database, HasStatementCache};
 
 use crate::{
     SqliteArgumentValue, SqliteArguments, SqliteColumn, SqliteConnection, SqliteQueryResult,
@@ -26,30 +24,16 @@ impl Database for Sqlite {
     type TypeInfo = SqliteTypeInfo;
 
     type Value = SqliteValue;
+    type ValueRef<'r> = SqliteValueRef<'r>;
+
+    type Arguments<'q> = SqliteArguments<'q>;
+    type ArgumentBuffer<'q> = Vec<SqliteArgumentValue<'q>>;
+
+    type Statement<'q> = SqliteStatement<'q>;
 
     const NAME: &'static str = "SQLite";
 
     const URL_SCHEMES: &'static [&'static str] = &["sqlite"];
-}
-
-impl<'r> HasValueRef<'r> for Sqlite {
-    type Database = Sqlite;
-
-    type ValueRef = SqliteValueRef<'r>;
-}
-
-impl<'q> HasArguments<'q> for Sqlite {
-    type Database = Sqlite;
-
-    type Arguments = SqliteArguments<'q>;
-
-    type ArgumentBuffer = Vec<SqliteArgumentValue<'q>>;
-}
-
-impl<'q> HasStatement<'q> for Sqlite {
-    type Database = Sqlite;
-
-    type Statement = SqliteStatement<'q>;
 }
 
 impl HasStatementCache for Sqlite {}


### PR DESCRIPTION
replaces the associated types from the generic traits `HasValueRef<'r>`, `HasArguments<'q>` and `HasStatement<'q>` with generic associated types in `Database`, as described in the (now removed) [comment](https://github.com/launchbadge/sqlx/blob/main/sqlx-core/src/database.rs#L114-L115):

> The upcoming Rust feature, [Generic Associated Types], should obviate
> the need for this trait.

This is obviously a breaking change.
GATs have been stable since [Rust 1.65](https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html#generic-associated-types-gats)