### PR TITLE
Sqlite explain graph

### DIFF
--- a/sqlx-sqlite/src/connection/explain.rs
+++ b/sqlx-sqlite/src/connection/explain.rs
@@ -915,6 +915,9 @@ pub(super) fn explain(
                         state.mem.program_i = (*return_i + 1) as usize;
                         state.mem.r.remove(&p1);
                         continue;
+                    } else if p3 == 1 {
+                        state.mem.program_i += 1;
+                        continue;
                     } else {
                         logger.add_result(state, BranchResult::Error);
                         break;

--- a/sqlx-sqlite/src/connection/explain.rs
+++ b/sqlx-sqlite/src/connection/explain.rs
@@ -432,7 +432,7 @@ impl QueryState {
     fn get_reference(&self) -> BranchParent {
         BranchParent {
             id: self.history.id,
-            program_i: self.mem.program_i,
+            idx: Ord::max(self.history.program_i.len(), 1) - 1, //new branches create reference before they've processed their first instruction
         }
     }
     fn new_branch(&self, branch_seq: &mut Sequence) -> Self {

--- a/sqlx-sqlite/src/connection/explain.rs
+++ b/sqlx-sqlite/src/connection/explain.rs
@@ -566,8 +566,7 @@ pub(super) fn explain(
             .collect::<Result<Vec<_>, Error>>()?;
     let program_size = program.len();
 
-    let mut logger =
-        crate::logger::QueryPlanLogger::new(query, &program, conn.log_settings.clone());
+    let mut logger = crate::logger::QueryPlanLogger::new(query, &program);
     let mut branch_seq = Sequence::new();
     let mut states = BranchList::new(QueryState {
         visited: vec![0; program_size],

--- a/sqlx-sqlite/src/connection/explain.rs
+++ b/sqlx-sqlite/src/connection/explain.rs
@@ -502,10 +502,10 @@ impl BranchList {
             visited_branch_state: HashMap::new(),
         }
     }
-    pub fn push<T: Debug, R: Debug, P: Debug>(
+    pub fn push<R: Debug, P: Debug>(
         &mut self,
         mut state: QueryState,
-        logger: &mut crate::logger::QueryPlanLogger<'_, T, R, MemoryState, P>,
+        logger: &mut crate::logger::QueryPlanLogger<'_, R, MemoryState, P>,
     ) {
         match self.visited_branch_state.entry(state.mem) {
             std::collections::hash_map::Entry::Vacant(entry) => {
@@ -1052,10 +1052,6 @@ pub(super) fn explain(
                             is_empty: None,
                         }
                     };
-
-                    if logger.log_enabled() {
-                        logger.add_table_info(state.get_reference(), table_info.clone());
-                    }
 
                     state.mem.t.insert(state.mem.program_i as i64, table_info);
                     state

--- a/sqlx-sqlite/src/connection/explain.rs
+++ b/sqlx-sqlite/src/connection/explain.rs
@@ -597,16 +597,12 @@ pub(super) fn explain(
             if gas > 0 {
                 gas -= 1;
             } else {
-                if logger.log_enabled() {
-                    logger.add_result(state, BranchResult::GasLimit);
-                }
+                logger.add_result(state, BranchResult::GasLimit);
                 break;
             }
 
             if state.visited[state.mem.program_i] > MAX_LOOP_COUNT {
-                if logger.log_enabled() {
-                    logger.add_result(state, BranchResult::LoopLimit);
-                }
+                logger.add_result(state, BranchResult::LoopLimit);
                 //avoid (infinite) loops by breaking if we ever hit the same instruction twice
                 break;
             }
@@ -697,9 +693,7 @@ pub(super) fn explain(
                         }
                         continue;
                     } else {
-                        if logger.log_enabled() {
-                            logger.add_result(state, BranchResult::Branched);
-                        }
+                        logger.add_result(state, BranchResult::Branched);
                         break;
                     }
                 }
@@ -737,9 +731,7 @@ pub(super) fn explain(
                             .insert(p1, RegDataType::Single(ColumnType::default()));
                         continue;
                     } else {
-                        if logger.log_enabled() {
-                            logger.add_result(state, BranchResult::Branched);
-                        }
+                        logger.add_result(state, BranchResult::Branched);
                         break;
                     }
                 }
@@ -789,9 +781,7 @@ pub(super) fn explain(
                         }
                         continue;
                     } else {
-                        if logger.log_enabled() {
-                            logger.add_result(state, BranchResult::Branched);
-                        }
+                        logger.add_result(state, BranchResult::Branched);
                         break;
                     }
                 }
@@ -838,9 +828,7 @@ pub(super) fn explain(
                         }
                         continue;
                     } else {
-                        if logger.log_enabled() {
-                            logger.add_result(state, BranchResult::Branched);
-                        }
+                        logger.add_result(state, BranchResult::Branched);
                         break;
                     }
                 }
@@ -873,16 +861,12 @@ pub(super) fn explain(
                             state.mem.program_i += 1;
                             continue;
                         } else {
-                            if logger.log_enabled() {
-                                logger.add_result(state, BranchResult::Branched);
-                            }
+                            logger.add_result(state, BranchResult::Branched);
                             break;
                         }
                     }
 
-                    if logger.log_enabled() {
-                        logger.add_result(state, BranchResult::Branched);
-                    }
+                    logger.add_result(state, BranchResult::Branched);
                     break;
                 }
 
