### PR TITLE
refactor: support disable prepared statement

### DIFF
--- a/sqlx-mysql/src/connection/establish.rs
+++ b/sqlx-mysql/src/connection/establish.rs
@@ -30,6 +30,7 @@ impl MySqlConnection {
                 transaction_depth: 0,
                 cache_statement: StatementCache::new(options.statement_cache_capacity),
                 log_settings: options.log_settings.clone(),
+                use_server_prep_stmts: options.use_server_prep_stmts,
             }),
         })
     }

--- a/sqlx-mysql/src/connection/mod.rs
+++ b/sqlx-mysql/src/connection/mod.rs
@@ -39,6 +39,9 @@ pub(crate) struct MySqlConnectionInner {
     cache_statement: StatementCache<(u32, MySqlStatementMetadata)>,
 
     log_settings: LogSettings,
+
+    // Sets the flag that enables or disables the `useServerPrepStmts` connection setting
+    pub(crate) use_server_prep_stmts: bool,
 }
 
 impl Debug for MySqlConnection {

--- a/sqlx-mysql/src/lib.rs
+++ b/sqlx-mysql/src/lib.rs
@@ -1,5 +1,4 @@
 //! **MySQL** database driver.
-
 #[macro_use]
 extern crate sqlx_core;
 

--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -80,6 +80,7 @@ pub struct MySqlConnectOptions {
     pub(crate) no_engine_subsitution: bool,
     pub(crate) timezone: Option<String>,
     pub(crate) set_names: bool,
+    pub(crate) use_server_prep_stmts: bool,
 }
 
 impl Default for MySqlConnectOptions {
@@ -111,6 +112,7 @@ impl MySqlConnectOptions {
             no_engine_subsitution: true,
             timezone: Some(String::from("+00:00")),
             set_names: true,
+            use_server_prep_stmts: true,
         }
     }
 
@@ -396,6 +398,17 @@ impl MySqlConnectOptions {
     /// is supported by your MySQL or MariaDB server version and compatible with UTF-8.
     pub fn set_names(mut self, flag_val: bool) -> Self {
         self.set_names = flag_val;
+        self
+    }
+
+
+    /// Sets the flag that enables or disables the `useServerPrepStmts` connection setting
+    ///
+    /// The default value is set to true, but some MySql databases such as Doris or Starrocks
+    /// error out with this connection setting so it needs to be set false in such
+    /// cases.
+    pub fn use_server_prep_stmts(mut self, flag_val: bool) -> Self {
+        self.use_server_prep_stmts = flag_val;
         self
     }
 }

--- a/sqlx-mysql/src/options/parse.rs
+++ b/sqlx-mysql/src/options/parse.rs
@@ -71,6 +71,9 @@ impl MySqlConnectOptions {
                 "socket" => {
                     options = options.socket(&*value);
                 }
+                "useServerPrepStmts" => {
+                    options = options.use_server_prep_stmts(value.parse().map_err(Error::config)?);
+                }
 
                 _ => {}
             }
@@ -175,4 +178,11 @@ fn it_returns_the_parsed_url() {
     expected_url.set_query(Some(query_string));
 
     assert_eq!(expected_url, opts.build_url());
+}
+
+#[test]
+fn it_parses_use_server_prep_stmts() {
+    let url = "mysql://username:p@ssw0rd@hostname:5432/database?useServerPrepStmts=false";
+    let opts = MySqlConnectOptions::from_str(url).unwrap();
+    assert_eq!(false, opts.use_server_prep_stmts);
 }


### PR DESCRIPTION
This pull request is meant to support "Disable prepared statement" for databases that do not support the feature, such as Starrock and Doris.

It expands the MySqlConnectOptions to include a "use_server_prep_stmts" field, defaulting to true. To disable the prepared statement, you can add a "useServerPrepStmts" parameter to the connection URL, for example: "mysql://username:p@ssw0rd@hostname:5432/database?useServerPrepStmts=false".

Fixed the issue: https://github.com/launchbadge/sqlx/issues/3273
