### PR TITLE
wrap timed streams and iterators in tracing::Spans; follow Opentelemetry conventions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3645,6 +3645,7 @@ dependencies = [
  "thiserror",
  "time",
  "tracing",
+ "tracing-futures",
  "uuid",
  "whoami",
 ]
@@ -3691,6 +3692,7 @@ dependencies = [
  "thiserror",
  "time",
  "tracing",
+ "tracing-futures",
  "uuid",
  "whoami",
 ]
@@ -4088,6 +4090,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "futures",
+ "futures-task",
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ mac_address = "1.1.5"
 rust_decimal = { version = "1.26.1", default-features = false, features = ["std"] }
 time = { version = "0.3.36", features = ["formatting", "parsing", "macros"] }
 uuid = "1.1.2"
+tracing-futures = { version = "0.2.5", features = ["futures-03", "std-future"] }
 
 # Common utility crates
 dotenvy = { version = "0.15.0", default-features = false }

--- a/sqlx-core/src/any/database.rs
+++ b/sqlx-core/src/any/database.rs
@@ -31,6 +31,7 @@ impl Database for Any {
     type Statement<'q> = AnyStatement<'q>;
 
     const NAME: &'static str = "Any";
+    const NAME_LOWERCASE: &'static str = "any";
 
     const URL_SCHEMES: &'static [&'static str] = &[];
 }

--- a/sqlx-core/src/any/options.rs
+++ b/sqlx-core/src/any/options.rs
@@ -62,4 +62,9 @@ impl ConnectOptions for AnyConnectOptions {
         self.log_settings.slow_statements_duration = duration;
         self
     }
+
+    fn set_span_level(mut self, level: LevelFilter) -> Self {
+        self.log_settings.span_level = level;
+        self
+    }
 }

--- a/sqlx-core/src/connection.rs
+++ b/sqlx-core/src/connection.rs
@@ -161,6 +161,7 @@ pub struct LogSettings {
     pub statements_level: LevelFilter,
     pub slow_statements_level: LevelFilter,
     pub slow_statements_duration: Duration,
+    pub span_level: LevelFilter,
 }
 
 impl Default for LogSettings {
@@ -169,6 +170,7 @@ impl Default for LogSettings {
             statements_level: LevelFilter::Debug,
             slow_statements_level: LevelFilter::Warn,
             slow_statements_duration: Duration::from_secs(1),
+            span_level: LevelFilter::Info,
         }
     }
 }
@@ -182,8 +184,8 @@ impl LogSettings {
         self.slow_statements_duration = duration;
     }
 
-    pub fn tracing_span_level(&self) -> LevelFilter {
-        std::cmp::max(self.slow_statements_level, self.statements_level)
+    pub fn set_span_level(&mut self, level: LevelFilter) {
+        self.span_level = level;
     }
 }
 
@@ -238,5 +240,8 @@ pub trait ConnectOptions: 'static + Send + Sync + FromStr<Err = Error> + Debug +
     fn disable_statement_logging(self) -> Self {
         self.log_statements(LevelFilter::Off)
             .log_slow_statements(LevelFilter::Off, Duration::default())
+            .set_span_level(LevelFilter::Off)
     }
+
+    fn set_span_level(self, level: LevelFilter) -> Self;
 }

--- a/sqlx-core/src/connection.rs
+++ b/sqlx-core/src/connection.rs
@@ -181,6 +181,10 @@ impl LogSettings {
         self.slow_statements_level = level;
         self.slow_statements_duration = duration;
     }
+
+    pub fn tracing_span_level(&self) -> LevelFilter {
+        std::cmp::max(self.slow_statements_level, self.statements_level)
+    }
 }
 
 pub trait ConnectOptions: 'static + Send + Sync + FromStr<Err = Error> + Debug + Clone {

--- a/sqlx-core/src/database.rs
+++ b/sqlx-core/src/database.rs
@@ -105,6 +105,7 @@ pub trait Database: 'static + Sized + Send + Debug {
 
     /// The display name for this database driver.
     const NAME: &'static str;
+    const NAME_LOWERCASE: &'static str;
 
     /// The schemes for database URLs that should match this driver.
     const URL_SCHEMES: &'static [&'static str];

--- a/sqlx-mysql/Cargo.toml
+++ b/sqlx-mysql/Cargo.toml
@@ -68,6 +68,7 @@ smallvec = "1.7.0"
 stringprep = "0.1.2"
 thiserror = "1.0.35"
 tracing = { version = "0.1.37", features = ["log"] }
+tracing-futures.workspace = true
 whoami = { version = "1.2.1", default-features = false }
 
 serde = { version = "1.0.144", optional = true }

--- a/sqlx-mysql/src/database.rs
+++ b/sqlx-mysql/src/database.rs
@@ -31,6 +31,7 @@ impl Database for MySql {
     type Statement<'q> = MySqlStatement<'q>;
 
     const NAME: &'static str = "MySQL";
+    const NAME_LOWERCASE: &'static str = "mysql";
 
     const URL_SCHEMES: &'static [&'static str] = &["mysql", "mariadb"];
 }

--- a/sqlx-mysql/src/options/connect.rs
+++ b/sqlx-mysql/src/options/connect.rs
@@ -94,4 +94,9 @@ impl ConnectOptions for MySqlConnectOptions {
         self.log_settings.log_slow_statements(level, duration);
         self
     }
