### PR TITLE
Change the name of "inner" function generated by `#[sqlx::test]`

### DIFF
--- a/sqlx-macros-core/src/test_attr.rs
+++ b/sqlx-macros-core/src/test_attr.rs
@@ -161,7 +161,7 @@ fn expand_advanced(args: syn::AttributeArgs, input: syn::ItemFn) -> crate::Resul
         #[::core::prelude::v1::test]
         #(#attrs)*
         fn #name() #ret {
-            async fn inner(#inputs) #ret {
+            async fn #name(#inputs) #ret {
                 #body
             }
 
@@ -172,7 +172,7 @@ fn expand_advanced(args: syn::AttributeArgs, input: syn::ItemFn) -> crate::Resul
             args.fixtures(&[#(#fixtures),*]);
 
             // We need to give a coercion site or else we get "unimplemented trait" errors.
-            let f: fn(#(#fn_arg_types),*) -> _ = inner;
+            let f: fn(#(#fn_arg_types),*) -> _ = #name;
 
             ::sqlx::testing::TestFn::run_test(f, args)
         }


### PR DESCRIPTION
# Summary

This patch addresses an issue with the `#[sqlx::test]` attribute macro that causes problems when used in conjunction with the [insta](https://github.com/mitsuhiko/insta) snapshot testing library.

```rust
#[sqlx::test(migrator = "mymodule::migrator")]
async fn select_foo(pool: PgPool) {
    let res = my_function_to_test(pool);
    insta::assert_debug_snapshot!(res); // we expect insta to generate a snapshot file named `mymodule__tests__select_foo.snap`
} 
```

When using `sqlx::test`, the test code is wrapped inside an inner function, which can lead to snapshot files being generated with the name of the inner function (`inner`), causing filename conflicts when multiple functions exist within the same module.

```rust
// expanded code
#[test]
fn select_foo() {
    async fn inner(pool: PgPool) {
        let res = my_function_to_test(pool);
        insta::assert_debug_snapshot!(res); // insta generates a snapshot file named `mymodule__tests__inner.snap`
    }
    // ...
    let f: fn(_) -> _ = inner;
    ::sqlx::testing::TestFn::run_test(f, args)
} 
```

https://github.com/mitsuhiko/insta/issues/434

This PR modifies the `sqlx::test` macro to ensure that insta uses the correct function name (`select_foo` in this case) when generating snapshot files, thereby avoiding filename conflicts and ensuring that snapshot tests work as expected.

# Changes

Modified the `sqlx::test` macro to generate the inner function with the original function name (`select_foo` in this case) when generating the test function, ensuring that insta uses the correct function name when generating snapshot files.

```rust
// expanded code
#[test]
fn select_foo() {
    async fn select_foo(pool: PgPool) {
        let res = my_function_to_test(pool);
        insta::assert_debug_snapshot!(res); // insta generates a snapshot file named `mymodule__tests__select_foo.snap`
    }
    // ...
    let f: fn(_) -> _ = select_foo;
    ::sqlx::testing::TestFn::run_test(f, args)
} 
```
