### PR TITLE
Bump deps that do not need code changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1565,9 +1571,9 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+checksum = "692eaaf7f7607518dd3cef090f1474b61edc5301d8012f09579920df68b725ee"
 dependencies = [
  "hashbrown 0.14.3",
 ]
@@ -1586,9 +1592,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-dependencies = [
- "unicode-segmentation",
-]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1899,9 +1908,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3233,7 +3242,7 @@ dependencies = [
  "digest",
  "either",
  "encoding_rs",
- "event-listener 2.5.3",
+ "event-listener 5.2.0",
  "futures-channel",
  "futures-core",
  "futures-intrusive",
@@ -3416,7 +3425,7 @@ dependencies = [
  "async-std",
  "dotenvy",
  "either",
- "heck 0.4.1",
+ "heck 0.5.0",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -3439,7 +3448,7 @@ name = "sqlx-mysql"
 version = "0.8.0-alpha.0"
 dependencies = [
  "atoi",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bigdecimal",
  "bitflags 2.4.2",
  "byteorder",
@@ -3484,7 +3493,7 @@ name = "sqlx-postgres"
 version = "0.8.0-alpha.0"
 dependencies = [
  "atoi",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bigdecimal",
  "bit-vec",
  "bitflags 2.4.2",

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -85,9 +85,9 @@ tracing = { version = "0.1.37", features = ["log"] }
 smallvec = "1.7.0"
 url = { version = "2.2.2", default-features = false }
 bstr = { version = "1.0", default-features = false, features = ["std"], optional = true }
-hashlink = "0.8.0"
+hashlink = "0.9.0"
 indexmap = "2.0"
-event-listener = "2.5.2"
+event-listener = "5.2.0"
 
 [dev-dependencies]
 sqlx = { workspace = true, features = ["postgres", "sqlite", "mysql", "migrate", "macros", "time", "uuid"] }

--- a/sqlx-macros-core/Cargo.toml
+++ b/sqlx-macros-core/Cargo.toml
@@ -51,7 +51,7 @@ tokio = { workspace = true, optional = true }
 dotenvy = { workspace = true }
 
 hex = { version = "0.4.3" }
-heck = { version = "0.4", features = ["unicode"] }
+heck = { version = "0.5" }
 either = "1.6.1"
 once_cell = "1.9.0"
 proc-macro2 = { version = "1.0.79", default-features = false }

--- a/sqlx-mysql/Cargo.toml
+++ b/sqlx-mysql/Cargo.toml
@@ -44,7 +44,7 @@ uuid = { workspace = true, optional = true }
 
 # Misc
 atoi = "2.0"
-base64 = { version = "0.21.0", default-features = false, features = ["std"] }
+base64 = { version = "0.22.0", default-features = false, features = ["std"] }
 bitflags = { version = "2", default-features = false, features = ["serde"] }
 byteorder = { version = "1.4.3", default-features = false, features = ["std"] }
 bytes = "1.1.0"

--- a/sqlx-postgres/Cargo.toml
+++ b/sqlx-postgres/Cargo.toml
@@ -46,7 +46,7 @@ uuid = { workspace = true, optional = true }
 
 # Misc
 atoi = "2.0"
-base64 = { version = "0.21.0", default-features = false, features = ["std"] }
+base64 = { version = "0.22.0", default-features = false, features = ["std"] }
 bitflags = { version = "2", default-features = false }
 byteorder = { version = "1.4.3", default-features = false, features = ["std"] }
 dotenvy = { workspace = true }


### PR DESCRIPTION
This cleans up the dep tree of projects depending and should duplicates over time. rustls still needs updating, but it seems like quite extensive migration is needed which I didn't feel comfortable to perform.