### PR TITLE
feat: add `raw_sql` API

### DIFF
--- a/sqlx-core/src/lib.rs
+++ b/sqlx-core/src/lib.rs
@@ -74,6 +74,8 @@ pub mod net;
 pub mod query_as;
 pub mod query_builder;
 pub mod query_scalar;
+
+pub mod raw_sql;
 pub mod row;
 pub mod rt;
 pub mod sync;

--- a/sqlx-core/src/query_as.rs
+++ b/sqlx-core/src/query_as.rs
@@ -13,8 +13,8 @@ use crate::from_row::FromRow;
 use crate::query::{query, query_statement, query_statement_with, query_with, Query};
 use crate::types::Type;
 
-/// Raw SQL query with bind parameters, mapped to a concrete type using [`FromRow`].
-/// Returned from [`query_as`][crate::query_as::query_as].
+/// A single SQL query as a prepared statement, mapping results using [`FromRow`].
+/// Returned by [`query_as()`].
 #[must_use = "query must be executed to affect database"]
 pub struct QueryAs<'q, DB: Database, O, A> {
     pub(crate) inner: Query<'q, DB, A>,
@@ -68,6 +68,8 @@ where
     /// matching the one with the flag will use the cached statement until the
     /// cache is cleared.
     ///
+    /// If `false`, the prepared statement will be closed after execution.
+    ///
     /// Default: `true`.
     pub fn persistent(mut self, value: bool) -> Self {
         self.inner = self.inner.persistent(value);
@@ -92,6 +94,9 @@ where
         O: 'e,
         A: 'e,
     {
+        // FIXME: this should have used `executor.fetch()` but that's a breaking change
+        // because this technically allows multiple statements in one query string.
+        #[allow(deprecated)]
         self.fetch_many(executor)
             .try_filter_map(|step| async move { Ok(step.right()) })
             .boxed()
@@ -99,6 +104,7 @@ where
 
     /// Execute multiple queries and return the generated results as a stream
     /// from each query, in a stream.
+    #[deprecated = "Only the SQLite driver supports multiple statements in one prepared statement and that behavior is deprecated. Use `sqlx::raw_sql()` instead."]
     pub fn fetch_many<'e, 'c: 'e, E>(
         self,
         executor: E,
@@ -120,7 +126,13 @@ where
             .boxed()
     }
 
-    /// Execute the query and return all the generated results, collected into a [`Vec`].
+    /// Execute the query and return all the resulting rows collected into a [`Vec`].
+    ///
+    /// ### Note: beware result set size.
+    /// This will attempt to collect the full result set of the query into memory.
+    ///
+    /// To avoid exhausting available memory, ensure the result set has a known upper bound,
+    /// e.g. using `LIMIT`.
     #[inline]
     pub async fn fetch_all<'e, 'c: 'e, E>(self, executor: E) -> Result<Vec<O>, Error>
     where
@@ -133,7 +145,18 @@ where
         self.fetch(executor).try_collect().await
     }
 
-    /// Execute the query and returns exactly one row.
+    /// Execute the query, returning the first row or [`Error::RowNotFound`] otherwise.
+    ///
+    /// ### Note: for best performance, ensure the query returns at most one row.
+    /// Depending on the driver implementation, if your query can return more than one row,
+    /// it may lead to wasted CPU time and bandwidth on the database server.
+    ///
+    /// Even when the driver implementation takes this into account, ensuring the query returns at most one row
+    /// can result in a more optimal query plan.
+    ///
+    /// If your query has a `WHERE` clause filtering a unique column by a single value, you're good.
+    ///
+    /// Otherwise, you might want to add `LIMIT 1` to your query.
     pub async fn fetch_one<'e, 'c: 'e, E>(self, executor: E) -> Result<O, Error>
     where
         'q: 'e,
@@ -147,7 +170,18 @@ where
             .and_then(|row| row.ok_or(Error::RowNotFound))
     }
 
-    /// Execute the query and returns at most one row.
+    /// Execute the query, returning the first row or `None` otherwise.
+    ///
+    /// ### Note: for best performance, ensure the query returns at most one row.
+    /// Depending on the driver implementation, if your query can return more than one row,
+    /// it may lead to wasted CPU time and bandwidth on the database server.
+    ///
+    /// Even when the driver implementation takes this into account, ensuring the query returns at most one row
+    /// can result in a more optimal query plan.
+    ///
+    /// If your query has a `WHERE` clause filtering a unique column by a single value, you're good.
+    ///
+    /// Otherwise, you might want to add `LIMIT 1` to your query.
     pub async fn fetch_optional<'e, 'c: 'e, E>(self, executor: E) -> Result<Option<O>, Error>
     where
         'q: 'e,
