### PR TITLE
feat(logging): Log slow acquires from connection pool

### DIFF
--- a/sqlx-core/src/logger.rs
+++ b/sqlx-core/src/logger.rs
@@ -54,6 +54,12 @@ pub fn private_level_filter_to_levels(
     tracing_level.zip(filter.to_level())
 }
 
+pub(crate) fn private_level_filter_to_trace_level(
+    filter: log::LevelFilter,
+) -> Option<tracing::Level> {
+    private_level_filter_to_levels(filter).map(|(level, _)| level)
+}
+
 pub use sqlformat;
 
 pub struct QueryLogger<'q> {

--- a/sqlx-core/src/pool/mod.rs
+++ b/sqlx-core/src/pool/mod.rs
@@ -230,7 +230,7 @@ pub use self::maybe::MaybePoolConnection;
 /// scheme. However, in a web context, telling a client "go away, maybe try again later" results in
 /// a sub-optimal user experience.
 ///
-/// Instead with a connection pool, clients are made to wait in a fair queue for a connection to
+/// Instead, with a connection pool, clients are made to wait in a fair queue for a connection to
 /// become available; by using a single connection pool for your whole application, you can ensure
 /// that you don't exceed the connection limit of your database server while allowing response
 /// time to degrade gracefully at high load.


### PR DESCRIPTION
If the connection pool is full, and all connections are in use, the next request for a connection involving `PoolInner::acquire` will block until a connection is released back to the pool.

* Track the time taken to acquire a connection from the connection pool
* Warn if a time threshold is exceeded
* Threshold duration is configurable via `PoolOptions` 
* Threshold defaults to three seconds, which should be reasonable to prevent false positives for apps connecting to a database server that is nearby on the network

The default tries to avoid reporting a slow acquire when the pool grows itself within its capacity limit by creating a new connection.