### PR TITLE
docs: improve clarity of dotenv setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,13 +378,13 @@ Differences from `query()`:
     queries against; the database does not have to contain any data but must be the same
     kind (MySQL, Postgres, etc.) and have the same schema as the database you will be connecting to at runtime.
 
-    For convenience, you can use [a `.env` file][dotenv]<sup>1</sup> to set DATABASE_URL so that you don't have to pass it every time:
+    For convenience, you can use [a `.env` file][dotenv] to set DATABASE_URL so that you don't have to pass it every time:
 
     ```
     DATABASE_URL=mysql://localhost/my_database
     ```
 
-[dotenv]: https://github.com/dotenv-rs/dotenv#examples
+[dotenv]: https://github.com/allan2/dotenvy#Usage
 
 The biggest downside to `query!()` is that the output type cannot be named (due to Rust not
 officially supporting anonymous records). To address that, there is a `query_as!()` macro that is 
@@ -424,9 +424,6 @@ putting the following in your `Cargo.toml` (More information in the
 [profile.dev.package.sqlx-macros]
 opt-level = 3
 ```
-
-<sup>1</sup> The `dotenv` crate itself appears abandoned as of [December 2021](https://github.com/dotenv-rs/dotenv/issues/74)
-so we now use the `dotenvy` crate instead. The file format is the same.
 
 ## Safety
 

--- a/README.md
+++ b/README.md
@@ -378,13 +378,13 @@ Differences from `query()`:
     queries against; the database does not have to contain any data but must be the same
     kind (MySQL, Postgres, etc.) and have the same schema as the database you will be connecting to at runtime.
 
-    For convenience, you can use [a `.env` file][dotenv] to set DATABASE_URL so that you don't have to pass it every time:
+    For convenience, you can use [a `.env` file][dotenvy] to set DATABASE_URL so that you don't have to pass it every time:
 
     ```
     DATABASE_URL=mysql://localhost/my_database
     ```
 
-[dotenv]: https://github.com/allan2/dotenvy#Usage
+[dotenvy]: https://github.com/allan2/dotenvy#Usage
 
 The biggest downside to `query!()` is that the output type cannot be named (due to Rust not
 officially supporting anonymous records). To address that, there is a `query_as!()` macro that is 

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -53,7 +53,7 @@
 /// ## Requirements
 /// * The `DATABASE_URL` environment variable must be set at build-time to point to a database
 /// server with the schema that the query string will be checked against. All variants of `query!()`
-/// use [dotenv]<sup>1</sup> so this can be in a `.env` file instead.
+/// use [dotenvy] so this can be in a `.env` file instead.
 ///
 ///     * Or, `.sqlx` must exist at the workspace root. See [Offline Mode](#offline-mode-requires-the-offline-feature)
 ///       below.
@@ -69,11 +69,7 @@
 ///     * The schema of the database URL (e.g. `postgres://` or `mysql://`) will be used to
 ///       determine the database type.
 ///
-/// <sup>1</sup> The `dotenv` crate itself appears abandoned as of [December 2021](https://github.com/dotenv-rs/dotenv/issues/74)
-/// so we now use the [dotenvy] crate instead. The file format is the same.
-///
-/// [dotenv]: https://crates.io/crates/dotenv
-/// [dotenvy]: https://crates.io/crates/dotenvy
+/// [dotenvy]: https://github.com/allan2/dotenvy
 /// ## Query Arguments
 /// Like `println!()` and the other formatting macros, you can add bind parameters to your SQL
 /// and this macro will typecheck passed arguments and error on missing ones:


### PR DESCRIPTION
Clarifies documentation by linking to dotenvy.
Removes the superscript note recommending the use of dotenvy as it is now the
linked repository.
This also ensures users are linked to maintained documentation 
and avoids confusion as in https://github.com/allan2/dotenvy/issues/92.

depends on https://github.com/allan2/dotenvy/pull/98
fixes #3168 
resolves root cause of https://github.com/allan2/dotenvy/issues/92