### PR TITLE
feat: Implement mysql connection attributes

### DIFF
--- a/sqlx-mysql/src/connection/establish.rs
+++ b/sqlx-mysql/src/connection/establish.rs
@@ -129,6 +129,7 @@ impl<'a> DoHandshake<'a> {
             database: options.database.as_deref(),
             auth_plugin: plugin,
             auth_response: auth_response.as_deref(),
+            attributes: &options.attributes,
         });
 
         stream.flush().await?;

--- a/sqlx-mysql/src/connection/stream.rs
+++ b/sqlx-mysql/src/connection/stream.rs
@@ -51,7 +51,8 @@ impl<S: Socket> MySqlStream<S> {
             | Capabilities::MULTI_RESULTS
             | Capabilities::PLUGIN_AUTH
             | Capabilities::PS_MULTI_RESULTS
-            | Capabilities::SSL;
+            | Capabilities::SSL
+            | Capabilities::CONNECT_ATTRS;
 
         if options.database.is_some() {
             capabilities |= Capabilities::CONNECT_WITH_DB;

--- a/sqlx-mysql/src/options/attributes.rs
+++ b/sqlx-mysql/src/options/attributes.rs
@@ -1,0 +1,76 @@
+use std::{collections::BTreeMap, str::FromStr};
+
+/// Connection Attributes
+///
+/// https://dev.mysql.com/doc/x-devapi-userguide-shell-python/en/connection-attributes-xdevapi.html
+/// https://dev.mysql.com/doc/connector-net/en/connector-net-8-0-connection-options.html
+#[derive(Debug, Clone)]
+pub(crate) enum Attributes {
+    /// No client attributes are send to the server
+    None,
+
+    /// Only the default client attributes are send to the server
+    ///
+    /// These attributes are:
+    /// * _client_name: sqlx-mysql
+    /// * _client_version: The version of the sqlx crate
+    ClientDefault,
+
+    /// The default client and additional specified attributes are send to the server
+    ClientDefaultAndCustom(BTreeMap<String, String>),
+
+    /// Only the specified attributes are send to the server
+    Custom(BTreeMap<String, String>),
+}
+
+/// The default is to only send the default client attributes to the server
+impl Default for Attributes {
+    fn default() -> Self {
+        Attributes::ClientDefault
+    }
+}
+
+impl FromStr for Attributes {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "false" {
+            return Ok(Attributes::None);
+        } else if s.is_empty() || s == "true" {
+            return Ok(Attributes::ClientDefault);
+        }
+
+        // The format for custom attributes is: [key1=value1,key2=value2]
+        // Remove outer [ ]
+        let s = s
+            .strip_prefix('[')
+            .and_then(|s| s.strip_suffix(']'))
+            .ok_or("Invalid attribute format")?;
+
+        let mut attributes = BTreeMap::new();
+        for (key, value) in s.split(',').map(|pair| pair.split_once('=')).flatten() {
+            if key.is_empty() {
+                return Err("Empty keys are not allowed in connection attributes");
+            }
+
+            attributes.insert(String::from(key), String::from(value));
+        }
+
+        Ok(Attributes::ClientDefaultAndCustom(attributes))
+    }
+}
+
+#[test]
+fn parse_attributes() {
+    assert!(matches!(
+    "[k1=@123,2=v2,k3=v3]".parse().unwrap(),
+    Attributes::ClientDefaultAndCustom(attr) if attr == BTreeMap::from([
+        (String::from("k1"), String::from("@123")),
+        (String::from("2"), String::from("v2")),
+        (String::from("k3"), String::from("v3")),
+    ])));
+
+    assert!(matches!("".parse().unwrap(), Attributes::ClientDefault));
+    assert!(matches!("true".parse().unwrap(), Attributes::ClientDefault));
+    assert!(matches!("false".parse().unwrap(), Attributes::None));
+}

--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -1,11 +1,17 @@
-use std::path::{Path, PathBuf};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
 
+mod attributes;
 mod connect;
 mod parse;
 mod ssl_mode;
 
 use crate::{connection::LogSettings, net::tls::CertificateInput};
 pub use ssl_mode::MySqlSslMode;
+
+pub(crate) use self::attributes::Attributes;
 
 /// Options and flags which can be used to configure a MySQL connection.
 ///
@@ -77,6 +83,7 @@ pub struct MySqlConnectOptions {
     pub(crate) log_settings: LogSettings,
     pub(crate) pipes_as_concat: bool,
     pub(crate) enable_cleartext_plugin: bool,
+    pub(crate) attributes: Attributes,
 }
 
 impl Default for MySqlConnectOptions {
@@ -105,6 +112,7 @@ impl MySqlConnectOptions {
             log_settings: Default::default(),
             pipes_as_concat: true,
             enable_cleartext_plugin: false,
+            attributes: Default::default(),
         }
     }
 
@@ -333,6 +341,62 @@ impl MySqlConnectOptions {
         self.enable_cleartext_plugin = flag_val;
         self
     }
+
+    /// Set a connection attribute.
+    ///
+    /// If a connection attribute with the same key already exists it is replaced.
+    pub fn attribute(mut self, key: &str, value: &str) -> Self {
+        let attributes = match &mut self.attributes {
+            Attributes::None => {
+                // No attributes defined yet => create
+                self.attributes = Attributes::Custom(BTreeMap::new());
+
+                let Attributes::Custom(ref mut new_attributes) =
+                    &mut self.attributes
+                else {
+                    unreachable!()
+                };
+                new_attributes
+            }
+            Attributes::ClientDefault => {
+                // No attributes defined yet => create
+                self.attributes = Attributes::ClientDefaultAndCustom(BTreeMap::new());
+
+                let Attributes::ClientDefaultAndCustom(ref mut new_attributes) =
+                    &mut self.attributes
+                else {
+                    unreachable!()
+                };
+                new_attributes
+            }
+            Attributes::ClientDefaultAndCustom(attr) | Attributes::Custom(attr) => attr,
+        };
+
+        _ = attributes.insert(String::from(key), String::from(value));
+        self
+    }
+
+    /// Disable sending the default client connection attributes.
+    pub fn no_default_attributes(mut self) -> Self {
+        match self.attributes {
+            Attributes::None => {},
+            Attributes::ClientDefault => self.attributes = Attributes::None,
+            Attributes::ClientDefaultAndCustom(attr) => self.attributes = Attributes::Custom(attr),
+            Attributes::Custom(_) => {},
+        }
+        self
+    }
+
+    /// Clear any previous defined custom connection attributes.
+    pub fn clear_custom_attributes(mut self) -> Self {
+        match self.attributes {
+            Attributes::None => {},
+            Attributes::ClientDefault => {},
+            Attributes::ClientDefaultAndCustom(_) => self.attributes = Attributes::ClientDefault,
+            Attributes::Custom(_) => self.attributes = Attributes::None,
+        }
+        self
+    }
 }
 
 impl MySqlConnectOptions {
@@ -444,5 +508,28 @@ impl MySqlConnectOptions {
     /// ```
     pub fn get_collation(&self) -> Option<&str> {
         self.collation.as_deref()
+    }
+
+    /// Get the custom connection attributes.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use sqlx_mysql::MySqlConnectOptions;
+    /// let options = MySqlConnectOptions::new()
+    ///     .attribute("key", "value");
+    ///
+    /// let mut attributes = options.get_custom_attributes().into_iter().flatten();
+    /// assert_eq!(Some(("key", "value")), attributes.next());
+    /// ```
+    pub fn get_custom_attributes(&self) -> Option<impl Iterator<Item = (&str, &str)>> {
+        match &self.attributes {
+            Attributes::None => None,
+            Attributes::ClientDefault => None,
+            Attributes::ClientDefaultAndCustom(attr) | Attributes::Custom(attr) => Some(
+                attr.iter()
+                    .map(|(key, value)| (key.as_str(), value.as_str())),
+            ),
+        }
     }
 }

--- a/sqlx-mysql/src/options/parse.rs
+++ b/sqlx-mysql/src/options/parse.rs
@@ -72,6 +72,12 @@ impl MySqlConnectOptions {
                     options = options.socket(&*value);
                 }
 
+                "connection-attributes" => {
+                    options.attributes = value
+                        .parse()
+                        .map_err(|err: &'static str| Error::Configuration(err.into()))?;
+                }
+
                 _ => {}
             }
         }
