### PR TITLE
chore: replace structopt with clap in examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,15 +77,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,17 +342,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -749,21 +729,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags 1.3.2",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
@@ -790,7 +755,7 @@ version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "885e4d7d5af40bfb99ae6f9433e292feac98d452dcb3ec3d25dfe7552b77da8c"
 dependencies = [
- "clap 4.5.2",
+ "clap",
 ]
 
 [[package]]
@@ -905,7 +870,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.5.2",
+ "clap",
  "criterion-plot",
  "futures",
  "is-terminal",
@@ -1579,15 +1544,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
@@ -1597,15 +1553,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1806,7 +1753,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -1826,7 +1773,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -2174,7 +2121,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -3206,7 +3153,7 @@ dependencies = [
  "backoff",
  "cargo_metadata",
  "chrono",
- "clap 4.5.2",
+ "clap",
  "clap_complete",
  "console",
  "dotenvy",
@@ -3286,9 +3233,9 @@ name = "sqlx-example-mysql-todos"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "futures",
  "sqlx",
- "structopt",
  "tokio",
 ]
 
@@ -3343,12 +3290,12 @@ name = "sqlx-example-postgres-json"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "dotenvy",
  "futures",
  "serde",
  "serde_json",
  "sqlx",
- "structopt",
  "tokio",
 ]
 
@@ -3367,11 +3314,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "clap",
  "dotenvy",
  "futures",
  "mockall",
  "sqlx",
- "structopt",
  "tokio",
 ]
 
@@ -3380,10 +3327,10 @@ name = "sqlx-example-postgres-todos"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "dotenvy",
  "futures",
  "sqlx",
- "structopt",
  "tokio",
 ]
 
@@ -3401,9 +3348,9 @@ name = "sqlx-example-sqlite-todos"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "futures",
  "sqlx",
- "structopt",
  "tokio",
 ]
 
@@ -3589,12 +3536,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -3604,30 +3545,6 @@ name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "subtle"
@@ -3707,15 +3624,6 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
 
 [[package]]
 name = "thiserror"
@@ -4094,12 +4002,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/examples/mysql/todos/Cargo.toml
+++ b/examples/mysql/todos/Cargo.toml
@@ -8,5 +8,5 @@ workspace = "../../../"
 anyhow = "1.0"
 futures = "0.3"
 sqlx = { path = "../../../", features = [ "mysql", "runtime-tokio-native-tls" ] }
-structopt = "0.3"
+clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.20.0", features = ["rt", "macros"]}

--- a/examples/mysql/todos/src/main.rs
+++ b/examples/mysql/todos/src/main.rs
@@ -1,14 +1,14 @@
+use clap::{Parser, Subcommand};
 use sqlx::mysql::MySqlPool;
 use std::env;
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Args {
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     cmd: Option<Command>,
 }
 
