### PR TITLE
feat: support `NonZero*` scalar types

### DIFF
--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -16,7 +16,6 @@ migrate = ["sha2", "crc"]
 
 any = []
 
-non-zero = []
 json = ["serde", "serde_json"]
 
 # for conditional compilation

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -16,6 +16,7 @@ migrate = ["sha2", "crc"]
 
 any = []
 
+non-zero = []
 json = ["serde", "serde_json"]
 
 # for conditional compilation

--- a/sqlx-core/src/types/mod.rs
+++ b/sqlx-core/src/types/mod.rs
@@ -20,8 +20,6 @@
 use crate::database::Database;
 use crate::type_info::TypeInfo;
 
-#[cfg(feature = "non-zero")]
-#[cfg_attr(docsrs, doc(cfg(feature = "non-zero")))]
 pub mod non_zero;
 
 #[cfg(feature = "bstr")]

--- a/sqlx-core/src/types/mod.rs
+++ b/sqlx-core/src/types/mod.rs
@@ -20,7 +20,7 @@
 use crate::database::Database;
 use crate::type_info::TypeInfo;
 
-pub mod non_zero;
+mod non_zero;
 
 #[cfg(feature = "bstr")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bstr")))]

--- a/sqlx-core/src/types/mod.rs
+++ b/sqlx-core/src/types/mod.rs
@@ -16,9 +16,13 @@
 //!
 //! To represent nullable SQL types, `Option<T>` is supported where `T` implements `Type`.
 //! An `Option<T>` represents a potentially `NULL` value from SQL.
-//!
 
-use crate::{database::Database, type_info::TypeInfo};
+use crate::database::Database;
+use crate::type_info::TypeInfo;
+
+#[cfg(feature = "non-zero")]
+#[cfg_attr(docsrs, doc(cfg(feature = "non-zero")))]
+pub mod non_zero;
 
 #[cfg(feature = "bstr")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bstr")))]
@@ -60,7 +64,6 @@ pub mod time {
 #[cfg_attr(docsrs, doc(cfg(feature = "bigdecimal")))]
 #[doc(no_inline)]
 pub use bigdecimal::BigDecimal;
-
 #[cfg(feature = "rust_decimal")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rust_decimal")))]
 #[doc(no_inline)]
@@ -82,7 +85,6 @@ pub mod mac_address {
 
 #[cfg(feature = "json")]
 pub use json::{Json, JsonRawValue, JsonValue};
-
 pub use text::Text;
 
 /// Indicates that a SQL type is supported for a database.
@@ -193,7 +195,6 @@ pub use text::Text;
 ///     price: f64
 /// }
 /// ```
-///
 pub trait Type<DB: Database> {
     /// Returns the canonical SQL type for this Rust type.
     ///

--- a/sqlx-core/src/types/non_zero.rs
+++ b/sqlx-core/src/types/non_zero.rs
@@ -1,0 +1,76 @@
+//! [`Type`], [`Encode`], and [`Decode`] implementations for the various [`NonZero*`][non-zero]
+//! types from the standard library.
+//!
+//! [non-zero]: core::num::NonZero
+
+use std::num::{
+    NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8,
+};
+
+use crate::database::Database;
+use crate::decode::Decode;
+use crate::encode::{Encode, IsNull};
+use crate::types::Type;
+
+macro_rules! impl_non_zero {
+    ($($int:ty => $non_zero:ty),* $(,)?) => {
+        $(impl<DB> Type<DB> for $non_zero
+        where
+            DB: Database,
+            $int: Type<DB>,
+        {
+            fn type_info() -> <DB as Database>::TypeInfo {
+                <$int as Type<DB>>::type_info()
+            }
+
+            fn compatible(ty: &<DB as Database>::TypeInfo) -> bool {
+                <$int as Type<DB>>::compatible(ty)
+            }
+        }
+
+        impl<'q, DB> Encode<'q, DB> for $non_zero
+        where
+            DB: Database,
+            $int: Encode<'q, DB>,
+        {
+            fn encode_by_ref(&self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> IsNull {
+                <$int as Encode<'q, DB>>::encode_by_ref(&self.get(), buf)
+            }
+
+            fn encode(self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> IsNull
+            where
+                Self: Sized,
+            {
+                <$int as Encode<'q, DB>>::encode(self.get(), buf)
+            }
+
+            fn produces(&self) -> Option<<DB as Database>::TypeInfo> {
+                <$int as Encode<'q, DB>>::produces(&self.get())
+            }
+        }
+
+        impl<'r, DB> Decode<'r, DB> for $non_zero
+        where
+            DB: Database,
+            $int: Decode<'r, DB>,
+        {
+            fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, crate::error::BoxDynError> {
+                let int = <$int as Decode<'r, DB>>::decode(value)?;
+                let non_zero = Self::try_from(int)?;
+
+                Ok(non_zero)
+            }
+        })*
+    };
+}
+
+impl_non_zero! {
+    i8 => NonZeroI8,
+    u8 => NonZeroU8,
+    i16 => NonZeroI16,
+    u16 => NonZeroU16,
+    i32 => NonZeroI32,
+    u32 => NonZeroU32,
+    i64 => NonZeroI64,
+    u64 => NonZeroU64,
+}

--- a/sqlx-core/src/types/non_zero.rs
+++ b/sqlx-core/src/types/non_zero.rs
@@ -33,11 +33,11 @@ macro_rules! impl_non_zero {
             DB: Database,
             $int: Encode<'q, DB>,
         {
-            fn encode_by_ref(&self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> IsNull {
+            fn encode_by_ref(&self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> Result<IsNull, crate::error::BoxDynError> {
                 <$int as Encode<'q, DB>>::encode_by_ref(&self.get(), buf)
             }
 
-            fn encode(self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> IsNull
+            fn encode(self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> Result<IsNull, crate::error::BoxDynError>
             where
                 Self: Sized,
             {


### PR DESCRIPTION
This commits adds `Type`, `Encode`, and `Decode` impls for all the `NonZero*` types from the standard library. They are implemented as direct proxies to their primitive counterparts, except that when decoding, the values are checked to not be zero.

fixes #1926