### PR TITLE
feat: new derive feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["any", "macros", "migrate", "json"]
-macros = ["sqlx-macros"]
+
+derive = ["sqlx-macros/derive"]
+macros = ["derive", "sqlx-macros/macros"]
 migrate = ["sqlx-core/migrate", "sqlx-macros?/migrate", "sqlx-mysql?/migrate", "sqlx-postgres?/migrate", "sqlx-sqlite?/migrate"]
 
 # intended mainly for CI and docs

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ be removed in the future.
 
 -   `any`: Add support for the `Any` database driver, which can proxy to a database driver at runtime.
 
+-   `derive`: Add support for the derive family macros, those are `FromRow`, `Type`, `Encode`, `Decode`.
+
 -   `macros`: Add support for the `query*!` macros, which allows compile-time checked queries.
 
 -   `migrate`: Add support for the migration management and `migrate!` macro, which allow compile-time embedded migrations.

--- a/sqlx-macros-core/Cargo.toml
+++ b/sqlx-macros-core/Cargo.toml
@@ -18,6 +18,8 @@ _tls-native-tls = ["sqlx-core/_tls-native-tls"]
 _tls-rustls = ["sqlx-core/_tls-rustls"]
 
 # SQLx features
+derive = []
+macros = []
 migrate = ["sqlx-core/migrate"]
 
 # database

--- a/sqlx-macros-core/src/lib.rs
+++ b/sqlx-macros-core/src/lib.rs
@@ -19,6 +19,7 @@
     feature(track_path)
 )]
 
+#[cfg(feature = "macros")]
 use crate::query::QueryDriver;
 
 pub type Error = Box<dyn std::error::Error>;
@@ -28,15 +29,19 @@ pub type Result<T> = std::result::Result<T, Error>;
 mod common;
 mod database;
 
+#[cfg(feature = "derive")]
 pub mod derives;
+#[cfg(feature = "macros")]
 pub mod query;
 
+#[cfg(feature = "macros")]
 // The compiler gives misleading help messages about `#[cfg(test)]` when this is just named `test`.
 pub mod test_attr;
 
 #[cfg(feature = "migrate")]
 pub mod migrate;
 
+#[cfg(feature = "macros")]
 pub const FOSS_DRIVERS: &[QueryDriver] = &[
     #[cfg(feature = "mysql")]
     QueryDriver::new::<sqlx_mysql::MySql>(),

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -21,6 +21,8 @@ _tls-native-tls = ["sqlx-macros-core/_tls-native-tls"]
 _tls-rustls = ["sqlx-macros-core/_tls-rustls"]
 
 # SQLx features
+derive = ["sqlx-macros-core/derive"]
+macros = ["sqlx-macros-core/macros"]
 migrate = ["sqlx-macros-core/migrate"]
 
 # database

--- a/sqlx-macros/src/lib.rs
+++ b/sqlx-macros/src/lib.rs
@@ -4,6 +4,7 @@ use quote::quote;
 
 use sqlx_macros_core::*;
 
+#[cfg(feature = "macros")]
 #[proc_macro]
 pub fn expand_query(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as query::QueryMacroInput);
@@ -21,6 +22,7 @@ pub fn expand_query(input: TokenStream) -> TokenStream {
     }
 }
 
+#[cfg(feature = "derive")]
 #[proc_macro_derive(Encode, attributes(sqlx))]
 pub fn derive_encode(tokenstream: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(tokenstream as syn::DeriveInput);
@@ -30,6 +32,7 @@ pub fn derive_encode(tokenstream: TokenStream) -> TokenStream {
     }
 }
 
+#[cfg(feature = "derive")]
 #[proc_macro_derive(Decode, attributes(sqlx))]
 pub fn derive_decode(tokenstream: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(tokenstream as syn::DeriveInput);
@@ -39,6 +42,7 @@ pub fn derive_decode(tokenstream: TokenStream) -> TokenStream {
     }
 }
 
+#[cfg(feature = "derive")]
 #[proc_macro_derive(Type, attributes(sqlx))]
 pub fn derive_type(tokenstream: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(tokenstream as syn::DeriveInput);
@@ -48,6 +52,7 @@ pub fn derive_type(tokenstream: TokenStream) -> TokenStream {
     }
 }
 
+#[cfg(feature = "derive")]
 #[proc_macro_derive(FromRow, attributes(sqlx))]
 pub fn derive_from_row(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
@@ -77,6 +82,7 @@ pub fn migrate(input: TokenStream) -> TokenStream {
     }
 }
 
+#[cfg(feature = "macros")]
 #[proc_macro_attribute]
 pub fn test(args: TokenStream, input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as syn::ItemFn);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,12 +49,12 @@ pub use sqlx_sqlite::{self as sqlite, Sqlite, SqliteConnection, SqliteExecutor, 
 #[cfg_attr(docsrs, doc(cfg(feature = "any")))]
 pub use crate::any::{reexports::*, Any, AnyExecutor};
 
-#[cfg(feature = "macros")]
+#[cfg(any(feature = "derive", feature = "macro"))]
 #[doc(hidden)]
 pub extern crate sqlx_macros;
 
 // derives
-#[cfg(feature = "macros")]
+#[cfg(feature = "derive")]
 #[doc(hidden)]
 pub use sqlx_macros::{FromRow, Type};
 
@@ -103,7 +103,7 @@ pub use sqlx_core::rt as __rt;
 pub mod types {
     pub use sqlx_core::types::*;
 
-    #[cfg(feature = "macros")]
+    #[cfg(feature = "derive")]
     #[doc(hidden)]
     pub use sqlx_macros::Type;
 }
@@ -112,7 +112,7 @@ pub mod types {
 pub mod encode {
     pub use sqlx_core::encode::{Encode, IsNull};
 
-    #[cfg(feature = "macros")]
+    #[cfg(feature = "derive")]
     #[doc(hidden)]
     pub use sqlx_macros::Encode;
 }
@@ -123,7 +123,7 @@ pub use self::encode::Encode;
 pub mod decode {
     pub use sqlx_core::decode::Decode;
 
-    #[cfg(feature = "macros")]
+    #[cfg(feature = "derive")]
     #[doc(hidden)]
     pub use sqlx_macros::Decode;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub use sqlx_sqlite::{self as sqlite, Sqlite, SqliteConnection, SqliteExecutor, 
 #[cfg_attr(docsrs, doc(cfg(feature = "any")))]
 pub use crate::any::{reexports::*, Any, AnyExecutor};
 
-#[cfg(any(feature = "derive", feature = "macro"))]
+#[cfg(any(feature = "derive", feature = "macros"))]
 #[doc(hidden)]
 pub extern crate sqlx_macros;
 


### PR DESCRIPTION
As mentioned in https://github.com/launchbadge/sqlx/pull/2482#issuecomment-1992717206, the current `macros` flag enables a ton of unrelated things. Personally, my use of SQLx is almost always limited to the derive macros, and I don't want to be bombarded with `query_*!` macros every time I enable the derives. The new `derive` feature flag solves this.

Derives will still be enabled when using the `macros` feature.