### PR TITLE
Bump libsqlite3-sys to v0.28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,7 @@ criterion = { version = "0.5.1", features = ["async_tokio"] }
 # even when SQLite isn't the intended test target, and fail if the build environment is not set up for compiling C code.
 [target.'cfg(sqlite_test_sqlcipher)'.dev-dependencies]
 # Enable testing with SQLCipher if specifically requested.
-libsqlite3-sys = { version = "0.27", features = ["bundled-sqlcipher"] }
+libsqlite3-sys = { version = "0.28", features = ["bundled-sqlcipher"] }
 
 #
 # Any

--- a/sqlx-sqlite/Cargo.toml
+++ b/sqlx-sqlite/Cargo.toml
@@ -46,7 +46,7 @@ regex = { version = "1.5.5", optional = true }
 urlencoding = "2.1.3"
 
 [dependencies.libsqlite3-sys]
-version = "0.27.0"
+version = "0.28.0"
 default-features = false
 features = [
     "pkg-config",


### PR DESCRIPTION
This includes SQLite v3.45(.1), which includes new JSONB functionality.