@@ -103,4 +109,47 @@ fn it_parses_password_with_non_ascii_chars_correctly() {
     let opts = MySqlConnectOptions::from_str(url).unwrap();
 
     assert_eq!(Some("p@ssw0rd".into()), opts.password);
+}
+
+#[test]
+fn it_parses_connection_attributes_false() {
+    let url = "mysql://username:password@hostname:5432/database?connection-attributes=false";
+    let opts = MySqlConnectOptions::from_str(url).unwrap();
+
+    assert!(matches!(opts.attributes, crate::options::Attributes::None));
+}
+
+#[test]
+fn it_parses_custom_connection_attributes() {
+    use std::collections::BTreeMap;
+
+    let url = "mysql://username:password@hostname:5432/database?collation=before&connection-attributes=[key1=value1,key2=value2]&charset=after";
+    let opts = MySqlConnectOptions::from_str(url).unwrap();
+
+    assert_eq!(opts.collation, Some("before".into()));
+    assert_eq!(opts.charset, "after");
+
+    match opts.attributes {
+        crate::options::Attributes::ClientDefaultAndCustom(attr) => {
+            assert_eq!(
+                BTreeMap::from([
+                    ("key1".into(), "value1".into()),
+                    ("key2".into(), "value2".into()),
+                ]),
+                attr
+            );
+        }
+        _ => panic!("Invalid connection attributes"),
+    }
+}
+
+#[test]
+fn connection_attributes_default_is_client_defined() {
+    let url = "mysql://username:password@hostname:5432/database";
+    let opts = MySqlConnectOptions::from_str(url).unwrap();
+
+    assert!(matches!(
+        opts.attributes,
+        crate::options::Attributes::ClientDefault
+    ));
 }

