### PR TITLE
chore(deps): Add deny.yaml and a cargo deny CI job to check dependencies

### DIFF
--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -8,6 +8,13 @@ on:
       - '*-dev'
 
 jobs:
+  deny:
+    name: Cargo Deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v1
+
   format:
     name: Format
     runs-on: ubuntu-22.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ async-std = { version = "1.12.0", features = ["attributes"] }
 tokio = { version = "1.15.0", features = ["full"] }
 dotenvy = "0.15.0"
 trybuild = "1.0.53"
-sqlx-test = { path = "./sqlx-test" }
+sqlx-test = { version = "0.1.0", path = "./sqlx-test" }
 paste = "1.0.6"
 serde = { version = "1.0.132", features = ["derive"] }
 serde_json = "1.0.73"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,66 @@
+[advisories]
+ignore = [
+    # No upgrade available for rsa 0.9.4, a direct dependency of sqlx-mysql
+    "RUSTSEC-2023-0071",
+]
+version = 2
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MIT",
+    "MPL-2.0",
+    "OpenSSL",
+    "Unicode-DFS-2016",
+    "Zlib",
+]
+confidence-threshold = 0.9
+version = 2
+
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 }
+]
+
+[bans]
+allow = []
+deny = []
+multiple-versions = "deny"
+skip = [
+    # async-std 1.12 uses two versions - this older version directly, and a newer verison transitively.
+    { name = "async-channel", version = "=1.9.0" },
+    # sqlx-core uses an older version of rustls-pemfile, which uses this older version
+    { name = "base64", version = "=0.21.7" },
+    # async-global-executor transitively depends on two different versions of this crate
+    { name = "event-listener", version = "^4.0.0" },
+    # async-global-executor transitively depends on two different versions of this crate
+    { name = "event-listener-strategy", version = "=0.4.0" },
+    # native-tls 0.2.11 has this older version as a transitive dependency
+    { name = "spin", version = "=0.5.2" },
+    # async-std depends on this older version
+    { name = "syn", version = "<2" },
+]
+skip-tree = [
+    # async-std 1.12 uses two versions - this older version directly, and a newer version transitively.
+    { name = "async-io", version = "=1.13.0" },
+]
+
+wildcards = "deny"
+
+[sources]
+allow-git = []
+allow-registry = [
+    "https://github.com/rust-lang/crates.io-index"
+]
+unknown-git = "deny"
+unknown-registry = "deny"
+
+[sources.allow-org]
+bitbucket = []
+github = []
+gitlab = []

--- a/sqlx-test/Cargo.toml
+++ b/sqlx-test/Cargo.toml
@@ -2,10 +2,11 @@
 name = "sqlx-test"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-sqlx = { default-features = false, path = ".." }
+sqlx = { workspace = true, default-features = false }
 env_logger = "0.11"
 dotenvy = "0.15.0"
 anyhow = "1.0.26"


### PR DESCRIPTION
`cargo deny` checks for dependencies with vulnerabilities, vulnerability advisories, unmaintained crates, duplicate dependencies, and other issues.

* Add `deny.yaml`
* Add exceptions for warnings without a resolution available
* Add `license` line `license = "MIT OR Apache-2.0"` to `sqlx-test` crate to satisfy license checker. This license spec matches what is already in the workspace `Cargo.toml` file
* Change `sqlx-test` crate to reference `sqlx` crate via `workspace=true` rather than a path`
* Change `Cargo.toml` at workspace root to reference `sqlx-test` using its version number