+
+    fn set_span_level(mut self, level: LevelFilter) -> Self {
+        self.log_settings.span_level = level;
+        self
+    }
 }

--- a/sqlx-postgres/Cargo.toml
+++ b/sqlx-postgres/Cargo.toml
@@ -31,6 +31,7 @@ futures-channel = { version = "0.3.19", default-features = false, features = ["s
 futures-core = { version = "0.3.19", default-features = false }
 futures-io = "0.3.24"
 futures-util = { version = "0.3.19", default-features = false, features = ["alloc", "sink", "io"] }
+tracing-futures.workspace = true
 
 # Cryptographic Primitives
 crc = "3.0.0"

--- a/sqlx-postgres/src/connection/stream.rs
+++ b/sqlx-postgres/src/connection/stream.rs
@@ -6,6 +6,7 @@ use futures_channel::mpsc::UnboundedSender;
 use futures_util::SinkExt;
 use log::Level;
 use sqlx_core::bytes::Buf;
+use sqlx_core::database::Database;
 
 use crate::connection::tls::MaybeUpgradeTls;
 use crate::error::Error;
@@ -14,7 +15,7 @@ use crate::message::{
     ParameterStatus, ReceivedMessage,
 };
 use crate::net::{self, BufferedSocket, Socket};
-use crate::{PgConnectOptions, PgDatabaseError, PgSeverity};
+use crate::{PgConnectOptions, PgDatabaseError, PgSeverity, Postgres};
 
 // the stream is a separate type from the connection to uphold the invariant where an instantiated
 // [PgConnection] is a **valid** connection to postgres
@@ -185,6 +186,7 @@ impl PgStream {
                         sqlx_core::private_tracing_dynamic_event!(
                             target: "sqlx::postgres::notice",
                             tracing_level,
+                            db.system = Postgres::NAME_LOWERCASE,
                             message = notice.message()
                         );
                     }

--- a/sqlx-postgres/src/database.rs
+++ b/sqlx-postgres/src/database.rs
@@ -33,6 +33,7 @@ impl Database for Postgres {
     type Statement<'q> = PgStatement<'q>;
 
     const NAME: &'static str = "PostgreSQL";
+    const NAME_LOWERCASE: &'static str = "postgresql";
 
     const URL_SCHEMES: &'static [&'static str] = &["postgres", "postgresql"];
 }

--- a/sqlx-postgres/src/options/connect.rs
+++ b/sqlx-postgres/src/options/connect.rs
@@ -33,4 +33,9 @@ impl ConnectOptions for PgConnectOptions {
         self.log_settings.log_slow_statements(level, duration);
         self
     }
+
+    fn set_span_level(mut self, level: LevelFilter) -> Self {
+        self.log_settings.span_level = level;
+        self
+    }
 }

--- a/sqlx-sqlite/src/database.rs
+++ b/sqlx-sqlite/src/database.rs
@@ -32,6 +32,7 @@ impl Database for Sqlite {
     type Statement<'q> = SqliteStatement<'q>;
 
     const NAME: &'static str = "SQLite";
+    const NAME_LOWERCASE: &'static str = "sqlite";
 
     const URL_SCHEMES: &'static [&'static str] = &["sqlite"];
 }

--- a/sqlx-sqlite/src/logger.rs
+++ b/sqlx-sqlite/src/logger.rs
@@ -7,10 +7,12 @@
 )]
 
 use crate::connection::intmap::IntMap;
+use crate::Sqlite;
 use std::collections::HashSet;
 use std::fmt::Debug;
 use std::hash::Hash;
 
+use sqlx_core::database::Database;
 pub(crate) use sqlx_core::logger::*;
 
 #[derive(Debug)]
@@ -429,6 +431,7 @@ impl<'q, R: Debug, S: Debug + DebugDiff, P: Debug> QueryPlanLogger<'q, R, S, P> 
         sqlx_core::private_tracing_dynamic_event!(
             target: "sqlx::explain",
             tracing::Level::TRACE,
+            db.system = Sqlite::NAME_LOWERCASE,
             "{}; program:\n{}\n\n{:?}", summary, self, sql
         );
     }

--- a/sqlx-sqlite/src/options/connect.rs
+++ b/sqlx-sqlite/src/options/connect.rs
@@ -59,6 +59,11 @@ impl ConnectOptions for SqliteConnectOptions {
         self.log_settings.log_slow_statements(level, duration);
         self
     }
+
+    fn set_span_level(mut self, level: LevelFilter) -> Self {
+        self.log_settings.span_level = level;
+        self
+    }
 }
 
 impl SqliteConnectOptions {


### PR DESCRIPTION
### Does your PR solve an issue?

When exporting to instrumentation collectors, timed spans are generally more desirable than discrete events annotated with timing data. This PR:

- wraps the existing logger and pool::acquire tracing events in tracing spans. Common metadata is moved to the span; generally the tracing subscriber can (and does by default in fmt::subscriber) write span-level metadata when events are logged, so the current output should be the same. The span level is set to the max level of the event log configuration, where appropriate.
- Adds an associated `NAME_LOWERCASE` constant to `Database`, which follows the semantic conventions defined by Opentelemetry (https://opentelemetry.io/docs/specs/semconv/attributes-registry/db/). This value is attached to the span as `db.system`.