### PR TITLE
fix: resolve `path` ownership problems when using `sqlx_macros_unstable`

### DIFF
--- a/sqlx-core/src/migrate/source.rs
+++ b/sqlx-core/src/migrate/source.rs
@@ -31,7 +31,7 @@ impl<'s> MigrationSource<'s> for &'s Path {
         Box::pin(async move {
             let canonical = self.canonicalize()?;
             let migrations_with_paths =
-                crate::rt::spawn_blocking(move || resolve_blocking(canonical)).await?;
+                crate::rt::spawn_blocking(move || resolve_blocking(&canonical)).await?;
 
             Ok(migrations_with_paths.into_iter().map(|(m, _p)| m).collect())
         })
@@ -54,8 +54,8 @@ pub struct ResolveError {
 
 // FIXME: paths should just be part of `Migration` but we can't add a field backwards compatibly
 // since it's `#[non_exhaustive]`.
-pub fn resolve_blocking(path: PathBuf) -> Result<Vec<(Migration, PathBuf)>, ResolveError> {
-    let mut s = fs::read_dir(&path).map_err(|e| ResolveError {
+pub fn resolve_blocking(path: &PathBuf) -> Result<Vec<(Migration, PathBuf)>, ResolveError> {
+    let mut s = fs::read_dir(path).map_err(|e| ResolveError {
         message: format!("error reading migration directory {}: {e}", path.display()),
         source: Some(e),
     })?;

--- a/sqlx-core/src/migrate/source.rs
+++ b/sqlx-core/src/migrate/source.rs
@@ -54,7 +54,7 @@ pub struct ResolveError {
 
 // FIXME: paths should just be part of `Migration` but we can't add a field backwards compatibly
 // since it's `#[non_exhaustive]`.
-pub fn resolve_blocking(path: &PathBuf) -> Result<Vec<(Migration, PathBuf)>, ResolveError> {
+pub fn resolve_blocking(path: &Path) -> Result<Vec<(Migration, PathBuf)>, ResolveError> {
     let mut s = fs::read_dir(path).map_err(|e| ResolveError {
         message: format!("error reading migration directory {}: {e}", path.display()),
         source: Some(e),

--- a/sqlx-macros-core/src/migrate.rs
+++ b/sqlx-macros-core/src/migrate.rs
@@ -103,7 +103,7 @@ pub(crate) fn expand_migrator(path: &Path) -> crate::Result<TokenStream> {
     })?;
 
     // Use the same code path to resolve migrations at compile time and runtime.
-    let migrations = sqlx_core::migrate::resolve_blocking(path)?
+    let migrations = sqlx_core::migrate::resolve_blocking(&path)?
         .into_iter()
         .map(|(migration, path)| QuoteMigration { migration, path });
 


### PR DESCRIPTION
When using `--cfg=sqlx_macros_unstable` the codepath taken uses the `path` variable which was taken earlier by `resolve_blocking`; this is solved by having `resolve_blocking` take a reference, as it is more convenient than cloning.

### Does your PR solve an issue?
Yes (however I did not create an issue here).
I was trying to get the effect of triggering recompilation on migration changes by setting the nightly flag as described here: https://docs.rs/sqlx/latest/sqlx/macro.migrate.html#nightly-rust-cfg-flag

But when adding to `.cargo/config.toml`:
```
[build]
rustflags = ["--cfg=sqlx_macros_unstable"]
```
and having the `sqlx::migrate!` macro in the code, the following error appears while compiling `sqlx-macros-core`:
```
error[E0382]: borrow of moved value: `path`
    |
98  |     let path = path.canonicalize().map_err(|e| {
    |         ---- move occurs because `path` has type `PathBuf`, which does not implement the `Copy` trait
...
107 |     let migrations = sqlx_core::migrate::resolve_blocking(path)?
    |                                                           ---- value moved here
...
113 |         let path = path.to_str().ok_or_else(|| {
    |                                              ^^ value borrowed here after move
...
116 |                 path
    |                 ---- borrow occurs due to use in closure
    |
help: consider cloning the value if the performance cost is acceptable
    |
107 |     let migrations = sqlx_core::migrate::resolve_blocking(path.clone())?
    |                                                               ++++++++
```
Alternatively I could simply clone the `path` variable (as suggested by the compiler), however it seems like `resolve_blocking` does not really need to take ownership of the `path` variable.

I'm not too sure how this could be tested. Please let me know if the "tests/x.py" script is a good place to setup a test for this.