### PR TITLE
chore: Ignore .sqlx folder created by running ci steps locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ target/
 # Integration testing extension library for SQLite.
 ipaddr.dylib
 ipaddr.so
+
+# Temporary files from running the tests locally like they would be run from CI
+.sqlx


### PR DESCRIPTION
Manually running the CI steps locally results in the creation of a `.sqlx` folder in the repo root that does not belong in source control.

Ignore that folder.