### PR TITLE
Invert boolean for `migrate` error message. (#3275)

### DIFF
--- a/sqlx-macros-core/src/test_attr.rs
+++ b/sqlx-macros-core/src/test_attr.rs
@@ -32,7 +32,7 @@ pub fn expand(args: TokenStream, input: syn::ItemFn) -> crate::Result<TokenStrea
 
     if input.sig.inputs.is_empty() {
         if !args.is_empty() {
-            if cfg!(feature = "migrate") {
+            if !cfg!(feature = "migrate") {
                 return Err(syn::Error::new_spanned(
                     args.first().unwrap(),
                     "control attributes are not allowed unless \

--- a/sqlx-macros-core/src/test_attr.rs
+++ b/sqlx-macros-core/src/test_attr.rs
@@ -32,7 +32,7 @@ pub fn expand(args: TokenStream, input: syn::ItemFn) -> crate::Result<TokenStrea
 
     if input.sig.inputs.is_empty() {
         if !args.is_empty() {
-            if !cfg!(feature = "migrate") {
+            if cfg!(not(feature = "migrate")) {
                 return Err(syn::Error::new_spanned(
                     args.first().unwrap(),
                     "control attributes are not allowed unless \


### PR DESCRIPTION
fixes #3275 