### PR TITLE
fix(sqlite): delete unused `ConnectionHandleRaw` type

### DIFF
--- a/sqlx-sqlite/src/connection/mod.rs
+++ b/sqlx-sqlite/src/connection/mod.rs
@@ -1,27 +1,27 @@
-use futures_core::future::BoxFuture;
-use futures_intrusive::sync::MutexGuard;
-use futures_util::future;
-use libsqlite3_sys::{sqlite3, sqlite3_progress_handler};
-use sqlx_core::common::StatementCache;
-use sqlx_core::error::Error;
-use sqlx_core::transaction::Transaction;
 use std::cmp::Ordering;
+use std::fmt::Write;
 use std::fmt::{self, Debug, Formatter};
 use std::os::raw::{c_int, c_void};
 use std::panic::catch_unwind;
 use std::ptr::NonNull;
+
+use futures_core::future::BoxFuture;
+use futures_intrusive::sync::MutexGuard;
+use futures_util::future;
+use libsqlite3_sys::{sqlite3, sqlite3_progress_handler};
+
+pub(crate) use handle::ConnectionHandle;
+use sqlx_core::common::StatementCache;
+pub(crate) use sqlx_core::connection::*;
+use sqlx_core::error::Error;
+use sqlx_core::executor::Executor;
+use sqlx_core::transaction::Transaction;
 
 use crate::connection::establish::EstablishParams;
 use crate::connection::worker::ConnectionWorker;
 use crate::options::OptimizeOnClose;
 use crate::statement::VirtualStatement;
 use crate::{Sqlite, SqliteConnectOptions};
-use sqlx_core::executor::Executor;
-use std::fmt::Write;
-
-pub(crate) use sqlx_core::connection::*;
-
-pub(crate) use handle::{ConnectionHandle, ConnectionHandleRaw};
 
 pub(crate) mod collation;
 pub(crate) mod describe;


### PR DESCRIPTION
This suddenly became an error for some reason. I guess tuple fields recently started getting checked by the `dead_code` lint.