### PR TITLE
refactor: Resolve cargo check warnings in postgres examples

### DIFF
--- a/examples/postgres/axum-social-with-tests/tests/common.rs
+++ b/examples/postgres/axum-social-with-tests/tests/common.rs
@@ -27,7 +27,6 @@ impl RequestBuilderExt for request::Builder {
     }
 }
 
-#[track_caller]
 pub async fn response_json(resp: &mut Response<BoxBody>) -> serde_json::Value {
     assert_eq!(
         resp.headers()

--- a/examples/postgres/files/src/main.rs
+++ b/examples/postgres/files/src/main.rs
@@ -1,4 +1,4 @@
-use sqlx::{query_file, query_file_as, query_file_unchecked, FromRow, PgPool};
+use sqlx::{query_file, query_file_as, FromRow, PgPool};
 use std::fmt::{Display, Formatter};
 
 #[derive(FromRow)]

--- a/examples/postgres/listen/src/main.rs
+++ b/examples/postgres/listen/src/main.rs
@@ -1,8 +1,6 @@
-use futures::StreamExt;
 use futures::TryStreamExt;
 use sqlx::postgres::PgListener;
 use sqlx::{Executor, PgPool};
-use std::pin;
 use std::pin::pin;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::time::Duration;


### PR DESCRIPTION
Fix causes of some of the `cargo check` warnings getting flagged in CI jobs.

This set is all in the `postgres` examples.

`#[track_caller]` is not supported on `async` functions. The rest are unused imports.