### PR TITLE
ci: MariaDB - add back 11.4 and add 11.5

### DIFF
--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -370,10 +370,6 @@ jobs:
         mariadb: [verylatest, 10_11, 10_4]
         runtime: [async-std, tokio]
         tls: [native-tls, rustls, none]
-        exclude:
-          # FIXME: `rustls` cannot accept MariaDB's new self-signed certificates: https://github.com/launchbadge/sqlx/issues/3091
-          - mariadb: verylatest
-            tls: rustls
     needs: check
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -367,7 +367,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        mariadb: [verylatest, 10_11, 10_4]
+        mariadb: [verylatest, 11_4, 10_11, 10_4]
         runtime: [async-std, tokio]
         tls: [native-tls, rustls, none]
     needs: check


### PR DESCRIPTION
With MariaDB upstream fixing the TLS issue (about to be confirmed in the CI test), adding back 11.4 (now GA/stable) and verylatest - now 11.5rc.

fixes: #3091
