### PR TITLE
chore(examples):Migrated the pg-chat example to ratatui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,6 +670,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "castaway"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,6 +801,19 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -935,11 +957,11 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crossterm"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -1797,6 +1819,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,6 +1923,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 dependencies = [
  "value-bag",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2578,6 +2618,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16546c5b5962abf8ce6e2881e722b4e0ae3b6f1a08a26ae3573c55853ca68d3"
+dependencies = [
+ "bitflags 2.4.2",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "stability",
+ "strum",
+ "strum_macros",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
 name = "rayon"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2797,6 +2858,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "rustyline"
@@ -3269,9 +3336,9 @@ version = "0.1.0"
 dependencies = [
  "crossterm",
  "futures",
+ "ratatui",
  "sqlx",
  "tokio",
- "tui",
  "unicode-width",
 ]
 
@@ -3518,6 +3585,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "stability"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
+dependencies = [
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "str-buf"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3545,6 +3628,28 @@ name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.52",
+]
 
 [[package]]
 name = "subtle"
@@ -3860,19 +3965,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tui"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
-dependencies = [
- "bitflags 1.3.2",
- "cassowary",
- "crossterm",
- "unicode-segmentation",
- "unicode-width",
-]
-
-[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3906,10 +3998,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.11"
+name = "unicode-truncate"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode_categories"

--- a/examples/postgres/chat/Cargo.toml
+++ b/examples/postgres/chat/Cargo.toml
@@ -8,6 +8,6 @@ workspace = "../../../"
 sqlx = { path = "../../../", features = [ "postgres", "runtime-tokio-native-tls" ] }
 futures = "0.3.1"
 tokio = { version = "1.20.0", features = [ "rt-multi-thread", "macros" ] }
-tui = "0.19.0"
-crossterm = "0.25"
+ratatui = "0.27.0"
+crossterm = "0.27.0"
 unicode-width = "0.1"

--- a/examples/postgres/chat/src/main.rs
+++ b/examples/postgres/chat/src/main.rs
@@ -3,11 +3,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use sqlx::postgres::PgListener;
-use sqlx::PgPool;
-use std::sync::Arc;
-use std::{error::Error, io};
-use tokio::{sync::Mutex, time::Duration};
+use ratatui::text::Line;
 use ratatui::{
     backend::{Backend, CrosstermBackend},
     layout::{Constraint, Direction, Layout},
@@ -16,7 +12,11 @@ use ratatui::{
     widgets::{Block, Borders, List, ListItem, Paragraph},
     Frame, Terminal,
 };
-use ratatui::text::Line;
+use sqlx::postgres::PgListener;
+use sqlx::PgPool;
+use std::sync::Arc;
+use std::{error::Error, io};
+use tokio::{sync::Mutex, time::Duration};
 use unicode_width::UnicodeWidthStr;
 
 struct ChatApp {

--- a/examples/postgres/chat/src/main.rs
+++ b/examples/postgres/chat/src/main.rs
@@ -8,14 +8,15 @@ use sqlx::PgPool;
 use std::sync::Arc;
 use std::{error::Error, io};
 use tokio::{sync::Mutex, time::Duration};
-use tui::{
+use ratatui::{
     backend::{Backend, CrosstermBackend},
     layout::{Constraint, Direction, Layout},
     style::{Color, Modifier, Style},
-    text::{Span, Spans, Text},
+    text::{Span, Text},
     widgets::{Block, Borders, List, ListItem, Paragraph},
     Frame, Terminal,
 };
+use ratatui::text::Line;
 use unicode_width::UnicodeWidthStr;
 
 struct ChatApp {
@@ -53,7 +54,7 @@ impl ChatApp {
                 .await
                 .iter()
                 .map(|m| {
-                    let content = vec![Spans::from(Span::raw(m.to_owned()))];
+                    let content = vec![Line::from(Span::raw(m.to_owned()))];
                     ListItem::new(content)
                 })
                 .collect();
@@ -85,7 +86,7 @@ impl ChatApp {
         }
     }
 
-    fn ui<B: Backend>(&mut self, frame: &mut Frame<B>, messages: Vec<ListItem>) {
+    fn ui(&mut self, frame: &mut Frame, messages: Vec<ListItem>) {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .margin(2)
@@ -99,7 +100,7 @@ impl ChatApp {
             )
             .split(frame.size());
 
-        let text = Text::from(Spans::from(vec![
+        let text = Text::from(Line::from(vec![
             Span::raw("Press "),
             Span::styled("Enter", Style::default().add_modifier(Modifier::BOLD)),
             Span::raw(" to send the message, "),
@@ -109,7 +110,7 @@ impl ChatApp {
         let help_message = Paragraph::new(text);
         frame.render_widget(help_message, chunks[0]);
 
-        let input = Paragraph::new(self.input.as_ref())
+        let input = Paragraph::new(self.input.as_str())
             .style(Style::default().fg(Color::Yellow))
             .block(Block::default().borders(Borders::ALL).title("Input"));
         frame.render_widget(input, chunks[1]);
@@ -131,7 +132,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // setup postgres
     let conn_url =
         std::env::var("DATABASE_URL").expect("Env var DATABASE_URL is required for this example.");
-    let pool = sqlx::PgPool::connect(&conn_url).await?;
+    let pool = PgPool::connect(&conn_url).await?;
 
     let mut listener = PgListener::connect(&conn_url).await?;
     listener.listen("chan0").await?;


### PR DESCRIPTION
### Does your PR solve an issue?

Currently, the `postgres/chat` example uses `tui`. Said library is unmaintained and switching to ratatui is recomended.
Advisory: https://rustsec.org/advisories/RUSTSEC-2023-0049


Proof that this still works:
![image](https://github.com/user-attachments/assets/24d72ecb-a3af-4984-893e-3a0c83adc340)