@@ -911,21 +895,15 @@ pub(super) fn explain(
                                 state.mem.r.remove(&p1);
                                 continue;
                             } else {
-                                if logger.log_enabled() {
-                                    logger.add_result(state, BranchResult::Error);
-                                }
+                                logger.add_result(state, BranchResult::Error);
                                 break;
                             }
                         } else {
-                            if logger.log_enabled() {
-                                logger.add_result(state, BranchResult::Error);
-                            }
+                            logger.add_result(state, BranchResult::Error);
                             break;
                         }
                     } else {
-                        if logger.log_enabled() {
-                            logger.add_result(state, BranchResult::Error);
-                        }
+                        logger.add_result(state, BranchResult::Error);
                         break;
                     }
                 }
@@ -938,9 +916,7 @@ pub(super) fn explain(
                         state.mem.r.remove(&p1);
                         continue;
                     } else {
-                        if logger.log_enabled() {
-                            logger.add_result(state, BranchResult::Error);
-                        }
+                        logger.add_result(state, BranchResult::Error);
                         break;
                     }
                 }
@@ -966,9 +942,7 @@ pub(super) fn explain(
                             continue;
                         }
                     } else {
-                        if logger.log_enabled() {
-                            logger.add_result(state, BranchResult::Error);
-                        }
+                        logger.add_result(state, BranchResult::Error);
                         break;
                     }
                 }
@@ -1484,21 +1458,17 @@ pub(super) fn explain(
                     branch_state.mem.program_i += 1;
                     states.push(branch_state, &mut logger);
 
-                    if logger.log_enabled() {
-                        logger.add_result(
-                            state,
-                            BranchResult::Result(IntMap::from_dense_record(&result)),
-                        );
-                    }
+                    logger.add_result(
+                        state,
+                        BranchResult::Result(IntMap::from_dense_record(&result)),
+                    );
 
                     result_states.push(result);
                     break;
                 }
 
                 OP_HALT => {
-                    if logger.log_enabled() {
-                        logger.add_result(state, BranchResult::Halt);
-                    }
+                    logger.add_result(state, BranchResult::Halt);
                     break;
                 }
 

