### PR TITLE
breaking: fix name collision in `FromRow`, return `Error::ColumnDecode` for `TryFrom` errors

### DIFF
--- a/sqlx-macros-core/src/derives/row.rs
+++ b/sqlx-macros-core/src/derives/row.rs
@@ -119,9 +119,11 @@ fn expand_derive_from_row_struct(
                             .and_then(|v| {
                                 <#ty as ::std::convert::TryFrom::<#try_from>>::try_from(v)
                                     .map_err(|e| {
+                                        // Triggers a lint warning if `TryFrom::Err = Infallible`
+                                        #[allow(unreachable_code)]
                                         ::sqlx::Error::ColumnDecode {
                                             index: #id_s.to_string(),
-                                            error: sqlx::__spec_error!(e),
+                                            source: sqlx::__spec_error!(e),
                                         }
                                     })
                             })
@@ -142,9 +144,11 @@ fn expand_derive_from_row_struct(
                             .and_then(|v| {
                                 <#ty as ::std::convert::TryFrom::<#try_from>>::try_from(v)
                                     .map_err(|e| {
+                                        // Triggers a lint warning if `TryFrom::Err = Infallible`
+                                        #[allow(unreachable_code)]
                                         ::sqlx::Error::ColumnDecode {
                                             index: #id_s.to_string(),
-                                            error: sqlx::__spec_error!(e),
+                                            source: sqlx::__spec_error!(e),
                                         }
                                     })
                             })
@@ -161,9 +165,11 @@ fn expand_derive_from_row_struct(
                             .and_then(|v| {
                                 <#ty as ::std::convert::TryFrom::<#try_from>>::try_from(v.0)
                                     .map_err(|e| {
+                                        // Triggers a lint warning if `TryFrom::Err = Infallible`
+                                        #[allow(unreachable_code)]
                                         ::sqlx::Error::ColumnDecode {
                                             index: #id_s.to_string(),
-                                            error: sqlx::__spec_error!(e),
+                                            source: sqlx::__spec_error!(e),
                                         }
                                     })
                             })

--- a/sqlx-macros-core/src/derives/row.rs
+++ b/sqlx-macros-core/src/derives/row.rs
@@ -119,7 +119,10 @@ fn expand_derive_from_row_struct(
                             .and_then(|v| {
                                 <#ty as ::std::convert::TryFrom::<#try_from>>::try_from(v)
                                     .map_err(|e| {
-                                        ::sqlx::Error::ColumnNotFound("FromRow: try_from failed".to_string())
+                                        ::sqlx::Error::ColumnDecode {
+                                            index: #id_s.to_string(),
+                                            error: sqlx::__spec_error!(e),
+                                        }
                                     })
                             })
                     )
@@ -138,7 +141,12 @@ fn expand_derive_from_row_struct(
                         __row.try_get(#id_s)
                             .and_then(|v| {
                                 <#ty as ::std::convert::TryFrom::<#try_from>>::try_from(v)
-                                    .map_err(|e| ::sqlx::Error::ColumnNotFound("FromRow: try_from failed".to_string()))
+                                    .map_err(|e| {
+                                        ::sqlx::Error::ColumnDecode {
+                                            index: #id_s.to_string(),
+                                            error: sqlx::__spec_error!(e),
+                                        }
+                                    })
                             })
                     )
                 }
@@ -152,8 +160,11 @@ fn expand_derive_from_row_struct(
                         __row.try_get::<::sqlx::types::Json<_>, _>(#id_s)
                             .and_then(|v| {
                                 <#ty as ::std::convert::TryFrom::<#try_from>>::try_from(v.0)
-                                    .map_err(|_| {
-                                        ::sqlx::Error::ColumnNotFound("FromRow: try_from failed".to_string())
+                                    .map_err(|e| {
+                                        ::sqlx::Error::ColumnDecode {
+                                            index: #id_s.to_string(),
+                                            error: sqlx::__spec_error!(e),
+                                        }
                                     })
                             })
                     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,9 @@ mod macros;
 #[doc(hidden)]
 pub mod ty_match;
 
+#[cfg(feature = "macros")]
+pub mod spec_error;
+
 #[doc(hidden)]
 pub use sqlx_core::rt as __rt;
 

--- a/src/spec_error.rs
+++ b/src/spec_error.rs
@@ -1,0 +1,70 @@
+use std::any::Any;
+use std::error::Error;
+use std::fmt::{Debug, Display};
+
+// Autoderef specialization similar to `clap::value_parser!()`.
+pub struct SpecErrorWrapper<E>(pub E);
+
+pub trait SpecError<E>: Sized {
+    fn __sqlx_spec_error(&self) -> fn(SpecErrorWrapper<E>) -> Box<dyn Error + Send + Sync + 'static>;
+}
+
+impl<E> SpecError<E> for &&&&SpecErrorWrapper<E> where E: Error + Send + Sync + 'static {
+    fn __sqlx_spec_error(&self) -> fn(SpecErrorWrapper<E>) -> Box<dyn Error + Send + Sync + 'static> {
+        |e| Box::new(e.0)
+    }
+}
+
+impl<E> SpecError<E> for &&&SpecErrorWrapper<E> where E: Display {
+    fn __sqlx_spec_error(&self) -> fn(SpecErrorWrapper<E>) -> Box<dyn Error + Send + Sync + 'static> {
+        |e| e.0.to_string().into()
+    }
+}
+
+impl<E> SpecError<E> for &&SpecErrorWrapper<E> where E: Debug {
+    fn __sqlx_spec_error(&self) -> fn(SpecErrorWrapper<E>) -> Box<dyn Error + Send + Sync + 'static> {
+        |e| format!("{:?}", e.0).into()
+    }
+}
+
+impl<E> SpecError<E> for &SpecErrorWrapper<E> where E: Any {
+    fn __sqlx_spec_error(&self) -> fn(SpecErrorWrapper<E>) -> Box<dyn Error + Send + Sync + 'static> {
+        |_e| format!("unprintable error: {}", std::any::type_name::<E>()).into()
+    }
+}
+
+impl<E> SpecError<E> for SpecErrorWrapper<E> {
+    fn __sqlx_spec_error(&self) -> fn(SpecErrorWrapper<E>) -> Box<dyn Error + Send + Sync + 'static> {
+        |_e| "unprintable error: (unprintable type)".into()
+    }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __spec_error {
+    ($e:expr) => {{
+        use $crate::spec_error::{SpecError, SpecErrorWrapper};
+
+        let wrapper = SpecErrorWrapper($e);
+        let wrap_err = wrapper.__sqlx_spec_error();
+        wrap_err(wrapper)
+    }};
+}
+
+#[test]
+fn test_spec_error() {
+    #[derive(Debug)]
+    struct DebugError;
+
+    struct AnyError;
+
+    let _e: Box<dyn Error + Send + Sync + 'static> = __spec_error!(std::io::Error::from(std::io::ErrorKind::Unsupported));
+
+    let _e: Box<dyn Error + Send + Sync + 'static> = __spec_error!("displayable error");
+
+    let _e: Box<dyn Error + Send + Sync + 'static> = __spec_error!(DebugError);
+
+    let _e: Box<dyn Error + Send + Sync + 'static> = __spec_error!(AnyError);
+
+    let _e: Box<dyn Error + Send + Sync + 'static> = __spec_error!(&1i32);
+}

--- a/src/spec_error.rs
+++ b/src/spec_error.rs
@@ -6,35 +6,59 @@ use std::fmt::{Debug, Display};
 pub struct SpecErrorWrapper<E>(pub E);
 
 pub trait SpecError<E>: Sized {
-    fn __sqlx_spec_error(&self) -> fn(SpecErrorWrapper<E>) -> Box<dyn Error + Send + Sync + 'static>;
+    fn __sqlx_spec_error(
+        &self,
+    ) -> fn(SpecErrorWrapper<E>) -> Box<dyn Error + Send + Sync + 'static>;
 }
 
-impl<E> SpecError<E> for &&&&SpecErrorWrapper<E> where E: Error + Send + Sync + 'static {
-    fn __sqlx_spec_error(&self) -> fn(SpecErrorWrapper<E>) -> Box<dyn Error + Send + Sync + 'static> {
+impl<E> SpecError<E> for &&&&SpecErrorWrapper<E>
+where
+    E: Error + Send + Sync + 'static,
+{
+    fn __sqlx_spec_error(
+        &self,
+    ) -> fn(SpecErrorWrapper<E>) -> Box<dyn Error + Send + Sync + 'static> {
         |e| Box::new(e.0)
     }
 }
 
-impl<E> SpecError<E> for &&&SpecErrorWrapper<E> where E: Display {
-    fn __sqlx_spec_error(&self) -> fn(SpecErrorWrapper<E>) -> Box<dyn Error + Send + Sync + 'static> {
+impl<E> SpecError<E> for &&&SpecErrorWrapper<E>
+where
+    E: Display,
+{
+    fn __sqlx_spec_error(
+        &self,
+    ) -> fn(SpecErrorWrapper<E>) -> Box<dyn Error + Send + Sync + 'static> {
         |e| e.0.to_string().into()
     }
 }
 
-impl<E> SpecError<E> for &&SpecErrorWrapper<E> where E: Debug {
-    fn __sqlx_spec_error(&self) -> fn(SpecErrorWrapper<E>) -> Box<dyn Error + Send + Sync + 'static> {
+impl<E> SpecError<E> for &&SpecErrorWrapper<E>
+where
+    E: Debug,
+{
+    fn __sqlx_spec_error(
+        &self,
+    ) -> fn(SpecErrorWrapper<E>) -> Box<dyn Error + Send + Sync + 'static> {
         |e| format!("{:?}", e.0).into()
     }
 }
 
-impl<E> SpecError<E> for &SpecErrorWrapper<E> where E: Any {
-    fn __sqlx_spec_error(&self) -> fn(SpecErrorWrapper<E>) -> Box<dyn Error + Send + Sync + 'static> {
+impl<E> SpecError<E> for &SpecErrorWrapper<E>
+where
+    E: Any,
+{
+    fn __sqlx_spec_error(
+        &self,
+    ) -> fn(SpecErrorWrapper<E>) -> Box<dyn Error + Send + Sync + 'static> {
         |_e| format!("unprintable error: {}", std::any::type_name::<E>()).into()
     }
 }
 
 impl<E> SpecError<E> for SpecErrorWrapper<E> {
-    fn __sqlx_spec_error(&self) -> fn(SpecErrorWrapper<E>) -> Box<dyn Error + Send + Sync + 'static> {
+    fn __sqlx_spec_error(
+        &self,
+    ) -> fn(SpecErrorWrapper<E>) -> Box<dyn Error + Send + Sync + 'static> {
         |_e| "unprintable error: (unprintable type)".into()
     }
 }
