### PR TITLE
Parse passfile parameter in Postgres connection URI

### DIFF
--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -40,6 +40,7 @@ mod ssl_mode;
 /// | `password` | `None` | Password to be used if the server demands password authentication. |
 /// | `port` | `5432` | Port number to connect to at the server host, or socket file name extension for Unix-domain connections. |
 /// | `dbname` | `None` | The database name. |
+/// | `passfile` | `None` | The path to the file used to store passwords. |
 /// | `options` | `None` | The runtime parameters to send to the server at connection start. |
 ///
 /// The URL scheme designator can be either `postgresql://` or `postgres://`.
@@ -101,6 +102,7 @@ pub struct PgConnectOptions {
     pub(crate) application_name: Option<String>,
     pub(crate) log_settings: LogSettings,
     pub(crate) extra_float_digits: Option<Cow<'static, str>>,
+    pub(crate) passfile: Option<String>,
     pub(crate) options: Option<String>,
 }
 
@@ -167,6 +169,7 @@ impl PgConnectOptions {
             application_name: var("PGAPPNAME").ok(),
             extra_float_digits: Some("2".into()),
             log_settings: Default::default(),
+            passfile: var("PGPASSFILE").ok(),
             options: var("PGOPTIONS").ok(),
         }
     }
@@ -178,6 +181,7 @@ impl PgConnectOptions {
                 self.port,
                 &self.username,
                 self.database.as_deref(),
+                self.passfile.as_deref(),
             );
         }
 
@@ -489,6 +493,20 @@ impl PgConnectOptions {
     /// ```
     pub fn extra_float_digits(mut self, extra_float_digits: impl Into<Option<i8>>) -> Self {
         self.extra_float_digits = extra_float_digits.into().map(|it| it.to_string().into());
+        self
+    }
+
+    /// Sets the path to the file used to store passwords. Defaults to None.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use sqlx_postgres::PgConnectOptions;
+    /// let options = PgConnectOptions::new()
+    ///     .passfile("~/.pgpass");
+    /// ```
+    pub fn passfile(mut self, passfile: &str) -> Self {
+        self.passfile = Some(passfile.to_owned());
         self
     }
 

--- a/sqlx-postgres/src/options/parse.rs
+++ b/sqlx-postgres/src/options/parse.rs
@@ -85,6 +85,8 @@ impl PgConnectOptions {
 
                 "application_name" => options = options.application_name(&value),
 
+                "passfile" => options = options.passfile(&value),
+
                 "options" => {
                     if let Some(options) = options.options.as_mut() {
                         options.push(' ');
@@ -278,6 +280,15 @@ fn it_parses_socket_correctly_with_username_percent_encoded() {
     assert_eq!(Some("/var/lib/postgres/".into()), opts.socket);
     assert_eq!(Some("database"), opts.database.as_deref());
 }
+
+#[test]
+fn it_parses_passfile_correctly_from_parameter() {
+    let url = "postgres:///?passfile=~/.some_file";
+    let opts = PgConnectOptions::from_str(url).unwrap();
+
+    assert_eq!(Some("~/.some_file"), opts.passfile.as_deref());
+}
+
 #[test]
 fn it_parses_libpq_options_correctly() {
     let url = "postgres:///?options=-c%20synchronous_commit%3Doff%20--search_path%3Dpostgres";

--- a/sqlx-postgres/src/options/pgpass.rs
+++ b/sqlx-postgres/src/options/pgpass.rs
@@ -44,7 +44,7 @@ fn load_password_from_file(
         .map_err(|e| {
             tracing::warn!(
                 path = %path.display(),
-                "Failed to open `.pgpass` file: {e:?}",
+                "Failed to open password file: {e:?}",
             );
         })
         .ok()?;

--- a/sqlx-postgres/src/options/pgpass.rs
+++ b/sqlx-postgres/src/options/pgpass.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::env::var_os;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
@@ -10,9 +9,9 @@ pub fn load_password(
     port: u16,
     username: &str,
     database: Option<&str>,
+    passfile: Option<&str>,
 ) -> Option<String> {
-    let custom_file = var_os("PGPASSFILE");
-    if let Some(file) = custom_file {
+    if let Some(file) = passfile {
         if let Some(password) =
             load_password_from_file(PathBuf::from(file), host, port, username, database)
         {


### PR DESCRIPTION
This PR builds upon #501 by having `PgConnectOptions` parse the `passfile` URI parameter.

- Previously, the passfile could only be specified via the `PGPASSFILE` env var. With this, `passfile` can be specified in the URI and it would take precedence over the env var.
- Updated a trace warning to state more generically "password file", since the passfile does not necessarily have to be named `.pgpass`

This is my first PR ever made to an open source project, hence I'm starting small and I appreciate any feedback. Have recently been trying out sqlx as well as SeaORM and enjoyed the experience!
