### PR TITLE
fix: sqlite pragma order for auto_vacuum

### DIFF
--- a/sqlx-sqlite/src/options/mod.rs
+++ b/sqlx-sqlite/src/options/mod.rs
@@ -162,6 +162,10 @@ impl SqliteConnectOptions {
         // https://www.sqlite.org/wal.html#use_of_wal_without_shared_memory
         pragmas.insert("locking_mode".into(), None);
 
+        // The `auto_vacuum` pragma defaults to NONE, but needs to
+        // come before before `journal_mode`.
+        pragmas.insert("auto_vacuum".into(), None);
+
         // Don't set `journal_mode` unless the user requested it.
         // WAL mode is a permanent setting for created databases and changing into or out of it
         // requires an exclusive lock that can't be waited on with `sqlite3_busy_timeout()`.
@@ -175,8 +179,6 @@ impl SqliteConnectOptions {
         // The `synchronous` pragma defaults to FULL
         // https://www.sqlite.org/compile.html#default_synchronous.
         pragmas.insert("synchronous".into(), None);
-
-        pragmas.insert("auto_vacuum".into(), None);
 
         // Soft limit on the number of rows that `ANALYZE` touches per index.
         pragmas.insert("analysis_limit".into(), None);

--- a/sqlx-sqlite/src/options/mod.rs
+++ b/sqlx-sqlite/src/options/mod.rs
@@ -162,8 +162,10 @@ impl SqliteConnectOptions {
         // https://www.sqlite.org/wal.html#use_of_wal_without_shared_memory
         pragmas.insert("locking_mode".into(), None);
 
-        // The `auto_vacuum` pragma defaults to NONE, but needs to
-        // come before before `journal_mode`.
+        // `auto_vacuum` needs to be executed before `journal_mode`, if set.
+        //
+        // Otherwise, a change in the `journal_mode` setting appears to mark even an empty database as dirty,
+        // requiring a `vacuum` command to be executed to actually apply the new `auto_vacuum` setting.
         pragmas.insert("auto_vacuum".into(), None);
 
         // Don't set `journal_mode` unless the user requested it.


### PR DESCRIPTION
Setting the auto_vacuum pragma must come before setting the journal mode otherwise it won't apply.

Simple test app:

```rust
use sqlx::sqlite::SqliteAutoVacuum;
use sqlx::sqlite::SqliteJournalMode;
use sqlx::sqlite::SqliteSynchronous;
use sqlx::Connection;
use sqlx::SqliteConnection;

#[tokio::main]
async fn main() {
    let options = sqlx::sqlite::SqliteConnectOptions::new()
        .create_if_missing(true)
        .filename("./test.sqlite")
        .synchronous(SqliteSynchronous::Off)
        .auto_vacuum(SqliteAutoVacuum::Full)
        .journal_mode(SqliteJournalMode::Wal);
    let mut conn = SqliteConnection::connect_with(&options).await.unwrap();
    let auto_vacuum: u8 = sqlx::query_scalar("PRAGMA auto_vacuum")
        .fetch_one(&mut conn)
        .await
        .unwrap();
    println!("auto_vacuum = {auto_vacuum}");
}
```

In current git main, if `journal_mode` option is set, `auto_vacuum` will not take affect.  Work-around is to execute a `PRAGMA auto_vacuum = 1; VACUUM` on the connection, but that shouldn't be needed for a newly created database.