### PR TITLE
docs: update example for MySqlConnectionOptions

### DIFF
--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -45,8 +45,7 @@ pub use ssl_mode::MySqlSslMode;
 ///     .host("localhost")
 ///     .username("root")
 ///     .password("password")
-///     .database("db")
-///     .connect().await?;
+///     .database("db")?;
 ///
 /// // Modifying options parsed from a string
 /// let mut opts: MySqlConnectOptions = "mysql://root:password@localhost/db".parse()?;


### PR DESCRIPTION
removed the .connect().await? from the construction of MySqlConnectionOptions as this is not a valid parameter for the constructor

### Does your PR solve an issue?
### Delete this text and add "fixes #(issue number)"
