### PR TITLE
Pass the `persistent` query setting when preparing queries with the `Any` driver

### DIFF
--- a/sqlx-core/src/any/connection/backend.rs
+++ b/sqlx-core/src/any/connection/backend.rs
@@ -72,12 +72,14 @@ pub trait AnyConnectionBackend: std::any::Any + Debug + Send + 'static {
     fn fetch_many<'q>(
         &'q mut self,
         query: &'q str,
+        persistent: bool,
         arguments: Option<AnyArguments<'q>>,
     ) -> BoxStream<'q, crate::Result<Either<AnyQueryResult, AnyRow>>>;
 
     fn fetch_optional<'q>(
         &'q mut self,
         query: &'q str,
+        persistent: bool,
         arguments: Option<AnyArguments<'q>>,
     ) -> BoxFuture<'q, crate::Result<Option<AnyRow>>>;
 

--- a/sqlx-core/src/any/connection/executor.rs
+++ b/sqlx-core/src/any/connection/executor.rs
@@ -23,7 +23,8 @@ impl<'c> Executor<'c> for &'c mut AnyConnection {
             Ok(arguments) => arguments,
             Err(error) => return stream::once(future::ready(Err(error))).boxed(),
         };
-        self.backend.fetch_many(query.sql(), arguments)
+        self.backend
+            .fetch_many(query.sql(), query.persistent(), arguments)
     }
 
     fn fetch_optional<'e, 'q: 'e, E>(
@@ -38,7 +39,8 @@ impl<'c> Executor<'c> for &'c mut AnyConnection {
             Ok(arguments) => arguments,
             Err(error) => return future::ready(Err(error)).boxed(),
         };
-        self.backend.fetch_optional(query.sql(), arguments)
+        self.backend
+            .fetch_optional(query.sql(), query.persistent(), arguments)
     }
 
     fn prepare_with<'e, 'q: 'e>(

--- a/sqlx-mysql/src/any.rs
+++ b/sqlx-mysql/src/any.rs
@@ -75,9 +75,10 @@ impl AnyConnectionBackend for MySqlConnection {
     fn fetch_many<'q>(
         &'q mut self,
         query: &'q str,
+        persistent: bool,
         arguments: Option<AnyArguments<'q>>,
     ) -> BoxStream<'q, sqlx_core::Result<Either<AnyQueryResult, AnyRow>>> {
-        let persistent = arguments.is_some();
+        let persistent = persistent && arguments.is_some();
         let arguments = match arguments.as_ref().map(AnyArguments::convert_to).transpose() {
             Ok(arguments) => arguments,
             Err(error) => {
@@ -100,9 +101,10 @@ impl AnyConnectionBackend for MySqlConnection {
     fn fetch_optional<'q>(
         &'q mut self,
         query: &'q str,
+        persistent: bool,
         arguments: Option<AnyArguments<'q>>,
     ) -> BoxFuture<'q, sqlx_core::Result<Option<AnyRow>>> {
-        let persistent = arguments.is_some();
+        let persistent = persistent && arguments.is_some();
         let arguments = arguments
             .as_ref()
             .map(AnyArguments::convert_to)

--- a/sqlx-postgres/src/any.rs
+++ b/sqlx-postgres/src/any.rs
@@ -74,9 +74,10 @@ impl AnyConnectionBackend for PgConnection {
     fn fetch_many<'q>(
         &'q mut self,
         query: &'q str,
+        persistent: bool,
         arguments: Option<AnyArguments<'q>>,
     ) -> BoxStream<'q, sqlx_core::Result<Either<AnyQueryResult, AnyRow>>> {
-        let persistent = arguments.is_some();
+        let persistent = persistent && arguments.is_some();
         let arguments = match arguments.as_ref().map(AnyArguments::convert_to).transpose() {
             Ok(arguments) => arguments,
             Err(error) => {
@@ -99,9 +100,10 @@ impl AnyConnectionBackend for PgConnection {
     fn fetch_optional<'q>(
         &'q mut self,
         query: &'q str,
+        persistent: bool,
         arguments: Option<AnyArguments<'q>>,
     ) -> BoxFuture<'q, sqlx_core::Result<Option<AnyRow>>> {
-        let persistent = arguments.is_some();
+        let persistent = persistent && arguments.is_some();
         let arguments = arguments
             .as_ref()
             .map(AnyArguments::convert_to)

--- a/sqlx-sqlite/src/any.rs
+++ b/sqlx-sqlite/src/any.rs
@@ -75,9 +75,10 @@ impl AnyConnectionBackend for SqliteConnection {
     fn fetch_many<'q>(
         &'q mut self,
         query: &'q str,
+        persistent: bool,
         arguments: Option<AnyArguments<'q>>,
     ) -> BoxStream<'q, sqlx_core::Result<Either<AnyQueryResult, AnyRow>>> {
-        let persistent = arguments.is_some();
+        let persistent = persistent && arguments.is_some();
         let args = arguments.map(map_arguments);
 
         Box::pin(
@@ -97,9 +98,10 @@ impl AnyConnectionBackend for SqliteConnection {
     fn fetch_optional<'q>(
         &'q mut self,
         query: &'q str,
+        persistent: bool,
         arguments: Option<AnyArguments<'q>>,
     ) -> BoxFuture<'q, sqlx_core::Result<Option<AnyRow>>> {
-        let persistent = arguments.is_some();
+        let persistent = persistent && arguments.is_some();
         let args = arguments.map(map_arguments);
 
         Box::pin(async move {


### PR DESCRIPTION
This PR passes the `query.persistent()` value to the `fetch_many` and `fetch_optional` function so that they can use it to cache prepared queries.

Note I have kept the existing logic for the SQLite driver where persisting queries requires both the persistent flag _and_ the existence of arguments.