--- a/sqlx-sqlite/src/connection/explain.rs
+++ b/sqlx-sqlite/src/connection/explain.rs
@@ -433,10 +433,7 @@ impl QueryState {
             visited: self.visited.clone(),
             history: crate::logger::BranchHistory {
                 id: branch_seq.next(),
-                parent: Some(crate::logger::BranchParent {
-                    id: self.history.id,
-                    program_i: self.mem.program_i,
-                }),
+                parent: self.history.get_reference(),
                 program_i: Vec::new(),
             },
             mem: self.mem.clone(),
@@ -993,7 +990,13 @@ pub(super) fn explain(
                     };
 
                     if logger.log_enabled() {
-                        logger.add_table_info(state.mem.program_i, Some(table_info.clone()));
+                        logger.add_table_info(
+                            state
+                                .history
+                                .get_reference()
+                                .expect("can't have table info without branch history"),
+                            table_info.clone(),
+                        );
                     }
 
                     state.mem.t.insert(state.mem.program_i as i64, table_info);

--- a/sqlx-sqlite/src/connection/intmap.rs
+++ b/sqlx-sqlite/src/connection/intmap.rs
@@ -67,6 +67,10 @@ impl<V: std::fmt::Debug + Clone + Eq + PartialEq + std::hash::Hash> IntMap<V> {
             None => None,
         }
     }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = Option<&V>> {
+        self.0.iter().map(Option::as_ref)
+    }
 }
 
 impl<V: std::fmt::Debug + Clone + Eq + PartialEq + std::hash::Hash> std::hash::Hash for IntMap<V> {

--- a/sqlx-sqlite/src/connection/intmap.rs
+++ b/sqlx-sqlite/src/connection/intmap.rs
@@ -71,6 +71,28 @@ impl<V: std::fmt::Debug + Clone + Eq + PartialEq + std::hash::Hash> IntMap<V> {
     pub(crate) fn iter(&self) -> impl Iterator<Item = Option<&V>> {
         self.0.iter().map(Option::as_ref)
     }
+
+    /// get the additions to this intmap compared to the prev intmap
+    pub(crate) fn diff<'a, 'b, 'c>(
+        &'a self,
+        prev: &'b Self,
+    ) -> impl Iterator<Item = (usize, Option<&'c V>)>
+    where
+        'a: 'c,
+        'b: 'c,
+    {
+        let self_pad = if prev.0.len() > self.0.len() {
+            prev.0.len() - self.0.len()
+        } else {
+            0
+        };
+        self.iter()
+            .chain(std::iter::repeat(None).take(self_pad))
+            .zip(prev.iter().chain(std::iter::repeat(None)))
+            .enumerate()
+            .filter(|(_i, (n, p))| n != p)
+            .map(|(i, (n, _p))| (i, n))
+    }
 }
 
 impl<V: std::fmt::Debug + Clone + Eq + PartialEq + std::hash::Hash> std::hash::Hash for IntMap<V> {

--- a/sqlx-sqlite/src/connection/intmap.rs
+++ b/sqlx-sqlite/src/connection/intmap.rs
@@ -30,6 +30,7 @@ impl<V> IntMap<V> {
     pub(crate) fn values(&self) -> impl Iterator<Item = &V> {
         self.0.iter().filter_map(Option::as_ref)
     }
+
     pub(crate) fn get(&self, idx: &i64) -> Option<&V> {
         let idx: usize = (*idx)
             .try_into()

--- a/sqlx-sqlite/src/connection/mod.rs
+++ b/sqlx-sqlite/src/connection/mod.rs
@@ -30,7 +30,7 @@ pub(crate) mod execute;
 mod executor;
 mod explain;
 mod handle;
-mod intmap;
+pub(crate) mod intmap;
 
 mod worker;
 

--- a/sqlx-sqlite/src/logger.rs
+++ b/sqlx-sqlite/src/logger.rs
@@ -365,6 +365,9 @@ impl<'q, R: Debug, S: Debug + DebugDiff, P: Debug> QueryPlanLogger<'q, R, S, P> 
     where
         BranchParent: From<I>,
     {
+        if !self.log_enabled() {
+            return;
+        }
         let branch: BranchParent = BranchParent::from(state);
         self.branch_origins.insert(branch.id, parent.clone());
     }
@@ -374,6 +377,9 @@ impl<'q, R: Debug, S: Debug + DebugDiff, P: Debug> QueryPlanLogger<'q, R, S, P> 
         BranchParent: From<I>,
         S: From<I>,
     {
+        if !self.log_enabled() {
+            return;
+        }
         let branch: BranchParent = BranchParent::from(state);
         let state: S = S::from(state);
         self.branch_operations
@@ -386,15 +392,24 @@ impl<'q, R: Debug, S: Debug + DebugDiff, P: Debug> QueryPlanLogger<'q, R, S, P> 
         BranchParent: for<'a> From<&'a I>,
         S: From<I>,
     {
+        if !self.log_enabled() {
+            return;
+        }
         let branch: BranchParent = BranchParent::from(&state);
         self.branch_results.insert(branch.id, result);
     }
 
     pub fn add_unknown_operation(&mut self, operation: usize) {
+        if !self.log_enabled() {
+            return;
+        }
         self.unknown_operations.insert(operation);
     }
 
     pub fn finish(&self) {
+        if !self.log_enabled() {
+            return;
+        }
         let lvl = self.settings.statements_level;
 
         if let Some((tracing_level, log_level)) = logger::private_level_filter_to_levels(lvl) {

--- a/sqlx-sqlite/src/logger.rs
+++ b/sqlx-sqlite/src/logger.rs
@@ -1,23 +1,115 @@
 use sqlx_core::{connection::LogSettings, logger};
 use std::collections::HashSet;
 use std::fmt::Debug;
-use std::hash::Hash;
 
 pub(crate) use sqlx_core::logger::*;
 
-pub struct QueryPlanLogger<'q, O: Debug + Hash + Eq, R: Debug, P: Debug> {
+pub struct QueryPlanLogger<'q, T: Debug + 'static, R: Debug + 'static, P: Debug> {
     sql: &'q str,
-    unknown_operations: HashSet<O>,
-    results: Vec<R>,
+    unknown_operations: HashSet<usize>,
+    table_info: Vec<Option<T>>,
+    results: Vec<(Vec<usize>, Option<R>)>,
     program: &'q [P],
     settings: LogSettings,
 }
 
-impl<'q, O: Debug + Hash + Eq, R: Debug, P: Debug> QueryPlanLogger<'q, O, R, P> {
+impl<T: Debug, R: Debug, P: Debug> core::fmt::Display for QueryPlanLogger<'_, T, R, P> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        //writes query plan history in dot format
+        f.write_str("digraph {")?;
+        for (idx, instruction) in self.program.iter().enumerate() {
+            let escaped_instruction = format!("{:?}", instruction)
+                .replace("\\", "\\\\")
+                .replace("\"", "'");
+            write!(f, "{} [label=\"{}\"", idx, escaped_instruction)?;
+
+            if self.unknown_operations.contains(&idx) {
+                f.write_str(" style=dashed")?;
+            }
+
+            f.write_str("];\n")?;
+        }
+
+        f.write_str("subgraph table_info {\n")?;
+        f.write_str("node [shape=box];\n")?;
+        for (idx, table_info_option) in self.table_info.iter().enumerate() {
+            if let Some(table_info) = table_info_option {
+                let escaped_data = format!("{:?}", table_info)
+                    .replace("\\", "\\\\")
+                    .replace("\"", "'");
+                write!(
+                    f,
+                    "{} -> table{}; table{} [label=\"{}\"];\n",
+                    idx, idx, idx, escaped_data
+                )?;
+            }
+        }
+        f.write_str("};\n")?;
+
+        for (idx, (history, result)) in self.results.iter().enumerate() {
+            f.write_str("subgraph {")?;
+
+            let color_names = [
+                "blue",
+                "red",
+                "cyan",
+                "yellow",
+                "green",
+                "magenta",
+                "orange",
+                "purple",
+                "orangered",
+                "sienna",
+                "olivedrab",
+                "pink",
+            ];
+            let color_name_root = color_names[idx % color_names.len()];
+            let color_name_suffix = match (idx / color_names.len()) % 4 {
+                0 => "1",
+                1 => "4",
+                2 => "3",
+                3 => "2",
+                _ => "",
+            }; //colors are easily confused after color_names.len() * 2, and outright reused after color_names.len() * 4
+            write!(
+                f,
+                "edge [colorscheme=x11 color={}{} label={}];",
+                color_name_root, color_name_suffix, idx
+            )?;
+
+            let mut history_iter = history.iter();
+            if let Some(item) = history_iter.next() {
+                write!(f, "{}", item)?;
+                while let Some(item) = history_iter.next() {
+                    write!(f, " -> {}", item)?;
+                }
+
+                let escaped_result = format!("{:?}", result)
+                    .replace("\\", "\\\\")
+                    .replace("\"", "'");
+                write!(
+                    f,
+                    " -> \"{}\"; \"{}\" [shape=box];",
+                    escaped_result, escaped_result
+                )?;
+            }
+            f.write_str("};\n")?;
+        }
+
+        f.write_str("}\n")?;
+        Ok(())
+    }
+}
+
+impl<'q, T: Debug, R: Debug, P: Debug> QueryPlanLogger<'q, T, R, P> {
     pub fn new(sql: &'q str, program: &'q [P], settings: LogSettings) -> Self {
+        let mut table_info = Vec::new();
+        table_info.resize_with(program.len(), || None);
+
         Self {
             sql,
             unknown_operations: HashSet::new(),
+            table_info,
             results: Vec::new(),
             program,
             settings,
@@ -35,11 +127,18 @@ impl<'q, O: Debug + Hash + Eq, R: Debug, P: Debug> QueryPlanLogger<'q, O, R, P> 
         }
     }
 
-    pub fn add_result(&mut self, result: R) {
+    pub fn add_table_info(&mut self, operation: usize, detail: Option<T>) {
+        while self.table_info.len() < operation {
+            self.table_info.push(None);
+        }
+        self.table_info.insert(operation, detail);
+    }
+
+    pub fn add_result(&mut self, result: (Vec<usize>, Option<R>)) {
         self.results.push(result);
     }
 
-    pub fn add_unknown_operation(&mut self, operation: O) {
+    pub fn add_unknown_operation(&mut self, operation: usize) {
         self.unknown_operations.insert(operation);
     }
 
@@ -66,22 +165,17 @@ impl<'q, O: Debug + Hash + Eq, R: Debug, P: Debug> QueryPlanLogger<'q, O, R, P> 
                     String::new()
                 };
 
-                let message = format!(
-                    "{}; program:{:?}, unknown_operations:{:?}, results: {:?}{}",
-                    summary, self.program, self.unknown_operations, self.results, sql
-                );
-
                 sqlx_core::private_tracing_dynamic_event!(
                     target: "sqlx::explain",
                     tracing_level,
-                    message,
+                    "{}; program:\n{}\n\n{:?}", summary, self, sql
                 );
             }
         }
     }
 }
 
-impl<'q, O: Debug + Hash + Eq, R: Debug, P: Debug> Drop for QueryPlanLogger<'q, O, R, P> {
+impl<'q, T: Debug, R: Debug, P: Debug> Drop for QueryPlanLogger<'q, T, R, P> {
     fn drop(&mut self) {
         self.finish();
     }

--- a/sqlx-sqlite/src/logger.rs
+++ b/sqlx-sqlite/src/logger.rs
@@ -320,6 +320,12 @@ impl<R: Debug, S: Debug + DebugDiff, P: Debug> core::fmt::Display for QueryPlanL
                             prev_ref.id, prev_ref.idx, escaped_result, escaped_result
                         )?;
                     }
+                } else {
+                    write!(
+                        f,
+                        "\"b{}p{}\" ->\"NoResult\"; \"NoResult\" [shape=box];",
+                        prev_ref.id, prev_ref.idx
+                    )?;
                 }
             }
             f.write_str("};\n")?;

--- a/sqlx-sqlite/src/logger.rs
+++ b/sqlx-sqlite/src/logger.rs
@@ -354,8 +354,8 @@ impl<'q, R: Debug, S: Debug + DebugDiff, P: Debug> QueryPlanLogger<'q, R, S, P> 
         if let Some((tracing_level, log_level)) =
             logger::private_level_filter_to_levels(self.settings.statements_level)
         {
-            log::log_enabled!(log_level)
-                || sqlx_core::private_tracing_dynamic_enabled!(tracing_level)
+            log::log_enabled!(target: "sqlx::explain", log_level)
+                || private_tracing_dynamic_enabled!(target: "sqlx::explain", tracing_level)
         } else {
             false
         }
@@ -412,10 +412,8 @@ impl<'q, R: Debug, S: Debug + DebugDiff, P: Debug> QueryPlanLogger<'q, R, S, P> 
         }
         let lvl = self.settings.statements_level;
 
