### PR TITLE
`Decode` with `postgres`: hr bound for fields

### DIFF
--- a/sqlx-macros-core/src/derives/decode.rs
+++ b/sqlx-macros-core/src/derives/decode.rs
@@ -278,7 +278,7 @@ fn expand_derive_decode_struct(
         for field in fields {
             let ty = &field.ty;
 
-            predicates.push(parse_quote!(#ty: ::sqlx::decode::Decode<'r, ::sqlx::Postgres>));
+            predicates.push(parse_quote!(#ty: for<'hr> ::sqlx::decode::Decode<'hr, ::sqlx::Postgres>));
             predicates.push(parse_quote!(#ty: ::sqlx::types::Type<::sqlx::Postgres>));
         }
 


### PR DESCRIPTION
fixes #3185

```rust
// sqlx = { git = "https://github.com/launchbadge/sqlx", features = ["postgres"] }
use sqlx::Type;
#[derive(Type)]
struct Foo {
    a: u32,
}
```

expands to the following impl for `Decode`
```rust
impl<'r> Decode<'r, Postgres> for Foo
where
    i32: Decode<'r, Postgres>,
    i32: Type<Postgres>,
{
    fn decode(
        value: Postgres::PgValueRef<'r>,
    ) -> Result<Self, Box<dyn Error + 'static + Send + Sync>> {
        let mut decoder = PgRecordDecoder::new(value)?;
        let a = decoder.try_decode::<i32>()?;
        Ok(Foo { a })
    }
}
```
`decoder.try_decode` has the following bound:
https://github.com/launchbadge/sqlx/blob/03926dec15b3838f57269ee177e63e4bdf0b1150/sqlx-postgres/src/types/record.rs#L97

The where-bound only provides `Decode` for a concrete lifetime `'r` however. This previously compiled because the compiler eagerly rejected the where-bound and used the more general impl. This behavior has changed in https://github.com/rust-lang/rust/pull/119820.

---

It would have already been broken before https://github.com/rust-lang/rust/pull/119820 if the type of `a` were generic, e.g.
```rust
struct Foo<T> {
    a: T,
}
```
However, this currently results in an unrelated error as the expansion does not add the generic arguments to `Foo`, resulting in
```rust
error[E0107]: missing generics for struct `Foo`
 --> src/main.rs:3:8
  |
3 | struct Foo<T> {
  |        ^^^ expected 1 generic argument
  |
note: struct defined here, with 1 generic parameter: `T`
 --> src/main.rs:3:8
  |
3 | struct Foo<T> {
  |        ^^^ -
help: add missing generic argument
  |
3 | struct Foo<T><T> {
  |           +++
```

---

I first tried to change `try_decode` to not require a higher-ranked bound, requiring `T: Decode<'r, Postgres>` instead. However, we need the higher ranked bound as `T::decode` is called with a local buffer:

https://github.com/launchbadge/sqlx/blob/03926dec15b3838f57269ee177e63e4bdf0b1150/sqlx-postgres/src/types/record.rs#L184-L201

I therefore ended up changing the `derive` to require a higher ranked bound instead. I tested this locally but did not add a test for this as I didn't immediately understand your test suite :sweat_smile:   
