### PR TITLE
cleanup outdated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,10 +218,10 @@ some info on) your SQL queries. This has some potentially surprising implication
 - Due to the different amount of information databases let you retrieve about queries, the extent of
   SQL verification you get from the query macros depends on the database
 
-**If you are looking for an (asynchronous) ORM,** you can check out [`ormx`] or [`SeaORM`], which is built on top
+**If you are looking for an (asynchronous) ORM,** you can check out [`Welds`] or [`SeaORM`], which is built on top
 of SQLx.
 
-[`ormx`]: https://crates.io/crates/ormx
+[`Welds`]: https://crates.io/crates/welds
 [`SeaORM`]: https://github.com/SeaQL/sea-orm
 ## Usage
 


### PR DESCRIPTION
Updated ORM notice. 

The ORM message points to `ormx` which hasn't been updated in 3 years and doesn't support anything newer than sqlx 0.5. 
