### PR TITLE
feat: Implement before_connect callback to modify connect options.

### DIFF
--- a/sqlx-core/src/pool/options.rs
+++ b/sqlx-core/src/pool/options.rs
@@ -378,7 +378,7 @@ impl<DB: Database> PoolOptions<DB> {
     /// use sqlx::postgres::PgPoolOptions;
     ///
     /// let pool = PgPoolOptions::new()
-    ///     .after_connect(move |opts, _num_attempts| Box::pin(async move {
+    ///     .before_connect(move |opts, _num_attempts| Box::pin(async move {
     ///         Ok(Cow::Owned(opts.clone().password("abc")))
     ///     }))
     ///     .connect("postgres:// …").await?;


### PR DESCRIPTION
Allows the user to see and maybe modify the connect options before each attempt to connect to a database. May be used in a number of ways, e.g.:
 - adding jitter to connection lifetime
 - validating/setting a per-connection password
 - using a custom server discovery process

One approach to the issue in #3051 
Also may help to fix #445

This is based on the signature suggestion from #3051. I'm not certain about the `Error` type used here; how should a user of the API represent an external error, `sqlx::Error::Io`?

Also, not sure how you would want this tested? The existing callback tests use a database connection which does not yet exist in this case.