### PR TITLE
feat: impl Encode, Decode and Type for Cow<T> where T: Encode + Decode + Type

### DIFF
--- a/sqlx-core/src/migrate/source.rs
+++ b/sqlx-core/src/migrate/source.rs
@@ -54,7 +54,8 @@ pub struct ResolveError {
 
 // FIXME: paths should just be part of `Migration` but we can't add a field backwards compatibly
 // since it's `#[non_exhaustive]`.
-pub fn resolve_blocking(path: PathBuf) -> Result<Vec<(Migration, PathBuf)>, ResolveError> {
+pub fn resolve_blocking(path: impl AsRef<Path>) -> Result<Vec<(Migration, PathBuf)>, ResolveError> {
+    let path = path.as_ref().to_path_buf();
     let mut s = fs::read_dir(&path).map_err(|e| ResolveError {
         message: format!("error reading migration directory {}: {e}", path.display()),
         source: Some(e),

--- a/sqlx-core/src/types/mod.rs
+++ b/sqlx-core/src/types/mod.rs
@@ -19,6 +19,7 @@
 //!
 
 use crate::database::Database;
+use std::borrow::Cow;
 
 #[cfg(feature = "bstr")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bstr")))]
@@ -235,5 +236,20 @@ impl<T: Type<DB>, DB: Database> Type<DB> for Option<T> {
 
     fn compatible(ty: &DB::TypeInfo) -> bool {
         <T as Type<DB>>::compatible(ty)
+    }
+}
+
+impl<T, DB> Type<DB> for Cow<'_, T>
+where
+    T: ToOwned + ?Sized,
+    T::Owned: Type<DB>,
+    DB: Database,
+{
+    fn type_info() -> DB::TypeInfo {
+        <T::Owned as Type<DB>>::type_info()
+    }
+
+    fn compatible(ty: &DB::TypeInfo) -> bool {
+        <T::Owned as Type<DB>>::compatible(ty)
     }
 }

--- a/sqlx-macros-core/src/migrate.rs
+++ b/sqlx-macros-core/src/migrate.rs
@@ -101,7 +101,7 @@ pub(crate) fn expand_migrator(path: &Path) -> crate::Result<TokenStream> {
     })?;
 
     // Use the same code path to resolve migrations at compile time and runtime.
-    let migrations = sqlx_core::migrate::resolve_blocking(path)?
+    let migrations = sqlx_core::migrate::resolve_blocking(&path)?
         .into_iter()
         .map(|(migration, path)| QuoteMigration { migration, path });
 

--- a/sqlx-mysql/src/types/str.rs
+++ b/sqlx-mysql/src/types/str.rs
@@ -105,28 +105,3 @@ impl Decode<'_, MySql> for String {
         <&str as Decode<MySql>>::decode(value).map(ToOwned::to_owned)
     }
 }
-
-impl Type<MySql> for Cow<'_, str> {
-    fn type_info() -> MySqlTypeInfo {
-        <&str as Type<MySql>>::type_info()
-    }
-
-    fn compatible(ty: &MySqlTypeInfo) -> bool {
-        <&str as Type<MySql>>::compatible(ty)
-    }
-}
-
-impl Encode<'_, MySql> for Cow<'_, str> {
-    fn encode_by_ref(&self, buf: &mut Vec<u8>) -> IsNull {
-        match self {
-            Cow::Borrowed(str) => <&str as Encode<MySql>>::encode(*str, buf),
-            Cow::Owned(str) => <&str as Encode<MySql>>::encode(&**str, buf),
-        }
-    }
-}
-
-impl<'r> Decode<'r, MySql> for Cow<'r, str> {
-    fn decode(value: MySqlValueRef<'r>) -> Result<Self, BoxDynError> {
-        value.as_str().map(Cow::Borrowed)
-    }
-}

--- a/sqlx-postgres/src/types/str.rs
+++ b/sqlx-postgres/src/types/str.rs
@@ -24,16 +24,6 @@ impl Type<Postgres> for str {
     }
 }
 
