### PR TITLE
Remove sha1 because it's not being used in postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3469,7 +3469,6 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "sha1",
  "sha2",
  "smallvec",
  "sqlx-core",

--- a/sqlx-postgres/Cargo.toml
+++ b/sqlx-postgres/Cargo.toml
@@ -32,7 +32,6 @@ hkdf = "0.12.0"
 hmac = { version = "0.12.0", default-features = false, features = ["reset"]}
 md-5 = { version = "0.10.0", default-features = false }
 rand = { version = "0.8.4", default-features = false, features = ["std", "std_rng"] }
-sha1 = { version = "0.10.1", default-features = false }
 sha2 = { version = "0.10.0", default-features = false }
 
 # Type Integrations (versions inherited from `[workspace.dependencies]`)


### PR DESCRIPTION
### Does your PR solve an issue?

There's no open issue for it. But SHA1 is not cryptographically secure and it wasn't being used in sqlx-postgres.

