### PR TITLE
chore: Update ahash to 0.8.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -1547,7 +1547,7 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 dependencies = [
- "ahash 0.8.6",
+ "ahash 0.8.7",
  "allocator-api2",
 ]
 
@@ -3264,7 +3264,7 @@ dependencies = [
 name = "sqlx-core"
 version = "0.7.3"
 dependencies = [
- "ahash 0.8.6",
+ "ahash 0.8.7",
  "async-io",
  "async-std",
  "atoi",
@@ -4482,18 +4482,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.26"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.26"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -51,7 +51,7 @@ uuid = { workspace = true, optional = true }
 
 async-io = { version = "1.9.0", optional = true }
 paste = "1.0.6"
-ahash = "0.8.6"
+ahash = "0.8.7"
 atoi = "2.0"
 
 bytes = "1.1.0"


### PR DESCRIPTION
Update ahash to version 0.8.7 to resolve vulnerability RUSTSEC-2023-0074.

```
Crate:     zerocopy
Version:   0.7.26
Title:     Some Ref methods are unsound with some type parameters
Date:      2023-12-14
ID:        RUSTSEC-2023-0074
URL:       https://rustsec.org/advisories/RUSTSEC-2023-0074
Solution:  Upgrade to >=0.2.9, <0.3.0 OR >=0.3.2, <0.4.0 OR >=0.4.1, <0.5.0 OR >=0.5.2, <0.6.0 OR >=0.6.6, <0.7.0 OR >=0.7.31
Dependency tree:
zerocopy 0.7.26
└── ahash 0.8.6
    ├── sqlx-core 0.7.3
    │   ├── sqlx-sqlite 0.7.3
    │   │   ├── sqlx-macros-core 0.7.3
    │   │   │   └── sqlx-macros 0.7.3
    │   │   │       └── sqlx 0.7.3
    │   │   │           ├── sqlx-test 0.1.0
    │   │   │           │   └── sqlx 0.7.3
    │   │   │           ├── sqlx-sqlite 0.7.3
    │   │   │           ├── sqlx-example-sqlite-todos 0.1.0
    │   │   │           ├── sqlx-example-postgres-transaction 0.1.0
    │   │   │           ├── sqlx-example-postgres-todos 0.1.0
    │   │   │           ├── sqlx-example-postgres-mockable-todos 0.1.0
    │   │   │           ├── sqlx-example-postgres-listen 0.1.0
    │   │   │           ├── sqlx-example-postgres-json 0.1.0
    │   │   │           ├── sqlx-example-postgres-files 0.1.0
    │   │   │           ├── sqlx-example-postgres-chat 0.1.0
    │   │   │           ├── sqlx-example-postgres-axum-social 0.1.0
    │   │   │           ├── sqlx-example-mysql-todos 0.1.0
    │   │   │           ├── sqlx-core 0.7.3
    │   │   │           └── sqlx-cli 0.7.3
    │   │   └── sqlx 0.7.3
    │   ├── sqlx-postgres 0.7.3
    │   │   ├── sqlx-macros-core 0.7.3
    │   │   └── sqlx 0.7.3
    │   ├── sqlx-mysql 0.7.3
    │   │   ├── sqlx-macros-core 0.7.3
    │   │   └── sqlx 0.7.3
    │   ├── sqlx-macros-core 0.7.3
    │   ├── sqlx-macros 0.7.3
    │   └── sqlx 0.7.3
    └── hashbrown 0.14.2
        ├── indexmap 2.1.0
        │   ├── toml_edit 0.20.7
        │   │   └── proc-macro-crate 2.0.0
        │   │       └── borsh-derive 1.2.0
        │   │           └── borsh 1.2.0
        │   │               └── rust_decimal 1.33.1
        │   │                   ├── sqlx-postgres 0.7.3
        │   │                   ├── sqlx-mysql 0.7.3
        │   │                   └── sqlx-core 0.7.3
        │   └── sqlx-core 0.7.3
        └── hashlink 0.8.4
            └── sqlx-core 0.7.3
```