### PR TITLE
ci: Add job to check that sqlx builds with its declared minimum dependencies

### DIFF
--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -50,6 +50,16 @@ jobs:
           --features all-databases,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }},macros
           --target-dir target/beta/
 
+  check-minimal-versions:
+    name: Check build using minimal versions
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup update
+      - run: rustup toolchain install nightly
+      - run: cargo +nightly generate-lockfile -Z minimal-versions
+      - run: cargo build --all-features
+
   test:
     name: Unit Test
     runs-on: ubuntu-22.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ sqlx = { version = "=0.8.0-alpha.0", path = ".", default-features = false }
 # These are optional unless enabled in a workspace crate.
 bigdecimal = "0.4.0"
 bit-vec = "0.6.3"
-chrono = { version = "0.4.22", default-features = false }
+chrono = { version = "0.4.34", default-features = false }
 ipnetwork = "0.20.0"
 mac_address = "1.1.5"
 rust_decimal = { version = "1.26.1", default-features = false, features = ["std"] }

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -55,7 +55,7 @@ atoi = "2.0"
 
 bytes = "1.1.0"
 byteorder = { version = "1.4.3", default-features = false, features = ["std"] }
-chrono = { version = "0.4.19", default-features = false, features = ["clock"], optional = true }
+chrono = { version = "0.4.34", default-features = false, features = ["clock"], optional = true }
 crc = { version = "3", optional = true }
 crossbeam-queue = "0.3.2"
 digest = { version = "0.10.0", default-features = false, optional = true, features = ["std"] }
@@ -67,7 +67,7 @@ futures-io = "0.3.24"
 futures-intrusive = "0.5.0"
 futures-util = { version = "0.3.19", default-features = false, features = ["alloc", "sink", "io"] }
 hex = "0.4.3"
-log = { version = "0.4.14", default-features = false }
+log = { version = "0.4.18", default-features = false }
 memchr = { version = "2.4.1", default-features = false }
 num-bigint = { version = "0.4.0", default-features = false, optional = true, features = ["std"] }
 once_cell = "1.9.0"

--- a/sqlx-mysql/Cargo.toml
+++ b/sqlx-mysql/Cargo.toml
@@ -53,7 +53,7 @@ either = "1.6.1"
 generic-array = { version = "0.14.4", default-features = false }
 hex = "0.4.3"
 itoa = "1.0.1"
-log = "0.4.17"
+log = "0.4.18"
 memchr = { version = "2.4.1", default-features = false }
 once_cell = "1.9.0"
 percent-encoding = "2.1.0"

--- a/sqlx-mysql/src/types/chrono.rs
+++ b/sqlx-mysql/src/types/chrono.rs
@@ -235,6 +235,7 @@ impl Encode<'_, MySql> for NaiveDateTime {
             self.hour(),
             self.minute(),
             self.second(),
+            #[allow(deprecated)]
             self.timestamp_subsec_nanos(),
         ) {
             // if hour, minutes, seconds and micro_seconds are all 0,

--- a/sqlx-postgres/Cargo.toml
+++ b/sqlx-postgres/Cargo.toml
@@ -53,7 +53,7 @@ dotenvy = { workspace = true }
 hex = "0.4.3"
 home = "0.5.5"
 itoa = "1.0.1"
-log = "0.4.17"
+log = "0.4.18"
 memchr = { version = "2.4.1", default-features = false }
 num-bigint = { version = "0.4.3", optional = true }
 once_cell = "1.9.0"

--- a/sqlx-sqlite/Cargo.toml
+++ b/sqlx-sqlite/Cargo.toml
@@ -39,7 +39,7 @@ flume = { version = "0.11.0", default-features = false, features = ["async"] }
 
 atoi = "2.0"
 
-log = "0.4.17"
+log = "0.4.18"
 tracing = { version = "0.1.37", features = ["log"] }
 
 serde = { version = "1.0.145", features = ["derive"], optional = true }


### PR DESCRIPTION
Prevents future occurrences of situations similar to https://github.com/launchbadge/sqlx/issues/3118, where a change was made to `sqlx` to resolve a deprecation warning, the change is not supported by the dependency version declared in `Cargo.toml`, and the lock file has a newer version than what is declared `Cargo.toml`.

New CI job forces a downgrade of all dependencies to their minimum versions (ignoring the committed lock file), and attempts to compile the crate and its tests.

In `Cargo.toml`, the `chrono` and `log` crates were both upgraded to the oldest version that allowed the `sqlx` crate to build. This did not impact the lock file, which has newer versions of both.