### PR TITLE
update rustls dependency and make edits to support its api changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2823,7 +2823,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afabcee0551bd1aa3e18e5adbf2c0544722014b899adb31bd186ec638d3da97e"
 dependencies = [
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,12 +467,6 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
@@ -2824,31 +2818,42 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.11"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
+checksum = "afabcee0551bd1aa3e18e5adbf2c0544722014b899adb31bd186ec638d3da97e"
 dependencies = [
+ "once_cell",
  "ring",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.4"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
+ "rustls-pki-types",
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.7"
+name = "rustls-pki-types"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "beb461507cee2c2ff151784c52762cf4d9ff6a61f3e80968600ed24fa837fa54"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
 dependencies = [
  "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -2905,16 +2910,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "seahash"
@@ -4232,9 +4227,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "whoami"

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -36,9 +36,9 @@ tokio = { workspace = true, optional = true }
 # TLS
 native-tls = { version = "0.2.10", optional = true }
 
-rustls = { version = "0.21.11", default-features = false, features = ["dangerous_configuration", "tls12"], optional = true }
-rustls-pemfile = { version = "1.0", optional = true }
-webpki-roots = { version = "0.25", optional = true }
+rustls = { version = "0.23.5", default-features = false, features = ["std", "ring", "tls12"], optional = true}
+rustls-pemfile = { version = "2.1.2", optional = true }
+webpki-roots = { version = "0.26.1", optional = true }
 
 # Type Integrations
 bit-vec = { workspace = true, optional = true }

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -36,7 +36,7 @@ tokio = { workspace = true, optional = true }
 # TLS
 native-tls = { version = "0.2.10", optional = true }
 
-rustls = { version = "0.23.5", default-features = false, features = ["std", "ring", "tls12"], optional = true}
+rustls = { version = "0.23.5", default-features = false, features = ["std", "tls12"], optional = true}
 rustls-pemfile = { version = "2.1.2", optional = true }
 webpki-roots = { version = "0.26.1", optional = true }
 

--- a/sqlx-core/src/error.rs
+++ b/sqlx-core/src/error.rs
@@ -6,6 +6,10 @@ use std::error::Error as StdError;
 use std::fmt::Display;
 use std::io;
 
+// use rustls::server::VerifierBuilderError;
+#[cfg(feature = "_tls-rustls")]
+use rustls::server::VerifierBuilderError;
+
 use crate::database::Database;
 
 use crate::type_info::TypeInfo;
@@ -107,6 +111,10 @@ pub enum Error {
     #[cfg(feature = "migrate")]
     #[error("{0}")]
     Migrate(#[source] Box<crate::migrate::MigrateError>),
+
+    #[cfg(feature = "_tls-rustls")]
+    #[error("Error building server verifier: {0}")]
+    VerifierBuilder(#[from] VerifierBuilderError)
 }
 
 impl StdError for Box<dyn DatabaseError> {}


### PR DESCRIPTION
The rustls crate made some significant changes to its api in v0.23.0, as summarized in the [release notes](https://github.com/rustls/rustls/releases/tag/v%2F0.23.0). This pull request bumps the versions of the rustls, rustls-pemfile, and webpki-roots crates, and makes a number of changes needed in response to the aforementioned api changes.

There is, unfortunately, an important drawback to consider. The v0.23.0 release introduced process-wide selection of crypto providers, which requires either that A) we make a breaking api change that requires users to pass in a CryptoProvider when creating a ClientConnection or that B) the user calls CryptoProvider::install_default() exactly once. This pull request does not implement option A, nor does it include the documentation necessary for users to make option B work. I'm interested in adding the documentation for B and maybe trying to figure out some way of putting A behind a feature gate if desired, but I wanted to get feedback first.