### PR TITLE
fix:the `json`-feature should activate `sqlx-postgres?/json` as well

### DIFF
--- a/sqlx-macros-core/Cargo.toml
+++ b/sqlx-macros-core/Cargo.toml
@@ -28,7 +28,7 @@ postgres = ["sqlx-postgres"]
 sqlite = ["sqlx-sqlite"]
 
 # type integrations
-json = ["sqlx-core/json", "sqlx-mysql?/json", "sqlx-sqlite?/json", "sqlx-postgres?/json"]
+json = ["sqlx-core/json", "sqlx-mysql?/json", "sqlx-postgres?/json", "sqlx-sqlite?/json"]
 
 bigdecimal = ["sqlx-core/bigdecimal", "sqlx-mysql?/bigdecimal", "sqlx-postgres?/bigdecimal"]
 bit-vec = ["sqlx-core/bit-vec", "sqlx-postgres?/bit-vec"]

--- a/sqlx-macros-core/Cargo.toml
+++ b/sqlx-macros-core/Cargo.toml
@@ -28,7 +28,7 @@ postgres = ["sqlx-postgres"]
 sqlite = ["sqlx-sqlite"]
 
 # type integrations
-json = ["sqlx-core/json", "sqlx-mysql?/json", "sqlx-sqlite?/json"]
+json = ["sqlx-core/json", "sqlx-mysql?/json", "sqlx-sqlite?/json", "sqlx-postgres?/json"]
 
 bigdecimal = ["sqlx-core/bigdecimal", "sqlx-mysql?/bigdecimal", "sqlx-postgres?/bigdecimal"]
 bit-vec = ["sqlx-core/bit-vec", "sqlx-postgres?/bit-vec"]


### PR DESCRIPTION
As discussed (or more accurately missed by me), the `json` feature should also activate the postgres' related `json` feature.

(I thought that you might like this as a PR as this is simpler for you to accept. If you want your commit in your name, that is fine too ^^)

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/52a0bbdc-81a5-4baf-972b-cff6bcc0e730) | ![image](https://github.com/user-attachments/assets/4f0e490c-5bfa-4f17-b202-e92851c7b3dc) | 


### Does your PR solve an issue?
Fixes https://github.com/launchbadge/sqlx/issues/3316
