### PR TITLE
parse timezone parameter in mysql connection url

### DIFF
--- a/sqlx-mysql/src/options/parse.rs
+++ b/sqlx-mysql/src/options/parse.rs
@@ -72,6 +72,10 @@ impl MySqlConnectOptions {
                     options = options.socket(&*value);
                 }
 
+                "timezone" | "time-zone" => {
+                    options = options.timezone(Some(value.to_string()));
+                }
+
                 _ => {}
             }
         }

--- a/sqlx-mysql/src/options/parse.rs
+++ b/sqlx-mysql/src/options/parse.rs
@@ -180,3 +180,16 @@ fn it_returns_the_parsed_url() {
 
     assert_eq!(expected_url, opts.build_url());
 }
+
+#[test]
+fn it_parses_timezone() {
+    let opts: MySqlConnectOptions = "mysql://user:password@hostname/database?timezone=%2B08:00"
+        .parse()
+        .unwrap();
+    assert_eq!(opts.timezone.as_deref(), Some("+08:00"));
+
+    let opts: MySqlConnectOptions = "mysql://user:password@hostname/database?time-zone=%2B08:00"
+        .parse()
+        .unwrap();
+    assert_eq!(opts.timezone.as_deref(), Some("+08:00"));
+}


### PR DESCRIPTION
Identify the timezone when parsing the url and set it by `MySqlConnectOptions::timezone`.

For example: `mysql://user:pass@host/db?timezone=+08:00`