### PR TITLE
fix: sqlite update_hook char types

### DIFF
--- a/sqlx-sqlite/src/connection/mod.rs
+++ b/sqlx-sqlite/src/connection/mod.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 use std::ffi::CStr;
 use std::fmt::Write;
 use std::fmt::{self, Debug, Formatter};
-use std::os::raw::{c_int, c_void};
+use std::os::raw::{c_char, c_int, c_void};
 use std::panic::catch_unwind;
 use std::ptr;
 use std::ptr::NonNull;
@@ -262,8 +262,8 @@ where
 extern "C" fn update_hook<F>(
     callback: *mut c_void,
     op_code: c_int,
-    database: *const i8,
-    table: *const i8,
+    database: *const c_char,
+    table: *const c_char,
     rowid: i64,
 ) where
     F: FnMut(UpdateHookResult),


### PR DESCRIPTION
Use "c_char" instead of "i8" as it resolves to the correct string type on different architectures.

Fixes: #3287
