### PR TITLE
sqlite: fix inconsistent read-after-write

### DIFF
--- a/sqlx-sqlite/src/any.rs
+++ b/sqlx-sqlite/src/any.rs
@@ -83,7 +83,7 @@ impl AnyConnectionBackend for SqliteConnection {
 
         Box::pin(
             self.worker
-                .execute(query, args, self.row_channel_size, persistent)
+                .execute(query, args, self.row_channel_size, persistent, crate::connection::Returning::Many)
                 .map_ok(flume::Receiver::into_stream)
                 .try_flatten_stream()
                 .map(
@@ -107,7 +107,7 @@ impl AnyConnectionBackend for SqliteConnection {
         Box::pin(async move {
             let stream = self
                 .worker
-                .execute(query, args, self.row_channel_size, persistent)
+                .execute(query, args, self.row_channel_size, persistent, crate::connection::Returning::One)
                 .map_ok(flume::Receiver::into_stream)
                 .await?;
             futures_util::pin_mut!(stream);

--- a/sqlx-sqlite/src/any.rs
+++ b/sqlx-sqlite/src/any.rs
@@ -83,7 +83,13 @@ impl AnyConnectionBackend for SqliteConnection {
 
         Box::pin(
             self.worker
-                .execute(query, args, self.row_channel_size, persistent, crate::connection::Returning::Many)
+                .execute(
+                    query,
+                    args,
+                    self.row_channel_size,
+                    persistent,
+                    crate::connection::Returning::Many,
+                )
                 .map_ok(flume::Receiver::into_stream)
                 .try_flatten_stream()
                 .map(
@@ -107,7 +113,13 @@ impl AnyConnectionBackend for SqliteConnection {
         Box::pin(async move {
             let stream = self
                 .worker
-                .execute(query, args, self.row_channel_size, persistent, crate::connection::Returning::One)
+                .execute(
+                    query,
+                    args,
+                    self.row_channel_size,
+                    persistent,
+                    crate::connection::Returning::One,
+                )
                 .map_ok(flume::Receiver::into_stream)
                 .await?;
             futures_util::pin_mut!(stream);

--- a/sqlx-sqlite/src/any.rs
+++ b/sqlx-sqlite/src/any.rs
@@ -83,13 +83,7 @@ impl AnyConnectionBackend for SqliteConnection {
 
         Box::pin(
             self.worker
-                .execute(
-                    query,
-                    args,
-                    self.row_channel_size,
-                    persistent,
-                    crate::connection::Returning::Many,
-                )
+                .execute(query, args, self.row_channel_size, persistent, None)
                 .map_ok(flume::Receiver::into_stream)
                 .try_flatten_stream()
                 .map(
@@ -113,13 +107,7 @@ impl AnyConnectionBackend for SqliteConnection {
         Box::pin(async move {
             let stream = self
                 .worker
-                .execute(
-                    query,
-                    args,
-                    self.row_channel_size,
-                    persistent,
-                    crate::connection::Returning::One,
-                )
+                .execute(query, args, self.row_channel_size, persistent, Some(1))
                 .map_ok(flume::Receiver::into_stream)
                 .await?;
             futures_util::pin_mut!(stream);

--- a/sqlx-sqlite/src/connection/executor.rs
+++ b/sqlx-sqlite/src/connection/executor.rs
@@ -32,13 +32,7 @@ impl<'c> Executor<'c> for &'c mut SqliteConnection {
 
         Box::pin(
             self.worker
-                .execute(
-                    sql,
-                    arguments,
-                    self.row_channel_size,
-                    persistent,
-                    crate::connection::Returning::Many,
-                )
+                .execute(sql, arguments, self.row_channel_size, persistent, None)
                 .map_ok(flume::Receiver::into_stream)
                 .try_flatten_stream(),
         )
@@ -64,13 +58,7 @@ impl<'c> Executor<'c> for &'c mut SqliteConnection {
         Box::pin(async move {
             let stream = self
                 .worker
-                .execute(
-                    sql,
-                    arguments,
-                    self.row_channel_size,
-                    persistent,
-                    crate::connection::Returning::One,
-                )
+                .execute(sql, arguments, self.row_channel_size, persistent, Some(1))
                 .map_ok(flume::Receiver::into_stream)
                 .try_flatten_stream();
 

--- a/sqlx-sqlite/src/connection/executor.rs
+++ b/sqlx-sqlite/src/connection/executor.rs
@@ -32,7 +32,13 @@ impl<'c> Executor<'c> for &'c mut SqliteConnection {
 
         Box::pin(
             self.worker
-                .execute(sql, arguments, self.row_channel_size, persistent, crate::connection::Returning::Many)
+                .execute(
+                    sql,
+                    arguments,
+                    self.row_channel_size,
+                    persistent,
+                    crate::connection::Returning::Many,
+                )
                 .map_ok(flume::Receiver::into_stream)
                 .try_flatten_stream(),
         )
@@ -58,7 +64,13 @@ impl<'c> Executor<'c> for &'c mut SqliteConnection {
         Box::pin(async move {
             let stream = self
                 .worker
-                .execute(sql, arguments, self.row_channel_size, persistent, crate::connection::Returning::One)
+                .execute(
+                    sql,
+                    arguments,
+                    self.row_channel_size,
+                    persistent,
+                    crate::connection::Returning::One,
+                )
                 .map_ok(flume::Receiver::into_stream)
                 .try_flatten_stream();
 
@@ -66,7 +78,7 @@ impl<'c> Executor<'c> for &'c mut SqliteConnection {
 
             while let Some(res) = stream.try_next().await? {
                 if let Either::Right(row) = res {
-                    return Ok(Some(row))
+                    return Ok(Some(row));
                 }
             }
 

--- a/sqlx-sqlite/src/connection/executor.rs
+++ b/sqlx-sqlite/src/connection/executor.rs
@@ -64,13 +64,15 @@ impl<'c> Executor<'c> for &'c mut SqliteConnection {
 
             futures_util::pin_mut!(stream);
 
+            let mut out = Ok(None);
+
             while let Some(res) = stream.try_next().await? {
                 if let Either::Right(row) = res {
-                    return Ok(Some(row));
+                    out = Ok(Some(row));
                 }
             }
 
-            Ok(None)
+            out
         })
     }
 

--- a/sqlx-sqlite/src/connection/mod.rs
+++ b/sqlx-sqlite/src/connection/mod.rs
@@ -426,8 +426,3 @@ impl Statements {
         self.temp = None;
     }
 }
-
-pub(crate) enum Returning {
-    Many,
-    One,
-}

--- a/sqlx-sqlite/src/connection/mod.rs
+++ b/sqlx-sqlite/src/connection/mod.rs
@@ -426,3 +426,8 @@ impl Statements {
         self.temp = None;
     }
 }
+
+pub(crate) enum Returning {
+    Many,
+    One
+}

--- a/sqlx-sqlite/src/connection/mod.rs
+++ b/sqlx-sqlite/src/connection/mod.rs
@@ -429,5 +429,5 @@ impl Statements {
 
 pub(crate) enum Returning {
     Many,
-    One
+    One,
 }

--- a/sqlx-sqlite/src/connection/worker.rs
+++ b/sqlx-sqlite/src/connection/worker.rs
@@ -160,9 +160,18 @@ impl ConnectionWorker {
                                 },
                                 Returning::One => {
                                     let mut iter = iter;
-                                    if let Some(res) = iter.next() {
-                                        drop(iter);
-                                        let _ = tx.send(res);
+
+                                    while let Some(res) = iter.next() {
+                                        if let Ok(ok) = &res {
+                                            if ok.is_right() {
+                                                drop(iter);
+                                                let _ = tx.send(res);
+                                                break;
+                                            }
+                                        }
+                                        if tx.send(res).is_err() {
+                                            break;
+                                        }
                                     }
                                 },
                             }

--- a/sqlx-sqlite/src/connection/worker.rs
+++ b/sqlx-sqlite/src/connection/worker.rs
@@ -54,7 +54,7 @@ enum Command {
         arguments: Option<SqliteArguments<'static>>,
         persistent: bool,
         tx: flume::Sender<Result<Either<SqliteQueryResult, SqliteRow>, Error>>,
-        returning: Returning
+        returning: Returning,
     },
     Begin {
         tx: rendezvous_oneshot::Sender<Result<(), Error>>,
@@ -299,7 +299,7 @@ impl ConnectionWorker {
         args: Option<SqliteArguments<'_>>,
         chan_size: usize,
         persistent: bool,
-        returning: Returning
+        returning: Returning,
     ) -> Result<flume::Receiver<Result<Either<SqliteQueryResult, SqliteRow>, Error>>, Error> {
         let (tx, rx) = flume::bounded(chan_size);
 
@@ -310,7 +310,7 @@ impl ConnectionWorker {
                     arguments: args.map(SqliteArguments::into_static),
                     persistent,
                     tx,
-                    returning
+                    returning,
                 },
                 Span::current(),
             ))


### PR DESCRIPTION
Fixes #3120

As far as I can tell, this fixes https://github.com/launchbadge/sqlx/issues/2099 (and I think https://github.com/launchbadge/sqlx/issues/3120, which appears to be the same)

My minimal reproduction looks like this (which is adapted from the example in https://github.com/launchbadge/sqlx/issues/2099):

```rust
use sqlx::sqlite::SqlitePoolOptions;

#[tokio::main]
async fn main() {
    let sqlite_options = sqlx::sqlite::SqliteConnectOptions::new()
        .filename("test.db")
        .busy_timeout(std::time::Duration::from_secs(5))
        .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
        .create_if_missing(true);

    let db = SqlitePoolOptions::new()
        .acquire_timeout(std::time::Duration::from_secs(5))
        .max_connections(5)
        .min_connections(5)
        .connect_with(sqlite_options)
        .await
        .unwrap();

    sqlx::query("create table if not exists some_table (id integer primary key, name text)")
        .execute(&db)
        .await
        .unwrap();

    let name = "name";

    let (id,): (i64,) = sqlx::query_as("INSERT INTO some_table (name) VALUES ($1) RETURNING id")
        .bind(name)
        .fetch_one(&db)
        .await
        .unwrap();

    let out: (i64, String) = sqlx::query_as("SELECT id, name FROM some_table WHERE id = $1")
        .bind(id)
        .fetch_one(&db)
        .await
        .unwrap(); // => sqlx::Error no row found

    dbg!(out);
}
```

I can pretty easily get this code to panic on the `main` branch, just by running it a few times. It doesn't panic every time, as other issue reporters have noted, but it's consistent enough to notice.

With this fix, I can't get it to panic at all.

The fix in this PR works by forcing the stream [here](https://github.com/launchbadge/sqlx/blob/main/sqlx-sqlite/src/connection/executor.rs#L59-L67) to run until completion, rather than returning early in the case that it returns rows (i.e., via a `RETURNING` in SQL).

As far as I can tell, this is related to how `step` in `sqlx-sqlite/src/statement/handle.rs` works:

```rust
    pub(crate) fn step(&mut self) -> Result<bool, SqliteError> {
        // SAFETY: we have exclusive access to the handle
        unsafe {
            loop {
                match sqlite3_step(self.0.as_ptr()) {
                    SQLITE_ROW => return Ok(true),
                    SQLITE_DONE => return Ok(false),
                    SQLITE_MISUSE => panic!("misuse!"),
                    SQLITE_LOCKED_SHAREDCACHE => {
                        // The shared cache is locked by another connection. Wait for unlock
                        // notification and try again.
                        unlock_notify::wait(self.db_handle())?;
                        // Need to reset the handle after the unlock
                        // (https://www.sqlite.org/unlock_notify.html)
                        sqlite3_reset(self.0.as_ptr());
                    }
                    _ => return Err(SqliteError::new(self.db_handle())),
                }
            }
        }
    }
```

where the `SQLITE_ROW => return Ok(true),` clause is causing the `ExecuteIter` to terminate early, before SQLite can return `SQLITE_DONE`, which I believe in turn means SQLite itself may not be committing the transaction: https://github.com/launchbadge/sqlx/blob/main/sqlx-sqlite/src/connection/execute.rs#L96

This `SQLITE_ROW` then causes this whole stream to terminate early, as it simply returns when it matches an `Either::Right(row)` rather than an `Either::Left(SqliteQueryResult)`: https://github.com/launchbadge/sqlx/blob/main/sqlx-sqlite/src/connection/executor.rs#L68-L70

I think this is what is happening, and I think this PR fixes it, but please let me know if my understanding is incorrect.

Thanks!