### PR TITLE
fix: build script new line at eof

### DIFF
--- a/sqlx-cli/src/migrate.rs
+++ b/sqlx-cli/src/migrate.rs
@@ -474,7 +474,8 @@ pub fn build_script(migration_source: &str, force: bool) -> anyhow::Result<()> {
 fn main() {{
     // trigger recompilation when a new migration is added
     println!("cargo:rerun-if-changed={migration_source}");
-}}"#,
+}}
+"#,
     );
 
     fs::write("build.rs", contents)?;


### PR DESCRIPTION
When generating the build script, it will fail `cargo fmt -- --check` because it is missing a new line at the end of the file.

### Does your PR solve an issue?

There is no existing issue for this, I thought the fix was easy enough that it was best discussed in a MR :) I'm happy to create an issue for this to link to if that is preferable.

### What's the problem?

When running `sqlx migrate build-script` CLI, it fails cargo-fmt. cargo-fmt suggests adding a newline at EOF. This was found because our CI runs `cargo fmt` as a CI step and it failed :)

Existing behaviour:

```bash
~/Projects/sqlx/sqlx-cli $ cargo run -- migrate build-script                      
   Compiling sqlx-cli v0.8.0-alpha.0 (/Users/jahrens/Projects/sqlx/sqlx-cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.36s
     Running `/Users/jahrens/Projects/sqlx/target/debug/sqlx migrate build-script`
Created `build.rs`; be sure to check it into version control!

~/Projects/sqlx/sqlx-cli $ cargo fmt -- --check                                  
Diff in /Users/jahrens/Projects/sqlx/sqlx-cli/build.rs at line 3:
     // trigger recompilation when a new migration is added
     println!("cargo:rerun-if-changed=migrations");
 }
+
```

### Fixed behaviour

```bash
~/Projects/sqlx/sqlx-cli $ cargo run -- migrate build-script                                             Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.15s
     Running `/Users/jahrens/Projects/sqlx/target/debug/sqlx migrate build-script`
Created `build.rs`; be sure to check it into version control!

~/Projects/sqlx/sqlx-cli $ cargo fmt -- --check                                                      
```
