### PR TITLE
Fix relative `DATABASE_URL` for SQLite

### DIFF
--- a/sqlx-macros-core/src/database/mod.rs
+++ b/sqlx-macros-core/src/database/mod.rs
@@ -36,7 +36,11 @@ pub trait DatabaseExt: Database {
 
     fn get_feature_gate(info: &Self::TypeInfo) -> Option<&'static str>;
 
-    fn describe_blocking(query: &str, database_url: &str) -> sqlx_core::Result<Describe<Self>>;
+    fn describe_blocking(
+        query: &str,
+        database_url: &str,
+        root: &str,
+    ) -> sqlx_core::Result<Describe<Self>>;
 }
 
 #[allow(dead_code)]
@@ -133,6 +137,7 @@ macro_rules! impl_describe_blocking {
         fn describe_blocking(
             query: &str,
             database_url: &str,
+            _root: &str,
         ) -> sqlx_core::Result<sqlx_core::describe::Describe<Self>> {
             use $crate::database::CachingDescribeBlocking;
 
@@ -146,8 +151,9 @@ macro_rules! impl_describe_blocking {
         fn describe_blocking(
             query: &str,
             database_url: &str,
+            root: &str,
         ) -> sqlx_core::Result<sqlx_core::describe::Describe<Self>> {
-            $describe(query, database_url)
+            $describe(query, database_url, root)
         }
     };
 }

--- a/sqlx-sqlite/src/lib.rs
+++ b/sqlx-sqlite/src/lib.rs
@@ -29,6 +29,8 @@
 #[macro_use]
 extern crate sqlx_core;
 
+use std::borrow::Cow;
+use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 
 pub use arguments::{SqliteArgumentValue, SqliteArguments};
@@ -106,8 +108,15 @@ pub static CREATE_DB_WAL: AtomicBool = AtomicBool::new(true);
 
 /// UNSTABLE: for use by `sqlite-macros-core` only.
 #[doc(hidden)]
-pub fn describe_blocking(query: &str, database_url: &str) -> Result<Describe<Sqlite>, Error> {
-    let opts: SqliteConnectOptions = database_url.parse()?;
+pub fn describe_blocking(
+    query: &str,
+    database_url: &str,
+    root: &str,
+) -> Result<Describe<Sqlite>, Error> {
+    let mut opts: SqliteConnectOptions = database_url.parse()?;
+    if opts.filename.is_relative() {
+        opts.filename = Cow::Owned(PathBuf::from(root).join(opts.filename));
+    }
     let params = EstablishParams::from_options(&opts)?;
     let mut conn = params.establish()?;
 


### PR DESCRIPTION
## Objective

Fixes #1399
Fixes #1260

It seems like `DATABASE_URL=sqlite:relative/path/to/database.db` is broken. In fact, following the instructions for the [todos example](https://github.com/launchbadge/sqlx/tree/main/examples/sqlite/todos) doesn't even work (or at least, it didn't work for me).

The current workaround is to use an absolute path instead. This isn't a great solution when, for example, you want to track `.env` and have it work between machines.

It would be much cleaner for relative paths to work correctly.

## Solution

Pass the "root" directory (aka the `CARGO_MANIFEST_DIR`) to `describe_blocking` and prepend the value to the `database_url` if it's a relative filepath.
