### PR TITLE
Remove deprecated feature-names from `Cargo.toml` files in examples

### DIFF
--- a/examples/mysql/todos/Cargo.toml
+++ b/examples/mysql/todos/Cargo.toml
@@ -7,6 +7,6 @@ workspace = "../../../"
 [dependencies]
 anyhow = "1.0"
 futures = "0.3"
-sqlx = { path = "../../../", features = [ "mysql", "runtime-tokio-native-tls" ] }
+sqlx = { path = "../../../", features = [ "mysql", "runtime-tokio", "tls-native-tls" ] }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.20.0", features = ["rt", "macros"]}

--- a/examples/postgres/axum-social-with-tests/Cargo.toml
+++ b/examples/postgres/axum-social-with-tests/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 # Primary crates
 axum = { version = "0.5.13", features = ["macros"] }
-sqlx = { path = "../../../", features = ["runtime-tokio-rustls", "postgres", "time", "uuid"] }
+sqlx = { path = "../../../", features = [ "runtime-tokio", "tls-rustls-ring", "postgres", "time", "uuid" ] }
 tokio = { version = "1.20.1", features = ["rt-multi-thread", "macros"] }
 
 # Important secondary crates

--- a/examples/postgres/chat/Cargo.toml
+++ b/examples/postgres/chat/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 workspace = "../../../"
 
 [dependencies]
-sqlx = { path = "../../../", features = [ "postgres", "runtime-tokio-native-tls" ] }
+sqlx = { path = "../../../", features = [ "postgres", "runtime-tokio", "tls-native-tls" ] }
 futures = "0.3.1"
 tokio = { version = "1.20.0", features = [ "rt-multi-thread", "macros" ] }
 ratatui = "0.27.0"

--- a/examples/postgres/files/Cargo.toml
+++ b/examples/postgres/files/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-sqlx = { path = "../../../", features = ["postgres", "runtime-tokio-native-tls"] }
+sqlx = { path = "../../../", features = [ "postgres", "runtime-tokio", "tls-native-tls" ] }
 tokio = { version = "1.20.0", features = ["rt", "macros"]}
 dotenvy = "0.15.0"

--- a/examples/postgres/json/Cargo.toml
+++ b/examples/postgres/json/Cargo.toml
@@ -10,6 +10,6 @@ dotenvy = "0.15.0"
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlx = { path = "../../../", features = ["runtime-tokio", "postgres", "json"] }
+sqlx = { path = "../../../", features = [ "runtime-tokio", "postgres", "json" ] }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.20.0", features = ["rt", "macros"]}

--- a/examples/postgres/mockable-todos/Cargo.toml
+++ b/examples/postgres/mockable-todos/Cargo.toml
@@ -7,7 +7,7 @@ workspace = "../../../"
 [dependencies]
 anyhow = "1.0"
 futures = "0.3"
-sqlx = { path = "../../../", features = ["postgres", "runtime-tokio-native-tls"] }
+sqlx = { path = "../../../", features = [ "postgres", "runtime-tokio", "tls-native-tls" ] }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.20.0", features = ["rt", "macros"]}
 dotenvy = "0.15.0"

--- a/examples/postgres/todos/Cargo.toml
+++ b/examples/postgres/todos/Cargo.toml
@@ -7,7 +7,7 @@ workspace = "../../../"
 [dependencies]
 anyhow = "1.0"
 futures = "0.3"
-sqlx = { path = "../../../", features = ["postgres", "runtime-tokio-native-tls"] }
+sqlx = { path = "../../../", features = [ "postgres", "runtime-tokio", "tls-native-tls" ] }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.20.0", features = ["rt", "macros"]}
 dotenvy = "0.15.0"

--- a/examples/postgres/transaction/Cargo.toml
+++ b/examples/postgres/transaction/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 workspace = "../../../"
 
 [dependencies]
-sqlx = { path = "../../../", features = [ "postgres", "runtime-tokio-native-tls" ] }
+sqlx = { path = "../../../", features = [ "postgres", "runtime-tokio", "tls-native-tls" ] }
 futures = "0.3.1"
 tokio = { version = "1.20.0", features = ["rt-multi-thread", "macros"]}

--- a/examples/sqlite/todos/Cargo.toml
+++ b/examples/sqlite/todos/Cargo.toml
@@ -7,6 +7,6 @@ workspace = "../../../"
 [dependencies]
 anyhow = "1.0"
 futures = "0.3"
-sqlx = { path = "../../../", features = ["sqlite", "runtime-tokio-native-tls"] }
+sqlx = { path = "../../../", features = [ "sqlite", "runtime-tokio", "tls-native-tls" ] }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1.20.0", features = ["rt", "macros"]}


### PR DESCRIPTION
Noticed that they used some of the soft-deprecated feature names.