### PR TITLE
add array support for NonZeroI* in postgres

### DIFF
--- a/sqlx-postgres/src/types/int.rs
+++ b/sqlx-postgres/src/types/int.rs
@@ -1,5 +1,5 @@
-use std::num::{NonZeroI16, NonZeroI32, NonZeroI64};
 use byteorder::{BigEndian, ByteOrder};
+use std::num::{NonZeroI16, NonZeroI32, NonZeroI64};
 
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
@@ -166,7 +166,6 @@ impl PgHasArrayType for NonZeroI32 {
         PgTypeInfo::INT4_ARRAY
     }
 }
-
 
 impl PgHasArrayType for NonZeroI64 {
     fn array_type_info() -> PgTypeInfo {

--- a/sqlx-postgres/src/types/int.rs
+++ b/sqlx-postgres/src/types/int.rs
@@ -1,3 +1,4 @@
+use std::num::{NonZeroI16, NonZeroI32, NonZeroI64};
 use byteorder::{BigEndian, ByteOrder};
 
 use crate::decode::Decode;
@@ -151,5 +152,24 @@ impl Encode<'_, Postgres> for i64 {
 impl Decode<'_, Postgres> for i64 {
     fn decode(value: PgValueRef<'_>) -> Result<Self, BoxDynError> {
         int_decode(value)
+    }
+}
+
+impl PgHasArrayType for NonZeroI16 {
+    fn array_type_info() -> PgTypeInfo {
+        PgTypeInfo::INT2_ARRAY
+    }
+}
+
+impl PgHasArrayType for NonZeroI32 {
+    fn array_type_info() -> PgTypeInfo {
+        PgTypeInfo::INT4_ARRAY
+    }
+}
+
+
+impl PgHasArrayType for NonZeroI64 {
+    fn array_type_info() -> PgTypeInfo {
+        PgTypeInfo::INT8_ARRAY
     }
 }


### PR DESCRIPTION
Implements `PgHasArrayType` for `NonZeroI16`, `NonZeroI32` and `NonZeroI64`