### PR TITLE
Always set `SQLITE_OPEN_URI` on in-memory sqlite

### DIFF
--- a/sqlx-sqlite/src/connection/establish.rs
+++ b/sqlx-sqlite/src/connection/establish.rs
@@ -87,6 +87,7 @@ impl EstablishParams {
 
         if options.in_memory {
             flags |= SQLITE_OPEN_MEMORY;
+            flags |= libsqlite3_sys::SQLITE_OPEN_URI;
         }
 
         flags |= if options.shared_cache {


### PR DESCRIPTION
### Does your PR solve an issue?

I have encountered this issue when trying to package a downstream project where the in-memory sqlite database was simply gone at subsequent accesses. The issue is that URI format is implicitly used, but the flag is never set
https://github.com/launchbadge/sqlx/blob/1388fc8acc07b41ab38f4dc096f03ba9c7b851f8/sqlx-sqlite/src/options/parse.rs#L18-L23

This issue was not detected because only the bundled `libsqlite3-sys` version is tested which has the `USE_URI` compile flag enabled. On distros, however this is not yet enabled, and it is just started to be investigated [^1]

Related to:
- https://github.com/launchbadge/sqlx/issues/2510
- https://github.com/launchbadge/sqlx/issues/362#issuecomment-636661146

[^1]: https://bugzilla.redhat.com/show_bug.cgi?id=2291157