### PR TITLE
correct spelling of `MySqlConnectOptions::no_engine_substitution()`

### DIFF
--- a/sqlx-mysql/src/options/connect.rs
+++ b/sqlx-mysql/src/options/connect.rs
@@ -54,7 +54,7 @@ impl ConnectOptions for MySqlConnectOptions {
             if self.pipes_as_concat {
                 sql_mode.push(r#"PIPES_AS_CONCAT"#);
             }
-            if self.no_engine_subsitution {
+            if self.no_engine_substitution {
                 sql_mode.push(r#"NO_ENGINE_SUBSTITUTION"#);
             }
 

--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -77,7 +77,7 @@ pub struct MySqlConnectOptions {
     pub(crate) log_settings: LogSettings,
     pub(crate) pipes_as_concat: bool,
     pub(crate) enable_cleartext_plugin: bool,
-    pub(crate) no_engine_subsitution: bool,
+    pub(crate) no_engine_substitution: bool,
     pub(crate) timezone: Option<String>,
     pub(crate) set_names: bool,
 }
@@ -108,7 +108,7 @@ impl MySqlConnectOptions {
             log_settings: Default::default(),
             pipes_as_concat: true,
             enable_cleartext_plugin: false,
-            no_engine_subsitution: true,
+            no_engine_substitution: true,
             timezone: Some(String::from("+00:00")),
             set_names: true,
         }
@@ -350,8 +350,8 @@ impl MySqlConnectOptions {
     /// substitution).
     ///
     /// <https://mariadb.com/kb/en/sql-mode/>
-    pub fn no_engine_subsitution(mut self, flag_val: bool) -> Self {
-        self.no_engine_subsitution = flag_val;
+    pub fn no_engine_substitution(mut self, flag_val: bool) -> Self {
+        self.no_engine_substitution = flag_val;
         self
     }
 

--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -365,7 +365,6 @@ impl MySqlConnectOptions {
     /// substitution).
     ///
     /// <https://mariadb.com/kb/en/sql-mode/>
-    #[deprecated = "renamed to .no_engine_substitution()"]
     pub fn no_engine_substitution(mut self, flag_val: bool) -> Self {
         self.no_engine_substitution = flag_val;
         self

--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -354,7 +354,18 @@ impl MySqlConnectOptions {
     pub fn no_engine_subsitution(self, flag_val: bool) -> Self {
         self.no_engine_substitution(flag_val)
     }
-    
+
+    /// Flag that enables or disables the `NO_ENGINE_SUBSTITUTION` sql_mode setting after
+    /// connection.
+    ///
+    /// If not set, if the available storage engine specified by a `CREATE TABLE` is not available,
+    /// a warning is given and the default storage engine is used instead.
+    ///
+    /// By default, this is `true` (`NO_ENGINE_SUBSTITUTION` is passed, forbidding engine
+    /// substitution).
+    ///
+    /// <https://mariadb.com/kb/en/sql-mode/>
+    #[deprecated = "renamed to .no_engine_substitution()"]
     pub fn no_engine_substitution(mut self, flag_val: bool) -> Self {
         self.no_engine_substitution = flag_val;
         self

--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -350,6 +350,11 @@ impl MySqlConnectOptions {
     /// substitution).
     ///
     /// <https://mariadb.com/kb/en/sql-mode/>
+    #[deprecated = "renamed to .no_engine_substitution()"]
+    pub fn no_engine_subsitution(self, flag_val: bool) -> Self {
+        self.no_engine_substitution(flag_val)
+    }
+    
     pub fn no_engine_substitution(mut self, flag_val: bool) -> Self {
         self.no_engine_substitution = flag_val;
         self

--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -340,16 +340,6 @@ impl MySqlConnectOptions {
         self
     }
 
-    /// Flag that enables or disables the `NO_ENGINE_SUBSTITUTION` sql_mode setting after
-    /// connection.
-    ///
-    /// If not set, if the available storage engine specified by a `CREATE TABLE` is not available,
-    /// a warning is given and the default storage engine is used instead.
-    ///
-    /// By default, this is `true` (`NO_ENGINE_SUBSTITUTION` is passed, forbidding engine
-    /// substitution).
-    ///
-    /// <https://mariadb.com/kb/en/sql-mode/>
     #[deprecated = "renamed to .no_engine_substitution()"]
     pub fn no_engine_subsitution(self, flag_val: bool) -> Self {
         self.no_engine_substitution(flag_val)


### PR DESCRIPTION
### Does your PR solve an issue?
no_engine_subsitution is named wrongly. giving a lot of issues when working with ai.

replaced
no_engine_subsitution
to 
no_engine_substitution