--- a/sqlx-mysql/src/protocol/connect/encode_attributes.rs
+++ b/sqlx-mysql/src/protocol/connect/encode_attributes.rs
@@ -1,0 +1,57 @@
+use std::collections::BTreeMap;
+
+use sqlx_core::io::Encode;
+
+use crate::{io::MySqlBufMutExt, options::Attributes, protocol::Capabilities};
+
+impl Encode<'_, Capabilities> for Attributes {
+    fn encode_with(&self, buf: &mut Vec<u8>, capabilities: Capabilities) {
+        // Connection attributes are not enabled or not supported
+        if !capabilities.contains(Capabilities::CONNECT_ATTRS) ||
+            matches!(self, Attributes::None) {
+            return;
+        }
+
+        let mut attributes_to_encode = BTreeMap::new();
+        match self {
+            Attributes::None => unreachable!(),
+            Attributes::ClientDefault => {
+                add_client_attributes(&mut attributes_to_encode);
+            }
+
+            Attributes::ClientDefaultAndCustom(custom_attributes) => {
+                add_client_attributes(&mut attributes_to_encode);
+                attributes_to_encode.extend(custom_attributes.iter().map(|(k,v)| (k.as_str(), v.as_str())));
+            }
+
+            Attributes::Custom(custom_attributes) => {
+                attributes_to_encode.extend(custom_attributes.iter().map(|(k,v)| (k.as_str(), v.as_str())));
+            }
+        }
+
+        if attributes_to_encode.is_empty() {
+            return;
+        }
+
+        // Use temporary buffer to get total length of encoded key/value pairs
+        let mut attribute_buffer = vec![];
+
+        // Add key/value pairs to the buffer
+        for (key, value) in attributes_to_encode {
+            attribute_buffer.put_str_lenenc(key);
+            attribute_buffer.put_str_lenenc(value);
+        }
+
+        // Finally add encoded connection attributes with prefixed length
+        buf.put_uint_lenenc(attribute_buffer.len() as u64);
+        buf.extend_from_slice(&attribute_buffer);
+    }
+}
+
+/// Add default client attributes
+///
+/// https://dev.mysql.com/doc/refman/8.0/en/performance-schema-connection-attribute-tables.html
+fn add_client_attributes(attr: &mut BTreeMap<&str, &str>) {
+    attr.insert("_client_name", "sqlx-mysql");
+    attr.insert("_client_version", env!("CARGO_PKG_VERSION"));
+}

--- a/sqlx-mysql/src/protocol/connect/handshake_response.rs
+++ b/sqlx-mysql/src/protocol/connect/handshake_response.rs
@@ -1,5 +1,6 @@
 use crate::io::MySqlBufMutExt;
 use crate::io::{BufMutExt, Encode};
+use crate::options::Attributes;
 use crate::protocol::auth::AuthPlugin;
 use crate::protocol::connect::ssl_request::SslRequest;
 use crate::protocol::Capabilities;
@@ -25,6 +26,9 @@ pub struct HandshakeResponse<'a> {
 
     /// Opaque authentication response
     pub auth_response: Option<&'a [u8]>,
+
+    /// Connection attributes
+    pub attributes: &'a Attributes,
 }
 
 impl Encode<'_, Capabilities> for HandshakeResponse<'_> {
@@ -69,5 +73,7 @@ impl Encode<'_, Capabilities> for HandshakeResponse<'_> {
                 buf.push(0);
             }
         }
+
+        self.attributes.encode_with(buf, capabilities);
     }
 }

--- a/sqlx-mysql/src/protocol/connect/mod.rs
+++ b/sqlx-mysql/src/protocol/connect/mod.rs
@@ -3,6 +3,7 @@
 //! <https://dev.mysql.com/doc/internals/en/connection-phase.html>
 
 mod auth_switch;
+mod encode_attributes;
 mod handshake;
 mod handshake_response;
 mod ssl_request;


### PR DESCRIPTION
Implements the support for connection attributes for mysql.

Up for discussion
* The default could be changed that the default is to not send any connection attributes.
* The library default attribute keys/values
* The ergonomics/names on the MySqlConnectOptions struct (.attribute(..), no_default_attributes(..), clear_custom_attributes

WIP, needs more tests but wanted to get some initial feedback

