### PR TITLE
feat: Add set_update_hook on SqliteConnection

### DIFF
--- a/sqlx-sqlite/src/connection/establish.rs
+++ b/sqlx-sqlite/src/connection/establish.rs
@@ -294,6 +294,7 @@ impl EstablishParams {
             transaction_depth: 0,
             log_settings: self.log_settings.clone(),
             progress_handler_callback: None,
+            update_hook_callback: None
         })
     }
 }

--- a/sqlx-sqlite/src/lib.rs
+++ b/sqlx-sqlite/src/lib.rs
@@ -33,8 +33,7 @@ use std::sync::atomic::AtomicBool;
 
 pub use arguments::{SqliteArgumentValue, SqliteArguments};
 pub use column::SqliteColumn;
-pub use connection::SqliteOperation;
-pub use connection::{LockedSqliteHandle, SqliteConnection};
+pub use connection::{LockedSqliteHandle, SqliteConnection, SqliteOperation, UpdateHookResult};
 pub use database::Sqlite;
 pub use error::SqliteError;
 pub use options::{

--- a/sqlx-sqlite/src/lib.rs
+++ b/sqlx-sqlite/src/lib.rs
@@ -33,6 +33,7 @@ use std::sync::atomic::AtomicBool;
 
 pub use arguments::{SqliteArgumentValue, SqliteArguments};
 pub use column::SqliteColumn;
+pub use connection::SqliteOperation;
 pub use connection::{LockedSqliteHandle, SqliteConnection};
 pub use database::Sqlite;
 pub use error::SqliteError;
@@ -41,7 +42,6 @@ pub use options::{
 };
 pub use query_result::SqliteQueryResult;
 pub use row::SqliteRow;
-pub use statement::SqliteOperation;
 pub use statement::SqliteStatement;
 pub use transaction::SqliteTransactionManager;
 pub use type_info::SqliteTypeInfo;

--- a/sqlx-sqlite/src/lib.rs
+++ b/sqlx-sqlite/src/lib.rs
@@ -41,6 +41,7 @@ pub use options::{
 };
 pub use query_result::SqliteQueryResult;
 pub use row::SqliteRow;
+pub use statement::SqliteOperation;
 pub use statement::SqliteStatement;
 pub use transaction::SqliteTransactionManager;
 pub use type_info::SqliteTypeInfo;

--- a/sqlx-sqlite/src/statement/mod.rs
+++ b/sqlx-sqlite/src/statement/mod.rs
@@ -2,7 +2,6 @@ use crate::column::ColumnIndex;
 use crate::error::Error;
 use crate::ext::ustr::UStr;
 use crate::{Sqlite, SqliteArguments, SqliteColumn, SqliteTypeInfo};
-use libsqlite3_sys::{SQLITE_DELETE, SQLITE_INSERT, SQLITE_UPDATE};
 use sqlx_core::{Either, HashMap};
 use std::borrow::Cow;
 use std::sync::Arc;
@@ -78,22 +77,3 @@ impl ColumnIndex<SqliteStatement<'_>> for &'_ str {
 //         }
 //     }
 // }
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum SqliteOperation {
-    Insert,
-    Update,
-    Delete,
-    Unknown,
-}
-
-impl From<i32> for SqliteOperation {
-    fn from(value: i32) -> Self {
-        match value {
-            SQLITE_INSERT => SqliteOperation::Insert,
-            SQLITE_UPDATE => SqliteOperation::Update,
-            SQLITE_DELETE => SqliteOperation::Delete,
-            _ => SqliteOperation::Unknown,
-        }
-    }
-}

--- a/sqlx-sqlite/src/statement/mod.rs
+++ b/sqlx-sqlite/src/statement/mod.rs
@@ -2,6 +2,7 @@ use crate::column::ColumnIndex;
 use crate::error::Error;
 use crate::ext::ustr::UStr;
 use crate::{Sqlite, SqliteArguments, SqliteColumn, SqliteTypeInfo};
+use libsqlite3_sys::{SQLITE_DELETE, SQLITE_INSERT, SQLITE_UPDATE};
 use sqlx_core::{Either, HashMap};
 use std::borrow::Cow;
 use std::sync::Arc;
@@ -77,3 +78,22 @@ impl ColumnIndex<SqliteStatement<'_>> for &'_ str {
 //         }
 //     }
 // }
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum SqliteOperation {
+    Insert,
+    Update,
+    Delete,
+    Unknown,
+}
+
+impl From<i32> for SqliteOperation {
+    fn from(value: i32) -> Self {
+        match value {
+            SQLITE_INSERT => SqliteOperation::Insert,
+            SQLITE_UPDATE => SqliteOperation::Update,
+            SQLITE_DELETE => SqliteOperation::Delete,
+            _ => SqliteOperation::Unknown,
+        }
+    }
+}

--- a/tests/sqlite/sqlite.rs
+++ b/tests/sqlite/sqlite.rs
@@ -1,7 +1,7 @@
 use futures::TryStreamExt;
 use rand::{Rng, SeedableRng};
 use rand_xoshiro::Xoshiro256PlusPlus;
-use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx::sqlite::{SqliteConnectOptions, SqliteOperation, SqlitePoolOptions};
 use sqlx::{
     query, sqlite::Sqlite, sqlite::SqliteRow, Column, ConnectOptions, Connection, Executor, Row,
     SqliteConnection, SqlitePool, Statement, TypeInfo,
@@ -789,6 +789,68 @@ async fn test_multiple_set_progress_handler_calls_drop_old_handler() -> anyhow::
         }
 
         conn.lock_handle().await?.remove_progress_handler();
+    }
+
+    assert_eq!(1, Arc::strong_count(&ref_counted_object));
+    Ok(())
+}
+
+#[sqlx_macros::test]
+async fn test_query_with_update_hook() -> anyhow::Result<()> {
+    let mut conn = new::<Sqlite>().await?;
+
+    // Using this string as a canary to ensure the callback doesn't get called with the wrong data pointer.
+    let state = format!("test");
+    conn.lock_handle()
+        .await?
+        .set_update_hook(move |operation, database, table, rowid| {
+            assert_eq!(state, "test");
+            assert_eq!(operation, SqliteOperation::Insert);
+            assert_eq!(database, "main");
+            assert_eq!(table, "tweet");
+            assert_eq!(rowid, 3);
+        });
+
+    let _ = sqlx::query("INSERT INTO tweet ( id, text ) VALUES ( 3, 'Hello, World' )")
+        .execute(&mut conn)
+        .await?;
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
+async fn test_multiple_set_update_hook_calls_drop_old_handler() -> anyhow::Result<()> {
+    let ref_counted_object = Arc::new(0);
+    assert_eq!(1, Arc::strong_count(&ref_counted_object));
+
+    {
+        let mut conn = new::<Sqlite>().await?;
+
+        let o = ref_counted_object.clone();
+        conn.lock_handle()
+            .await?
+            .set_update_hook(move |_, _, _, _| {
+                println!("{o:?}");
+            });
+        assert_eq!(2, Arc::strong_count(&ref_counted_object));
+
+        let o = ref_counted_object.clone();
+        conn.lock_handle()
+            .await?
+            .set_update_hook(move |_, _, _, _| {
+                println!("{o:?}");
+            });
+        assert_eq!(2, Arc::strong_count(&ref_counted_object));
+
+        let o = ref_counted_object.clone();
+        conn.lock_handle()
+            .await?
+            .set_update_hook(move |_, _, _, _| {
+                println!("{o:?}");
+            });
+        assert_eq!(2, Arc::strong_count(&ref_counted_object));
+
+        conn.lock_handle().await?.remove_update_hook();
     }
 
     assert_eq!(1, Arc::strong_count(&ref_counted_object));

--- a/tests/sqlite/sqlite.rs
+++ b/tests/sqlite/sqlite.rs
@@ -801,15 +801,13 @@ async fn test_query_with_update_hook() -> anyhow::Result<()> {
 
     // Using this string as a canary to ensure the callback doesn't get called with the wrong data pointer.
     let state = format!("test");
-    conn.lock_handle()
-        .await?
-        .set_update_hook(move |operation, database, table, rowid| {
-            assert_eq!(state, "test");
-            assert_eq!(operation, SqliteOperation::Insert);
-            assert_eq!(database, "main");
-            assert_eq!(table, "tweet");
-            assert_eq!(rowid, 3);
-        });
+    conn.lock_handle().await?.set_update_hook(move |result| {
+        assert_eq!(state, "test");
+        assert_eq!(result.operation, SqliteOperation::Insert);
+        assert_eq!(result.database, "main");
+        assert_eq!(result.table, "tweet");
+        assert_eq!(result.rowid, 3);
+    });
 
     let _ = sqlx::query("INSERT INTO tweet ( id, text ) VALUES ( 3, 'Hello, World' )")
         .execute(&mut conn)
@@ -827,27 +825,21 @@ async fn test_multiple_set_update_hook_calls_drop_old_handler() -> anyhow::Resul
         let mut conn = new::<Sqlite>().await?;
 
         let o = ref_counted_object.clone();
-        conn.lock_handle()
-            .await?
-            .set_update_hook(move |_, _, _, _| {
-                println!("{o:?}");
-            });
+        conn.lock_handle().await?.set_update_hook(move |_| {
+            println!("{o:?}");
+        });
         assert_eq!(2, Arc::strong_count(&ref_counted_object));
 
         let o = ref_counted_object.clone();
-        conn.lock_handle()
-            .await?
-            .set_update_hook(move |_, _, _, _| {
-                println!("{o:?}");
-            });
+        conn.lock_handle().await?.set_update_hook(move |_| {
+            println!("{o:?}");
+        });
         assert_eq!(2, Arc::strong_count(&ref_counted_object));
 
         let o = ref_counted_object.clone();
-        conn.lock_handle()
-            .await?
-            .set_update_hook(move |_, _, _, _| {
-                println!("{o:?}");
-            });
+        conn.lock_handle().await?.set_update_hook(move |_| {
+            println!("{o:?}");
+        });
         assert_eq!(2, Arc::strong_count(&ref_counted_object));
 
         conn.lock_handle().await?.remove_update_hook();


### PR DESCRIPTION
Fixes #3114 

This is an initial pass at exposing the Sqlite update hook.  I used set_progress_handler as a guide.  This allows the consuming code to register a callback on the connection and receive the operation, database name, table name, and rowid of the affected record.

I'm in the process of adding listener functionality in my own code which will use channels to publish data changes but thought that may be out of scope for sqlx itself.
