### PR TITLE
fix(dependencys):bumped cargo_metadata to `v0.18.1` to avoid yanked `v0.14.3`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,15 +646,16 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.14.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/sqlx-cli/Cargo.toml
+++ b/sqlx-cli/Cargo.toml
@@ -45,7 +45,7 @@ serde_json = "1.0.73"
 serde = { version = "1.0.132", features = ["derive"] }
 glob = "0.3.0"
 openssl = { version = "0.10.38", optional = true }
-cargo_metadata = "0.14"
+cargo_metadata = "0.18.1"
 filetime = "0.2"
 
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }


### PR DESCRIPTION
### Does your PR solve an issue?

docs.rs for this package currently does not build due to yanked dependencys
=> This is a yanked dependency https://docs.rs/cargo_metadata/0.14.3/cargo_metadata/index.html

I have followed the commit trail from https://github.com/oli-obk/cargo_metadata/blame/d7d326f8458bf7dbc7af380c454e922a5661898d to https://github.com/oli-obk/cargo_metadata/blame/709d508c54593e4ee0ef00e94dd04a6158e6e5d7/Cargo.toml and have not found things which are breaking for our usage
