### PR TITLE
feat: add bulk execute for mariadb

### DIFF
--- a/sqlx-mysql/src/connection/executor.rs
+++ b/sqlx-mysql/src/connection/executor.rs
@@ -127,6 +127,7 @@ impl MySqlConnection {
                     self.inner.stream
                         .send_packet(StatementExecute {
                             statement: id,
+                            metadata: &metadata,
                             arguments: &arguments,
                         })
                         .await?;
@@ -141,6 +142,7 @@ impl MySqlConnection {
                     self.inner.stream
                         .send_packet(StatementExecute {
                             statement: id,
+                            metadata: &metadata,
                             arguments: &arguments,
                         })
                         .await?;

--- a/sqlx-mysql/src/connection/stream.rs
+++ b/sqlx-mysql/src/connection/stream.rs
@@ -51,7 +51,8 @@ impl<S: Socket> MySqlStream<S> {
             | Capabilities::MULTI_RESULTS
             | Capabilities::PLUGIN_AUTH
             | Capabilities::PS_MULTI_RESULTS
-            | Capabilities::SSL;
+            | Capabilities::SSL
+            | Capabilities::MARIADB_CLIENT_STMT_BULK_OPERATIONS;
 
         if options.database.is_some() {
             capabilities |= Capabilities::CONNECT_WITH_DB;

--- a/sqlx-mysql/src/protocol/capabilities.rs
+++ b/sqlx-mysql/src/protocol/capabilities.rs
@@ -83,5 +83,8 @@ bitflags::bitflags! {
 
         // Don't reset the options after an unsuccessful connect
         const REMEMBER_OPTIONS = (1 << 31);
+
+        // Permit bulk operations
+        const MARIADB_CLIENT_STMT_BULK_OPERATIONS = (1 << 34);
     }
 }

--- a/sqlx-mysql/src/protocol/statement/execute.rs
+++ b/sqlx-mysql/src/protocol/statement/execute.rs
@@ -1,6 +1,7 @@
 use crate::io::Encode;
 use crate::protocol::text::ColumnFlags;
 use crate::protocol::Capabilities;
+use crate::statement::MySqlStatementMetadata;
 use crate::MySqlArguments;
 
 // https://dev.mysql.com/doc/dev/mysql-server/8.0.12/page_protocol_com_stmt_execute.html
@@ -8,11 +9,22 @@ use crate::MySqlArguments;
 #[derive(Debug)]
 pub struct Execute<'q> {
     pub statement: u32,
+    pub metadata: &'q MySqlStatementMetadata,
     pub arguments: &'q MySqlArguments,
 }
 
 impl<'q> Encode<'_, Capabilities> for Execute<'q> {
     fn encode_with(&self, buf: &mut Vec<u8>, _: Capabilities) {
+        if self.arguments.is_bulk {
+            self.encode_stmt_bulk_execute(buf)
+        } else {
+            self.encode_stmt_execute(buf)
+        }
+    }
+}
+
+impl<'q> Execute<'q> {
+    fn encode_stmt_execute(&self, buf: &mut Vec<u8>) {
         buf.push(0x17); // COM_STMT_EXECUTE
         buf.extend(&self.statement.to_le_bytes());
         buf.push(0); // NO_CURSOR
@@ -34,5 +46,25 @@ impl<'q> Encode<'_, Capabilities> for Execute<'q> {
 
             buf.extend(&*self.arguments.values);
         }
+    }
+
+    // https://mariadb.com/kb/en/com_stmt_bulk_execute/
+    fn encode_stmt_bulk_execute(&self, buf: &mut Vec<u8>) {
+        buf.push(0xfa); // COM_STMT_BULK_EXECUTE
+        buf.extend(&self.statement.to_le_bytes());
+        buf.extend(&128_u16.to_le_bytes()); // bulk flags = SEND_TYPES_TO_SERVER
+
+        let parameters = std::cmp::min(self.metadata.parameters, self.arguments.types.len());
+        for ty in &self.arguments.types[..parameters] {
+            buf.push(ty.r#type as u8);
+
+            buf.push(if ty.flags.contains(ColumnFlags::UNSIGNED) {
+                0x80
+            } else {
+                0
+            });
+        }
+
+        buf.extend(&*self.arguments.values);
     }
 }

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -34,6 +34,7 @@ services:
 
     mysql_5_7:
         image: mysql:5.7
+        platform: linux/amd64 # image doesn't exist for other platforms
         volumes:
             - "./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql:z"
         ports:
@@ -44,6 +45,7 @@ services:
             MYSQL_DATABASE: sqlx
 
     mysql_5_7_client_ssl:
+        platform: linux/amd64 # image doesn't exist for other platforms
         build:
             context: .
             dockerfile: mysql/Dockerfile


### PR DESCRIPTION
This is an implementation of https://mariadb.com/kb/en/com_stmt_bulk_execute/
Bulk execute allows reusing the same prepared statement for inserting any number of rows.

It requires an "indicator" before each value, therefore `MySqlArguments` has changed. Example of usage can be seen in tests.