-        if let Some((tracing_level, log_level)) = logger::private_level_filter_to_levels(lvl) {
-            let log_is_enabled = log::log_enabled!(target: "sqlx::explain", log_level)
-                || private_tracing_dynamic_enabled!(target: "sqlx::explain", tracing_level);
-            if log_is_enabled {
+        if let Some((tracing_level, _)) = logger::private_level_filter_to_levels(lvl) {
+            if self.log_enabled() {
                 let mut summary = parse_query_summary(&self.sql);
 
                 let sql = if summary != self.sql {

--- a/sqlx-sqlite/src/logger.rs
+++ b/sqlx-sqlite/src/logger.rs
@@ -183,7 +183,10 @@ impl<'q, T: Debug, R: Debug, P: Debug> QueryPlanLogger<'q, T, R, P> {
     }
 
     pub fn add_result(&mut self, result: (BranchHistory, Option<R>)) {
-        self.results.push(result);
+        //don't record any branches that didn't execute any instructions
+        if result.0.program_i.len() > 1 {
+            self.results.push(result);
+        }
     }
 
     pub fn add_unknown_operation(&mut self, operation: usize) {

--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -290,6 +290,14 @@ async fn it_describes_update_with_returning() -> anyhow::Result<()> {
     assert_eq!(d.column(2).type_info().name(), "BOOLEAN");
     //assert_eq!(d.nullable(2), Some(false)); //query analysis is allowed to notice that it is always set to true by the update
 
+    let d = conn
+        .describe("UPDATE accounts SET is_active=true WHERE id=?1 RETURNING id")
+        .await?;
+
+    assert_eq!(d.columns().len(), 1);
+    assert_eq!(d.column(0).type_info().name(), "INTEGER");
+    assert_eq!(d.nullable(0), Some(false));
+
     Ok(())
 }
 

--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -278,6 +278,18 @@ async fn it_describes_update_with_returning() -> anyhow::Result<()> {
     assert_eq!(d.column(0).type_info().name(), "INTEGER");
     assert_eq!(d.nullable(0), Some(false));
 
+    let d = conn
+        .describe("UPDATE accounts SET is_active=true WHERE id=?1 RETURNING *")
+        .await?;
+
+    assert_eq!(d.columns().len(), 3);
+    assert_eq!(d.column(0).type_info().name(), "INTEGER");
+    assert_eq!(d.nullable(0), Some(false));
+    assert_eq!(d.column(1).type_info().name(), "TEXT");
+    assert_eq!(d.nullable(1), Some(false));
+    assert_eq!(d.column(2).type_info().name(), "BOOLEAN");
+    //assert_eq!(d.nullable(2), Some(false)); //query analysis is allowed to notice that it is always set to true by the update
+
     Ok(())
 }
 


### PR DESCRIPTION
Improve diagnostic log message of sqlite explain processing to illustrate HOW the explain planner arrives to the output data types it finds. Then add a few simple fixes found with the improved diagnostic view.

Example command to get the dot format graphviz:
``` 
RUST_LOG="sqlx::explain=trace" DATABASE_URL=sqlite://tests/sqlite/sqlite.db cargo test --features sqlite,runtime-tokio,tls-rustls,chrono -- --nocapture update
```
Then the graphviz markup can be copy-pasted into the graphviz renderer/editor of choice. The process isn't elegant, but it works.

**Warning**: this only actually works when running a program which directly uses the 'describe' operation (such as sqlx's sqlite unit tests). Logger output is not available when compiling a library USING sqlx (the output is ignored - probably by rustc itself?).

### Does your PR solve an issue?
Fixes test cases derived from #2939 & #1923  (which involves breaking changes)