@@ -165,8 +199,145 @@ where
     }
 }
 
-/// Make a SQL query that is mapped to a concrete type
-/// using [`FromRow`].
+/// Execute a single SQL query as a prepared statement (transparently cached).
+/// Maps rows to Rust types using [`FromRow`].
+///
+/// For details about prepared statements and allowed SQL syntax, see [`query()`][crate::query::query].
+///
+/// ### Example: Map Rows using Tuples
+/// [`FromRow`] is implemented for tuples of up to 16 elements<sup>1</sup>.
+/// Using a tuple of N elements will extract the first N columns from each row using [`Decode`][crate::decode::Decode].
+/// Any extra columns are ignored.
+///
+/// See [`sqlx::types`][crate::types] for the types that can be used.
+///
+/// The `FromRow` implementation will check [`Type::compatible()`] for each column to ensure a compatible type mapping
+/// is used. If an incompatible mapping is detected, an error is returned.
+/// To statically assert compatible types at compile time, see the `query!()` family of macros.
+///
+/// **NOTE**: `SELECT *` is not recommended with this approach because the ordering of returned columns may be different
+/// than expected, especially when using joins.
+///
+/// ```rust,no_run
+/// # async fn example1() -> sqlx::Result<()> {
+/// use sqlx::Connection;
+/// use sqlx::PgConnection;
+///
+/// // This example can be applied to any database as it only uses standard types and syntax.
+/// let mut conn: PgConnection = PgConnection::connect("<Database URL>").await?;
+///
+/// sqlx::raw_sql(
+///     "CREATE TABLE users(id INTEGER PRIMARY KEY, username TEXT UNIQUE, created_at TIMESTAMP DEFAULT (now())"
+/// )
+///     .execute(&mut conn)
+///     .await?;
+///
+/// sqlx::query("INSERT INTO users(id, username) VALUES (1, 'alice'), (2, 'bob');")
+///     .execute(&mut conn)
+///     .await?;
+///
+/// // Get the first row of the result (note the `LIMIT 1` for efficiency)
+/// // This assumes the `time` feature of SQLx is enabled.
+/// let oldest_user: (i64, String, time::OffsetDateTime) = sqlx::query_as(
+///     "SELECT id, username, created_at FROM users ORDER BY created_at LIMIT 1"
+/// )
+///     .fetch_one(&mut conn)
+///     .await?;
+///
+/// assert_eq!(oldest_user.0, 1);
+/// assert_eq!(oldest_user.1, "alice");
+///
+/// // Get at most one row
+/// let maybe_charlie: Option<(i64, String, time::OffsetDateTime)> = sqlx::query_as(
+///     "SELECT id, username, created_at FROM users WHERE username = 'charlie'"
+/// )
+///     .fetch_optional(&mut conn)
+///     .await?;
+///
+/// assert_eq!(maybe_charlie, None);
+///
+/// // Get all rows in result (Beware of the size of the result set! Consider using `LIMIT`)
+/// let users: Vec<(i64, String, time::OffsetDateTime)> = sqlx::query_as(
+///     "SELECT id, username, created_at FROM users ORDER BY id"
+/// )
+///     .fetch_all(&mut conn)
+///     .await?;
+///
+/// println!("{users:?}");
+/// # Ok(())
+/// # }
+/// ```
+///
+/// <sup>1</sup>: It's impossible in Rust to implement a trait for tuples of arbitrary size.
+/// For larger result sets, either use an explicit struct (see below) or use [`query()`][crate::query::query]
+/// instead and extract columns dynamically.
+///
+/// ### Example: Map Rows using `#[derive(FromRow)]`
+/// Using `#[derive(FromRow)]`, we can create a Rust struct to represent our row type
+/// so we can look up fields by name instead of tuple index.
+///
+/// When querying this way, columns will be matched up to the corresponding fields by name, so `SELECT *` is safe to use.
+/// However, you will still want to be aware of duplicate column names in your query when using joins.
+///
+/// The derived `FromRow` implementation will check [`Type::compatible()`] for each column to ensure a compatible type
+/// mapping is used. If an incompatible mapping is detected, an error is returned.
+/// To statically assert compatible types at compile time, see the `query!()` family of macros.
+///
+/// An error will also be returned if an expected column is missing from the result set.
+///
+/// `#[derive(FromRow)]` supports several control attributes which can be used to change how column names and types
+/// are mapped. See [`FromRow`] for details.
+///
+/// Using our previous table definition, we can convert our queries like so:
+/// ```rust,no_run
+/// # async fn example2() -> sqlx::Result<()> {
+/// use sqlx::Connection;
+/// use sqlx::PgConnection;
+///
+/// use time::OffsetDateTime;
+///
+/// #[derive(sqlx::FromRow, Debug, PartialEq, Eq)]
+/// struct User {
+///     id: i64,
+///     username: String,
+///     // Note: the derive won't compile if the `time` feature of SQLx is not enabled.
+///     created_at: OffsetDateTime,
+/// }
+///
+/// let mut conn: PgConnection = PgConnection::connect("<Database URL>").await?;
+///
+/// // Get the first row of the result (note the `LIMIT 1` for efficiency)
+/// let oldest_user: User = sqlx::query_as(
+///     "SELECT id, username, created_at FROM users ORDER BY created_at LIMIT 1"
+/// )
+///     .fetch_one(&mut conn)
+///     .await?;
+///
+/// assert_eq!(oldest_user.id, 1);
+/// assert_eq!(oldest_user.username, "alice");
+///
+/// // Get at most one row
+/// let maybe_charlie: Option<User> = sqlx::query_as(
+///     "SELECT id, username, created_at FROM users WHERE username = 'charlie'"
+/// )
+///     .fetch_optional(&mut conn)
+///     .await?;
+///
+/// assert_eq!(maybe_charlie, None);
+///
+/// // Get all rows in result (Beware of the size of the result set! Consider using `LIMIT`)
+/// let users: Vec<User> = sqlx::query_as(
+///     "SELECT id, username, created_at FROM users ORDER BY id"
+/// )
+///     .fetch_all(&mut conn)
+///     .await?;
+///
+/// assert_eq!(users[1].id, 2);
+/// assert_eq!(users[1].username, "bob");
+/// # Ok(())
+/// # }
+///
+/// ```
 #[inline]
 pub fn query_as<'q, DB, O>(sql: &'q str) -> QueryAs<'q, DB, O, <DB as HasArguments<'q>>::Arguments>
 where
