### PR TITLE
feat(logging): Add numeric elapsed time field elapsed_secs

### DIFF
--- a/sqlx-core/src/logger.rs
+++ b/sqlx-core/src/logger.rs
@@ -124,7 +124,10 @@ impl<'q> QueryLogger<'q> {
                         db.statement = sql,
                         rows_affected = self.rows_affected,
                         rows_returned = self.rows_returned,
+                        // Human-friendly - includes units (usually ms). Also kept for backward compatibility
                         ?elapsed,
+                        // Search friendly - numeric
+                        elapsed_secs = elapsed.as_secs_f64(),
                         // When logging to JSON, one can trigger alerts from the presence of this field.
                         slow_threshold=?self.settings.slow_statements_duration,
                         // Make sure to use "slow" in the message as that's likely
@@ -139,7 +142,10 @@ impl<'q> QueryLogger<'q> {
                         db.statement = sql,
                         rows_affected = self.rows_affected,
                         rows_returned = self.rows_returned,
+                        // Human-friendly - includes units (usually ms). Also kept for backward compatibility
                         ?elapsed,
+                        // Search friendly - numeric
+                        elapsed_secs = elapsed.as_secs_f64(),
                     );
                 }
             }


### PR DESCRIPTION
This is a partial resolution to https://github.com/launchbadge/sqlx/issues/2671.

I chose `elapsed_ms` over `elapsed_us` as sub-millisecond latencies are not likely interesting for a relational database query, and individuals searching and filtering logs would find milliseconds more convenient.

I also left the existing `elapsed` string field in place in case it is being used by others in ops and monitoring (which seems to be the case with @Matthias247).