### PR TITLE
chore: fixed one usage of `select_input_type!()` being unhygenic

### DIFF
--- a/sqlx-core/src/type_checking.rs
+++ b/sqlx-core/src/type_checking.rs
@@ -146,7 +146,7 @@ macro_rules! impl_type_checking {
                     )*
                     $(
                         $(#[$meta])?
-                        _ if <$ty as sqlx_core::types::Type<$database>>::compatible(info) => Some(select_input_type!($ty $(, $input)?)),
+                        _ if <$ty as sqlx_core::types::Type<$database>>::compatible(info) => Some($crate::select_input_type!($ty $(, $input)?)),
                     )*
                     _ => None
                 }


### PR DESCRIPTION
### Does your PR solve an issue?

no, basically it is just a typo I came across during trying to debugg https://github.com/launchbadge/sqlx/issues/3316

The `$crate::` is currently not nessesary, but future refactorings might get tripped up if the typo is not fixed