### PR TITLE
Added support to IpAddr with MySQL/MariaDB.

### DIFF
--- a/sqlx-mysql/src/types/inet.rs
+++ b/sqlx-mysql/src/types/inet.rs
@@ -1,0 +1,92 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use crate::decode::Decode;
+use crate::encode::{Encode, IsNull};
+use crate::error::BoxDynError;
+use crate::io::MySqlBufMutExt;
+use crate::types::Type;
+use crate::{MySql, MySqlTypeInfo, MySqlValueRef};
+
+impl Type<MySql> for Ipv4Addr {
+    fn type_info() -> MySqlTypeInfo {
+        <&str as Type<MySql>>::type_info()
+    }
+
+    fn compatible(ty: &MySqlTypeInfo) -> bool {
+        <&str as Type<MySql>>::compatible(ty)
+    }
+}
+
+impl Encode<'_, MySql> for Ipv4Addr {
+    fn encode_by_ref(&self, buf: &mut Vec<u8>) -> IsNull {
+        buf.put_str_lenenc(&self.to_string());
+
+        IsNull::No
+    }
+}
+
+impl Decode<'_, MySql> for Ipv4Addr {
+    fn decode(value: MySqlValueRef<'_>) -> Result<Self, BoxDynError> {
+        // delegate to the &str type to decode from MySQL
+        let text = <&str as Decode<MySql>>::decode(value)?;
+
+        // parse a Ipv4Addr from the text
+        text.parse().map_err(Into::into)
+    }
+}
+
+impl Type<MySql> for Ipv6Addr {
+    fn type_info() -> MySqlTypeInfo {
+        <&str as Type<MySql>>::type_info()
+    }
+
+    fn compatible(ty: &MySqlTypeInfo) -> bool {
+        <&str as Type<MySql>>::compatible(ty)
+    }
+}
+
+impl Encode<'_, MySql> for Ipv6Addr {
+    fn encode_by_ref(&self, buf: &mut Vec<u8>) -> IsNull {
+        buf.put_str_lenenc(&self.to_string());
+
+        IsNull::No
+    }
+}
+
+impl Decode<'_, MySql> for Ipv6Addr {
+    fn decode(value: MySqlValueRef<'_>) -> Result<Self, BoxDynError> {
+        // delegate to the &str type to decode from MySQL
+        let text = <&str as Decode<MySql>>::decode(value)?;
+
+        // parse a Ipv6Addr from the text
+        text.parse().map_err(Into::into)
+    }
+}
+
+impl Type<MySql> for IpAddr {
+    fn type_info() -> MySqlTypeInfo {
+        <&str as Type<MySql>>::type_info()
+    }
+
+    fn compatible(ty: &MySqlTypeInfo) -> bool {
+        <&str as Type<MySql>>::compatible(ty)
+    }
+}
+
+impl Encode<'_, MySql> for IpAddr {
+    fn encode_by_ref(&self, buf: &mut Vec<u8>) -> IsNull {
+        buf.put_str_lenenc(&self.to_string());
+
+        IsNull::No
+    }
+}
+
+impl Decode<'_, MySql> for IpAddr {
+    fn decode(value: MySqlValueRef<'_>) -> Result<Self, BoxDynError> {
+        // delegate to the &str type to decode from MySQL
+        let text = <&str as Decode<MySql>>::decode(value)?;
+
+        // parse a IpAddr from the text
+        text.parse().map_err(Into::into)
+    }
+}

--- a/sqlx-mysql/src/types/mod.rs
+++ b/sqlx-mysql/src/types/mod.rs
@@ -17,6 +17,7 @@
 //! | `f64`                                 | DOUBLE                                               |
 //! | `&str`, [`String`]                    | VARCHAR, CHAR, TEXT                                  |
 //! | `&[u8]`, `Vec<u8>`                    | VARBINARY, BINARY, BLOB                              |
+//! | `IpAddr`, `Ipv4Addr`, `Ipv6Addr`      | VARCHAR, TEXT                                        |
 //!
 //! ##### Note: `BOOLEAN`/`BOOL` Type
 //! MySQL and MariaDB treat `BOOLEAN` as an alias of the `TINYINT` type:

--- a/sqlx-mysql/src/types/mod.rs
+++ b/sqlx-mysql/src/types/mod.rs
@@ -102,6 +102,7 @@ pub(crate) use sqlx_core::types::*;
 mod bool;
 mod bytes;
 mod float;
+mod inet;
 mod int;
 mod str;
 mod text;


### PR DESCRIPTION
Allow using `IpAddr`/`Ipv4Addr`/`Ipv6Addr` with the mysql driver.

These can also be used with MariaDB's INET4 and INET6 types.