### PR TITLE
Fix "requires that `'r` must outlive `'static`"

### DIFF
--- a/sqlx-macros-core/src/derives/decode.rs
+++ b/sqlx-macros-core/src/derives/decode.rs
@@ -278,7 +278,7 @@ fn expand_derive_decode_struct(
         for field in fields {
             let ty = &field.ty;
 
-            predicates.push(parse_quote!(#ty: ::sqlx::decode::Decode<'r, ::sqlx::Postgres>));
+            predicates.push(parse_quote!(#ty: for<'a> ::sqlx::decode::Decode<'a, ::sqlx::Postgres>));
             predicates.push(parse_quote!(#ty: ::sqlx::types::Type<::sqlx::Postgres>));
         }
 


### PR DESCRIPTION
When building the following on nightly

```rust
#[derive(sqlx::Type)]
struct Foobar {
    a: String,
}
```

Compilation fails with

```
error: lifetime may not live long enough
  --> tests/foo.rs:1:10
   |
5  | #[derive(sqlx::Type)]
   |          ^^^^^^^^^^
   |          |
   |          lifetime `'r` defined here
   |          requires that `'r` must outlive `'static`
   |
note: due to current limitations in the borrow checker, this implies a `'static` lifetime
  --> /home/b/.cargo/registry/src/index.crates.io-6f17d22bba15001f/sqlx-core-0.6.3/src/postgres/types/record.rs:97:12
   |
97 |         T: for<'a> Decode<'a, Postgres> + Type<Postgres>,
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = note: this error originates in the derive macro `sqlx::Type` (in Nightly builds, run with -Z macro-backtrace for more info)

error: implementation of `sqlx::Decode` is not general enough
 --> tests/foo.rs:5:10
  |
5 | #[derive(sqlx::Type)]
  |          ^^^^^^^^^^ implementation of `sqlx::Decode` is not general enough
  |
  = note: `std::string::String` must implement `sqlx::Decode<'0, Postgres>`, for any lifetime `'0`...
  = note: ...but it actually implements `sqlx::Decode<'1, Postgres>`, for some specific lifetime `'1`
  = note: this error originates in the derive macro `sqlx::Type` (in Nightly builds, run with -Z macro-backtrace for more info)

error: could not compile `foo` (test "foo") due to 2 previous errors
```

To quick-fix this in our project, we resorted to expanding the code generated by `sqlx::Type` and manually applying the fix that this PR now proposes to implement in the macro.

The changes are not tested yet, but I could invest some additional effort if you can guide me.