-#[derive(StructOpt)]
+#[derive(Subcommand)]
 enum Command {
     Add { description: String },
     Done { id: u64 },
@@ -16,7 +16,7 @@ enum Command {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    let args = Args::from_args_safe()?;
+    let args = Args::parse();
     let pool = MySqlPool::connect(&env::var("DATABASE_URL")?).await?;
 
     match args.cmd {

--- a/examples/postgres/json/Cargo.toml
+++ b/examples/postgres/json/Cargo.toml
@@ -11,5 +11,5 @@ futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlx = { path = "../../../", features = ["runtime-tokio", "postgres", "json"] }
-structopt = "0.3"
+clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.20.0", features = ["rt", "macros"]}

--- a/examples/postgres/json/src/main.rs
+++ b/examples/postgres/json/src/main.rs
@@ -1,18 +1,18 @@
+use clap::{Parser, Subcommand};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use sqlx::postgres::PgPool;
 use sqlx::types::Json;
 use std::io::{self, Read};
 use std::num::NonZeroU8;
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Args {
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     cmd: Option<Command>,
 }
 
-#[derive(StructOpt)]
+#[derive(Subcommand)]
 enum Command {
     Add,
 }
@@ -32,7 +32,7 @@ struct Row {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    let args = Args::from_args_safe()?;
+    let args = Args::parse();
     let pool = PgPool::connect(&dotenvy::var("DATABASE_URL")?).await?;
 
     match args.cmd {

--- a/examples/postgres/mockable-todos/Cargo.toml
+++ b/examples/postgres/mockable-todos/Cargo.toml
@@ -8,7 +8,7 @@ workspace = "../../../"
 anyhow = "1.0"
 futures = "0.3"
 sqlx = { path = "../../../", features = ["postgres", "runtime-tokio-native-tls"] }
-structopt = "0.3"
+clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.20.0", features = ["rt", "macros"]}
 dotenvy = "0.15.0"
 async-trait = "0.1.41"

--- a/examples/postgres/mockable-todos/src/main.rs
+++ b/examples/postgres/mockable-todos/src/main.rs
@@ -1,15 +1,15 @@
 use async_trait::async_trait;
+use clap::{Parser, Subcommand};
 use sqlx::postgres::PgPool;
 use std::{env, io::Write, sync::Arc};
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Args {
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     cmd: Option<Command>,
 }
 
-#[derive(StructOpt)]
+#[derive(Subcommand)]
 enum Command {
     Add { description: String },
     Done { id: i64 },
@@ -18,7 +18,7 @@ enum Command {
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
-    let args = Args::from_args_safe()?;
+    let args = Args::parse();
     let pool = PgPool::connect(&env::var("DATABASE_URL")?).await?;
     let todo_repo = PostgresTodoRepo::new(pool);
     let mut writer = std::io::stdout();

--- a/examples/postgres/todos/Cargo.toml
+++ b/examples/postgres/todos/Cargo.toml
@@ -8,6 +8,6 @@ workspace = "../../../"
 anyhow = "1.0"
 futures = "0.3"
 sqlx = { path = "../../../", features = ["postgres", "runtime-tokio-native-tls"] }
-structopt = "0.3"
+clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.20.0", features = ["rt", "macros"]}
 dotenvy = "0.15.0"

--- a/examples/postgres/todos/src/main.rs
+++ b/examples/postgres/todos/src/main.rs
@@ -1,14 +1,14 @@
+use clap::{Parser, Subcommand};
 use sqlx::postgres::PgPool;
 use std::env;
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Args {
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     cmd: Option<Command>,
 }
 
-#[derive(StructOpt)]
+#[derive(Subcommand)]
 enum Command {
     Add { description: String },
     Done { id: i64 },
@@ -16,7 +16,7 @@ enum Command {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    let args = Args::from_args_safe()?;
+    let args = Args::parse();
     let pool = PgPool::connect(&env::var("DATABASE_URL")?).await?;
 
     match args.cmd {

--- a/examples/sqlite/todos/Cargo.toml
+++ b/examples/sqlite/todos/Cargo.toml
@@ -8,5 +8,5 @@ workspace = "../../../"
 anyhow = "1.0"
 futures = "0.3"
 sqlx = { path = "../../../", features = ["sqlite", "runtime-tokio-native-tls"] }
-structopt = "0.3"
+clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.20.0", features = ["rt", "macros"]}

--- a/examples/sqlite/todos/src/main.rs
+++ b/examples/sqlite/todos/src/main.rs
@@ -1,14 +1,14 @@
+use clap::{Parser, Subcommand};
 use sqlx::sqlite::SqlitePool;
 use std::env;
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 struct Args {
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     cmd: Option<Command>,
 }
 
-#[derive(StructOpt)]
+#[derive(Subcommand)]
 enum Command {
     Add { description: String },
     Done { id: i64 },
@@ -16,7 +16,7 @@ enum Command {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
-    let args = Args::from_args_safe()?;
+    let args = Args::parse();
     let pool = SqlitePool::connect(&env::var("DATABASE_URL")?).await?;
 
     match args.cmd {


### PR DESCRIPTION
Replaces structopt with clap in examples.