### PR TITLE
Drop urlencoding dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3541,12 +3541,12 @@ dependencies = [
  "percent-encoding",
  "regex",
  "serde",
+ "serde_urlencoded",
  "sqlx",
  "sqlx-core",
  "time",
  "tracing",
  "url",
- "urlencoding",
  "uuid",
 ]
 
@@ -4017,12 +4017,6 @@ dependencies = [
  "idna 0.5.0",
  "percent-encoding",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"

--- a/sqlx-sqlite/Cargo.toml
+++ b/sqlx-sqlite/Cargo.toml
@@ -33,6 +33,7 @@ uuid = { workspace = true, optional = true }
 
 url = { version = "2.2.2", default-features = false }
 percent-encoding = "2.1.0"
+serde_urlencoded = "0.7"
 
 flume = { version = "0.11.0", default-features = false, features = ["async"] }
 
@@ -43,7 +44,6 @@ tracing = { version = "0.1.37", features = ["log"] }
 
 serde = { version = "1.0.145", features = ["derive"], optional = true }
 regex = { version = "1.5.5", optional = true }
-urlencoding = "2.1.3"
 
 [dependencies.libsqlite3-sys]
 version = "0.27.0"


### PR DESCRIPTION
This drops the [unmaintained](https://github.com/kornelski/rust_urlencoding/commit/3cc277fc4e577a0bef99294d7ab9bc85232f0730) and scary looking use of the `urlencoding` crate with a more proper implementation using `serde_urlencoded` and `percent-encoding`