### PR TITLE
security: bump rustls to 0.21.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,9 +2824,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.21.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
 dependencies = [
  "ring",
  "rustls-webpki",

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -36,7 +36,7 @@ tokio = { workspace = true, optional = true }
 # TLS
 native-tls = { version = "0.2.10", optional = true }
 
-rustls = { version = "0.21.7", default-features = false, features = ["dangerous_configuration", "tls12"], optional = true }
+rustls = { version = "0.21.11", default-features = false, features = ["dangerous_configuration", "tls12"], optional = true }
 rustls-pemfile = { version = "1.0", optional = true }
 webpki-roots = { version = "0.25", optional = true }
 


### PR DESCRIPTION
This fixes security issue RUSTSEC-2024-0336 [1].

[1] https://rustsec.org/advisories/RUSTSEC-2024-0336