### PR TITLE
Fix leaking connections in fetch_optional (#2647)

### DIFF
--- a/sqlx-mysql/src/any.rs
+++ b/sqlx-mysql/src/any.rs
@@ -103,8 +103,10 @@ impl AnyConnectionBackend for MySqlConnection {
             let stream = self.run(query, args, persistent).await?;
             futures_util::pin_mut!(stream);
 
-            if let Some(Either::Right(row)) = stream.try_next().await? {
-                return Ok(Some(AnyRow::try_from(&row)?));
+            while let Some(result) = stream.try_next().await? {
+                if let Either::Right(row) = result {
+                    return Ok(Some(AnyRow::try_from(&row)?));
+                }
             }
 
             Ok(None)


### PR DESCRIPTION
When using the 'Any' driver with MySQL backend, fetch_optional does not return the connection to the pool if no results are returned from the query. This is due to not all of the packets being read from the underlying stream.

This fix continues to read result packets from the stream until they have all been exhausted (just like the normal MySql drivers implementation of fetch_optional). In general, a better refactoring would be to call the MySQL fetch_optional code in the Any driver, rather than re-implementing and duplicating code.

fixes #(2647)