-impl Type<Postgres> for Cow<'_, str> {
-    fn type_info() -> PgTypeInfo {
-        <&str as Type<Postgres>>::type_info()
-    }
-
-    fn compatible(ty: &PgTypeInfo) -> bool {
-        <&str as Type<Postgres>>::compatible(ty)
-    }
-}
-
 impl Type<Postgres> for Box<str> {
     fn type_info() -> PgTypeInfo {
         <&str as Type<Postgres>>::type_info()
@@ -102,15 +92,6 @@ impl Encode<'_, Postgres> for &'_ str {
     }
 }
 
-impl Encode<'_, Postgres> for Cow<'_, str> {
-    fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> IsNull {
-        match self {
-            Cow::Borrowed(str) => <&str as Encode<Postgres>>::encode(*str, buf),
-            Cow::Owned(str) => <&str as Encode<Postgres>>::encode(&**str, buf),
-        }
-    }
-}
-
 impl Encode<'_, Postgres> for Box<str> {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> IsNull {
         <&str as Encode<Postgres>>::encode(&**self, buf)
@@ -126,12 +107,6 @@ impl Encode<'_, Postgres> for String {
 impl<'r> Decode<'r, Postgres> for &'r str {
     fn decode(value: PgValueRef<'r>) -> Result<Self, BoxDynError> {
         Ok(value.as_str()?)
-    }
-}
-
-impl<'r> Decode<'r, Postgres> for Cow<'r, str> {
-    fn decode(value: PgValueRef<'r>) -> Result<Self, BoxDynError> {
-        Ok(Cow::Borrowed(value.as_str()?))
     }
 }
 

--- a/sqlx-sqlite/src/types/str.rs
+++ b/sqlx-sqlite/src/types/str.rs
@@ -80,33 +80,3 @@ impl<'r> Decode<'r, Sqlite> for String {
         value.text().map(ToOwned::to_owned)
     }
 }
-
-impl Type<Sqlite> for Cow<'_, str> {
-    fn type_info() -> SqliteTypeInfo {
-        <&str as Type<Sqlite>>::type_info()
-    }
-
-    fn compatible(ty: &SqliteTypeInfo) -> bool {
-        <&str as Type<Sqlite>>::compatible(ty)
-    }
-}
-
-impl<'q> Encode<'q, Sqlite> for Cow<'q, str> {
-    fn encode(self, args: &mut Vec<SqliteArgumentValue<'q>>) -> IsNull {
-        args.push(SqliteArgumentValue::Text(self));
-
-        IsNull::No
-    }
-
-    fn encode_by_ref(&self, args: &mut Vec<SqliteArgumentValue<'q>>) -> IsNull {
-        args.push(SqliteArgumentValue::Text(self.clone()));
-
-        IsNull::No
-    }
-}
-
-impl<'r> Decode<'r, Sqlite> for Cow<'r, str> {
-    fn decode(value: SqliteValueRef<'r>) -> Result<Self, BoxDynError> {
-        value.text().map(Cow::Borrowed)
-    }
-}


### PR DESCRIPTION
This allows to use Cow<T> for every T that implements `Encode`, `Decode`, and `Type`.
The motivation for this is that I can use the same struct to decode and encode without having unnecessary copies of data. This is especially helpful in situations where you a have struct for all db tables, since then you would need clone the participating keys of each relation into those structs.

This allows to write this

```rust
pub(super) struct TableA<'a> {
  pub(super) id: Cow<'a, Uuid>,
  pub(super) content: Cow<'a, str>,
  ...
}
```
, instead of this.
```rust 

// Cannot be used to receive data since decoding into a pointer is not possible, since the Uuid needs to live somewhere
pub(super) struct TableARef<'a> {
  pub(super) id:  &'a Uuid,
  pub(super) content: &'a str,
  ...
}

// Can be used to decode, but encoding requires cloning the data or taking ownership 
pub(super) struct TableA {
  pub(super) id:  Uuid,
  pub(super) content: String,
  ...
}
```

The implementation for `Encode` and `Type` will just delegate to the implementation of T.

The `Decode` trait is implemented by creating an owned Cow<T>. 
The owned variant is used here, because 
1.  e.g. the `query_as` function has the bound  `for<'r> FromRow<'r, DB::Row>`. 
This can only be implemented if the lifetime of the type is arbitrary/static, which necessitate the owned variant.
2. the expansion of the `query_as!`  won't work with an object with the same lifetime as the row, which also leads to the owned variant.

I believe that the current `impl<'r, DB> Decode<'r, DB> for Cow<'r, str>` is broken/ useless, but maybe i've miss the use case for the borrowed variant while decoding.


This implementation currently does not work with the derive macro for FromRow, because the macro implements
 `impl<'r, R> FromRow<'r, R> for TableA<'r>` instead of `impl<'r,'a, R> FromRow<'r, R> for TableA<'a>`.
But manually implementing `FromRow` works.  


fixed #3100 