### PR TITLE
feat: support the Postgres Bool type for the Any driver

### DIFF
--- a/sqlx-postgres/src/any.rs
+++ b/sqlx-postgres/src/any.rs
@@ -182,6 +182,7 @@ impl<'a> TryFrom<&'a PgTypeInfo> for AnyTypeInfo {
     fn try_from(pg_type: &'a PgTypeInfo) -> Result<Self, Self::Error> {
         Ok(AnyTypeInfo {
             kind: match &pg_type.0 {
+                PgType::Bool => AnyTypeInfoKind::Bool,
                 PgType::Void => AnyTypeInfoKind::Null,
                 PgType::Int2 => AnyTypeInfoKind::SmallInt,
                 PgType::Int4 => AnyTypeInfoKind::Integer,


### PR DESCRIPTION
### Does your PR solve an issue?

This `PgType::Bool` type is now mapped to the `Any` type `Bool`.

fixes #3290