@@ -58,7 +82,8 @@ fn test_spec_error() {
 
     struct AnyError;
 
-    let _e: Box<dyn Error + Send + Sync + 'static> = __spec_error!(std::io::Error::from(std::io::ErrorKind::Unsupported));
+    let _e: Box<dyn Error + Send + Sync + 'static> =
+        __spec_error!(std::io::Error::from(std::io::ErrorKind::Unsupported));
 
     let _e: Box<dyn Error + Send + Sync + 'static> = __spec_error!("displayable error");
 

--- a/tests/postgres/derives.rs
+++ b/tests/postgres/derives.rs
@@ -772,13 +772,13 @@ async fn test_enum_with_schema() -> anyhow::Result<()> {
 
 #[cfg(feature = "macros")]
 #[sqlx_macros::test]
-async fn test_from_row_hygiene() -> anyhow::Result<()> { 
+async fn test_from_row_hygiene() -> anyhow::Result<()> {
     // A field named `row` previously would shadow the `row` parameter of `FromRow::from_row()`:
     // https://github.com/launchbadge/sqlx/issues/3344
     #[derive(Debug, sqlx::FromRow)]
     pub struct Foo {
         pub row: i32,
-        pub bar: i32
+        pub bar: i32,
     }
 
     let mut conn = new::<Postgres>().await?;
@@ -786,7 +786,7 @@ async fn test_from_row_hygiene() -> anyhow::Result<()> {
     let foo: Foo = sqlx::query_as("SELECT 1234 as row, 5678 as bar")
         .fetch_one(&mut conn)
         .await?;
-    
+
     assert_eq!(foo.row, 1234);
     assert_eq!(foo.bar, 5678);
 

--- a/tests/postgres/derives.rs
+++ b/tests/postgres/derives.rs
@@ -769,3 +769,26 @@ async fn test_enum_with_schema() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[cfg(feature = "macros")]
+#[sqlx_macros::test]
+async fn test_from_row_hygiene() -> anyhow::Result<()> { 
+    // A field named `row` previously would shadow the `row` parameter of `FromRow::from_row()`:
+    // https://github.com/launchbadge/sqlx/issues/3344
+    #[derive(Debug, sqlx::FromRow)]
+    pub struct Foo {
+        pub row: i32,
+        pub bar: i32
+    }
+
+    let mut conn = new::<Postgres>().await?;
+
+    let foo: Foo = sqlx::query_as("SELECT 1234 as row, 5678 as bar")
+        .fetch_one(&mut conn)
+        .await?;
+    
+    assert_eq!(foo.row, 1234);
+    assert_eq!(foo.bar, 5678);
+
+    Ok(())
+}


### PR DESCRIPTION
fixes #3344 

Breaking because `#[sqlx(default)]` on an individual field or the struct itself would have previously suppressed the error. This doesn't seem like good behavior as it could result in some potentially very difficult bugs.

Instead of using `TryFrom` for these fields, just implement `From` and apply the default explicitly.