### PR TITLE
fix: hide `sqlx_postgres::any`

### DIFF
--- a/sqlx-postgres/src/lib.rs
+++ b/sqlx-postgres/src/lib.rs
@@ -26,6 +26,12 @@ pub mod types;
 mod value;
 
 #[cfg(feature = "any")]
+// We are hiding the any module with its AnyConnectionBackend trait
+// so that IDEs don't show it in the autocompletion list
+// and end users don't accidentally use it. This can result in
+// nested transactions not behaving as expected.
+// For more information, see https://github.com/launchbadge/sqlx/pull/3254#issuecomment-2144043823
+#[doc(hidden)]
 pub mod any;
 
 #[cfg(feature = "migrate")]


### PR DESCRIPTION
Currently you can call `begin()` on a postgres transaction without causing an error.

This causes errors such as:
```rust
    let url = "postgres://dario@localhost/sqlx".parse().unwrap();
    let opts: PgConnectOptions = ConnectOptions::from_url(&url).unwrap();

    let pool = PgPoolOptions::new()
        .max_connections(10)
        .connect_with(opts)
        .await
        .expect("PgPool");

    sqlx::query("drop table if exists sqlx_issue").execute(&pool).await.unwrap();
    sqlx::query("create table sqlx_issue (name varchar(255))").execute(&pool).await.unwrap();
    sqlx::query("insert into sqlx_issue (name) values ('issue')").execute(&pool).await.unwrap();

    {
        let mut trans: Transaction<'static, Postgres> = pool.begin().await.unwrap();
        // Call begin again()
        trans.begin().await.unwrap();

        sqlx::query("delete from sqlx_issue").execute(&mut *trans).await.unwrap();
        trans.commit().await.unwrap();
    }
        

    let row = sqlx::query("select name from sqlx_issue").fetch_optional(&pool).await.unwrap();
    // This will fail because we started the transaction twice. 
    // Calling commit does not actually commit the transaction because we rewrapped the inner transaction.
    // As a result the delete query had never been committed. 
    assert!(row.is_none());
```


