### PR TITLE
fix(migrate): improve error message when parsing version from filename

### DIFF
--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -470,6 +470,10 @@ jobs:
         mariadb: [verylatest, 10_11, 10_4]
         runtime: [async-std, tokio]
         tls: [native-tls, rustls, none]
+        exclude:
+          # FIXME: `rustls` cannot accept MariaDB's new self-signed certificates: https://github.com/launchbadge/sqlx/issues/3091
+          - mariadb: verylatest
+            tls: rustls
     needs: check
     steps:
       - uses: actions/checkout@v2

--- a/sqlx-core/src/migrate/source.rs
+++ b/sqlx-core/src/migrate/source.rs
@@ -47,7 +47,10 @@ impl<'s> MigrationSource<'s> for &'s Path {
                     continue;
                 }
 
-                let version: i64 = parts[0].parse()?;
+                let version: i64 = parts[0].parse()
+                    .map_err(|_e| {
+                        format!("error parsing migration filename {file_name:?}; expected integer version prefix (e.g. `01_foo.sql`)")
+                    })?;
 
                 let migration_type = MigrationType::from_filename(parts[1]);
                 // remove the `.sql` and replace `_` with ` `


### PR DESCRIPTION
supercedes #2906 