### PR TITLE
doc: hide `spec_error` module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ mod macros;
 pub mod ty_match;
 
 #[cfg(feature = "macros")]
+#[doc(hidden)]
 pub mod spec_error;
 
 #[doc(hidden)]


### PR DESCRIPTION
The `spec_error` module implements the autoref specialization hack that's used in a single place in the derive macros. It wasn't meant to be a public API.

Given how arcane it must appear, I doubt anyone's tried using it outside of this project anyway.