### PR TITLE
Support multiple types of DBs at once

### DIFF
--- a/sqlx-macros-core/src/query/mod.rs
+++ b/sqlx-macros-core/src/query/mod.rs
@@ -190,11 +190,13 @@ static METADATA: Lazy<Metadata> = Lazy::new(|| {
         .unwrap_or(false);
 
     let database_urls = vec![
-        env("DATABASE_URL").ok(),
         env("DATABASE_URL_POSTGRES").ok(),
         env("DATABASE_URL_MARIADB").ok(),
         env("DATABASE_URL_MYSQL").ok(),
         env("DATABASE_URL_SQLITE").ok(),
+
+        // Generic one last as a fallback
+        env("DATABASE_URL").ok(),
     ].into_iter().flatten().collect();
 
     Metadata {


### PR DESCRIPTION
This PR is meant as a starting point and baseline for discussions.

It implements support for multiple types of DBs by using mutliple "DATABASE_URL_*" environment variables, falling back to the current "DATABASE_URL" variable.

This doesn't allow using multiple DBs of the same type, but two different DBs as long as they don't share a driver (so e.g. Postgres and SQLite).

fixes #121 