### PR TITLE
Add version information for failed cli migration (#3129)

### DIFF
--- a/sqlx-core/src/migrate/error.rs
+++ b/sqlx-core/src/migrate/error.rs
@@ -6,6 +6,9 @@ pub enum MigrateError {
     #[error("while executing migrations: {0}")]
     Execute(#[from] Error),
 
+    #[error("while executing migration {1}: {0}")]
+    ExecuteMigration(#[source] Error, i64),
+
     #[error("while resolving migrations: {0}")]
     Source(#[source] BoxDynError),
 

--- a/sqlx-mysql/src/migrate.rs
+++ b/sqlx-mysql/src/migrate.rs
@@ -199,7 +199,10 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
             .execute(&mut *tx)
             .await?;
 
-            let _ = tx.execute(&*migration.sql).await?;
+            let _ = tx
+                .execute(&*migration.sql)
+                .await
+                .map_err(|e| MigrateError::ExecuteMigration(e, migration.version))?;
 
             // language=MySQL
             let _ = query(

--- a/sqlx-postgres/src/migrate.rs
+++ b/sqlx-postgres/src/migrate.rs
@@ -216,7 +216,10 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
             // The `execution_time` however can only be measured for the whole transaction. This value _only_ exists for
             // data lineage and debugging reasons, so it is not super important if it is lost. So we initialize it to -1
             // and update it once the actual transaction completed.
-            let _ = tx.execute(&*migration.sql).await?;
+            let _ = tx
+                .execute(&*migration.sql)
+                .await
+                .map_err(|e| MigrateError::ExecuteMigration(e, migration.version))?;
 
             // language=SQL
             let _ = query(

--- a/sqlx-sqlite/src/migrate.rs
+++ b/sqlx-sqlite/src/migrate.rs
@@ -142,7 +142,10 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
             // The `execution_time` however can only be measured for the whole transaction. This value _only_ exists for
             // data lineage and debugging reasons, so it is not super important if it is lost. So we initialize it to -1
             // and update it once the actual transaction completed.
-            let _ = tx.execute(&*migration.sql).await?;
+            let _ = tx
+                .execute(&*migration.sql)
+                .await
+                .map_err(|e| MigrateError::ExecuteMigration(e, migration.version))?;
 
             // language=SQL
             let _ = query(


### PR DESCRIPTION
### Does your PR solve an issue?
Yes - it shows following output:

```
❯ sqlx migrate run --ignore-missing
error: while executing migration 20240314125700: error returned from database: column "email" of relation "customer_status_extended" already exists
```

fixes #3129