### PR TITLE
sqlx-core: Remove dotenvy dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3277,7 +3277,6 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "digest",
- "dotenvy",
  "either",
  "encoding_rs",
  "event-listener 2.5.3",

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -89,8 +89,6 @@ hashlink = "0.8.0"
 indexmap = "2.0"
 event-listener = "2.5.2"
 
-dotenvy = "0.15"
-
 [dev-dependencies]
 sqlx = { workspace = true, features = ["postgres", "sqlite", "mysql", "migrate", "macros", "time", "uuid"] }
 tokio = { version = "1", features = ["rt"] }


### PR DESCRIPTION
sqlx-core doesn't use dotenvy. Removing it means that users who only
depend on sqlx with sqlite and default-feature = false don't need it.
