### PR TITLE
Expose Mysql column information in `TypeInfo`

### DIFF
--- a/sqlx-mysql/src/lib.rs
+++ b/sqlx-mysql/src/lib.rs
@@ -40,6 +40,7 @@ pub use connection::MySqlConnection;
 pub use database::MySql;
 pub use error::MySqlDatabaseError;
 pub use options::{MySqlConnectOptions, MySqlSslMode};
+pub use protocol::text::ColumnType;
 pub use query_result::MySqlQueryResult;
 pub use row::MySqlRow;
 pub use statement::MySqlStatement;

--- a/sqlx-mysql/src/lib.rs
+++ b/sqlx-mysql/src/lib.rs
@@ -40,7 +40,7 @@ pub use connection::MySqlConnection;
 pub use database::MySql;
 pub use error::MySqlDatabaseError;
 pub use options::{MySqlConnectOptions, MySqlSslMode};
-pub use protocol::text::ColumnType;
+pub use protocol::text::{ColumnFlags, ColumnType};
 pub use query_result::MySqlQueryResult;
 pub use row::MySqlRow;
 pub use statement::MySqlStatement;

--- a/sqlx-mysql/src/protocol/text/column.rs
+++ b/sqlx-mysql/src/protocol/text/column.rs
@@ -13,7 +13,7 @@ use crate::protocol::Capabilities;
 bitflags! {
     #[cfg_attr(feature = "offline", derive(serde::Serialize, serde::Deserialize))]
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub(crate) struct ColumnFlags: u16 {
+    pub struct ColumnFlags: u16 {
         /// Field can't be `NULL`.
         const NOT_NULL = 1;
 

--- a/sqlx-mysql/src/protocol/text/mod.rs
+++ b/sqlx-mysql/src/protocol/text/mod.rs
@@ -4,7 +4,8 @@ mod query;
 mod quit;
 mod row;
 
-pub(crate) use column::{ColumnDefinition, ColumnFlags, ColumnType};
+pub(crate) use column::{ColumnDefinition, ColumnFlags};
+pub use column::ColumnType;
 pub(crate) use ping::Ping;
 pub(crate) use query::Query;
 pub(crate) use quit::Quit;

--- a/sqlx-mysql/src/protocol/text/mod.rs
+++ b/sqlx-mysql/src/protocol/text/mod.rs
@@ -4,8 +4,8 @@ mod query;
 mod quit;
 mod row;
 
-pub(crate) use column::{ColumnDefinition, ColumnFlags};
-pub use column::ColumnType;
+pub(crate) use column::ColumnDefinition;
+pub use column::{ColumnFlags, ColumnType};
 pub(crate) use ping::Ping;
 pub(crate) use query::Query;
 pub(crate) use quit::Quit;

--- a/sqlx-mysql/src/type_info.rs
+++ b/sqlx-mysql/src/type_info.rs
@@ -27,6 +27,14 @@ impl MySqlTypeInfo {
         }
     }
 
+    pub fn column_type(&self) -> ColumnType {
+        self.r#type
+    }
+
+    pub fn max_size(&self) -> Option<u32> {
+        self.max_size
+    }
+
     #[doc(hidden)]
     pub const fn __enum() -> Self {
         Self {

--- a/sqlx-mysql/src/type_info.rs
+++ b/sqlx-mysql/src/type_info.rs
@@ -31,6 +31,10 @@ impl MySqlTypeInfo {
         self.r#type
     }
 
+    pub fn column_flags(&self) -> ColumnFlags {
+        self.flags
+    }
+
     pub fn max_size(&self) -> Option<u32> {
         self.max_size
     }


### PR DESCRIPTION
### Does your PR solve an issue?

Because `ColumnType` and friends are not public, it makes it impossible to implement custom decoding that depend on column type or flags.