@@ -179,8 +350,12 @@ where
     }
 }
 
-/// Make a SQL query, with the given arguments, that is mapped to a concrete type
-/// using [`FromRow`].
+/// Execute a single SQL query, with the given arguments as a prepared statement (transparently cached).
+/// Maps rows to Rust types using [`FromRow`].
+///
+/// For details about prepared statements and allowed SQL syntax, see [`query()`][crate::query::query].
+///
+/// For details about type mapping from [`FromRow`], see [`query_as()`].
 #[inline]
 pub fn query_as_with<'q, DB, O, A>(sql: &'q str, arguments: A) -> QueryAs<'q, DB, O, A>
 where

--- a/sqlx-core/src/raw_sql.rs
+++ b/sqlx-core/src/raw_sql.rs
@@ -1,0 +1,267 @@
+use crate::database::{Database, HasArguments, HasStatement};
+use crate::executor::{Execute, Executor};
+use crate::Error;
+use either::Either;
+use futures_core::stream::BoxStream;
+
+// AUTHOR'S NOTE: I was just going to call this API `sql()` and `Sql`, respectively,
+// but realized that would be extremely annoying to deal with as a SQLite user
+// because IDE smart completion would always recommend the `Sql` type first.
+//
+// It doesn't really need a super convenient name anyway as it's not meant to be used very often.
+
+/// One or more raw SQL statements, separated by semicolons (`;`).
+///
+/// See [`raw_sql()`] for details.
+pub struct RawSql<'q>(&'q str);
+
+/// Execute one or more statements as raw SQL, separated by semicolons (`;`).
+///
+/// This interface can be used to execute both DML
+/// (Data Manipulation Language: `SELECT`, `INSERT`, `UPDATE`, `DELETE` and variants)
+/// as well as DDL (Data Definition Language: `CREATE TABLE`, `ALTER TABLE`, etc).
+///
+/// This will not create or cache any prepared statements.
+///
+/// ### Note: singular DML queries, prefer `query()`
+/// This API does not use prepared statements, so usage of it is missing out on their benefits.
+///
+/// Prefer [`query()`][crate::query::query] instead if executing a single query.
+///
+/// It's also possible to combine multiple DML queries into one for use with `query()`:
+///
+/// ##### Common Table Expressions (CTEs: i.e The `WITH` Clause)
+/// Common Table Expressions effectively allow you to define aliases for queries
+/// that can be referenced like temporary tables:
+///
+/// ```sql
+/// WITH inserted_foos AS (
+///     -- Note that only Postgres allows data-modifying statements in CTEs
+///     INSERT INTO foo (bar_id) VALUES ($1)
+///     RETURNING foo_id, bar_id
+/// )
+/// SELECT foo_id, bar_id, bar
+/// FROM inserted_foos
+/// INNER JOIN bar USING (bar_id)
+/// ```
+///
+/// It's important to note that data modifying statements (`INSERT`, `UPDATE`, `DELETE`) may
+/// behave differently than expected. In Postgres, all data-modifying subqueries in a `WITH`
+/// clause execute with the same view of the data; they *cannot* see each other's modifications.
+///
+/// MySQL, MariaDB and SQLite appear to *only* allow `SELECT` statements in CTEs.
+///
+/// See the appropriate entry in your database's manual for details:
+/// * [MySQL](https://dev.mysql.com/doc/refman/8.0/en/with.html)
+///     * [MariaDB](https://mariadb.com/kb/en/with/)
+/// * [Postgres](https://www.postgresql.org/docs/current/queries-with.html)
+/// * [SQLite](https://www.sqlite.org/lang_with.html)
+///
+/// ##### `UNION`/`INTERSECT`/`EXCEPT`
+/// You can also use various set-theory operations on queries,
+/// including `UNION ALL` which simply concatenates their results.
+///
+/// See the appropriate entry in your database's manual for details:
+/// * [MySQL](https://dev.mysql.com/doc/refman/8.0/en/set-operations.html)
+///    * [MariaDB](https://mariadb.com/kb/en/joins-subqueries/)
+/// * [Postgres](https://www.postgresql.org/docs/current/queries-union.html)
+/// * [SQLite](https://www.sqlite.org/lang_select.html#compound_select_statements)
+///
+/// ### Note: query parameters are not supported.
+/// Query parameters require the use of prepared statements which this API does support.
+///
+/// If you require dynamic input data in your SQL, you can use `format!()` but **be very careful
+/// doing this with user input**. SQLx does **not** provide escaping or sanitization for inserting
+/// dynamic input into queries this way.
+///
+/// See [`query()`][crate::query::query] for details.
+///
+/// ### Note: multiple statements and autocommit.
+/// By default, when you use this API to execute a SQL string containing multiple statements
+/// separated by semicolons (`;`), the database server will treat those statements as all executing
+/// within the same transaction block, i.e. wrapped in `BEGIN` and `COMMIT`:
+///
+/// ```rust,no_run
+/// # async fn example() -> sqlx::Result<()> {
+/// let mut conn: sqlx::PgConnection = todo!("e.g. PgConnection::connect(<DATABASE URL>)");
+///
+/// sqlx::raw_sql(
+///     // Imagine we're moving data from one table to another:
+///     // Implicit `BEGIN;`
+///     "UPDATE foo SET bar = foobar.bar FROM foobar WHERE foobar.foo_id = foo.id;\
+///      DELETE FROM foobar;"
+///     // Implicit `COMMIT;`
+/// )
+///    .execute(&mut conn)
+///    .await?;
+///
+/// # Ok(())
+/// # }
+/// ```
+///
+/// If one statement triggers an error, the whole script aborts and rolls back.
+/// You can include explicit `BEGIN` and `COMMIT` statements in the SQL string
+/// to designate units that can be committed or rolled back piecemeal.
+///
+/// This also allows for a rudimentary form of pipelining as the whole SQL string is sent in one go.
+///
+/// ##### MySQL and MariaDB: DDL implicitly commits!
+/// MySQL and MariaDB do not support DDL in transactions. Instead, any active transaction is
+/// immediately and implicitly committed by the database server when executing a DDL statement.
+/// Beware of this behavior.
+///
+/// See [MySQL manual, section 13.3.3: Statements That Cause an Implicit Commit](https://dev.mysql.com/doc/refman/8.0/en/implicit-commit.html) for details.
+/// See also: [MariaDB manual: SQL statements That Cause an Implicit Commit](https://mariadb.com/kb/en/sql-statements-that-cause-an-implicit-commit/).
+pub fn raw_sql(sql: &str) -> RawSql<'_> {
+    RawSql(sql)
+}
+
+impl<'q, DB: Database> Execute<'q, DB> for RawSql<'q> {
+    fn sql(&self) -> &'q str {
+        self.0
+    }
+
+    fn statement(&self) -> Option<&<DB as HasStatement<'q>>::Statement> {
+        None
+    }
+
+    fn take_arguments(&mut self) -> Option<<DB as HasArguments<'q>>::Arguments> {
+        None
+    }
+
+    fn persistent(&self) -> bool {
+        false
+    }
+}
+
+impl<'q> RawSql<'q> {
+    /// Execute the SQL string and return the total number of rows affected.
+    #[inline]
+    pub async fn execute<'e, E>(
+        self,
+        executor: E,
+    ) -> crate::Result<<E::Database as Database>::QueryResult>
+    where
+        'q: 'e,
+        E: Executor<'e>,
+    {
+        executor.execute(self).await
+    }
+
+    /// Execute the SQL string. Returns a stream which gives the number of rows affected for each statement in the string.
+    #[inline]
+    pub fn execute_many<'e, E>(
+        self,
+        executor: E,
+    ) -> BoxStream<'e, crate::Result<<E::Database as Database>::QueryResult>>
+    where
+        'q: 'e,
+        E: Executor<'e>,
+    {
+        executor.execute_many(self)
+    }
+
+    /// Execute the SQL string and return the generated results as a stream.
+    ///
+    /// If the string contains multiple statements, their results will be concatenated together.
+    #[inline]
+    pub fn fetch<'e, E>(
+        self,
+        executor: E,
+    ) -> BoxStream<'e, Result<<E::Database as Database>::Row, Error>>
+    where
+        'q: 'e,
+        E: Executor<'e>,
+    {
+        executor.fetch(self)
+    }
+
+    /// Execute the SQL string and return the generated results as a stream.
+    ///
+    /// For each query in the stream, any generated rows are returned first,
+    /// then the `QueryResult` with the number of rows affected.
+    #[inline]
+    pub fn fetch_many<'e, E>(
+        self,
+        executor: E,
+    ) -> BoxStream<
+        'e,
+        Result<
+            Either<<E::Database as Database>::QueryResult, <E::Database as Database>::Row>,
+            Error,
+        >,
+    >
+    where
+        'q: 'e,
+        E: Executor<'e>,
+    {
+        executor.fetch_many(self)
+    }
+
+    /// Execute the SQL string and return all the resulting rows collected into a [`Vec`].
+    ///
+    /// ### Note: beware result set size.
+    /// This will attempt to collect the full result set of the query into memory.
+    ///
+    /// To avoid exhausting available memory, ensure the result set has a known upper bound,
+    /// e.g. using `LIMIT`.
+    #[inline]
+    pub async fn fetch_all<'e, E>(
+        self,
+        executor: E,
+    ) -> crate::Result<Vec<<E::Database as Database>::Row>>
+    where
+        'q: 'e,
+        E: Executor<'e>,
+    {
+        executor.fetch_all(self).await
+    }
+
+    /// Execute the SQL string, returning the first row or [`Error::RowNotFound`] otherwise.
+    ///
+    /// ### Note: for best performance, ensure the query returns at most one row.
+    /// Depending on the driver implementation, if your query can return more than one row,
+    /// it may lead to wasted CPU time and bandwidth on the database server.
+    ///
+    /// Even when the driver implementation takes this into account, ensuring the query returns
+    /// at most one row can result in a more optimal query plan.
+    ///
+    /// If your query has a `WHERE` clause filtering a unique column by a single value, you're good.
+    ///
+    /// Otherwise, you might want to add `LIMIT 1` to your query.
+    #[inline]
+    pub async fn fetch_one<'e, E>(
+        self,
+        executor: E,
+    ) -> crate::Result<<E::Database as Database>::Row>
+    where
+        'q: 'e,
+        E: Executor<'e>,
+    {
+        executor.fetch_one(self).await
+    }
+
+    /// Execute the SQL string, returning the first row or [`None`] otherwise.
+    ///
+    /// ### Note: for best performance, ensure the query returns at most one row.
+    /// Depending on the driver implementation, if your query can return more than one row,
+    /// it may lead to wasted CPU time and bandwidth on the database server.
+    ///
+    /// Even when the driver implementation takes this into account, ensuring the query returns
+    /// at most one row can result in a more optimal query plan.
+    ///
+    /// If your query has a `WHERE` clause filtering a unique column by a single value, you're good.
+    ///
+    /// Otherwise, you might want to add `LIMIT 1` to your query.
+    #[inline]
+    pub async fn fetch_optional<'e, E>(
+        self,
+        executor: E,
+    ) -> crate::Result<<E::Database as Database>::Row>
+    where
+        'q: 'e,
+        E: Executor<'e>,
+    {
+        executor.fetch_one(self).await
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub use sqlx_core::query::{query, query_with};
 pub use sqlx_core::query_as::{query_as, query_as_with};
 pub use sqlx_core::query_builder::{self, QueryBuilder};
 pub use sqlx_core::query_scalar::{query_scalar, query_scalar_with};
+pub use sqlx_core::raw_sql::{raw_sql, RawSql};
 pub use sqlx_core::row::Row;
 pub use sqlx_core::statement::Statement;
 pub use sqlx_core::transaction::{Transaction, TransactionManager};

--- a/tests/mysql/mysql.rs
+++ b/tests/mysql/mysql.rs
@@ -327,7 +327,7 @@ async fn it_can_bind_only_null_issue_540() -> anyhow::Result<()> {
 async fn it_can_bind_and_return_years() -> anyhow::Result<()> {
     let mut conn = new::<MySql>().await?;
 
-    conn.execute(
+    sqlx::raw_sql(
         r#"
 CREATE TEMPORARY TABLE too_many_years (
     id INT PRIMARY KEY AUTO_INCREMENT,
@@ -335,6 +335,7 @@ CREATE TEMPORARY TABLE too_many_years (
 );
     "#,
     )
+    .execute(&mut conn)
     .await?;
 
     sqlx::query(
@@ -442,7 +443,8 @@ async fn test_issue_622() -> anyhow::Result<()> {
 #[sqlx_macros::test]
 async fn it_can_work_with_transactions() -> anyhow::Result<()> {
     let mut conn = new::<MySql>().await?;
-    conn.execute("CREATE TEMPORARY TABLE users (id INTEGER PRIMARY KEY);")
+    sqlx::raw_sql("CREATE TEMPORARY TABLE users (id INTEGER PRIMARY KEY);")
+        .execute(&mut conn)
         .await?;
 
     // begin .. rollback

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -49,7 +49,8 @@ async fn it_pings() -> anyhow::Result<()> {
 async fn it_pings_after_suspended_query() -> anyhow::Result<()> {
     let mut conn = new::<Postgres>().await?;
 
-    conn.execute("create temporary table processed_row(val int4 primary key)")
+    sqlx::raw_sql("create temporary table processed_row(val int4 primary key)")
+        .execute(&mut conn)
         .await?;
 
     // This query wants to return 50 rows but we only read the first one.

--- a/tests/sqlite/sqlite.rs
+++ b/tests/sqlite/sqlite.rs
@@ -243,7 +243,7 @@ async fn it_opens_temp_on_disk() -> anyhow::Result<()> {
 #[sqlx_macros::test]
 async fn it_fails_to_parse() -> anyhow::Result<()> {
     let mut conn = new::<Sqlite>().await?;
-    let res = conn.execute("SEELCT 1").await;
+    let res = sqlx::raw_sql("SEELCT 1").execute(&mut conn).await;
 
     assert!(res.is_err());
 


### PR DESCRIPTION
This is meant to be much easier to discover than the current approach of directly invoking `Executor` methods.

In addition, I'm improving documentation for the `query*()` functions across the board.

This also deprecates `.execute_many()` and `.fetch_many()` on these types because only the SQLite driver actually ever supported multiple statements in a single query string with the prepared statement interface, and that's just a consequence of the fact that it handles all statements as prepared statements.