### PR TITLE
fix: audit protocol handling

### DIFF
--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -61,12 +61,8 @@ jobs:
       - run: cargo build --all-features
 
   test:
-    name: Unit Test
+    name: Unit Tests
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        runtime: [async-std, tokio]
-        tls: [native-tls, rustls-aws-lc-rs, rustls-ring, none]
     steps:
       - uses: actions/checkout@v4
 
@@ -74,10 +70,44 @@ jobs:
         with:
           key: ${{ runner.os }}-test
 
-      - run: >
+      - name: Install Rust
+        run: rustup update
+
+      - name: Test sqlx-core
+        run: >
           cargo test
-          --manifest-path sqlx-core/Cargo.toml
-          --features json,_rt-${{ matrix.runtime }},_tls-${{ matrix.tls }}
+          -p sqlx-core
+          --all-features      
+
+      - name: Test sqlx-mysql
+        run: >
+          cargo test
+          -p sqlx-mysql
+          --all-features      
+
+      - name: Test sqlx-postgres
+        run: >
+          cargo test
+          -p sqlx-postgres
+          --all-features      
+
+      - name: Test sqlx-sqlite
+        run: >
+          cargo test
+          -p sqlx-sqlite
+          --all-features      
+
+      - name: Test sqlx-macros-core
+        run: >
+          cargo test
+          -p sqlx-macros-core
+          --all-features
+
+      - name: Test sqlx
+        run: >
+          cargo test
+          -p sqlx
+          --all-features
 
   sqlite:
     name: SQLite

--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -204,7 +204,7 @@ jobs:
       - run: >
           cargo test
           --no-default-features
-          --features any,postgres,macros,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }}
+          --features any,postgres,macros,migrate,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }}
         env:
           DATABASE_URL: postgres://postgres:password@localhost:5432/sqlx
           SQLX_OFFLINE_DIR: .sqlx
@@ -216,7 +216,7 @@ jobs:
         run: >
           cargo test
           --no-default-features
-          --features any,postgres,macros,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }}
+          --features any,postgres,macros,migrate,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }}
         env:
           DATABASE_URL: postgres://postgres:password@localhost:5432/sqlx?sslmode=verify-ca&sslrootcert=.%2Ftests%2Fcerts%2Fca.crt
           SQLX_OFFLINE_DIR: .sqlx

--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -103,10 +103,12 @@ jobs:
           -p sqlx-macros-core
           --all-features
 
+      # Note: use `--lib` to not run integration tests that require a DB
       - name: Test sqlx
         run: >
           cargo test
           -p sqlx
+          --lib
           --all-features
 
   sqlite:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3639,6 +3639,7 @@ dependencies = [
  "sha1",
  "sha2",
  "smallvec",
+ "sqlx",
  "sqlx-core",
  "stringprep",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,6 +273,11 @@ name = "sqlite-migrate"
 path = "tests/sqlite/migrate.rs"
 required-features = ["sqlite", "macros", "migrate"]
 
+[[test]]
+name = "sqlite-rustsec"
+path = "tests/sqlite/rustsec.rs"
+required-features = ["sqlite"]
+
 [[bench]]
 name = "sqlite-describe"
 path = "benches/sqlite/describe.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -372,3 +372,8 @@ required-features = ["postgres", "macros", "migrate"]
 name = "postgres-query-builder"
 path = "tests/postgres/query_builder.rs"
 required-features = ["postgres"]
+
+[[test]]
+name = "postgres-rustsec"
+path = "tests/postgres/rustsec.rs"
+required-features = ["postgres", "macros", "migrate"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -328,6 +328,11 @@ name = "mysql-migrate"
 path = "tests/mysql/migrate.rs"
 required-features = ["mysql", "macros", "migrate"]
 
+[[test]]
+name = "mysql-rustsec"
+path = "tests/mysql/rustsec.rs"
+required-features = ["mysql"]
+
 #
 # PostgreSQL
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,6 +187,15 @@ criterion = { version = "0.5.1", features = ["async_tokio"] }
 # Enable testing with SQLCipher if specifically requested.
 libsqlite3-sys = { version = "0.30.1", features = ["bundled-sqlcipher"] }
 
+# Common lint settings for the workspace
+[workspace.lints.clippy]
+# https://github.com/launchbadge/sqlx/issues/3440
+cast_possible_truncation = 'deny'
+cast_possible_wrap = 'deny'
+cast_sign_loss = 'deny'
+# See `clippy.toml`
+disallowed_methods = 'deny'
+
 #
 # Any
 #

--- a/sqlx-bench/Cargo.toml
+++ b/sqlx-bench/Cargo.toml
@@ -42,3 +42,6 @@ required-features = ["postgres"]
 name = "sqlite_fetch_all"
 harness = false
 required-features = ["sqlite"]
+
+[lints]
+workspace = true

--- a/sqlx-cli/Cargo.toml
+++ b/sqlx-cli/Cargo.toml
@@ -68,3 +68,6 @@ completions = ["dep:clap_complete"]
 [dev-dependencies]
 assert_cmd = "2.0.11"
 tempfile = "3.10.1"
+
+[lints]
+workspace = true

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -94,3 +94,6 @@ hashbrown = "0.14.5"
 [dev-dependencies]
 sqlx = { workspace = true, features = ["postgres", "sqlite", "mysql", "migrate", "macros", "time", "uuid"] }
 tokio = { version = "1", features = ["rt"] }
+
+[lints]
+workspace = true

--- a/sqlx-core/src/error.rs
+++ b/sqlx-core/src/error.rs
@@ -312,11 +312,16 @@ impl From<crate::migrate::MigrateError> for Error {
 /// Format an error message as a `Protocol` error
 #[macro_export]
 macro_rules! err_protocol {
-    ($expr:expr) => {
-        $crate::error::Error::Protocol($expr.into())
-    };
-
-    ($fmt:expr, $($arg:tt)*) => {
-        $crate::error::Error::Protocol(format!($fmt, $($arg)*))
+    ($($fmt_args:tt)*) => {
+        $crate::error::Error::Protocol(
+            format!(
+                "{} ({}:{})",
+                // Note: the format string needs to be unmodified (e.g. by `concat!()`)
+                // for implicit formatting arguments to work
+                format_args!($($fmt_args)*),
+                module_path!(),
+                line!(),
+            )
+        )
     };
 }

--- a/sqlx-core/src/io/decode.rs
+++ b/sqlx-core/src/io/decode.rs
@@ -2,13 +2,13 @@ use bytes::Bytes;
 
 use crate::error::Error;
 
-pub trait Decode<'de, Context = ()>
+pub trait ProtocolDecode<'de, Context = ()>
 where
     Self: Sized,
 {
     fn decode(buf: Bytes) -> Result<Self, Error>
     where
-        Self: Decode<'de, ()>,
+        Self: ProtocolDecode<'de, ()>,
     {
         Self::decode_with(buf, ())
     }
@@ -16,13 +16,13 @@ where
     fn decode_with(buf: Bytes, context: Context) -> Result<Self, Error>;
 }
 
-impl Decode<'_> for Bytes {
+impl ProtocolDecode<'_> for Bytes {
     fn decode_with(buf: Bytes, _: ()) -> Result<Self, Error> {
         Ok(buf)
     }
 }
 
-impl Decode<'_> for () {
+impl ProtocolDecode<'_> for () {
     fn decode_with(_: Bytes, _: ()) -> Result<(), Error> {
         Ok(())
     }

--- a/sqlx-core/src/io/encode.rs
+++ b/sqlx-core/src/io/encode.rs
@@ -1,16 +1,17 @@
-pub trait Encode<'en, Context = ()> {
-    fn encode(&self, buf: &mut Vec<u8>)
+pub trait ProtocolEncode<'en, Context = ()> {
+    fn encode(&self, buf: &mut Vec<u8>) -> Result<(), crate::Error>
     where
-        Self: Encode<'en, ()>,
+        Self: ProtocolEncode<'en, ()>,
     {
-        self.encode_with(buf, ());
+        self.encode_with(buf, ())
     }
 
-    fn encode_with(&self, buf: &mut Vec<u8>, context: Context);
+    fn encode_with(&self, buf: &mut Vec<u8>, context: Context) -> Result<(), crate::Error>;
 }
 
-impl<'en, C> Encode<'en, C> for &'_ [u8] {
-    fn encode_with(&self, buf: &mut Vec<u8>, _: C) {
+impl<'en, C> ProtocolEncode<'en, C> for &'_ [u8] {
+    fn encode_with(&self, buf: &mut Vec<u8>, _context: C) -> Result<(), crate::Error> {
         buf.extend_from_slice(self);
+        Ok(())
     }
 }

--- a/sqlx-core/src/io/mod.rs
+++ b/sqlx-core/src/io/mod.rs
@@ -9,8 +9,8 @@ mod read_buf;
 pub use buf::BufExt;
 pub use buf_mut::BufMutExt;
 //pub use buf_stream::BufStream;
-pub use decode::Decode;
-pub use encode::Encode;
+pub use decode::ProtocolDecode;
+pub use encode::ProtocolEncode;
 pub use read_buf::ReadBuf;
 
 #[cfg(not(feature = "_rt-tokio"))]

--- a/sqlx-core/src/lib.rs
+++ b/sqlx-core/src/lib.rs
@@ -15,10 +15,6 @@
 #![recursion_limit = "512"]
 #![warn(future_incompatible, rust_2018_idioms)]
 #![allow(clippy::needless_doctest_main, clippy::type_complexity)]
-// See `clippy.toml` at the workspace root
-#![deny(clippy::disallowed_methods)]
-#![deny(clippy::cast_possible_truncation)]
-#![deny(clippy::cast_possible_wrap)]
 // The only unsafe code in SQLx is that necessary to interact with native APIs like with SQLite,
 // and that can live in its own separate driver crate.
 #![forbid(unsafe_code)]

--- a/sqlx-core/src/lib.rs
+++ b/sqlx-core/src/lib.rs
@@ -17,6 +17,8 @@
 #![allow(clippy::needless_doctest_main, clippy::type_complexity)]
 // See `clippy.toml` at the workspace root
 #![deny(clippy::disallowed_methods)]
+#![deny(clippy::cast_possible_truncation)]
+#![deny(clippy::cast_possible_wrap)]
 // The only unsafe code in SQLx is that necessary to interact with native APIs like with SQLite,
 // and that can live in its own separate driver crate.
 #![forbid(unsafe_code)]

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -49,3 +49,6 @@ sqlx-macros-core = { workspace = true }
 proc-macro2 = { version = "1.0.36", default-features = false }
 syn = { version = "2.0.52", default-features = false, features = ["parsing", "proc-macro"] }
 quote = { version = "1.0.26", default-features = false }
+
+[lints]
+workspace = true

--- a/sqlx-mysql/Cargo.toml
+++ b/sqlx-mysql/Cargo.toml
@@ -71,3 +71,6 @@ tracing = { version = "0.1.37", features = ["log"] }
 whoami = { version = "1.2.1", default-features = false }
 
 serde = { version = "1.0.144", optional = true }
+
+[lints]
+workspace = true

--- a/sqlx-mysql/Cargo.toml
+++ b/sqlx-mysql/Cargo.toml
@@ -72,5 +72,8 @@ whoami = { version = "1.2.1", default-features = false }
 
 serde = { version = "1.0.144", optional = true }
 
+[dev-dependencies]
+sqlx = { workspace = true, features = ["mysql"] }
+
 [lints]
 workspace = true

--- a/sqlx-mysql/Cargo.toml
+++ b/sqlx-mysql/Cargo.toml
@@ -15,6 +15,13 @@ any = ["sqlx-core/any"]
 offline = ["sqlx-core/offline", "serde/derive"]
 migrate = ["sqlx-core/migrate"]
 
+# Type Integration features
+bigdecimal = ["dep:bigdecimal", "sqlx-core/bigdecimal"]
+chrono = ["dep:chrono", "sqlx-core/chrono"]
+rust_decimal = ["dep:rust_decimal", "rust_decimal/maths", "sqlx-core/rust_decimal"]
+time = ["dep:time", "sqlx-core/time"]
+uuid = ["dep:uuid", "sqlx-core/uuid"]
+
 [dependencies]
 sqlx-core = { workspace = true }
 

--- a/sqlx-mysql/src/any.rs
+++ b/sqlx-mysql/src/any.rs
@@ -213,6 +213,8 @@ impl<'a> TryFrom<&'a AnyConnectOptions> for MySqlConnectOptions {
 fn map_result(result: MySqlQueryResult) -> AnyQueryResult {
     AnyQueryResult {
         rows_affected: result.rows_affected,
+        // Don't expect this to be a problem
+        #[allow(clippy::cast_possible_wrap)]
         last_insert_id: Some(result.last_insert_id as i64),
     }
 }

--- a/sqlx-mysql/src/connection/auth.rs
+++ b/sqlx-mysql/src/connection/auth.rs
@@ -53,7 +53,7 @@ impl AuthPlugin {
                     0x04 => {
                         let payload = encrypt_rsa(stream, 0x02, password, nonce).await?;
 
-                        stream.write_packet(&*payload);
+                        stream.write_packet(&*payload)?;
                         stream.flush().await?;
 
                         Ok(false)
@@ -143,7 +143,7 @@ async fn encrypt_rsa<'s>(
     }
 
     // client sends a public key request
-    stream.write_packet(&[public_key_request_id][..]);
+    stream.write_packet(&[public_key_request_id][..])?;
     stream.flush().await?;
 
     // server sends a public key response

--- a/sqlx-mysql/src/connection/establish.rs
+++ b/sqlx-mysql/src/connection/establish.rs
@@ -131,7 +131,7 @@ impl<'a> DoHandshake<'a> {
             database: options.database.as_deref(),
             auth_plugin: plugin,
             auth_response: auth_response.as_deref(),
-        });
+        })?;
 
         stream.flush().await?;
 
@@ -160,7 +160,7 @@ impl<'a> DoHandshake<'a> {
                         )
                         .await?;
 
-                    stream.write_packet(AuthSwitchResponse(response));
+                    stream.write_packet(AuthSwitchResponse(response))?;
                     stream.flush().await?;
                 }
 

--- a/sqlx-mysql/src/connection/stream.rs
+++ b/sqlx-mysql/src/connection/stream.rs
@@ -6,7 +6,7 @@ use bytes::{Buf, Bytes, BytesMut};
 use crate::collation::{CharSet, Collation};
 use crate::error::Error;
 use crate::io::MySqlBufExt;
-use crate::io::{Decode, Encode};
+use crate::io::{ProtocolDecode, ProtocolEncode};
 use crate::net::{BufferedSocket, Socket};
 use crate::protocol::response::{EofPacket, ErrPacket, OkPacket, Status};
 use crate::protocol::{Capabilities, Packet};
@@ -110,7 +110,7 @@ impl<S: Socket> MySqlStream<S> {
 
     pub(crate) async fn send_packet<'en, T>(&mut self, payload: T) -> Result<(), Error>
     where
-        T: Encode<'en, Capabilities>,
+        T: ProtocolEncode<'en, Capabilities>,
     {
         self.sequence_id = 0;
         self.write_packet(payload);
@@ -120,7 +120,7 @@ impl<S: Socket> MySqlStream<S> {
 
     pub(crate) fn write_packet<'en, T>(&mut self, payload: T)
     where
-        T: Encode<'en, Capabilities>,
+        T: ProtocolEncode<'en, Capabilities>,
     {
         self.socket
             .write_with(Packet(payload), (self.capabilities, &mut self.sequence_id));
@@ -184,7 +184,7 @@ impl<S: Socket> MySqlStream<S> {
 
     pub(crate) async fn recv<'de, T>(&mut self) -> Result<T, Error>
     where
-        T: Decode<'de, Capabilities>,
+        T: ProtocolDecode<'de, Capabilities>,
     {
         self.recv_packet().await?.decode_with(self.capabilities)
     }

--- a/sqlx-mysql/src/connection/tls.rs
+++ b/sqlx-mysql/src/connection/tls.rs
@@ -72,7 +72,7 @@ pub(super) async fn maybe_upgrade<S: Socket>(
     stream.write_packet(SslRequest {
         max_packet_size: super::MAX_PACKET_SIZE,
         collation: stream.collation as u8,
-    });
+    })?;
 
     stream.flush().await?;
 

--- a/sqlx-mysql/src/io/buf_mut.rs
+++ b/sqlx-mysql/src/io/buf_mut.rs
@@ -13,17 +13,22 @@ impl MySqlBufMutExt for Vec<u8> {
         // https://dev.mysql.com/doc/internals/en/integer.html
         // https://mariadb.com/kb/en/library/protocol-data-types/#length-encoded-integers
 
-        if v < 251 {
-            self.push(v as u8);
-        } else if v < 0x1_00_00 {
-            self.push(0xfc);
-            self.extend(&(v as u16).to_le_bytes());
-        } else if v < 0x1_00_00_00 {
-            self.push(0xfd);
-            self.extend(&(v as u32).to_le_bytes()[..3]);
-        } else {
-            self.push(0xfe);
-            self.extend(&v.to_le_bytes());
+        let encoded_le = v.to_le_bytes();
+
+        match v {
+            ..251 => self.push(encoded_le[0]),
+            251..0x1_00_00 => {
+                self.push(0xfc);
+                self.extend_from_slice(&encoded_le[..2]);
+            }
+            0x1_00_00..0x1_00_00_00 => {
+                self.push(0xfd);
+                self.extend_from_slice(&encoded_le[..3]);
+            }
+            _ => {
+                self.push(0xfe);
+                self.extend_from_slice(&encoded_le);
+            }
         }
     }
 

--- a/sqlx-mysql/src/lib.rs
+++ b/sqlx-mysql/src/lib.rs
@@ -1,4 +1,7 @@
 //! **MySQL** database driver.
+#![deny(clippy::cast_possible_truncation)]
+#![deny(clippy::cast_possible_wrap)]
+#![deny(clippy::cast_sign_loss)]
 
 #[macro_use]
 extern crate sqlx_core;

--- a/sqlx-mysql/src/migrate.rs
+++ b/sqlx-mysql/src/migrate.rs
@@ -231,7 +231,9 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
     WHERE version = ?
                 "#,
             )
-            .bind(elapsed.as_nanos() as i64)
+            // Unlikely unless the execution time exceeds ~292 years,
+            // then we're probably okay losing that information.
+            .bind(i64::try_from(elapsed.as_nanos()).ok())
             .bind(migration.version)
             .execute(self)
             .await?;

--- a/sqlx-mysql/src/migrate.rs
+++ b/sqlx-mysql/src/migrate.rs
@@ -224,6 +224,7 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
 
             let elapsed = start.elapsed();
 
+            #[allow(clippy::cast_possible_truncation)]
             let _ = query(
                 r#"
     UPDATE _sqlx_migrations
@@ -231,9 +232,7 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
     WHERE version = ?
                 "#,
             )
-            // Unlikely unless the execution time exceeds ~292 years,
-            // then we're probably okay losing that information.
-            .bind(i64::try_from(elapsed.as_nanos()).ok())
+            .bind(elapsed.as_nanos() as i64)
             .bind(migration.version)
             .execute(self)
             .await?;

--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -53,9 +53,9 @@ pub use ssl_mode::MySqlSslMode;
 ///
 /// // Change the log verbosity level for queries.
 /// // Information about SQL queries is logged at `DEBUG` level by default.
-/// opts.log_statements(log::LevelFilter::Trace);
+/// opts = opts.log_statements(log::LevelFilter::Trace);
 ///
-/// let pool = MySqlPool::connect_with(&opts).await?;
+/// let pool = MySqlPool::connect_with(opts).await?;
 /// # Ok(())
 /// # }
 /// ```

--- a/sqlx-mysql/src/protocol/capabilities.rs
+++ b/sqlx-mysql/src/protocol/capabilities.rs
@@ -1,5 +1,9 @@
 // https://dev.mysql.com/doc/dev/mysql-server/8.0.12/group__group__cs__capabilities__flags.html
 // https://mariadb.com/kb/en/library/connection/#capabilities
+//
+// MySQL defines the capabilities flags as fitting in an `int<4>` but MariaDB
+// extends this with more bits sent in a separate field.
+// For simplicity, we've chosen to combine these into one type.
 bitflags::bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct Capabilities: u64 {
@@ -43,45 +47,65 @@ bitflags::bitflags! {
         const TRANSACTIONS = 8192;
 
         // 4.1+ authentication
-        const SECURE_CONNECTION = (1 << 15);
+        const SECURE_CONNECTION = 1 << 15;
 
         // Enable/disable multi-statement support for COM_QUERY *and* COM_STMT_PREPARE
-        const MULTI_STATEMENTS = (1 << 16);
+        const MULTI_STATEMENTS = 1 << 16;
 
         // Enable/disable multi-results for COM_QUERY
-        const MULTI_RESULTS = (1 << 17);
+        const MULTI_RESULTS = 1 << 17;
 
         // Enable/disable multi-results for COM_STMT_PREPARE
-        const PS_MULTI_RESULTS = (1 << 18);
+        const PS_MULTI_RESULTS = 1 << 18;
 
         // Client supports plugin authentication
-        const PLUGIN_AUTH = (1 << 19);
+        const PLUGIN_AUTH = 1 << 19;
 
         // Client supports connection attributes
-        const CONNECT_ATTRS = (1 << 20);
+        const CONNECT_ATTRS = 1 << 20;
 
         // Enable authentication response packet to be larger than 255 bytes.
-        const PLUGIN_AUTH_LENENC_DATA = (1 << 21);
+        const PLUGIN_AUTH_LENENC_DATA = 1 << 21;
 
         // Don't close the connection for a user account with expired password.
-        const CAN_HANDLE_EXPIRED_PASSWORDS = (1 << 22);
+        const CAN_HANDLE_EXPIRED_PASSWORDS = 1 << 22;
 
         // Capable of handling server state change information.
-        const SESSION_TRACK = (1 << 23);
+        const SESSION_TRACK = 1 << 23;
 
         // Client no longer needs EOF_Packet and will use OK_Packet instead.
-        const DEPRECATE_EOF = (1 << 24);
+        const DEPRECATE_EOF = 1 << 24;
 
         // Support ZSTD protocol compression
-        const ZSTD_COMPRESSION_ALGORITHM = (1 << 26);
+        const ZSTD_COMPRESSION_ALGORITHM = 1 << 26;
 
         // Verify server certificate
-        const SSL_VERIFY_SERVER_CERT = (1 << 30);
+        const SSL_VERIFY_SERVER_CERT = 1 << 30;
 
         // The client can handle optional metadata information in the resultset
-        const OPTIONAL_RESULTSET_METADATA = (1 << 25);
+        const OPTIONAL_RESULTSET_METADATA = 1 << 25;
 
         // Don't reset the options after an unsuccessful connect
-        const REMEMBER_OPTIONS = (1 << 31);
+        const REMEMBER_OPTIONS = 1 << 31;
+
+        // Extended capabilities (MariaDB only, as of writing)
+        // Client support progress indicator (since 10.2)
+        const MARIADB_CLIENT_PROGRESS = 1 << 32;
+
+        // Permit COM_MULTI protocol
+        const MARIADB_CLIENT_MULTI = 1 << 33;
+
+        // Permit bulk insert
+        const MARIADB_CLIENT_STMT_BULK_OPERATIONS = 1 << 34;
+
+        // Add extended metadata information
+        const MARIADB_CLIENT_EXTENDED_TYPE_INFO = 1 << 35;
+
+        // Permit skipping metadata
+        const MARIADB_CLIENT_CACHE_METADATA = 1 << 36;
+
+        // when enabled, indicate that Bulk command can use STMT_BULK_FLAG_SEND_UNIT_RESULTS flag
+        // that permit to return a result-set of all affected rows and auto-increment values
+        const MARIADB_CLIENT_BULK_UNIT_RESULTS = 1 << 37;
     }
 }

--- a/sqlx-mysql/src/protocol/connect/auth_switch.rs
+++ b/sqlx-mysql/src/protocol/connect/auth_switch.rs
@@ -81,9 +81,14 @@ fn test_decode_auth_switch_cleartext_disabled() {
 
     let e = AuthSwitchRequest::decode_with(AUTH_SWITCH_CLEARTEXT.into(), false).unwrap_err();
 
-    assert_eq!(
-        e.to_string(),
-        "encountered unexpected or invalid data: mysql_cleartext_plugin disabled"
+    let e_str = e.to_string();
+
+    let expected = "encountered unexpected or invalid data: mysql_cleartext_plugin disabled";
+
+    assert!(
+        // Don't want to assert the full string since it contains the module path now.
+        e_str.starts_with(expected),
+        "expected error string to start with {expected:?}, got {e_str:?}"
     );
 }
 

--- a/sqlx-mysql/src/protocol/connect/auth_switch.rs
+++ b/sqlx-mysql/src/protocol/connect/auth_switch.rs
@@ -1,8 +1,8 @@
 use bytes::{Buf, Bytes};
 
 use crate::error::Error;
-use crate::io::Encode;
-use crate::io::{BufExt, Decode};
+use crate::io::ProtocolEncode;
+use crate::io::{BufExt, ProtocolDecode};
 use crate::protocol::auth::AuthPlugin;
 use crate::protocol::Capabilities;
 
@@ -14,7 +14,7 @@ pub struct AuthSwitchRequest {
     pub data: Bytes,
 }
 
-impl Decode<'_, bool> for AuthSwitchRequest {
+impl ProtocolDecode<'_, bool> for AuthSwitchRequest {
     fn decode_with(mut buf: Bytes, enable_cleartext_plugin: bool) -> Result<Self, Error> {
         let header = buf.get_u8();
         if header != 0xfe {
@@ -58,9 +58,10 @@ impl Decode<'_, bool> for AuthSwitchRequest {
 #[derive(Debug)]
 pub struct AuthSwitchResponse(pub Vec<u8>);
 
-impl Encode<'_, Capabilities> for AuthSwitchResponse {
-    fn encode_with(&self, buf: &mut Vec<u8>, _: Capabilities) {
+impl ProtocolEncode<'_, Capabilities> for AuthSwitchResponse {
+    fn encode_with(&self, buf: &mut Vec<u8>, _: Capabilities) -> Result<(), Error> {
         buf.extend_from_slice(&self.0);
+        Ok(())
     }
 }
 

--- a/sqlx-mysql/src/protocol/connect/handshake.rs
+++ b/sqlx-mysql/src/protocol/connect/handshake.rs
@@ -3,7 +3,7 @@ use bytes::{Buf, Bytes};
 use std::cmp;
 
 use crate::error::Error;
-use crate::io::{BufExt, Decode};
+use crate::io::{BufExt, ProtocolDecode};
 use crate::protocol::auth::AuthPlugin;
 use crate::protocol::response::Status;
 use crate::protocol::Capabilities;
@@ -27,7 +27,7 @@ pub(crate) struct Handshake {
     pub(crate) auth_plugin_data: Chain<Bytes, Bytes>,
 }
 
-impl Decode<'_> for Handshake {
+impl ProtocolDecode<'_> for Handshake {
     fn decode_with(mut buf: Bytes, _: ()) -> Result<Self, Error> {
         let protocol_version = buf.get_u8(); // int<1>
         let server_version = buf.get_str_nul()?; // string<NUL>

--- a/sqlx-mysql/src/protocol/connect/handshake.rs
+++ b/sqlx-mysql/src/protocol/connect/handshake.rs
@@ -94,11 +94,12 @@ impl ProtocolDecode<'_> for Handshake {
 fn test_decode_handshake_mysql_8_0_18() {
     const HANDSHAKE_MYSQL_8_0_18: &[u8] = b"\n8.0.18\x00\x19\x00\x00\x00\x114aB0c\x06g\x00\xff\xff\xff\x02\x00\xff\xc7\x15\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00tL\x03s\x0f[4\rl4. \x00caching_sha2_password\x00";
 
-    let mut p = Handshake::decode(HANDSHAKE_MYSQL_8_0_18.into()).unwrap();
+    let p = Handshake::decode(HANDSHAKE_MYSQL_8_0_18.into()).unwrap();
 
     assert_eq!(p.protocol_version, 10);
 
-    p.server_capabilities.toggle(
+    assert_eq!(
+        p.server_capabilities,
         Capabilities::MYSQL
             | Capabilities::FOUND_ROWS
             | Capabilities::LONG_FLAG
@@ -128,8 +129,6 @@ fn test_decode_handshake_mysql_8_0_18() {
             | Capabilities::REMEMBER_OPTIONS,
     );
 
-    assert!(p.server_capabilities.is_empty());
-
     assert_eq!(p.server_default_collation, 255);
     assert!(p.status.contains(Status::SERVER_STATUS_AUTOCOMMIT));
 
@@ -148,7 +147,7 @@ fn test_decode_handshake_mysql_8_0_18() {
 fn test_decode_handshake_mariadb_10_4_7() {
     const HANDSHAKE_MARIA_DB_10_4_7: &[u8] = b"\n5.5.5-10.4.7-MariaDB-1:10.4.7+maria~bionic\x00\x0b\x00\x00\x00t6L\\j\"dS\x00\xfe\xf7\x08\x02\x00\xff\x81\x15\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00U14Oph9\"<H5n\x00mysql_native_password\x00";
 
-    let mut p = Handshake::decode(HANDSHAKE_MARIA_DB_10_4_7.into()).unwrap();
+    let p = Handshake::decode(HANDSHAKE_MARIA_DB_10_4_7.into()).unwrap();
 
     assert_eq!(p.protocol_version, 10);
 
@@ -157,7 +156,8 @@ fn test_decode_handshake_mariadb_10_4_7() {
         "5.5.5-10.4.7-MariaDB-1:10.4.7+maria~bionic"
     );
 
-    p.server_capabilities.toggle(
+    assert_eq!(
+        p.server_capabilities,
         Capabilities::FOUND_ROWS
             | Capabilities::LONG_FLAG
             | Capabilities::CONNECT_WITH_DB
@@ -179,10 +179,11 @@ fn test_decode_handshake_mariadb_10_4_7() {
             | Capabilities::CAN_HANDLE_EXPIRED_PASSWORDS
             | Capabilities::SESSION_TRACK
             | Capabilities::DEPRECATE_EOF
-            | Capabilities::REMEMBER_OPTIONS,
+            | Capabilities::REMEMBER_OPTIONS
+            | Capabilities::MARIADB_CLIENT_PROGRESS
+            | Capabilities::MARIADB_CLIENT_MULTI
+            | Capabilities::MARIADB_CLIENT_STMT_BULK_OPERATIONS
     );
-
-    assert!(p.server_capabilities.is_empty());
 
     assert_eq!(p.server_default_collation, 8);
     assert!(p.status.contains(Status::SERVER_STATUS_AUTOCOMMIT));

--- a/sqlx-mysql/src/protocol/connect/handshake.rs
+++ b/sqlx-mysql/src/protocol/connect/handshake.rs
@@ -62,8 +62,8 @@ impl ProtocolDecode<'_> for Handshake {
         }
 
         let auth_plugin_data_2 = if capabilities.contains(Capabilities::SECURE_CONNECTION) {
-            let len = cmp::max((auth_plugin_data_len as isize) - 9, 12) as usize;
-            let v = buf.get_bytes(len);
+            let len = cmp::max(auth_plugin_data_len.saturating_sub(9), 12);
+            let v = buf.get_bytes(len as usize);
             buf.advance(1); // NUL-terminator
 
             v

--- a/sqlx-mysql/src/protocol/connect/handshake_response.rs
+++ b/sqlx-mysql/src/protocol/connect/handshake_response.rs
@@ -1,5 +1,5 @@
 use crate::io::MySqlBufMutExt;
-use crate::io::{BufMutExt, Encode};
+use crate::io::{BufMutExt, ProtocolEncode};
 use crate::protocol::auth::AuthPlugin;
 use crate::protocol::connect::ssl_request::SslRequest;
 use crate::protocol::Capabilities;
@@ -27,11 +27,15 @@ pub struct HandshakeResponse<'a> {
     pub auth_response: Option<&'a [u8]>,
 }
 
-impl Encode<'_, Capabilities> for HandshakeResponse<'_> {
-    fn encode_with(&self, buf: &mut Vec<u8>, mut capabilities: Capabilities) {
+impl ProtocolEncode<'_, Capabilities> for HandshakeResponse<'_> {
+    fn encode_with(
+        &self,
+        buf: &mut Vec<u8>,
+        mut context: Capabilities,
+    ) -> Result<(), crate::Error> {
         if self.auth_plugin.is_none() {
             // ensure PLUGIN_AUTH is set *only* if we have a defined plugin
-            capabilities.remove(Capabilities::PLUGIN_AUTH);
+            context.remove(Capabilities::PLUGIN_AUTH);
         }
 
         // NOTE: Half of this packet is identical to the SSL Request packet
@@ -39,13 +43,13 @@ impl Encode<'_, Capabilities> for HandshakeResponse<'_> {
             max_packet_size: self.max_packet_size,
             collation: self.collation,
         }
-        .encode_with(buf, capabilities);
+        .encode_with(buf, context)?;
 
         buf.put_str_nul(self.username);
 
-        if capabilities.contains(Capabilities::PLUGIN_AUTH_LENENC_DATA) {
+        if context.contains(Capabilities::PLUGIN_AUTH_LENENC_DATA) {
             buf.put_bytes_lenenc(self.auth_response.unwrap_or_default());
-        } else if capabilities.contains(Capabilities::SECURE_CONNECTION) {
+        } else if context.contains(Capabilities::SECURE_CONNECTION) {
             let response = self.auth_response.unwrap_or_default();
 
             buf.push(response.len() as u8);
@@ -54,7 +58,7 @@ impl Encode<'_, Capabilities> for HandshakeResponse<'_> {
             buf.push(0);
         }
 
-        if capabilities.contains(Capabilities::CONNECT_WITH_DB) {
+        if context.contains(Capabilities::CONNECT_WITH_DB) {
             if let Some(database) = &self.database {
                 buf.put_str_nul(database);
             } else {
@@ -62,12 +66,14 @@ impl Encode<'_, Capabilities> for HandshakeResponse<'_> {
             }
         }
 
-        if capabilities.contains(Capabilities::PLUGIN_AUTH) {
+        if context.contains(Capabilities::PLUGIN_AUTH) {
             if let Some(plugin) = &self.auth_plugin {
                 buf.put_str_nul(plugin.name());
             } else {
                 buf.push(0);
             }
         }
+
+        Ok(())
     }
 }

--- a/sqlx-mysql/src/protocol/connect/handshake_response.rs
+++ b/sqlx-mysql/src/protocol/connect/handshake_response.rs
@@ -52,7 +52,10 @@ impl ProtocolEncode<'_, Capabilities> for HandshakeResponse<'_> {
         } else if context.contains(Capabilities::SECURE_CONNECTION) {
             let response = self.auth_response.unwrap_or_default();
 
-            buf.push(response.len() as u8);
+            let response_len = u8::try_from(response.len())
+                .map_err(|_| err_protocol!("auth_response.len() too long: {}", response.len()))?;
+
+            buf.push(response_len);
             buf.extend(response);
         } else {
             buf.push(0);

--- a/sqlx-mysql/src/protocol/connect/ssl_request.rs
+++ b/sqlx-mysql/src/protocol/connect/ssl_request.rs
@@ -12,6 +12,8 @@ pub struct SslRequest {
 
 impl ProtocolEncode<'_, Capabilities> for SslRequest {
     fn encode_with(&self, buf: &mut Vec<u8>, context: Capabilities) -> Result<(), crate::Error> {
+        // truncation is intended
+        #[allow(clippy::cast_possible_truncation)]
         buf.extend(&(context.bits() as u32).to_le_bytes());
         buf.extend(&self.max_packet_size.to_le_bytes());
         buf.push(self.collation);

--- a/sqlx-mysql/src/protocol/connect/ssl_request.rs
+++ b/sqlx-mysql/src/protocol/connect/ssl_request.rs
@@ -1,4 +1,4 @@
-use crate::io::Encode;
+use crate::io::ProtocolEncode;
 use crate::protocol::Capabilities;
 
 // https://dev.mysql.com/doc/dev/mysql-server/8.0.12/page_protocol_connection_phase_packets_protocol_handshake_response.html
@@ -10,21 +10,23 @@ pub struct SslRequest {
     pub collation: u8,
 }
 
-impl Encode<'_, Capabilities> for SslRequest {
-    fn encode_with(&self, buf: &mut Vec<u8>, capabilities: Capabilities) {
-        buf.extend(&(capabilities.bits() as u32).to_le_bytes());
+impl ProtocolEncode<'_, Capabilities> for SslRequest {
+    fn encode_with(&self, buf: &mut Vec<u8>, context: Capabilities) -> Result<(), crate::Error> {
+        buf.extend(&(context.bits() as u32).to_le_bytes());
         buf.extend(&self.max_packet_size.to_le_bytes());
         buf.push(self.collation);
 
         // reserved: string<19>
         buf.extend(&[0_u8; 19]);
 
-        if capabilities.contains(Capabilities::MYSQL) {
+        if context.contains(Capabilities::MYSQL) {
             // reserved: string<4>
             buf.extend(&[0_u8; 4]);
         } else {
             // extended client capabilities (MariaDB-specified): int<4>
-            buf.extend(&((capabilities.bits() >> 32) as u32).to_le_bytes());
+            buf.extend(&((context.bits() >> 32) as u32).to_le_bytes());
         }
+
+        Ok(())
     }
 }

--- a/sqlx-mysql/src/protocol/packet.rs
+++ b/sqlx-mysql/src/protocol/packet.rs
@@ -40,6 +40,8 @@ where
         let len = buf.len() - offset - 4;
         let header = &mut buf[offset..];
 
+        // // `min(.., 0xFF_FF_FF)` cannot overflow
+        #[allow(clippy::cast_possible_truncation)]
         header[..4].copy_from_slice(&next_header(min(len, 0xFF_FF_FF) as u32));
 
         // add more packets if we need to split the data
@@ -49,6 +51,9 @@ where
 
             for chunk in chunks.by_ref() {
                 buf.reserve(chunk.len() + 4);
+
+                // `chunk.len() == 0xFF_FF_FF`
+                #[allow(clippy::cast_possible_truncation)]
                 buf.extend(&next_header(chunk.len() as u32));
                 buf.extend(chunk);
             }
@@ -56,6 +61,9 @@ where
             // this will also handle adding a zero sized packet if the data size is a multiple of 0xFF_FF_FF
             let remainder = chunks.remainder();
             buf.reserve(remainder.len() + 4);
+
+            // `remainder.len() < 0xFF_FF_FF`
+            #[allow(clippy::cast_possible_truncation)]
             buf.extend(&next_header(remainder.len() as u32));
             buf.extend(remainder);
         }

--- a/sqlx-mysql/src/protocol/response/eof.rs
+++ b/sqlx-mysql/src/protocol/response/eof.rs
@@ -1,7 +1,7 @@
 use bytes::{Buf, Bytes};
 
 use crate::error::Error;
-use crate::io::Decode;
+use crate::io::ProtocolDecode;
 use crate::protocol::response::Status;
 use crate::protocol::Capabilities;
 
@@ -18,7 +18,7 @@ pub struct EofPacket {
     pub status: Status,
 }
 
-impl Decode<'_, Capabilities> for EofPacket {
+impl ProtocolDecode<'_, Capabilities> for EofPacket {
     fn decode_with(mut buf: Bytes, _: Capabilities) -> Result<Self, Error> {
         let header = buf.get_u8();
         if header != 0xfe {

--- a/sqlx-mysql/src/protocol/response/err.rs
+++ b/sqlx-mysql/src/protocol/response/err.rs
@@ -1,7 +1,7 @@
 use bytes::{Buf, Bytes};
 
 use crate::error::Error;
-use crate::io::{BufExt, Decode};
+use crate::io::{BufExt, ProtocolDecode};
 use crate::protocol::Capabilities;
 
 // https://dev.mysql.com/doc/dev/mysql-server/8.0.12/page_protocol_basic_err_packet.html
@@ -15,7 +15,7 @@ pub struct ErrPacket {
     pub error_message: String,
 }
 
-impl Decode<'_, Capabilities> for ErrPacket {
+impl ProtocolDecode<'_, Capabilities> for ErrPacket {
     fn decode_with(mut buf: Bytes, capabilities: Capabilities) -> Result<Self, Error> {
         let header = buf.get_u8();
         if header != 0xff {

--- a/sqlx-mysql/src/protocol/response/ok.rs
+++ b/sqlx-mysql/src/protocol/response/ok.rs
@@ -1,8 +1,8 @@
 use bytes::{Buf, Bytes};
 
 use crate::error::Error;
-use crate::io::Decode;
 use crate::io::MySqlBufExt;
+use crate::io::ProtocolDecode;
 use crate::protocol::response::Status;
 
 /// Indicates successful completion of a previous command sent by the client.
@@ -14,7 +14,7 @@ pub struct OkPacket {
     pub warnings: u16,
 }
 
-impl Decode<'_> for OkPacket {
+impl ProtocolDecode<'_> for OkPacket {
     fn decode_with(mut buf: Bytes, _: ()) -> Result<Self, Error> {
         let header = buf.get_u8();
         if header != 0 && header != 0xfe {

--- a/sqlx-mysql/src/protocol/statement/execute.rs
+++ b/sqlx-mysql/src/protocol/statement/execute.rs
@@ -1,4 +1,4 @@
-use crate::io::Encode;
+use crate::io::ProtocolEncode;
 use crate::protocol::text::ColumnFlags;
 use crate::protocol::Capabilities;
 use crate::MySqlArguments;
@@ -11,8 +11,8 @@ pub struct Execute<'q> {
     pub arguments: &'q MySqlArguments,
 }
 
-impl<'q> Encode<'_, Capabilities> for Execute<'q> {
-    fn encode_with(&self, buf: &mut Vec<u8>, _: Capabilities) {
+impl<'q> ProtocolEncode<'_, Capabilities> for Execute<'q> {
+    fn encode_with(&self, buf: &mut Vec<u8>, _: Capabilities) -> Result<(), crate::Error> {
         buf.push(0x17); // COM_STMT_EXECUTE
         buf.extend(&self.statement.to_le_bytes());
         buf.push(0); // NO_CURSOR
@@ -34,5 +34,7 @@ impl<'q> Encode<'_, Capabilities> for Execute<'q> {
 
             buf.extend(&*self.arguments.values);
         }
+
+        Ok(())
     }
 }

--- a/sqlx-mysql/src/protocol/statement/prepare.rs
+++ b/sqlx-mysql/src/protocol/statement/prepare.rs
@@ -1,4 +1,4 @@
-use crate::io::Encode;
+use crate::io::ProtocolEncode;
 use crate::protocol::Capabilities;
 
 // https://dev.mysql.com/doc/internals/en/com-stmt-prepare.html#packet-COM_STMT_PREPARE
@@ -7,9 +7,10 @@ pub struct Prepare<'a> {
     pub query: &'a str,
 }
 
-impl Encode<'_, Capabilities> for Prepare<'_> {
-    fn encode_with(&self, buf: &mut Vec<u8>, _: Capabilities) {
+impl ProtocolEncode<'_, Capabilities> for Prepare<'_> {
+    fn encode_with(&self, buf: &mut Vec<u8>, _: Capabilities) -> Result<(), crate::Error> {
         buf.push(0x16); // COM_STMT_PREPARE
         buf.extend(self.query.as_bytes());
+        Ok(())
     }
 }

--- a/sqlx-mysql/src/protocol/statement/prepare_ok.rs
+++ b/sqlx-mysql/src/protocol/statement/prepare_ok.rs
@@ -1,7 +1,7 @@
 use bytes::{Buf, Bytes};
 
 use crate::error::Error;
-use crate::io::Decode;
+use crate::io::ProtocolDecode;
 use crate::protocol::Capabilities;
 
 // https://dev.mysql.com/doc/internals/en/com-stmt-prepare-response.html#packet-COM_STMT_PREPARE_OK
@@ -15,7 +15,7 @@ pub(crate) struct PrepareOk {
     pub(crate) warnings: u16,
 }
 
-impl Decode<'_, Capabilities> for PrepareOk {
+impl ProtocolDecode<'_, Capabilities> for PrepareOk {
     fn decode_with(buf: Bytes, _: Capabilities) -> Result<Self, Error> {
         const SIZE: usize = 12;
 

--- a/sqlx-mysql/src/protocol/statement/row.rs
+++ b/sqlx-mysql/src/protocol/statement/row.rs
@@ -2,7 +2,7 @@ use bytes::{Buf, Bytes};
 
 use crate::error::Error;
 use crate::io::MySqlBufExt;
-use crate::io::{BufExt, Decode};
+use crate::io::{BufExt, ProtocolDecode};
 use crate::protocol::text::ColumnType;
 use crate::protocol::Row;
 use crate::MySqlColumn;
@@ -13,7 +13,7 @@ use crate::MySqlColumn;
 #[derive(Debug)]
 pub(crate) struct BinaryRow(pub(crate) Row);
 
-impl<'de> Decode<'de, &'de [MySqlColumn]> for BinaryRow {
+impl<'de> ProtocolDecode<'de, &'de [MySqlColumn]> for BinaryRow {
     fn decode_with(mut buf: Bytes, columns: &'de [MySqlColumn]) -> Result<Self, Error> {
         let header = buf.get_u8();
         if header != 0 {

--- a/sqlx-mysql/src/protocol/statement/stmt_close.rs
+++ b/sqlx-mysql/src/protocol/statement/stmt_close.rs
@@ -1,4 +1,4 @@
-use crate::io::Encode;
+use crate::io::ProtocolEncode;
 use crate::protocol::Capabilities;
 
 // https://dev.mysql.com/doc/internals/en/com-stmt-close.html
@@ -8,9 +8,10 @@ pub struct StmtClose {
     pub statement: u32,
 }
 
-impl Encode<'_, Capabilities> for StmtClose {
-    fn encode_with(&self, buf: &mut Vec<u8>, _: Capabilities) {
+impl ProtocolEncode<'_, Capabilities> for StmtClose {
+    fn encode_with(&self, buf: &mut Vec<u8>, _: Capabilities) -> Result<(), crate::Error> {
         buf.push(0x19); // COM_STMT_CLOSE
         buf.extend(&self.statement.to_le_bytes());
+        Ok(())
     }
 }

--- a/sqlx-mysql/src/protocol/text/column.rs
+++ b/sqlx-mysql/src/protocol/text/column.rs
@@ -4,8 +4,8 @@ use bitflags::bitflags;
 use bytes::{Buf, Bytes};
 
 use crate::error::Error;
-use crate::io::Decode;
 use crate::io::MySqlBufExt;
+use crate::io::ProtocolDecode;
 use crate::protocol::Capabilities;
 
 // https://dev.mysql.com/doc/dev/mysql-server/8.0.12/group__group__cs__column__definition__flags.html
@@ -134,7 +134,7 @@ impl ColumnDefinition {
     }
 }
 
-impl Decode<'_, Capabilities> for ColumnDefinition {
+impl ProtocolDecode<'_, Capabilities> for ColumnDefinition {
     fn decode_with(mut buf: Bytes, _: Capabilities) -> Result<Self, Error> {
         let catalog = buf.get_bytes_lenenc();
         let schema = buf.get_bytes_lenenc();

--- a/sqlx-mysql/src/protocol/text/column.rs
+++ b/sqlx-mysql/src/protocol/text/column.rs
@@ -136,12 +136,12 @@ impl ColumnDefinition {
 
 impl ProtocolDecode<'_, Capabilities> for ColumnDefinition {
     fn decode_with(mut buf: Bytes, _: Capabilities) -> Result<Self, Error> {
-        let catalog = buf.get_bytes_lenenc();
-        let schema = buf.get_bytes_lenenc();
-        let table_alias = buf.get_bytes_lenenc();
-        let table = buf.get_bytes_lenenc();
-        let alias = buf.get_bytes_lenenc();
-        let name = buf.get_bytes_lenenc();
+        let catalog = buf.get_bytes_lenenc()?;
+        let schema = buf.get_bytes_lenenc()?;
+        let table_alias = buf.get_bytes_lenenc()?;
+        let table = buf.get_bytes_lenenc()?;
+        let alias = buf.get_bytes_lenenc()?;
+        let name = buf.get_bytes_lenenc()?;
         let _next_len = buf.get_uint_lenenc(); // always 0x0c
         let collation = buf.get_u16_le();
         let max_size = buf.get_u32_le();

--- a/sqlx-mysql/src/protocol/text/ping.rs
+++ b/sqlx-mysql/src/protocol/text/ping.rs
@@ -1,4 +1,4 @@
-use crate::io::Encode;
+use crate::io::ProtocolEncode;
 use crate::protocol::Capabilities;
 
 // https://dev.mysql.com/doc/internals/en/com-ping.html
@@ -6,8 +6,9 @@ use crate::protocol::Capabilities;
 #[derive(Debug)]
 pub(crate) struct Ping;
 
-impl Encode<'_, Capabilities> for Ping {
-    fn encode_with(&self, buf: &mut Vec<u8>, _: Capabilities) {
+impl ProtocolEncode<'_, Capabilities> for Ping {
+    fn encode_with(&self, buf: &mut Vec<u8>, _: Capabilities) -> Result<(), crate::Error> {
         buf.push(0x0e); // COM_PING
+        Ok(())
     }
 }

--- a/sqlx-mysql/src/protocol/text/query.rs
+++ b/sqlx-mysql/src/protocol/text/query.rs
@@ -1,4 +1,4 @@
-use crate::io::Encode;
+use crate::io::ProtocolEncode;
 use crate::protocol::Capabilities;
 
 // https://dev.mysql.com/doc/internals/en/com-query.html
@@ -6,9 +6,10 @@ use crate::protocol::Capabilities;
 #[derive(Debug)]
 pub(crate) struct Query<'q>(pub(crate) &'q str);
 
-impl Encode<'_, Capabilities> for Query<'_> {
-    fn encode_with(&self, buf: &mut Vec<u8>, _: Capabilities) {
+impl ProtocolEncode<'_, Capabilities> for Query<'_> {
+    fn encode_with(&self, buf: &mut Vec<u8>, _: Capabilities) -> Result<(), crate::Error> {
         buf.push(0x03); // COM_QUERY
-        buf.extend(self.0.as_bytes())
+        buf.extend(self.0.as_bytes());
+        Ok(())
     }
 }

--- a/sqlx-mysql/src/protocol/text/quit.rs
+++ b/sqlx-mysql/src/protocol/text/quit.rs
@@ -1,4 +1,4 @@
-use crate::io::Encode;
+use crate::io::ProtocolEncode;
 use crate::protocol::Capabilities;
 
 // https://dev.mysql.com/doc/internals/en/com-quit.html
@@ -6,8 +6,9 @@ use crate::protocol::Capabilities;
 #[derive(Debug)]
 pub(crate) struct Quit;
 
-impl Encode<'_, Capabilities> for Quit {
-    fn encode_with(&self, buf: &mut Vec<u8>, _: Capabilities) {
+impl ProtocolEncode<'_, Capabilities> for Quit {
+    fn encode_with(&self, buf: &mut Vec<u8>, _: Capabilities) -> Result<(), crate::Error> {
         buf.push(0x01); // COM_QUIT
+        Ok(())
     }
 }

--- a/sqlx-mysql/src/protocol/text/row.rs
+++ b/sqlx-mysql/src/protocol/text/row.rs
@@ -2,14 +2,14 @@ use bytes::{Buf, Bytes};
 
 use crate::column::MySqlColumn;
 use crate::error::Error;
-use crate::io::Decode;
 use crate::io::MySqlBufExt;
+use crate::io::ProtocolDecode;
 use crate::protocol::Row;
 
 #[derive(Debug)]
 pub(crate) struct TextRow(pub(crate) Row);
 
-impl<'de> Decode<'de, &'de [MySqlColumn]> for TextRow {
+impl<'de> ProtocolDecode<'de, &'de [MySqlColumn]> for TextRow {
     fn decode_with(mut buf: Bytes, columns: &'de [MySqlColumn]) -> Result<Self, Error> {
         let storage = buf.clone();
         let offset = buf.len();

--- a/sqlx-mysql/src/protocol/text/row.rs
+++ b/sqlx-mysql/src/protocol/text/row.rs
@@ -22,7 +22,10 @@ impl<'de> ProtocolDecode<'de, &'de [MySqlColumn]> for TextRow {
                 values.push(None);
                 buf.advance(1);
             } else {
-                let size = buf.get_uint_lenenc() as usize;
+                let size = buf.get_uint_lenenc();
+                let size = usize::try_from(size)
+                    .map_err(|_| err_protocol!("TextRow length out of range: {size}"))?;
+
                 let offset = offset - buf.len();
 
                 values.push(Some(offset..(offset + size)));

--- a/sqlx-mysql/src/transaction.rs
+++ b/sqlx-mysql/src/transaction.rs
@@ -59,7 +59,8 @@ impl TransactionManager for MySqlTransactionManager {
             conn.inner.stream.sequence_id = 0;
             conn.inner
                 .stream
-                .write_packet(Query(&rollback_ansi_transaction_sql(depth)));
+                .write_packet(Query(&rollback_ansi_transaction_sql(depth)))
+                .expect("BUG: unexpected error queueing ROLLBACK");
 
             conn.inner.transaction_depth = depth - 1;
         }

--- a/sqlx-mysql/src/types/float.rs
+++ b/sqlx-mysql/src/types/float.rs
@@ -59,6 +59,7 @@ impl Decode<'_, MySql> for f32 {
                     4 => LittleEndian::read_f32(buf),
                     // MySQL can return 8-byte DOUBLE values for a FLOAT
                     // We take and truncate to f32 as that's the same behavior as *in* MySQL,
+                    #[allow(clippy::cast_possible_truncation)]
                     8 => LittleEndian::read_f64(buf) as f32,
                     other => {
                         // Users may try to decode a DECIMAL as floating point;

--- a/sqlx-mysql/src/types/mysql_time.rs
+++ b/sqlx-mysql/src/types/mysql_time.rs
@@ -617,6 +617,8 @@ fn parse_microseconds(micros: &str) -> Result<u32, BoxDynError> {
         len @ ..=EXPECTED_DIGITS => {
             // Fewer than 6 digits, multiply to the correct magnitude
             let micros: u32 = micros.parse()?;
+            // cast cannot overflow
+            #[allow(clippy::cast_possible_truncation)]
             Ok(micros * 10u32.pow((EXPECTED_DIGITS - len) as u32))
         }
         // More digits than expected, truncate

--- a/sqlx-postgres/Cargo.toml
+++ b/sqlx-postgres/Cargo.toml
@@ -15,9 +15,15 @@ json = ["sqlx-core/json"]
 migrate = ["sqlx-core/migrate"]
 offline = ["sqlx-core/offline"]
 
-# Type integration features which require additional dependencies
-rust_decimal = ["dep:rust_decimal", "rust_decimal/maths"]
-bigdecimal = ["dep:bigdecimal", "dep:num-bigint"]
+# Type Integration features
+bigdecimal = ["dep:bigdecimal", "dep:num-bigint", "sqlx-core/bigdecimal"]
+bit-vec = ["dep:bit-vec", "sqlx-core/bit-vec"]
+chrono = ["dep:chrono", "sqlx-core/chrono"]
+ipnetwork = ["dep:ipnetwork", "sqlx-core/ipnetwork"]
+mac_address = ["dep:mac_address", "sqlx-core/mac_address"]
+rust_decimal = ["dep:rust_decimal", "rust_decimal/maths", "sqlx-core/rust_decimal"]
+time = ["dep:time", "sqlx-core/time"]
+uuid = ["dep:uuid", "sqlx-core/uuid"]
 
 [dependencies]
 # Futures crates
@@ -71,8 +77,9 @@ workspace = true
 # We use JSON in the driver implementation itself so there's no reason not to enable it here.
 features = ["json"]
 
-[dev-dependencies]
-sqlx.workspace = true
+[dev-dependencies.sqlx]
+workspace = true
+features = ["postgres", "derive"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
 etcetera = "0.8.0"

--- a/sqlx-postgres/Cargo.toml
+++ b/sqlx-postgres/Cargo.toml
@@ -83,3 +83,6 @@ features = ["postgres", "derive"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
 etcetera = "0.8.0"
+
+[lints]
+workspace = true

--- a/sqlx-postgres/src/advisory_lock.rs
+++ b/sqlx-postgres/src/advisory_lock.rs
@@ -414,7 +414,8 @@ impl<'lock, C: AsMut<PgConnection>> Drop for PgAdvisoryLockGuard<'lock, C> {
             // The `async fn` versions can safely use the prepared statement protocol,
             // but this is the safest way to queue a query to execute on the next opportunity.
             conn.as_mut()
-                .queue_simple_query(self.lock.get_release_query());
+                .queue_simple_query(self.lock.get_release_query())
+                .expect("BUG: PgAdvisoryLock::get_release_query() somehow too long for protocol");
         }
     }
 }

--- a/sqlx-postgres/src/advisory_lock.rs
+++ b/sqlx-postgres/src/advisory_lock.rs
@@ -98,7 +98,6 @@ impl PgAdvisoryLock {
     /// [hkdf]: https://datatracker.ietf.org/doc/html/rfc5869
     /// ### Example
     /// ```rust
-    /// # extern crate sqlx_core as sqlx;
     /// use sqlx::postgres::{PgAdvisoryLock, PgAdvisoryLockKey};
     ///
     /// let lock = PgAdvisoryLock::new("my first Postgres advisory lock!");

--- a/sqlx-postgres/src/arguments.rs
+++ b/sqlx-postgres/src/arguments.rs
@@ -274,6 +274,10 @@ impl DerefMut for PgArgumentBuffer {
 }
 
 pub(crate) fn value_size_int4_checked(size: usize) -> Result<i32, String> {
-    i32::try_from(size)
-        .map_err(|_| format!("value size would overflow in the binary protocol encoding: {size} > {}", i32::MAX))
+    i32::try_from(size).map_err(|_| {
+        format!(
+            "value size would overflow in the binary protocol encoding: {size} > {}",
+            i32::MAX
+        )
+    })
 }

--- a/sqlx-postgres/src/arguments.rs
+++ b/sqlx-postgres/src/arguments.rs
@@ -145,6 +145,7 @@ impl<'q> Arguments<'q> for PgArguments {
         write!(writer, "${}", self.buffer.count)
     }
 
+    #[inline(always)]
     fn len(&self) -> usize {
         self.buffer.count
     }

--- a/sqlx-postgres/src/arguments.rs
+++ b/sqlx-postgres/src/arguments.rs
@@ -79,7 +79,8 @@ impl PgArguments {
 
         // encode the value into our buffer
         if let Err(error) = self.buffer.encode(value) {
-            // reset the value buffer to its previous value if encoding failed so we don't leave a half-encoded value behind
+            // reset the value buffer to its previous value if encoding failed,
+            // so we don't leave a half-encoded value behind
             self.buffer.reset_to_snapshot(buffer_snapshot);
             return Err(error);
         };
@@ -154,13 +155,18 @@ impl PgArgumentBuffer {
     where
         T: Encode<'q, Postgres>,
     {
+        // Won't catch everything but is a good sanity check
+        value_size_int4_checked(value.size_hint())?;
+
         // reserve space to write the prefixed length of the value
         let offset = self.len();
+
         self.extend(&[0; 4]);
 
         // encode the value into our buffer
         let len = if let IsNull::No = value.encode(self)? {
-            (self.len() - offset - 4) as i32
+            // Ensure that the value size does not overflow i32
+            value_size_int4_checked(self.len() - offset - 4)?
         } else {
             // Write a -1 to indicate NULL
             // NOTE: It is illegal for [encode] to write any data
@@ -169,6 +175,7 @@ impl PgArgumentBuffer {
         };
 
         // write the len to the beginning of the value
+        // (offset + 4) cannot overflow because it would have failed at `self.extend()`.
         self[offset..(offset + 4)].copy_from_slice(&len.to_be_bytes());
 
         Ok(())
@@ -264,4 +271,9 @@ impl DerefMut for PgArgumentBuffer {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.buffer
     }
+}
+
+pub(crate) fn value_size_int4_checked(size: usize) -> Result<i32, String> {
+    i32::try_from(size)
+        .map_err(|_| format!("value size would overflow in the binary protocol encoding: {size} > {}", i32::MAX))
 }

--- a/sqlx-postgres/src/connection/describe.rs
+++ b/sqlx-postgres/src/connection/describe.rs
@@ -500,7 +500,11 @@ WHERE rngtypid = $1
         stmt_id: StatementId,
         params_len: usize,
     ) -> Result<Vec<Option<bool>>, Error> {
-        let mut explain = format!("EXPLAIN (VERBOSE, FORMAT JSON) EXECUTE {stmt_id}");
+        let stmt_id_display = stmt_id
+            .display()
+            .ok_or_else(|| err_protocol!("cannot EXPLAIN unnamed statement: {stmt_id:?}"))?;
+
+        let mut explain = format!("EXPLAIN (VERBOSE, FORMAT JSON) EXECUTE {stmt_id_display}");
         let mut comma = false;
 
         if params_len > 0 {

--- a/sqlx-postgres/src/connection/describe.rs
+++ b/sqlx-postgres/src/connection/describe.rs
@@ -466,7 +466,13 @@ WHERE rngtypid = $1
         let mut nullables: Vec<Option<bool>> = nullable_query
             .build_query_scalar()
             .fetch_all(&mut *self)
-            .await?;
+            .await
+            .map_err(|e| {
+                err_protocol!(
+                    "error from nullables query: {e}; query: {:?}",
+                    nullable_query.sql()
+                )
+            })?;
 
         // If the server is CockroachDB or Materialize, skip this step (#1248).
         if !self.stream.parameter_statuses.contains_key("crdb_version")

--- a/sqlx-postgres/src/connection/describe.rs
+++ b/sqlx-postgres/src/connection/describe.rs
@@ -451,7 +451,7 @@ WHERE rngtypid = $1
                 .push_unseparated("::int4");
             tuple
                 .push_bind(column.relation_attribute_no)
-                .push_bind_unseparated("::int2");
+                .push_unseparated("::int2");
         });
 
         nullable_query.push(

--- a/sqlx-postgres/src/connection/describe.rs
+++ b/sqlx-postgres/src/connection/describe.rs
@@ -2,17 +2,17 @@ use crate::error::Error;
 use crate::ext::ustr::UStr;
 use crate::message::{ParameterDescription, RowDescription};
 use crate::query_as::query_as;
-use crate::query_scalar::{query_scalar, query_scalar_with};
+use crate::query_scalar::{query_scalar};
 use crate::statement::PgStatementMetadata;
 use crate::type_info::{PgArrayOf, PgCustomType, PgType, PgTypeKind};
 use crate::types::Json;
 use crate::types::Oid;
 use crate::HashMap;
-use crate::{PgArguments, PgColumn, PgConnection, PgTypeInfo};
+use crate::{PgColumn, PgConnection, PgTypeInfo};
 use futures_core::future::BoxFuture;
 use smallvec::SmallVec;
-use std::fmt::Write;
 use std::sync::Arc;
+use sqlx_core::query_builder::QueryBuilder;
 
 /// Describes the type of the `pg_type.typtype` column
 ///
@@ -423,29 +423,34 @@ WHERE rngtypid = $1
             return Ok(vec![]);
         }
 
-        let mut nullable_query = String::from("SELECT NOT pg_attribute.attnotnull FROM (VALUES ");
-        let mut args = PgArguments::default();
-
-        for (i, (column, bind)) in meta.columns.iter().zip((1..).step_by(3)).enumerate() {
-            if !args.buffer.is_empty() {
-                nullable_query += ", ";
-            }
-
-            let _ = write!(
-                nullable_query,
-                "(${}::int4, ${}::int4, ${}::int2)",
-                bind,
-                bind + 1,
-                bind + 2
+        if meta.columns.len() * 3 > 65535 {
+            tracing::debug!(
+                ?stmt_id,
+                num_columns=meta.columns.len(),
+                "number of columns in query is too large to pull nullability for"
             );
-
-            args.add(i as i32).map_err(Error::Encode)?;
-            args.add(column.relation_id).map_err(Error::Encode)?;
-            args.add(column.relation_attribute_no)
-                .map_err(Error::Encode)?;
         }
 
-        nullable_query.push_str(
+        // Query for NOT NULL constraints for each column in the query.
+        //
+        // This will include columns that don't have a `relation_id` (are not from a table);
+        // assuming those are a minority of columns, it's less code to _not_ work around it
+        // and just let Postgres return `NULL`.
+        let mut nullable_query = QueryBuilder::new(
+            "SELECT NOT pg_attribute.attnotnull FROM ( "
+        );
+
+        nullable_query.push_values(
+            meta.columns.iter().zip(0i32..),
+            |mut tuple, (column, i)| {
+                // ({i}::int4, {column.relation_id}::int4, {column.relation_attribute_no}::int2)
+                tuple.push_bind(i).push_unseparated("::int4");
+                tuple.push_bind(column.relation_id).push_unseparated("::int4");
+                tuple.push_bind(column.relation_attribute_no).push_bind_unseparated("::int2");
+            },
+        );
+
+        nullable_query.push(
             ") as col(idx, table_id, col_idx) \
             LEFT JOIN pg_catalog.pg_attribute \
                 ON table_id IS NOT NULL \
@@ -454,7 +459,8 @@ WHERE rngtypid = $1
             ORDER BY col.idx",
         );
 
-        let mut nullables = query_scalar_with::<_, Option<bool>, _>(&nullable_query, args)
+        let mut nullables: Vec<Option<bool>> = nullable_query
+            .build_query_scalar()
             .fetch_all(&mut *self)
             .await?;
 

--- a/sqlx-postgres/src/connection/establish.rs
+++ b/sqlx-postgres/src/connection/establish.rs
@@ -3,11 +3,10 @@ use crate::HashMap;
 use crate::common::StatementCache;
 use crate::connection::{sasl, stream::PgStream};
 use crate::error::Error;
-use crate::io::Decode;
+use crate::io::StatementId;
 use crate::message::{
-    Authentication, BackendKeyData, MessageFormat, Password, ReadyForQuery, Startup,
+    Authentication, BackendKeyData, BackendMessageFormat, Password, ReadyForQuery, Startup,
 };
-use crate::types::Oid;
 use crate::{PgConnectOptions, PgConnection};
 
 // https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.5.7.3
@@ -44,13 +43,13 @@ impl PgConnection {
             params.push(("options", options));
         }
 
-        stream
-            .send(Startup {
-                username: Some(&options.username),
-                database: options.database.as_deref(),
-                params: &params,
-            })
-            .await?;
+        stream.write(Startup {
+            username: Some(&options.username),
+            database: options.database.as_deref(),
+            params: &params,
+        })?;
+
+        stream.flush().await?;
 
         // The server then uses this information and the contents of
         // its configuration files (such as pg_hba.conf) to determine whether the connection is
@@ -64,7 +63,7 @@ impl PgConnection {
         loop {
             let message = stream.recv().await?;
             match message.format {
-                MessageFormat::Authentication => match message.decode()? {
+                BackendMessageFormat::Authentication => match message.decode()? {
                     Authentication::Ok => {
                         // the authentication exchange is successfully completed
                         // do nothing; no more information is required to continue
@@ -108,7 +107,7 @@ impl PgConnection {
                     }
                 },
 
-                MessageFormat::BackendKeyData => {
+                BackendMessageFormat::BackendKeyData => {
                     // provides secret-key data that the frontend must save if it wants to be
                     // able to issue cancel requests later
 
@@ -118,10 +117,9 @@ impl PgConnection {
                     secret_key = data.secret_key;
                 }
 
-                MessageFormat::ReadyForQuery => {
+                BackendMessageFormat::ReadyForQuery => {
                     // start-up is completed. The frontend can now issue commands
-                    transaction_status =
-                        ReadyForQuery::decode(message.contents)?.transaction_status;
+                    transaction_status = message.decode::<ReadyForQuery>()?.transaction_status;
 
                     break;
                 }
@@ -142,7 +140,7 @@ impl PgConnection {
             transaction_status,
             transaction_depth: 0,
             pending_ready_for_query_count: 0,
-            next_statement_id: Oid(1),
+            next_statement_id: StatementId::NAMED_START,
             cache_statement: StatementCache::new(options.statement_cache_capacity),
             cache_type_oid: HashMap::new(),
             cache_type_info: HashMap::new(),

--- a/sqlx-postgres/src/connection/executor.rs
+++ b/sqlx-postgres/src/connection/executor.rs
@@ -1,13 +1,13 @@
 use crate::describe::Describe;
 use crate::error::Error;
 use crate::executor::{Execute, Executor};
+use crate::io::{PortalId, StatementId};
 use crate::logger::QueryLogger;
 use crate::message::{
-    self, Bind, Close, CommandComplete, DataRow, MessageFormat, ParameterDescription, Parse, Query,
-    RowDescription,
+    self, BackendMessageFormat, Bind, Close, CommandComplete, DataRow, ParameterDescription, Parse,
+    ParseComplete, Query, RowDescription,
 };
 use crate::statement::PgStatementMetadata;
-use crate::types::Oid;
 use crate::{
     statement::PgStatement, PgArguments, PgConnection, PgQueryResult, PgRow, PgTypeInfo,
     PgValueFormat, Postgres,
@@ -16,6 +16,7 @@ use futures_core::future::BoxFuture;
 use futures_core::stream::BoxStream;
 use futures_core::Stream;
 use futures_util::{pin_mut, TryStreamExt};
+use sqlx_core::arguments::Arguments;
 use sqlx_core::Either;
 use std::{borrow::Cow, sync::Arc};
 
@@ -24,9 +25,9 @@ async fn prepare(
     sql: &str,
     parameters: &[PgTypeInfo],
     metadata: Option<Arc<PgStatementMetadata>>,
-) -> Result<(Oid, Arc<PgStatementMetadata>), Error> {
+) -> Result<(StatementId, Arc<PgStatementMetadata>), Error> {
     let id = conn.next_statement_id;
-    conn.next_statement_id.incr_one();
+    conn.next_statement_id = id.next();
 
     // build a list of type OIDs to send to the database in the PARSE command
     // we have not yet started the query sequence, so we are *safe* to cleanly make
@@ -42,15 +43,15 @@ async fn prepare(
     conn.wait_until_ready().await?;
 
     // next we send the PARSE command to the server
-    conn.stream.write(Parse {
+    conn.stream.write_msg(Parse {
         param_types: &param_types,
         query: sql,
         statement: id,
-    });
+    })?;
 
     if metadata.is_none() {
         // get the statement columns and parameters
-        conn.stream.write(message::Describe::Statement(id));
+        conn.stream.write_msg(message::Describe::Statement(id))?;
     }
 
     // we ask for the server to immediately send us the result of the PARSE command
@@ -58,9 +59,7 @@ async fn prepare(
     conn.stream.flush().await?;
 
     // indicates that the SQL query string is now successfully parsed and has semantic validity
-    conn.stream
-        .recv_expect(MessageFormat::ParseComplete)
-        .await?;
+    conn.stream.recv_expect::<ParseComplete>().await?;
 
     let metadata = if let Some(metadata) = metadata {
         // each SYNC produces one READY FOR QUERY
@@ -95,18 +94,18 @@ async fn prepare(
 }
 
 async fn recv_desc_params(conn: &mut PgConnection) -> Result<ParameterDescription, Error> {
-    conn.stream
-        .recv_expect(MessageFormat::ParameterDescription)
-        .await
+    conn.stream.recv_expect().await
 }
 
 async fn recv_desc_rows(conn: &mut PgConnection) -> Result<Option<RowDescription>, Error> {
     let rows: Option<RowDescription> = match conn.stream.recv().await? {
         // describes the rows that will be returned when the statement is eventually executed
-        message if message.format == MessageFormat::RowDescription => Some(message.decode()?),
+        message if message.format == BackendMessageFormat::RowDescription => {
+            Some(message.decode()?)
+        }
 
         // no data would be returned if this statement was executed
-        message if message.format == MessageFormat::NoData => None,
+        message if message.format == BackendMessageFormat::NoData => None,
 
         message => {
             return Err(err_protocol!(
@@ -125,12 +124,12 @@ impl PgConnection {
         // we need to wait for the [CloseComplete] to be returned from the server
         while count > 0 {
             match self.stream.recv().await? {
-                message if message.format == MessageFormat::PortalSuspended => {
+                message if message.format == BackendMessageFormat::PortalSuspended => {
                     // there was an open portal
                     // this can happen if the last time a statement was used it was not fully executed
                 }
 
-                message if message.format == MessageFormat::CloseComplete => {
+                message if message.format == BackendMessageFormat::CloseComplete => {
                     // successfully closed the statement (and freed up the server resources)
                     count -= 1;
                 }
@@ -147,8 +146,11 @@ impl PgConnection {
         Ok(())
     }
 
+    #[inline(always)]
     pub(crate) fn write_sync(&mut self) {
-        self.stream.write(message::Sync);
+        self.stream
+            .write_msg(message::Sync)
+            .expect("BUG: Sync should not be too big for protocol");
 
         // all SYNC messages will return a ReadyForQuery
         self.pending_ready_for_query_count += 1;
@@ -163,7 +165,7 @@ impl PgConnection {
         // optional metadata that was provided by the user, this means they are reusing
         // a statement object
         metadata: Option<Arc<PgStatementMetadata>>,
-    ) -> Result<(Oid, Arc<PgStatementMetadata>), Error> {
+    ) -> Result<(StatementId, Arc<PgStatementMetadata>), Error> {
         if let Some(statement) = self.cache_statement.get_mut(sql) {
             return Ok((*statement).clone());
         }
@@ -172,7 +174,7 @@ impl PgConnection {
 
         if store_to_cache && self.cache_statement.is_enabled() {
             if let Some((id, _)) = self.cache_statement.insert(sql, statement.clone()) {
-                self.stream.write(Close::Statement(id));
+                self.stream.write_msg(Close::Statement(id))?;
                 self.write_sync();
 
                 self.stream.flush().await?;
@@ -201,6 +203,14 @@ impl PgConnection {
         let mut metadata: Arc<PgStatementMetadata>;
 
         let format = if let Some(mut arguments) = arguments {
+            // Check this before we write anything to the stream.
+            let num_params = i16::try_from(arguments.len()).map_err(|_| {
+                err_protocol!(
+                    "PgConnection::run(): too many arguments for query: {}",
+                    arguments.len()
+                )
+            })?;
+
             // prepare the statement if this our first time executing it
             // always return the statement ID here
             let (statement, metadata_) = self
@@ -216,21 +226,21 @@ impl PgConnection {
             self.wait_until_ready().await?;
 
             // bind to attach the arguments to the statement and create a portal
-            self.stream.write(Bind {
-                portal: None,
+            self.stream.write_msg(Bind {
+                portal: PortalId::UNNAMED,
                 statement,
                 formats: &[PgValueFormat::Binary],
-                num_params: arguments.types.len() as i16,
+                num_params,
                 params: &arguments.buffer,
                 result_formats: &[PgValueFormat::Binary],
-            });
+            })?;
 
             // executes the portal up to the passed limit
             // the protocol-level limit acts nearly identically to the `LIMIT` in SQL
-            self.stream.write(message::Execute {
-                portal: None,
+            self.stream.write_msg(message::Execute {
+                portal: PortalId::UNNAMED,
                 limit: limit.into(),
-            });
+            })?;
             // From https://www.postgresql.org/docs/current/protocol-flow.html:
             //
             // "An unnamed portal is destroyed at the end of the transaction, or as
@@ -240,7 +250,7 @@ impl PgConnection {
 
             // we ask the database server to close the unnamed portal and free the associated resources
             // earlier - after the execution of the current query.
-            self.stream.write(message::Close::Portal(None));
+            self.stream.write_msg(Close::Portal(PortalId::UNNAMED))?;
 
             // finally, [Sync] asks postgres to process the messages that we sent and respond with
             // a [ReadyForQuery] message when it's completely done. Theoretically, we could send
@@ -253,7 +263,7 @@ impl PgConnection {
             PgValueFormat::Binary
         } else {
             // Query will trigger a ReadyForQuery
-            self.stream.write(Query(query));
+            self.stream.write_msg(Query(query))?;
             self.pending_ready_for_query_count += 1;
 
             // metadata starts out as "nothing"
@@ -270,12 +280,12 @@ impl PgConnection {
                 let message = self.stream.recv().await?;
 
                 match message.format {
-                    MessageFormat::BindComplete
-                    | MessageFormat::ParseComplete
-                    | MessageFormat::ParameterDescription
-                    | MessageFormat::NoData
+                    BackendMessageFormat::BindComplete
+                    | BackendMessageFormat::ParseComplete
+                    | BackendMessageFormat::ParameterDescription
+                    | BackendMessageFormat::NoData
                     // unnamed portal has been closed
-                    | MessageFormat::CloseComplete
+                    | BackendMessageFormat::CloseComplete
                     => {
                         // harmless messages to ignore
                     }
@@ -284,7 +294,7 @@ impl PgConnection {
                     // exactly one of these messages: CommandComplete,
                     // EmptyQueryResponse (if the portal was created from an
                     // empty query string), ErrorResponse, or PortalSuspended"
-                    MessageFormat::CommandComplete => {
+                    BackendMessageFormat::CommandComplete => {
                         // a SQL command completed normally
                         let cc: CommandComplete = message.decode()?;
 
@@ -295,16 +305,16 @@ impl PgConnection {
                         }));
                     }
 
-                    MessageFormat::EmptyQueryResponse => {
+                    BackendMessageFormat::EmptyQueryResponse => {
                         // empty query string passed to an unprepared execute
                     }
 
                     // Message::ErrorResponse is handled in self.stream.recv()
 
                     // incomplete query execution has finished
-                    MessageFormat::PortalSuspended => {}
+                    BackendMessageFormat::PortalSuspended => {}
 
-                    MessageFormat::RowDescription => {
+                    BackendMessageFormat::RowDescription => {
                         // indicates that a *new* set of rows are about to be returned
                         let (columns, column_names) = self
                             .handle_row_description(Some(message.decode()?), false)
@@ -317,7 +327,7 @@ impl PgConnection {
                         });
                     }
 
-                    MessageFormat::DataRow => {
+                    BackendMessageFormat::DataRow => {
                         logger.increment_rows_returned();
 
                         // one of the set of rows returned by a SELECT, FETCH, etc query
@@ -331,7 +341,7 @@ impl PgConnection {
                         r#yield!(Either::Right(row));
                     }
 
-                    MessageFormat::ReadyForQuery => {
+                    BackendMessageFormat::ReadyForQuery => {
                         // processing of the query string is complete
                         self.handle_ready_for_query(message)?;
                         break;

--- a/sqlx-postgres/src/connection/mod.rs
+++ b/sqlx-postgres/src/connection/mod.rs
@@ -8,9 +8,10 @@ use futures_util::FutureExt;
 use crate::common::StatementCache;
 use crate::error::Error;
 use crate::ext::ustr::UStr;
-use crate::io::Decode;
+use crate::io::StatementId;
 use crate::message::{
-    Close, Message, MessageFormat, Query, ReadyForQuery, Terminate, TransactionStatus,
+    BackendMessageFormat, Close, Query, ReadyForQuery, ReceivedMessage, Terminate,
+    TransactionStatus,
 };
 use crate::statement::PgStatementMetadata;
 use crate::transaction::Transaction;
@@ -47,10 +48,10 @@ pub struct PgConnection {
 
     // sequence of statement IDs for use in preparing statements
     // in PostgreSQL, the statement is prepared to a user-supplied identifier
-    next_statement_id: Oid,
+    next_statement_id: StatementId,
 
     // cache statement by query string to the id and columns
-    cache_statement: StatementCache<(Oid, Arc<PgStatementMetadata>)>,
+    cache_statement: StatementCache<(StatementId, Arc<PgStatementMetadata>)>,
 
     // cache user-defined types by id <-> info
     cache_type_info: HashMap<Oid, PgTypeInfo>,
@@ -82,7 +83,7 @@ impl PgConnection {
         while self.pending_ready_for_query_count > 0 {
             let message = self.stream.recv().await?;
 
-            if let MessageFormat::ReadyForQuery = message.format {
+            if let BackendMessageFormat::ReadyForQuery = message.format {
                 self.handle_ready_for_query(message)?;
             }
         }
@@ -91,10 +92,7 @@ impl PgConnection {
     }
 
     async fn recv_ready_for_query(&mut self) -> Result<(), Error> {
-        let r: ReadyForQuery = self
-            .stream
-            .recv_expect(MessageFormat::ReadyForQuery)
-            .await?;
+        let r: ReadyForQuery = self.stream.recv_expect().await?;
 
         self.pending_ready_for_query_count -= 1;
         self.transaction_status = r.transaction_status;
@@ -102,9 +100,10 @@ impl PgConnection {
         Ok(())
     }
 
-    fn handle_ready_for_query(&mut self, message: Message) -> Result<(), Error> {
+    #[inline(always)]
+    fn handle_ready_for_query(&mut self, message: ReceivedMessage) -> Result<(), Error> {
         self.pending_ready_for_query_count -= 1;
-        self.transaction_status = ReadyForQuery::decode(message.contents)?.transaction_status;
+        self.transaction_status = message.decode::<ReadyForQuery>()?.transaction_status;
 
         Ok(())
     }
@@ -112,9 +111,12 @@ impl PgConnection {
     /// Queue a simple query (not prepared) to execute the next time this connection is used.
     ///
     /// Used for rolling back transactions and releasing advisory locks.
-    pub(crate) fn queue_simple_query(&mut self, query: &str) {
+    #[inline(always)]
+    pub(crate) fn queue_simple_query(&mut self, query: &str) -> Result<(), Error> {
+        self.stream.write_msg(Query(query))?;
         self.pending_ready_for_query_count += 1;
-        self.stream.write(Query(query));
+
+        Ok(())
     }
 }
 
@@ -184,7 +186,7 @@ impl Connection for PgConnection {
             self.wait_until_ready().await?;
 
             while let Some((id, _)) = self.cache_statement.remove_lru() {
-                self.stream.write(Close::Statement(id));
+                self.stream.write_msg(Close::Statement(id))?;
                 cleared += 1;
             }
 

--- a/sqlx-postgres/src/connection/mod.rs
+++ b/sqlx-postgres/src/connection/mod.rs
@@ -102,7 +102,11 @@ impl PgConnection {
 
     #[inline(always)]
     fn handle_ready_for_query(&mut self, message: ReceivedMessage) -> Result<(), Error> {
-        self.pending_ready_for_query_count -= 1;
+        self.pending_ready_for_query_count = self
+            .pending_ready_for_query_count
+            .checked_sub(1)
+            .ok_or_else(|| err_protocol!("received more ReadyForQuery messages than expected"))?;
+
         self.transaction_status = message.decode::<ReadyForQuery>()?.transaction_status;
 
         Ok(())

--- a/sqlx-postgres/src/connection/stream.rs
+++ b/sqlx-postgres/src/connection/stream.rs
@@ -9,8 +9,10 @@ use sqlx_core::bytes::{Buf, Bytes};
 
 use crate::connection::tls::MaybeUpgradeTls;
 use crate::error::Error;
-use crate::io::{Decode, Encode};
-use crate::message::{Message, MessageFormat, Notice, Notification, ParameterStatus};
+use crate::message::{
+    BackendMessage, BackendMessageFormat, EncodeMessage, FrontendMessage, Notice, Notification,
+    ParameterStatus, ReceivedMessage,
+};
 use crate::net::{self, BufferedSocket, Socket};
 use crate::{PgConnectOptions, PgDatabaseError, PgSeverity};
 
@@ -55,59 +57,51 @@ impl PgStream {
         })
     }
 
-    pub(crate) async fn send<'en, T>(&mut self, message: T) -> Result<(), Error>
+    #[inline(always)]
+    pub(crate) fn write_msg(&mut self, message: impl FrontendMessage) -> Result<(), Error> {
+        self.write(EncodeMessage(message))
+    }
+
+    pub(crate) async fn send<T>(&mut self, message: T) -> Result<(), Error>
     where
-        T: Encode<'en>,
+        T: FrontendMessage,
     {
-        self.write(message);
+        self.write_msg(message)?;
         self.flush().await?;
         Ok(())
     }
 
     // Expect a specific type and format
-    pub(crate) async fn recv_expect<'de, T: Decode<'de>>(
-        &mut self,
-        format: MessageFormat,
-    ) -> Result<T, Error> {
-        let message = self.recv().await?;
-
-        if message.format != format {
-            return Err(err_protocol!(
-                "expecting {:?} but received {:?}",
-                format,
-                message.format
-            ));
-        }
-
-        message.decode()
+    pub(crate) async fn recv_expect<B: BackendMessage>(&mut self) -> Result<B, Error> {
+        self.recv().await?.decode()
     }
 
-    pub(crate) async fn recv_unchecked(&mut self) -> Result<Message, Error> {
+    pub(crate) async fn recv_unchecked(&mut self) -> Result<ReceivedMessage, Error> {
         // all packets in postgres start with a 5-byte header
         // this header contains the message type and the total length of the message
         let mut header: Bytes = self.inner.read(5).await?;
 
-        let format = MessageFormat::try_from_u8(header.get_u8())?;
+        let format = BackendMessageFormat::try_from_u8(header.get_u8())?;
         let size = (header.get_u32() - 4) as usize;
 
         let contents = self.inner.read(size).await?;
 
-        Ok(Message { format, contents })
+        Ok(ReceivedMessage { format, contents })
     }
 
     // Get the next message from the server
     // May wait for more data from the server
-    pub(crate) async fn recv(&mut self) -> Result<Message, Error> {
+    pub(crate) async fn recv(&mut self) -> Result<ReceivedMessage, Error> {
         loop {
             let message = self.recv_unchecked().await?;
 
             match message.format {
-                MessageFormat::ErrorResponse => {
+                BackendMessageFormat::ErrorResponse => {
                     // An error returned from the database server.
                     return Err(PgDatabaseError(message.decode()?).into());
                 }
 
-                MessageFormat::NotificationResponse => {
+                BackendMessageFormat::NotificationResponse => {
                     if let Some(buffer) = &mut self.notifications {
                         let notification: Notification = message.decode()?;
                         let _ = buffer.send(notification).await;
@@ -116,7 +110,7 @@ impl PgStream {
                     }
                 }
 
-                MessageFormat::ParameterStatus => {
+                BackendMessageFormat::ParameterStatus => {
                     // informs the frontend about the current (initial)
                     // setting of backend parameters
 
@@ -135,7 +129,7 @@ impl PgStream {
                     continue;
                 }
 
-                MessageFormat::NoticeResponse => {
+                BackendMessageFormat::NoticeResponse => {
                     // do we need this to be more configurable?
                     // if you are reading this comment and think so, open an issue
 

--- a/sqlx-postgres/src/connection/stream.rs
+++ b/sqlx-postgres/src/connection/stream.rs
@@ -98,7 +98,7 @@ impl PgStream {
             match message.format {
                 BackendMessageFormat::ErrorResponse => {
                     // An error returned from the database server.
-                    return Err(PgDatabaseError(message.decode()?).into());
+                    return Err(message.decode::<PgDatabaseError>()?.into());
                 }
 
                 BackendMessageFormat::NotificationResponse => {

--- a/sqlx-postgres/src/io/buf_mut.rs
+++ b/sqlx-postgres/src/io/buf_mut.rs
@@ -1,54 +1,64 @@
-use crate::types::Oid;
+use crate::io::{PortalId, StatementId};
 
 pub trait PgBufMutExt {
-    fn put_length_prefixed<F>(&mut self, f: F)
+    fn put_length_prefixed<F>(&mut self, f: F) -> Result<(), crate::Error>
     where
-        F: FnOnce(&mut Vec<u8>);
+        F: FnOnce(&mut Vec<u8>) -> Result<(), crate::Error>;
 
-    fn put_statement_name(&mut self, id: Oid);
+    fn put_statement_name(&mut self, id: StatementId);
 
-    fn put_portal_name(&mut self, id: Option<Oid>);
+    fn put_portal_name(&mut self, id: PortalId);
 }
 
 impl PgBufMutExt for Vec<u8> {
     // writes a length-prefixed message, this is used when encoding nearly all messages as postgres
     // wants us to send the length of the often-variable-sized messages up front
-    fn put_length_prefixed<F>(&mut self, f: F)
+    fn put_length_prefixed<F>(&mut self, write_contents: F) -> Result<(), crate::Error>
     where
-        F: FnOnce(&mut Vec<u8>),
+        F: FnOnce(&mut Vec<u8>) -> Result<(), crate::Error>,
     {
         // reserve space to write the prefixed length
         let offset = self.len();
         self.extend(&[0; 4]);
 
         // write the main body of the message
-        f(self);
+        let write_result = write_contents(self);
 
-        // now calculate the size of what we wrote and set the length value
-        let size = (self.len() - offset) as i32;
-        self[offset..(offset + 4)].copy_from_slice(&size.to_be_bytes());
+        let size_result = write_result.and_then(|_| {
+            let size = self.len() - offset;
+            i32::try_from(size)
+                .map_err(|_| err_protocol!("message size out of range for Pg protocol: {size"))
+        });
+
+        match size_result {
+            Ok(size) => {
+                // now calculate the size of what we wrote and set the length value
+                self[offset..(offset + 4)].copy_from_slice(&size.to_be_bytes());
+                Ok(())
+            }
+            Err(e) => {
+                // Put the buffer back to where it was.
+                self.truncate(offset);
+                Err(e)
+            }
+        }
     }
 
     // writes a statement name by ID
     #[inline]
-    fn put_statement_name(&mut self, id: Oid) {
-        // N.B. if you change this don't forget to update it in ../describe.rs
-        self.extend(b"sqlx_s_");
-
-        self.extend(itoa::Buffer::new().format(id.0).as_bytes());
-
-        self.push(0);
+    fn put_statement_name(&mut self, id: StatementId) {
+        let _: Result<(), ()> = id.write_name(|s| {
+            self.extend_from_slice(s.as_bytes());
+            Ok(())
+        });
     }
 
     // writes a portal name by ID
     #[inline]
-    fn put_portal_name(&mut self, id: Option<Oid>) {
-        if let Some(id) = id {
-            self.extend(b"sqlx_p_");
-
-            self.extend(itoa::Buffer::new().format(id.0).as_bytes());
-        }
-
-        self.push(0);
+    fn put_portal_name(&mut self, id: PortalId) {
+        let _: Result<(), ()> = id.write_name(|s| {
+            self.extend_from_slice(s.as_bytes());
+            Ok(())
+        });
     }
 }

--- a/sqlx-postgres/src/io/buf_mut.rs
+++ b/sqlx-postgres/src/io/buf_mut.rs
@@ -47,18 +47,12 @@ impl PgBufMutExt for Vec<u8> {
     // writes a statement name by ID
     #[inline]
     fn put_statement_name(&mut self, id: StatementId) {
-        let _: Result<(), ()> = id.write_name(|s| {
-            self.extend_from_slice(s.as_bytes());
-            Ok(())
-        });
+        id.put_name_with_nul(self);
     }
 
     // writes a portal name by ID
     #[inline]
     fn put_portal_name(&mut self, id: PortalId) {
-        let _: Result<(), ()> = id.write_name(|s| {
-            self.extend_from_slice(s.as_bytes());
-            Ok(())
-        });
+        id.put_name_with_nul(self);
     }
 }

--- a/sqlx-postgres/src/io/buf_mut.rs
+++ b/sqlx-postgres/src/io/buf_mut.rs
@@ -27,7 +27,7 @@ impl PgBufMutExt for Vec<u8> {
         let size_result = write_result.and_then(|_| {
             let size = self.len() - offset;
             i32::try_from(size)
-                .map_err(|_| err_protocol!("message size out of range for Pg protocol: {size"))
+                .map_err(|_| err_protocol!("message size out of range for protocol: {size}"))
         });
 
         match size_result {

--- a/sqlx-postgres/src/io/mod.rs
+++ b/sqlx-postgres/src/io/mod.rs
@@ -10,7 +10,6 @@ pub(crate) use sqlx_core::io::*;
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) struct StatementId(IdInner);
 
-#[allow(dead_code)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) struct PortalId(IdInner);
 
@@ -18,6 +17,7 @@ pub(crate) struct PortalId(IdInner);
 struct IdInner(Option<NonZeroU32>);
 
 impl StatementId {
+    #[allow(dead_code)]
     pub const UNNAMED: Self = Self(IdInner::UNNAMED);
 
     pub const NAMED_START: Self = Self(IdInner::NAMED_START);

--- a/sqlx-postgres/src/io/mod.rs
+++ b/sqlx-postgres/src/io/mod.rs
@@ -1,5 +1,130 @@
 mod buf_mut;
 
 pub use buf_mut::PgBufMutExt;
+use std::fmt;
+use std::fmt::{Display, Formatter};
+use std::num::{NonZeroU32, Saturating};
 
 pub(crate) use sqlx_core::io::*;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) struct StatementId(IdInner);
+
+#[allow(dead_code)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) struct PortalId(IdInner);
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+struct IdInner(Option<NonZeroU32>);
+
+impl StatementId {
+    pub const UNNAMED: Self = Self(IdInner::UNNAMED);
+
+    pub const NAMED_START: Self = Self(IdInner::NAMED_START);
+
+    #[cfg(test)]
+    pub const TEST_VAL: Self = Self(IdInner::TEST_VAL);
+
+    const NAME_PREFIX: &'static str = "sqlx_s_";
+
+    pub fn next(&self) -> Self {
+        Self(self.0.next())
+    }
+
+    pub fn name_len(&self) -> Saturating<usize> {
+        self.0.name_len(Self::NAME_PREFIX)
+    }
+
+    // There's no common trait implemented by `Formatter` and `Vec<u8>` for this purpose;
+    // we're deliberately avoiding the formatting machinery because it's known to be slow.
+    pub fn write_name<E>(&self, write: impl FnMut(&str) -> Result<(), E>) -> Result<(), E> {
+        self.0.write_name(Self::NAME_PREFIX, write)
+    }
+}
+
+impl Display for StatementId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.write_name(|s| f.write_str(s))
+    }
+}
+
+#[allow(dead_code)]
+impl PortalId {
+    // None selects the unnamed portal
+    pub const UNNAMED: Self = PortalId(IdInner::UNNAMED);
+
+    pub const NAMED_START: Self = PortalId(IdInner::NAMED_START);
+
+    #[cfg(test)]
+    pub const TEST_VAL: Self = Self(IdInner::TEST_VAL);
+
+    const NAME_PREFIX: &'static str = "sqlx_p_";
+
+    /// If ID represents a named portal, return the next ID, wrapping on overflow.
+    ///
+    /// If this ID represents the unnamed portal, return the same.
+    pub fn next(&self) -> Self {
+        Self(self.0.next())
+    }
+
+    /// Calculate the number of bytes that will be written by [`Self::write_name()`].
+    pub fn name_len(&self) -> Saturating<usize> {
+        self.0.name_len(Self::NAME_PREFIX)
+    }
+
+    pub fn write_name<E>(&self, write: impl FnMut(&str) -> Result<(), E>) -> Result<(), E> {
+        self.0.write_name(Self::NAME_PREFIX, write)
+    }
+}
+
+impl IdInner {
+    const UNNAMED: Self = Self(None);
+
+    const NAMED_START: Self = Self(Some(NonZeroU32::MIN));
+
+    #[cfg(test)]
+    pub const TEST_VAL: Self = Self(NonZeroU32::new(1234567890));
+
+    #[inline(always)]
+    fn next(&self) -> Self {
+        Self(
+            self.0
+                .map(|id| id.checked_add(1).unwrap_or(NonZeroU32::MIN)),
+        )
+    }
+
+    #[inline(always)]
+    fn name_len(&self, name_prefix: &str) -> Saturating<usize> {
+        let mut len = Saturating(0);
+
+        if let Some(id) = self.0 {
+            len += name_prefix.len();
+            // estimate the length of the ID in decimal
+            // `.ilog10()` can't panic since the value is never zero
+            len += id.get().ilog10() as usize;
+            // add one to compensate for `ilog10()` rounding down.
+            len += 1;
+        }
+
+        // count the NUL terminator
+        len += 1;
+
+        len
+    }
+
+    #[inline(always)]
+    fn write_name<E>(
+        &self,
+        name_prefix: &str,
+        mut write: impl FnMut(&str) -> Result<(), E>,
+    ) -> Result<(), E> {
+        if let Some(id) = self.0 {
+            write(name_prefix)?;
+            write(itoa::Buffer::new().format(id.get()))?;
+        }
+
+        write("\0")?;
+
+        Ok(())
+    }
+}

--- a/sqlx-postgres/src/lib.rs
+++ b/sqlx-postgres/src/lib.rs
@@ -1,8 +1,4 @@
 //! **PostgreSQL** database driver.
-// https://github.com/launchbadge/sqlx/issues/3440
-#![deny(clippy::cast_possible_truncation)]
-#![deny(clippy::cast_possible_wrap)]
-#![deny(clippy::cast_sign_loss)]
 
 #[macro_use]
 extern crate sqlx_core;

--- a/sqlx-postgres/src/lib.rs
+++ b/sqlx-postgres/src/lib.rs
@@ -1,4 +1,6 @@
 //! **PostgreSQL** database driver.
+#![deny(clippy::cast_possible_truncation)]
+#![deny(clippy::cast_possible_wrap)]
 
 #[macro_use]
 extern crate sqlx_core;

--- a/sqlx-postgres/src/lib.rs
+++ b/sqlx-postgres/src/lib.rs
@@ -1,6 +1,8 @@
 //! **PostgreSQL** database driver.
+// https://github.com/launchbadge/sqlx/issues/3440
 #![deny(clippy::cast_possible_truncation)]
 #![deny(clippy::cast_possible_wrap)]
+#![deny(clippy::cast_sign_loss)]
 
 #[macro_use]
 extern crate sqlx_core;

--- a/sqlx-postgres/src/listener.rs
+++ b/sqlx-postgres/src/listener.rs
@@ -188,19 +188,17 @@ impl PgListener {
     /// # Example
     ///
     /// ```rust,no_run
-    /// # use sqlx_core::postgres::PgListener;
-    /// # use sqlx_core::error::Error;
+    /// # use sqlx::postgres::PgListener;
     /// #
-    /// # #[cfg(feature = "_rt")]
     /// # sqlx::__rt::test_block_on(async move {
-    /// # let mut listener = PgListener::connect("postgres:// ...").await?;
+    /// let mut listener = PgListener::connect("postgres:// ...").await?;
     /// loop {
     ///     // ask for next notification, re-connecting (transparently) if needed
     ///     let notification = listener.recv().await?;
     ///
     ///     // handle notification, do something interesting
     /// }
-    /// # Result::<(), Error>::Ok(())
+    /// # Result::<(), sqlx::Error>::Ok(())
     /// # }).unwrap();
     /// ```
     pub async fn recv(&mut self) -> Result<PgNotification, Error> {
@@ -219,10 +217,8 @@ impl PgListener {
     /// # Example
     ///
     /// ```rust,no_run
-    /// # use sqlx_core::postgres::PgListener;
-    /// # use sqlx_core::error::Error;
+    /// # use sqlx::postgres::PgListener;
     /// #
-    /// # #[cfg(feature = "_rt")]
     /// # sqlx::__rt::test_block_on(async move {
     /// # let mut listener = PgListener::connect("postgres:// ...").await?;
     /// loop {
@@ -233,7 +229,7 @@ impl PgListener {
     ///
     ///     // connection lost, do something interesting
     /// }
-    /// # Result::<(), Error>::Ok(())
+    /// # Result::<(), sqlx::Error>::Ok(())
     /// # }).unwrap();
     /// ```
     pub async fn try_recv(&mut self) -> Result<Option<PgNotification>, Error> {

--- a/sqlx-postgres/src/listener.rs
+++ b/sqlx-postgres/src/listener.rs
@@ -11,7 +11,7 @@ use sqlx_core::Either;
 use crate::describe::Describe;
 use crate::error::Error;
 use crate::executor::{Execute, Executor};
-use crate::message::{MessageFormat, Notification};
+use crate::message::{BackendMessageFormat, Notification};
 use crate::pool::PoolOptions;
 use crate::pool::{Pool, PoolConnection};
 use crate::{PgConnection, PgQueryResult, PgRow, PgStatement, PgTypeInfo, Postgres};
@@ -277,12 +277,12 @@ impl PgListener {
 
             match message.format {
                 // We've received an async notification, return it.
-                MessageFormat::NotificationResponse => {
+                BackendMessageFormat::NotificationResponse => {
                     return Ok(Some(PgNotification(message.decode()?)));
                 }
 
                 // Mark the connection as ready for another query
-                MessageFormat::ReadyForQuery => {
+                BackendMessageFormat::ReadyForQuery => {
                     self.connection().await?.pending_ready_for_query_count -= 1;
                 }
 

--- a/sqlx-postgres/src/message/bind.rs
+++ b/sqlx-postgres/src/message/bind.rs
@@ -1,15 +1,15 @@
-use crate::io::Encode;
-use crate::io::PgBufMutExt;
-use crate::types::Oid;
+use crate::io::{PgBufMutExt, PortalId, StatementId};
+use crate::message::{FrontendMessage, FrontendMessageFormat};
 use crate::PgValueFormat;
+use std::num::Saturating;
 
 #[derive(Debug)]
 pub struct Bind<'a> {
-    /// The ID of the destination portal (`None` selects the unnamed portal).
-    pub portal: Option<Oid>,
+    /// The ID of the destination portal (`PortalId::UNNAMED` selects the unnamed portal).
+    pub portal: PortalId,
 
     /// The id of the source prepared statement.
-    pub statement: Oid,
+    pub statement: StatementId,
 
     /// The parameter format codes. Each must presently be zero (text) or one (binary).
     ///
@@ -19,6 +19,8 @@ pub struct Bind<'a> {
     pub formats: &'a [PgValueFormat],
 
     /// The number of parameters.
+    ///
+    /// May be different from `formats.len()`
     pub num_params: i16,
 
     /// The value of each parameter, in the indicated format.
@@ -33,31 +35,59 @@ pub struct Bind<'a> {
     pub result_formats: &'a [PgValueFormat],
 }
 
-impl Encode<'_> for Bind<'_> {
-    fn encode_with(&self, buf: &mut Vec<u8>, _: ()) {
-        buf.push(b'B');
+impl FrontendMessage for Bind<'_> {
+    const FORMAT: FrontendMessageFormat = FrontendMessageFormat::Bind;
 
-        buf.put_length_prefixed(|buf| {
-            buf.put_portal_name(self.portal);
+    fn body_size_hint(&self) -> Saturating<usize> {
+        let mut size = Saturating(0);
+        size += self.portal.name_len();
+        size += self.statement.name_len();
 
-            buf.put_statement_name(self.statement);
+        // Parameter formats and length prefix
+        size += 2;
+        size += self.formats.len();
 
-            buf.extend(&(self.formats.len() as i16).to_be_bytes());
+        // `num_params`
+        size += 2;
 
-            for &format in self.formats {
-                buf.extend(&(format as i16).to_be_bytes());
-            }
+        size += self.params.len();
 
-            buf.extend(&self.num_params.to_be_bytes());
+        // Result formats and length prefix
+        size += 2;
+        size += self.result_formats.len();
 
-            buf.extend(self.params);
+        size
+    }
 
-            buf.extend(&(self.result_formats.len() as i16).to_be_bytes());
+    fn encode_body(&self, buf: &mut Vec<u8>) -> Result<(), crate::Error> {
+        buf.put_portal_name(self.portal);
 
-            for &format in self.result_formats {
-                buf.extend(&(format as i16).to_be_bytes());
-            }
-        });
+        buf.put_statement_name(self.statement);
+
+        let formats_len = i16::try_from(self.formats.len()).map_err(|_| {
+            err_protocol!("too many parameter format codes ({})", self.formats.len())
+        })?;
+
+        buf.extend(formats_len.to_be_bytes());
+
+        for &format in self.formats {
+            buf.extend((format as i16).to_be_bytes());
+        }
+
+        buf.extend(self.num_params.to_be_bytes());
+
+        buf.extend(self.params);
+
+        let result_formats_len = i16::try_from(self.formats.len())
+            .map_err(|_| err_protocol!("too many result format codes ({})", self.formats.len()))?;
+
+        buf.extend(result_formats_len.to_be_bytes());
+
+        for &format in self.result_formats {
+            buf.extend((format as i16).to_be_bytes());
+        }
+
+        Ok(())
     }
 }
 

--- a/sqlx-postgres/src/message/describe.rs
+++ b/sqlx-postgres/src/message/describe.rs
@@ -1,127 +1,103 @@
-use crate::io::Encode;
-use crate::io::PgBufMutExt;
-use crate::types::Oid;
+use crate::io::{PgBufMutExt, PortalId, StatementId};
+use crate::message::{FrontendMessage, FrontendMessageFormat};
+use sqlx_core::Error;
+use std::num::Saturating;
 
 const DESCRIBE_PORTAL: u8 = b'P';
 const DESCRIBE_STATEMENT: u8 = b'S';
 
-// [Describe] will emit both a [RowDescription] and a [ParameterDescription] message
-
+/// Note: will emit both a RowDescription and a ParameterDescription message
 #[derive(Debug)]
 #[allow(dead_code)]
 pub enum Describe {
-    UnnamedStatement,
-    Statement(Oid),
-
-    UnnamedPortal,
-    Portal(Oid),
+    Statement(StatementId),
+    Portal(PortalId),
 }
 
-impl Encode<'_> for Describe {
-    fn encode_with(&self, buf: &mut Vec<u8>, _: ()) {
-        // 15 bytes for 1-digit statement/portal IDs
-        buf.reserve(20);
-        buf.push(b'D');
+impl FrontendMessage for Describe {
+    const FORMAT: FrontendMessageFormat = FrontendMessageFormat::Describe;
 
-        buf.put_length_prefixed(|buf| {
-            match self {
-                // #[likely]
-                Describe::Statement(id) => {
-                    buf.push(DESCRIBE_STATEMENT);
-                    buf.put_statement_name(*id);
-                }
+    fn body_size_hint(&self) -> Saturating<usize> {
+        // Either `DESCRIBE_PORTAL` or `DESCRIBE_STATEMENT`
+        let mut size = Saturating(1);
 
-                Describe::UnnamedPortal => {
-                    buf.push(DESCRIBE_PORTAL);
-                    buf.push(0);
-                }
+        match self {
+            Describe::Statement(id) => size += id.name_len(),
+            Describe::Portal(id) => size += id.name_len(),
+        }
 
-                Describe::UnnamedStatement => {
-                    buf.push(DESCRIBE_STATEMENT);
-                    buf.push(0);
-                }
+        size
+    }
 
-                Describe::Portal(id) => {
-                    buf.push(DESCRIBE_PORTAL);
-                    buf.put_portal_name(Some(*id));
-                }
+    fn encode_body(&self, buf: &mut Vec<u8>) -> Result<(), Error> {
+        match self {
+            // #[likely]
+            Describe::Statement(id) => {
+                buf.push(DESCRIBE_STATEMENT);
+                buf.put_statement_name(*id);
             }
-        });
+
+            Describe::Portal(id) => {
+                buf.push(DESCRIBE_PORTAL);
+                buf.put_portal_name(*id);
+            }
+        }
+
+        Ok(())
     }
 }
 
-#[test]
-fn test_encode_describe_portal() {
-    const EXPECTED: &[u8] = b"D\0\0\0\x0EPsqlx_p_5\0";
+#[cfg(test)]
+mod tests {
+    use crate::message::FrontendMessage;
 
-    let mut buf = Vec::new();
-    let m = Describe::Portal(Oid(5));
+    use super::{Describe, PortalId, StatementId};
 
-    m.encode(&mut buf);
+    #[test]
+    fn test_encode_describe_portal() {
+        const EXPECTED: &[u8] = b"D\0\0\0\x17Psqlx_p_1234567890\0";
 
-    assert_eq!(buf, EXPECTED);
-}
+        let mut buf = Vec::new();
+        let m = Describe::Portal(PortalId::TEST_VAL);
 
-#[test]
-fn test_encode_describe_unnamed_portal() {
-    const EXPECTED: &[u8] = b"D\0\0\0\x06P\0";
+        m.encode_msg(&mut buf).unwrap();
 
-    let mut buf = Vec::new();
-    let m = Describe::UnnamedPortal;
+        assert_eq!(buf, EXPECTED);
+    }
 
-    m.encode(&mut buf);
+    #[test]
+    fn test_encode_describe_unnamed_portal() {
+        const EXPECTED: &[u8] = b"D\0\0\0\x06P\0";
 
-    assert_eq!(buf, EXPECTED);
-}
+        let mut buf = Vec::new();
+        let m = Describe::Portal(PortalId::UNNAMED);
 
-#[test]
-fn test_encode_describe_statement() {
-    const EXPECTED: &[u8] = b"D\0\0\0\x0ESsqlx_s_5\0";
+        m.encode_msg(&mut buf).unwrap();
 
-    let mut buf = Vec::new();
-    let m = Describe::Statement(Oid(5));
+        assert_eq!(buf, EXPECTED);
+    }
 
-    m.encode(&mut buf);
+    #[test]
+    fn test_encode_describe_statement() {
+        const EXPECTED: &[u8] = b"D\0\0\0\x17Ssqlx_s_1234567890\0";
 
-    assert_eq!(buf, EXPECTED);
-}
+        let mut buf = Vec::new();
+        let m = Describe::Statement(StatementId::TEST_VAL);
 
-#[test]
-fn test_encode_describe_unnamed_statement() {
-    const EXPECTED: &[u8] = b"D\0\0\0\x06S\0";
+        m.encode_msg(&mut buf).unwrap();
 
-    let mut buf = Vec::new();
-    let m = Describe::UnnamedStatement;
+        assert_eq!(buf, EXPECTED);
+    }
 
-    m.encode(&mut buf);
+    #[test]
+    fn test_encode_describe_unnamed_statement() {
+        const EXPECTED: &[u8] = b"D\0\0\0\x06S\0";
 
-    assert_eq!(buf, EXPECTED);
-}
+        let mut buf = Vec::new();
+        let m = Describe::Statement(StatementId::UNNAMED);
 
-#[cfg(all(test, not(debug_assertions)))]
-#[bench]
-fn bench_encode_describe_portal(b: &mut test::Bencher) {
-    use test::black_box;
+        m.encode_msg(&mut buf).unwrap();
 
-    let mut buf = Vec::with_capacity(128);
-
-    b.iter(|| {
-        buf.clear();
-
-        black_box(Describe::Portal(5)).encode(&mut buf);
-    });
-}
-
-#[cfg(all(test, not(debug_assertions)))]
-#[bench]
-fn bench_encode_describe_unnamed_statement(b: &mut test::Bencher) {
-    use test::black_box;
-
-    let mut buf = Vec::with_capacity(128);
-
-    b.iter(|| {
-        buf.clear();
-
-        black_box(Describe::UnnamedStatement).encode(&mut buf);
-    });
+        assert_eq!(buf, EXPECTED);
+    }
 }

--- a/sqlx-postgres/src/message/execute.rs
+++ b/sqlx-postgres/src/message/execute.rs
@@ -1,39 +1,73 @@
-use crate::io::Encode;
-use crate::io::PgBufMutExt;
-use crate::types::Oid;
+use std::num::Saturating;
+
+use sqlx_core::Error;
+
+use crate::io::{PgBufMutExt, PortalId};
+use crate::message::{FrontendMessage, FrontendMessageFormat};
 
 pub struct Execute {
-    /// The id of the portal to execute (`None` selects the unnamed portal).
-    pub portal: Option<Oid>,
+    /// The id of the portal to execute.
+    pub portal: PortalId,
 
     /// Maximum number of rows to return, if portal contains a query
     /// that returns rows (ignored otherwise). Zero denotes “no limit”.
     pub limit: u32,
 }
 
-impl Encode<'_> for Execute {
-    fn encode_with(&self, buf: &mut Vec<u8>, _: ()) {
-        buf.reserve(20);
-        buf.push(b'E');
+impl FrontendMessage for Execute {
+    const FORMAT: FrontendMessageFormat = FrontendMessageFormat::Execute;
 
-        buf.put_length_prefixed(|buf| {
-            buf.put_portal_name(self.portal);
-            buf.extend(&self.limit.to_be_bytes());
-        });
+    fn body_size_hint(&self) -> Saturating<usize> {
+        let mut size = Saturating(0);
+
+        size += self.portal.name_len();
+        size += 2; // limit
+
+        size
+    }
+
+    fn encode_body(&self, buf: &mut Vec<u8>) -> Result<(), Error> {
+        buf.put_portal_name(self.portal);
+        buf.extend(&self.limit.to_be_bytes());
+
+        Ok(())
     }
 }
 
-#[test]
-fn test_encode_execute() {
-    const EXPECTED: &[u8] = b"E\0\0\0\x11sqlx_p_5\0\0\0\0\x02";
+#[cfg(test)]
+mod tests {
+    use crate::io::PortalId;
+    use crate::message::FrontendMessage;
 
-    let mut buf = Vec::new();
-    let m = Execute {
-        portal: Some(Oid(5)),
-        limit: 2,
-    };
+    use super::Execute;
 
-    m.encode(&mut buf);
+    #[test]
+    fn test_encode_execute_named_portal() {
+        const EXPECTED: &[u8] = b"E\0\0\0\x1Asqlx_p_1234567890\0\0\0\0\x02";
 
-    assert_eq!(buf, EXPECTED);
+        let mut buf = Vec::new();
+        let m = Execute {
+            portal: PortalId::TEST_VAL,
+            limit: 2,
+        };
+
+        m.encode_msg(&mut buf).unwrap();
+
+        assert_eq!(buf, EXPECTED);
+    }
+
+    #[test]
+    fn test_encode_execute_unnamed_portal() {
+        const EXPECTED: &[u8] = b"E\0\0\0\x09\0\x49\x96\x02\xD2";
+
+        let mut buf = Vec::new();
+        let m = Execute {
+            portal: PortalId::UNNAMED,
+            limit: 1234567890,
+        };
+
+        m.encode_msg(&mut buf).unwrap();
+
+        assert_eq!(buf, EXPECTED);
+    }
 }

--- a/sqlx-postgres/src/message/flush.rs
+++ b/sqlx-postgres/src/message/flush.rs
@@ -1,17 +1,25 @@
-use crate::io::Encode;
+use crate::message::{FrontendMessage, FrontendMessageFormat};
+use sqlx_core::Error;
+use std::num::Saturating;
 
-// The Flush message does not cause any specific output to be generated,
-// but forces the backend to deliver any data pending in its output buffers.
-
-// A Flush must be sent after any extended-query command except Sync, if the
-// frontend wishes to examine the results of that command before issuing more commands.
-
+/// The Flush message does not cause any specific output to be generated,
+/// but forces the backend to deliver any data pending in its output buffers.
+///
+/// A Flush must be sent after any extended-query command except Sync, if the
+/// frontend wishes to examine the results of that command before issuing more commands.
 #[derive(Debug)]
 pub struct Flush;
 
-impl Encode<'_> for Flush {
-    fn encode_with(&self, buf: &mut Vec<u8>, _: ()) {
-        buf.push(b'H');
-        buf.extend(&4_i32.to_be_bytes());
+impl FrontendMessage for Flush {
+    const FORMAT: FrontendMessageFormat = FrontendMessageFormat::Flush;
+
+    #[inline(always)]
+    fn body_size_hint(&self) -> Saturating<usize> {
+        Saturating(0)
+    }
+
+    #[inline(always)]
+    fn encode_body(&self, _buf: &mut Vec<u8>) -> Result<(), Error> {
+        Ok(())
     }
 }

--- a/sqlx-postgres/src/message/mod.rs
+++ b/sqlx-postgres/src/message/mod.rs
@@ -1,7 +1,8 @@
 use sqlx_core::bytes::Bytes;
+use std::num::Saturating;
 
 use crate::error::Error;
-use crate::io::Decode;
+use crate::io::PgBufMutExt;
 
 mod authentication;
 mod backend_key_data;
@@ -17,6 +18,7 @@ mod notification;
 mod parameter_description;
 mod parameter_status;
 mod parse;
+mod parse_complete;
 mod password;
 mod query;
 mod ready_for_query;
@@ -33,7 +35,7 @@ pub use backend_key_data::BackendKeyData;
 pub use bind::Bind;
 pub use close::Close;
 pub use command_complete::CommandComplete;
-pub use copy::{CopyData, CopyDone, CopyFail, CopyResponse};
+pub use copy::{CopyData, CopyDone, CopyFail, CopyInResponse, CopyOutResponse, CopyResponseData};
 pub use data_row::DataRow;
 pub use describe::Describe;
 pub use execute::Execute;
@@ -43,20 +45,51 @@ pub use notification::Notification;
 pub use parameter_description::ParameterDescription;
 pub use parameter_status::ParameterStatus;
 pub use parse::Parse;
+pub use parse_complete::ParseComplete;
 pub use password::Password;
 pub use query::Query;
 pub use ready_for_query::{ReadyForQuery, TransactionStatus};
 pub use response::{Notice, PgSeverity};
 pub use row_description::RowDescription;
 pub use sasl::{SaslInitialResponse, SaslResponse};
+use sqlx_core::io::ProtocolEncode;
 pub use ssl_request::SslRequest;
 pub use startup::Startup;
 pub use sync::Sync;
 pub use terminate::Terminate;
 
+// Note: we can't use the same enum for both frontend and backend message formats
+// because there are duplicated format codes between them.
+//
+// For example, `Close` (frontend) and `CommandComplete` (backend) both use format code `C`.
+// <https://www.postgresql.org/docs/current/protocol-message-formats.html>
 #[derive(Debug, PartialOrd, PartialEq)]
 #[repr(u8)]
-pub enum MessageFormat {
+pub enum FrontendMessageFormat {
+    Bind = b'B',
+    Close = b'C',
+    CopyData = b'd',
+    CopyDone = b'c',
+    CopyFail = b'f',
+    Describe = b'D',
+    Execute = b'E',
+    Flush = b'H',
+    Parse = b'P',
+    /// This message format is polymorphic. It's used for:
+    ///
+    /// * Plain password responses
+    /// * MD5 password responses
+    /// * SASL responses
+    /// * GSSAPI/SSPI responses
+    PasswordPolymorphic = b'p',
+    Query = b'Q',
+    Sync = b'S',
+    Terminate = b'X',
+}
+
+#[derive(Debug, PartialOrd, PartialEq)]
+#[repr(u8)]
+pub enum BackendMessageFormat {
     Authentication,
     BackendKeyData,
     BindComplete,
@@ -81,49 +114,116 @@ pub enum MessageFormat {
 }
 
 #[derive(Debug)]
-pub struct Message {
-    pub format: MessageFormat,
+pub struct ReceivedMessage {
+    pub format: BackendMessageFormat,
     pub contents: Bytes,
 }
 
-impl Message {
+impl ReceivedMessage {
     #[inline]
-    pub fn decode<'de, T>(self) -> Result<T, Error>
+    pub fn decode<T>(self) -> Result<T, Error>
     where
-        T: Decode<'de>,
+        T: BackendMessage,
     {
-        T::decode(self.contents)
+        if T::FORMAT != self.format {
+            return Err(err_protocol!(
+                "Postgres protocol error: expected {:?}, got {:?}",
+                T::FORMAT,
+                self.format
+            ));
+        }
+
+        T::decode_body(self.contents).map_err(|e| match e {
+            Error::Protocol(s) => {
+                err_protocol!("Postgres protocol error (reading {:?}): {s}", self.format)
+            }
+            other => other,
+        })
     }
 }
 
-impl MessageFormat {
+impl BackendMessageFormat {
     pub fn try_from_u8(v: u8) -> Result<Self, Error> {
         // https://www.postgresql.org/docs/current/protocol-message-formats.html
 
         Ok(match v {
-            b'1' => MessageFormat::ParseComplete,
-            b'2' => MessageFormat::BindComplete,
-            b'3' => MessageFormat::CloseComplete,
-            b'C' => MessageFormat::CommandComplete,
-            b'd' => MessageFormat::CopyData,
-            b'c' => MessageFormat::CopyDone,
-            b'G' => MessageFormat::CopyInResponse,
-            b'H' => MessageFormat::CopyOutResponse,
-            b'D' => MessageFormat::DataRow,
-            b'E' => MessageFormat::ErrorResponse,
-            b'I' => MessageFormat::EmptyQueryResponse,
-            b'A' => MessageFormat::NotificationResponse,
-            b'K' => MessageFormat::BackendKeyData,
-            b'N' => MessageFormat::NoticeResponse,
-            b'R' => MessageFormat::Authentication,
-            b'S' => MessageFormat::ParameterStatus,
-            b'T' => MessageFormat::RowDescription,
-            b'Z' => MessageFormat::ReadyForQuery,
-            b'n' => MessageFormat::NoData,
-            b's' => MessageFormat::PortalSuspended,
-            b't' => MessageFormat::ParameterDescription,
+            b'1' => BackendMessageFormat::ParseComplete,
+            b'2' => BackendMessageFormat::BindComplete,
+            b'3' => BackendMessageFormat::CloseComplete,
+            b'C' => BackendMessageFormat::CommandComplete,
+            b'd' => BackendMessageFormat::CopyData,
+            b'c' => BackendMessageFormat::CopyDone,
+            b'G' => BackendMessageFormat::CopyInResponse,
+            b'H' => BackendMessageFormat::CopyOutResponse,
+            b'D' => BackendMessageFormat::DataRow,
+            b'E' => BackendMessageFormat::ErrorResponse,
+            b'I' => BackendMessageFormat::EmptyQueryResponse,
+            b'A' => BackendMessageFormat::NotificationResponse,
+            b'K' => BackendMessageFormat::BackendKeyData,
+            b'N' => BackendMessageFormat::NoticeResponse,
+            b'R' => BackendMessageFormat::Authentication,
+            b'S' => BackendMessageFormat::ParameterStatus,
+            b'T' => BackendMessageFormat::RowDescription,
+            b'Z' => BackendMessageFormat::ReadyForQuery,
+            b'n' => BackendMessageFormat::NoData,
+            b's' => BackendMessageFormat::PortalSuspended,
+            b't' => BackendMessageFormat::ParameterDescription,
 
             _ => return Err(err_protocol!("unknown message type: {:?}", v as char)),
         })
+    }
+}
+
+pub(crate) trait FrontendMessage: Sized {
+    /// The format prefix of this message.
+    const FORMAT: FrontendMessageFormat;
+
+    /// Return the amount of space, in bytes, to reserve in the buffer passed to [`Self::encode_body()`].
+    fn body_size_hint(&self) -> Saturating<usize>;
+
+    /// Encode this type as a Frontend message in the Postgres protocol.
+    ///
+    /// The implementation should *not* include `Self::FORMAT` or the length prefix.
+    fn encode_body(&self, buf: &mut Vec<u8>) -> Result<(), Error>;
+
+    #[inline(always)]
+    #[cfg_attr(not(test), allow(dead_code))]
+    fn encode_msg(self, buf: &mut Vec<u8>) -> Result<(), Error> {
+        EncodeMessage(self).encode(buf)
+    }
+}
+
+pub(crate) trait BackendMessage: Sized {
+    /// The expected message format.
+    ///
+    /// <https://www.postgresql.org/docs/current/protocol-message-formats.html>
+    const FORMAT: BackendMessageFormat;
+
+    /// Decode this type from a Backend message in the Postgres protocol.
+    ///
+    /// The format code and length prefix have already been read and are not at the start of `bytes`.
+    fn decode_body(buf: Bytes) -> Result<Self, Error>;
+}
+
+pub struct EncodeMessage<F>(pub F);
+
+impl<F: FrontendMessage> ProtocolEncode<'_, ()> for EncodeMessage<F> {
+    fn encode_with(&self, buf: &mut Vec<u8>, _context: ()) -> Result<(), Error> {
+        let mut size_hint = self.0.body_size_hint();
+        // plus format code and length prefix
+        size_hint += 5;
+
+        // don't panic if `size_hint` is ridiculous
+        buf.try_reserve(size_hint.0).map_err(|e| {
+            err_protocol!(
+                "Postgres protocol: error allocating {} bytes for encoding message {:?}: {e}",
+                size_hint.0,
+                F::FORMAT,
+            )
+        })?;
+
+        buf.push(F::FORMAT as u8);
+
+        buf.put_length_prefixed(|buf| self.0.encode_body(buf))
     }
 }

--- a/sqlx-postgres/src/message/notification.rs
+++ b/sqlx-postgres/src/message/notification.rs
@@ -1,7 +1,8 @@
 use sqlx_core::bytes::{Buf, Bytes};
 
 use crate::error::Error;
-use crate::io::{BufExt, Decode};
+use crate::io::BufExt;
+use crate::message::{BackendMessage, BackendMessageFormat};
 
 #[derive(Debug)]
 pub struct Notification {
@@ -10,9 +11,10 @@ pub struct Notification {
     pub(crate) payload: Bytes,
 }
 
-impl Decode<'_> for Notification {
-    #[inline]
-    fn decode_with(mut buf: Bytes, _: ()) -> Result<Self, Error> {
+impl BackendMessage for Notification {
+    const FORMAT: BackendMessageFormat = BackendMessageFormat::NotificationResponse;
+
+    fn decode_body(mut buf: Bytes) -> Result<Self, Error> {
         let process_id = buf.get_u32();
         let channel = buf.get_bytes_nul()?;
         let payload = buf.get_bytes_nul()?;
@@ -29,7 +31,7 @@ impl Decode<'_> for Notification {
 fn test_decode_notification_response() {
     const NOTIFICATION_RESPONSE: &[u8] = b"\x34\x20\x10\x02TEST-CHANNEL\0THIS IS A TEST\0";
 
-    let message = Notification::decode(Bytes::from(NOTIFICATION_RESPONSE)).unwrap();
+    let message = Notification::decode_body(Bytes::from(NOTIFICATION_RESPONSE)).unwrap();
 
     assert_eq!(message.process_id, 0x34201002);
     assert_eq!(&*message.channel, &b"TEST-CHANNEL"[..]);

--- a/sqlx-postgres/src/message/parameter_description.rs
+++ b/sqlx-postgres/src/message/parameter_description.rs
@@ -2,7 +2,7 @@ use smallvec::SmallVec;
 use sqlx_core::bytes::{Buf, Bytes};
 
 use crate::error::Error;
-use crate::io::Decode;
+use crate::message::{BackendMessage, BackendMessageFormat};
 use crate::types::Oid;
 
 #[derive(Debug)]
@@ -10,8 +10,10 @@ pub struct ParameterDescription {
     pub types: SmallVec<[Oid; 6]>,
 }
 
-impl Decode<'_> for ParameterDescription {
-    fn decode_with(mut buf: Bytes, _: ()) -> Result<Self, Error> {
+impl BackendMessage for ParameterDescription {
+    const FORMAT: BackendMessageFormat = BackendMessageFormat::ParameterDescription;
+
+    fn decode_body(mut buf: Bytes) -> Result<Self, Error> {
         let cnt = buf.get_u16();
         let mut types = SmallVec::with_capacity(cnt as usize);
 
@@ -27,7 +29,7 @@ impl Decode<'_> for ParameterDescription {
 fn test_decode_parameter_description() {
     const DATA: &[u8] = b"\x00\x02\x00\x00\x00\x00\x00\x00\x05\x00";
 
-    let m = ParameterDescription::decode(DATA.into()).unwrap();
+    let m = ParameterDescription::decode_body(DATA.into()).unwrap();
 
     assert_eq!(m.types.len(), 2);
     assert_eq!(m.types[0], Oid(0x0000_0000));
@@ -38,7 +40,7 @@ fn test_decode_parameter_description() {
 fn test_decode_empty_parameter_description() {
     const DATA: &[u8] = b"\x00\x00";
 
-    let m = ParameterDescription::decode(DATA.into()).unwrap();
+    let m = ParameterDescription::decode_body(DATA.into()).unwrap();
 
     assert!(m.types.is_empty());
 }
@@ -49,6 +51,6 @@ fn bench_decode_parameter_description(b: &mut test::Bencher) {
     const DATA: &[u8] = b"\x00\x02\x00\x00\x00\x00\x00\x00\x05\x00";
 
     b.iter(|| {
-        ParameterDescription::decode(test::black_box(Bytes::from_static(DATA))).unwrap();
+        ParameterDescription::decode_body(test::black_box(Bytes::from_static(DATA))).unwrap();
     });
 }

--- a/sqlx-postgres/src/message/parse.rs
+++ b/sqlx-postgres/src/message/parse.rs
@@ -1,11 +1,14 @@
-use crate::io::PgBufMutExt;
-use crate::io::{BufMutExt, Encode};
+use crate::io::BufMutExt;
+use crate::io::{PgBufMutExt, StatementId};
+use crate::message::{FrontendMessage, FrontendMessageFormat};
 use crate::types::Oid;
+use sqlx_core::Error;
+use std::num::Saturating;
 
 #[derive(Debug)]
 pub struct Parse<'a> {
     /// The ID of the destination prepared statement.
-    pub statement: Oid,
+    pub statement: StatementId,
 
     /// The query string to be parsed.
     pub query: &'a str,
@@ -16,39 +19,59 @@ pub struct Parse<'a> {
     pub param_types: &'a [Oid],
 }
 
-impl Encode<'_> for Parse<'_> {
-    fn encode_with(&self, buf: &mut Vec<u8>, _: ()) {
-        buf.push(b'P');
+impl FrontendMessage for Parse<'_> {
+    const FORMAT: FrontendMessageFormat = FrontendMessageFormat::Parse;
 
-        buf.put_length_prefixed(|buf| {
-            buf.put_statement_name(self.statement);
+    fn body_size_hint(&self) -> Saturating<usize> {
+        let mut size = Saturating(0);
 
-            buf.put_str_nul(self.query);
+        size += self.statement.name_len();
 
-            // TODO: Return an error here instead
-            assert!(self.param_types.len() <= (u16::MAX as usize));
+        size += self.query.len();
+        size += 1; // NUL terminator
 
-            buf.extend(&(self.param_types.len() as i16).to_be_bytes());
+        size += 2; // param_types_len
 
-            for &oid in self.param_types {
-                buf.extend(&oid.0.to_be_bytes());
-            }
-        })
+        // `param_types`
+        size += self.param_types.len().saturating_mul(4);
+
+        size
+    }
+
+    fn encode_body(&self, buf: &mut Vec<u8>) -> Result<(), Error> {
+        buf.put_statement_name(self.statement);
+
+        buf.put_str_nul(self.query);
+
+        let param_types_len = i16::try_from(self.param_types.len()).map_err(|_| {
+            err_protocol!(
+                "param_types.len() too large for binary protocol: {}",
+                self.param_types.len()
+            )
+        })?;
+
+        buf.extend(param_types_len.to_be_bytes());
+
+        for &oid in self.param_types {
+            buf.extend(oid.0.to_be_bytes());
+        }
+
+        Ok(())
     }
 }
 
 #[test]
 fn test_encode_parse() {
-    const EXPECTED: &[u8] = b"P\0\0\0\x1dsqlx_s_1\0SELECT $1\0\0\x01\0\0\0\x19";
+    const EXPECTED: &[u8] = b"P\0\0\0\x26sqlx_s_1234567890\0SELECT $1\0\0\x01\0\0\0\x19";
 
     let mut buf = Vec::new();
     let m = Parse {
-        statement: Oid(1),
+        statement: StatementId::TEST_VAL,
         query: "SELECT $1",
         param_types: &[Oid(25)],
     };
 
-    m.encode(&mut buf);
+    m.encode_msg(&mut buf).unwrap();
 
     assert_eq!(buf, EXPECTED);
 }

--- a/sqlx-postgres/src/message/parse_complete.rs
+++ b/sqlx-postgres/src/message/parse_complete.rs
@@ -1,0 +1,13 @@
+use crate::message::{BackendMessage, BackendMessageFormat};
+use sqlx_core::bytes::Bytes;
+use sqlx_core::Error;
+
+pub struct ParseComplete;
+
+impl BackendMessage for ParseComplete {
+    const FORMAT: BackendMessageFormat = BackendMessageFormat::ParseComplete;
+
+    fn decode_body(_bytes: Bytes) -> Result<Self, Error> {
+        Ok(ParseComplete)
+    }
+}

--- a/sqlx-postgres/src/message/password.rs
+++ b/sqlx-postgres/src/message/password.rs
@@ -1,9 +1,9 @@
-use std::fmt::Write;
-
+use crate::io::BufMutExt;
+use crate::message::{FrontendMessage, FrontendMessageFormat};
 use md5::{Digest, Md5};
-
-use crate::io::PgBufMutExt;
-use crate::io::{BufMutExt, Encode};
+use sqlx_core::Error;
+use std::fmt::Write;
+use std::num::Saturating;
 
 #[derive(Debug)]
 pub enum Password<'a> {
@@ -16,117 +16,138 @@ pub enum Password<'a> {
     },
 }
 
-impl Password<'_> {
-    #[inline]
-    fn len(&self) -> usize {
+impl FrontendMessage for Password<'_> {
+    const FORMAT: FrontendMessageFormat = FrontendMessageFormat::PasswordPolymorphic;
+
+    #[inline(always)]
+    fn body_size_hint(&self) -> Saturating<usize> {
+        let mut size = Saturating(0);
+
         match self {
-            Password::Cleartext(s) => s.len() + 5,
-            Password::Md5 { .. } => 35 + 5,
-        }
-    }
-}
-
-impl Encode<'_> for Password<'_> {
-    fn encode_with(&self, buf: &mut Vec<u8>, _: ()) {
-        buf.reserve(1 + 4 + self.len());
-        buf.push(b'p');
-
-        buf.put_length_prefixed(|buf| {
-            match self {
-                Password::Cleartext(password) => {
-                    buf.put_str_nul(password);
-                }
-
-                Password::Md5 {
-                    username,
-                    password,
-                    salt,
-                } => {
-                    // The actual `PasswordMessage` can be computed in SQL as
-                    // `concat('md5', md5(concat(md5(concat(password, username)), random-salt)))`.
-
-                    // Keep in mind the md5() function returns its result as a hex string.
-
-                    let mut hasher = Md5::new();
-
-                    hasher.update(password);
-                    hasher.update(username);
-
-                    let mut output = String::with_capacity(35);
-
-                    let _ = write!(output, "{:x}", hasher.finalize_reset());
-
-                    hasher.update(&output);
-                    hasher.update(salt);
-
-                    output.clear();
-
-                    let _ = write!(output, "md5{:x}", hasher.finalize());
-
-                    buf.put_str_nul(&output);
-                }
+            Password::Cleartext(password) => {
+                // To avoid reporting the exact password length anywhere,
+                // we deliberately give a bad estimate.
+                //
+                // This shouldn't affect performance in the long run.
+                size += password
+                    .len()
+                    .saturating_add(1) // NUL terminator
+                    .checked_next_power_of_two()
+                    .unwrap_or(usize::MAX);
             }
-        });
+            Password::Md5 { .. } => {
+                // "md5<32 hex chars>\0"
+                size += 36;
+            }
+        }
+
+        size
+    }
+
+    fn encode_body(&self, buf: &mut Vec<u8>) -> Result<(), Error> {
+        match self {
+            Password::Cleartext(password) => {
+                buf.put_str_nul(password);
+            }
+
+            Password::Md5 {
+                username,
+                password,
+                salt,
+            } => {
+                // The actual `PasswordMessage` can be computed in SQL as
+                // `concat('md5', md5(concat(md5(concat(password, username)), random-salt)))`.
+
+                // Keep in mind the md5() function returns its result as a hex string.
+
+                let mut hasher = Md5::new();
+
+                hasher.update(password);
+                hasher.update(username);
+
+                let mut output = String::with_capacity(35);
+
+                let _ = write!(output, "{:x}", hasher.finalize_reset());
+
+                hasher.update(&output);
+                hasher.update(salt);
+
+                output.clear();
+
+                let _ = write!(output, "md5{:x}", hasher.finalize());
+
+                buf.put_str_nul(&output);
+            }
+        }
+
+        Ok(())
     }
 }
 
-#[test]
-fn test_encode_clear_password() {
-    const EXPECTED: &[u8] = b"p\0\0\0\rpassword\0";
+#[cfg(test)]
+mod tests {
+    use crate::message::FrontendMessage;
 
-    let mut buf = Vec::new();
-    let m = Password::Cleartext("password");
+    use super::Password;
 
-    m.encode(&mut buf);
+    #[test]
+    fn test_encode_clear_password() {
+        const EXPECTED: &[u8] = b"p\0\0\0\rpassword\0";
 
-    assert_eq!(buf, EXPECTED);
-}
+        let mut buf = Vec::new();
+        let m = Password::Cleartext("password");
 
-#[test]
-fn test_encode_md5_password() {
-    const EXPECTED: &[u8] = b"p\0\0\0(md53e2c9d99d49b201ef867a36f3f9ed62c\0";
+        m.encode_msg(&mut buf).unwrap();
 
-    let mut buf = Vec::new();
-    let m = Password::Md5 {
-        password: "password",
-        username: "root",
-        salt: [147, 24, 57, 152],
-    };
+        assert_eq!(buf, EXPECTED);
+    }
 
-    m.encode(&mut buf);
+    #[test]
+    fn test_encode_md5_password() {
+        const EXPECTED: &[u8] = b"p\0\0\0(md53e2c9d99d49b201ef867a36f3f9ed62c\0";
 
-    assert_eq!(buf, EXPECTED);
-}
-
-#[cfg(all(test, not(debug_assertions)))]
-#[bench]
-fn bench_encode_clear_password(b: &mut test::Bencher) {
-    use test::black_box;
-
-    let mut buf = Vec::with_capacity(128);
-
-    b.iter(|| {
-        buf.clear();
-
-        black_box(Password::Cleartext("password")).encode(&mut buf);
-    });
-}
-
-#[cfg(all(test, not(debug_assertions)))]
-#[bench]
-fn bench_encode_md5_password(b: &mut test::Bencher) {
-    use test::black_box;
-
-    let mut buf = Vec::with_capacity(128);
-
-    b.iter(|| {
-        buf.clear();
-
-        black_box(Password::Md5 {
+        let mut buf = Vec::new();
+        let m = Password::Md5 {
             password: "password",
             username: "root",
             salt: [147, 24, 57, 152],
-        })
-        .encode(&mut buf);
-    });
+        };
+
+        m.encode_msg(&mut buf).unwrap();
+
+        assert_eq!(buf, EXPECTED);
+    }
+
+    #[cfg(all(test, not(debug_assertions)))]
+    #[bench]
+    fn bench_encode_clear_password(b: &mut test::Bencher) {
+        use test::black_box;
+
+        let mut buf = Vec::with_capacity(128);
+
+        b.iter(|| {
+            buf.clear();
+
+            black_box(Password::Cleartext("password")).encode_msg(&mut buf);
+        });
+    }
+
+    #[cfg(all(test, not(debug_assertions)))]
+    #[bench]
+    fn bench_encode_md5_password(b: &mut test::Bencher) {
+        use test::black_box;
+
+        let mut buf = Vec::with_capacity(128);
+
+        b.iter(|| {
+            buf.clear();
+
+            black_box(Password::Md5 {
+                password: "password",
+                username: "root",
+                salt: [147, 24, 57, 152],
+            })
+            .encode_msg(&mut buf);
+        });
+    }
 }

--- a/sqlx-postgres/src/message/query.rs
+++ b/sqlx-postgres/src/message/query.rs
@@ -1,27 +1,37 @@
-use crate::io::{BufMutExt, Encode};
+use crate::io::BufMutExt;
+use crate::message::{FrontendMessage, FrontendMessageFormat};
+use sqlx_core::Error;
+use std::num::Saturating;
 
 #[derive(Debug)]
 pub struct Query<'a>(pub &'a str);
 
-impl Encode<'_> for Query<'_> {
-    fn encode_with(&self, buf: &mut Vec<u8>, _: ()) {
-        let len = 4 + self.0.len() + 1;
+impl FrontendMessage for Query<'_> {
+    const FORMAT: FrontendMessageFormat = FrontendMessageFormat::Query;
 
-        buf.reserve(len + 1);
-        buf.push(b'Q');
-        buf.extend(&(len as i32).to_be_bytes());
+    fn body_size_hint(&self) -> Saturating<usize> {
+        let mut size = Saturating(0);
+
+        size += self.0.len();
+        size += 1; // NUL terminator
+
+        size
+    }
+
+    fn encode_body(&self, buf: &mut Vec<u8>) -> Result<(), Error> {
         buf.put_str_nul(self.0);
+        Ok(())
     }
 }
 
 #[test]
 fn test_encode_query() {
-    const EXPECTED: &[u8] = b"Q\0\0\0\rSELECT 1\0";
+    const EXPECTED: &[u8] = b"Q\0\0\0\x0DSELECT 1\0";
 
     let mut buf = Vec::new();
     let m = Query("SELECT 1");
 
-    m.encode(&mut buf);
+    m.encode_msg(&mut buf).unwrap();
 
     assert_eq!(buf, EXPECTED);
 }

--- a/sqlx-postgres/src/message/row_description.rs
+++ b/sqlx-postgres/src/message/row_description.rs
@@ -1,7 +1,8 @@
 use sqlx_core::bytes::{Buf, Bytes};
 
 use crate::error::Error;
-use crate::io::{BufExt, Decode};
+use crate::io::BufExt;
+use crate::message::{BackendMessage, BackendMessageFormat};
 use crate::types::Oid;
 
 #[derive(Debug)]
@@ -40,13 +41,30 @@ pub struct Field {
     pub format: i16,
 }
 
-impl Decode<'_> for RowDescription {
-    fn decode_with(mut buf: Bytes, _: ()) -> Result<Self, Error> {
+impl BackendMessage for RowDescription {
+    const FORMAT: BackendMessageFormat = BackendMessageFormat::RowDescription;
+
+    fn decode_body(mut buf: Bytes) -> Result<Self, Error> {
+        if buf.len() < 2 {
+            return Err(err_protocol!(
+                "expected at least 2 bytes, got {}",
+                buf.len()
+            ));
+        }
+
         let cnt = buf.get_u16();
         let mut fields = Vec::with_capacity(cnt as usize);
 
         for _ in 0..cnt {
             let name = buf.get_str_nul()?.to_owned();
+
+            if buf.len() < 18 {
+                return Err(err_protocol!(
+                    "expected at least 18 bytes after field name {name:?}, got {}",
+                    buf.len()
+                ));
+            }
+
             let relation_id = buf.get_i32();
             let relation_attribute_no = buf.get_i16();
             let data_type_id = Oid(buf.get_u32());

--- a/sqlx-postgres/src/message/sasl.rs
+++ b/sqlx-postgres/src/message/sasl.rs
@@ -1,35 +1,69 @@
-use crate::io::PgBufMutExt;
-use crate::io::{BufMutExt, Encode};
+use crate::io::BufMutExt;
+use crate::message::{FrontendMessage, FrontendMessageFormat};
+use sqlx_core::Error;
+use std::num::Saturating;
 
 pub struct SaslInitialResponse<'a> {
     pub response: &'a str,
     pub plus: bool,
 }
 
-impl Encode<'_> for SaslInitialResponse<'_> {
-    fn encode_with(&self, buf: &mut Vec<u8>, _: ()) {
-        buf.push(b'p');
-        buf.put_length_prefixed(|buf| {
-            // name of the SASL authentication mechanism that the client selected
-            buf.put_str_nul(if self.plus {
-                "SCRAM-SHA-256-PLUS"
-            } else {
-                "SCRAM-SHA-256"
-            });
+impl SaslInitialResponse<'_> {
+    #[inline(always)]
+    fn selected_mechanism(&self) -> &'static str {
+        if self.plus {
+            "SCRAM-SHA-256-PLUS"
+        } else {
+            "SCRAM-SHA-256"
+        }
+    }
+}
 
-            buf.extend(&(self.response.as_bytes().len() as i32).to_be_bytes());
-            buf.extend(self.response.as_bytes());
-        });
+impl FrontendMessage for SaslInitialResponse<'_> {
+    const FORMAT: FrontendMessageFormat = FrontendMessageFormat::PasswordPolymorphic;
+
+    #[inline(always)]
+    fn body_size_hint(&self) -> Saturating<usize> {
+        let mut size = Saturating(0);
+
+        size += self.selected_mechanism().len();
+        size += 1; // NUL terminator
+
+        size += 4; // response_len
+        size += self.response.len();
+
+        size
+    }
+
+    fn encode_body(&self, buf: &mut Vec<u8>) -> Result<(), Error> {
+        // name of the SASL authentication mechanism that the client selected
+        buf.put_str_nul(self.selected_mechanism());
+
+        let response_len = i32::try_from(self.response.len()).map_err(|_| {
+            err_protocol!(
+                "SASL Initial Response length too long for protcol: {}",
+                self.response.len()
+            )
+        })?;
+
+        buf.extend_from_slice(&response_len.to_be_bytes());
+        buf.extend_from_slice(self.response.as_bytes());
+
+        Ok(())
     }
 }
 
 pub struct SaslResponse<'a>(pub &'a str);
 
-impl Encode<'_> for SaslResponse<'_> {
-    fn encode_with(&self, buf: &mut Vec<u8>, _: ()) {
-        buf.push(b'p');
-        buf.put_length_prefixed(|buf| {
-            buf.extend(self.0.as_bytes());
-        });
+impl FrontendMessage for SaslResponse<'_> {
+    const FORMAT: FrontendMessageFormat = FrontendMessageFormat::PasswordPolymorphic;
+
+    fn body_size_hint(&self) -> Saturating<usize> {
+        Saturating(self.0.len())
+    }
+
+    fn encode_body(&self, buf: &mut Vec<u8>) -> Result<(), Error> {
+        buf.extend(self.0.as_bytes());
+        Ok(())
     }
 }

--- a/sqlx-postgres/src/message/ssl_request.rs
+++ b/sqlx-postgres/src/message/ssl_request.rs
@@ -1,23 +1,38 @@
-use crate::io::Encode;
+use crate::io::ProtocolEncode;
 
 pub struct SslRequest;
 
 impl SslRequest {
-    pub const BYTES: &'static [u8] = b"\x00\x00\x00\x08\x04\xd2\x16/";
+    // https://www.postgresql.org/docs/current/protocol-message-formats.html#PROTOCOL-MESSAGE-FORMATS-SSLREQUEST
+    pub const BYTES: &'static [u8] = b"\x00\x00\x00\x08\x04\xd2\x16\x2f";
 }
 
-impl Encode<'_> for SslRequest {
-    #[inline]
-    fn encode_with(&self, buf: &mut Vec<u8>, _: ()) {
-        buf.extend(&8_u32.to_be_bytes());
-        buf.extend(&(((1234 << 16) | 5679) as u32).to_be_bytes());
+// Cannot impl FrontendMessage because it does not have a format code
+impl ProtocolEncode<'_> for SslRequest {
+    #[inline(always)]
+    fn encode_with(&self, buf: &mut Vec<u8>, _context: ()) -> Result<(), crate::Error> {
+        buf.extend_from_slice(Self::BYTES);
+        Ok(())
     }
 }
 
 #[test]
 fn test_encode_ssl_request() {
     let mut buf = Vec::new();
-    SslRequest.encode(&mut buf);
+
+    // Int32(8)
+    // Length of message contents in bytes, including self.
+    buf.extend_from_slice(&8_u32.to_be_bytes());
+
+    // Int32(80877103)
+    // The SSL request code. The value is chosen to contain 1234 in the most significant 16 bits,
+    // and 5679 in the least significant 16 bits.
+    // (To avoid confusion, this code must not be the same as any protocol version number.)
+    buf.extend_from_slice(&(((1234 << 16) | 5679) as u32).to_be_bytes());
+
+    let mut encoded = Vec::new();
+    SslRequest.encode(&mut encoded).unwrap();
 
     assert_eq!(buf, SslRequest::BYTES);
+    assert_eq!(buf, encoded);
 }

--- a/sqlx-postgres/src/message/sync.rs
+++ b/sqlx-postgres/src/message/sync.rs
@@ -1,11 +1,20 @@
-use crate::io::Encode;
+use crate::message::{FrontendMessage, FrontendMessageFormat};
+use sqlx_core::Error;
+use std::num::Saturating;
 
 #[derive(Debug)]
 pub struct Sync;
 
-impl Encode<'_> for Sync {
-    fn encode_with(&self, buf: &mut Vec<u8>, _: ()) {
-        buf.push(b'S');
-        buf.extend(&4_i32.to_be_bytes());
+impl FrontendMessage for Sync {
+    const FORMAT: FrontendMessageFormat = FrontendMessageFormat::Sync;
+
+    #[inline(always)]
+    fn body_size_hint(&self) -> Saturating<usize> {
+        Saturating(0)
+    }
+
+    #[inline(always)]
+    fn encode_body(&self, _buf: &mut Vec<u8>) -> Result<(), Error> {
+        Ok(())
     }
 }

--- a/sqlx-postgres/src/message/terminate.rs
+++ b/sqlx-postgres/src/message/terminate.rs
@@ -1,10 +1,19 @@
-use crate::io::Encode;
+use crate::message::{FrontendMessage, FrontendMessageFormat};
+use sqlx_core::Error;
+use std::num::Saturating;
 
 pub struct Terminate;
 
-impl Encode<'_> for Terminate {
-    fn encode_with(&self, buf: &mut Vec<u8>, _: ()) {
-        buf.push(b'X');
-        buf.extend(&4_u32.to_be_bytes());
+impl FrontendMessage for Terminate {
+    const FORMAT: FrontendMessageFormat = FrontendMessageFormat::Terminate;
+
+    #[inline(always)]
+    fn body_size_hint(&self) -> Saturating<usize> {
+        Saturating(0)
+    }
+
+    #[inline(always)]
+    fn encode_body(&self, _buf: &mut Vec<u8>) -> Result<(), Error> {
+        Ok(())
     }
 }

--- a/sqlx-postgres/src/migrate.rs
+++ b/sqlx-postgres/src/migrate.rs
@@ -230,6 +230,7 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
             let elapsed = start.elapsed();
 
             // language=SQL
+            #[allow(clippy::cast_possible_truncation)]
             let _ = query(
                 r#"
     UPDATE _sqlx_migrations

--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -82,7 +82,8 @@ mod ssl_mode;
 /// // Information about SQL queries is logged at `DEBUG` level by default.
 /// opts = opts.log_statements(log::LevelFilter::Trace);
 ///
-/// let pool = PgPool::connect_with(&opts).await?;
+/// let pool = PgPool::connect_with(opts).await?;
+/// # Ok(())
 /// # }
 /// ```
 #[derive(Debug, Clone)]

--- a/sqlx-postgres/src/type_info.rs
+++ b/sqlx-postgres/src/type_info.rs
@@ -294,7 +294,7 @@ impl PgTypeInfo {
     /// in quotes, e.g.:
     /// ```
     /// use sqlx::postgres::PgTypeInfo;
-    /// use sqlx::Type;
+    /// use sqlx::{Type, TypeInfo};
     ///
     /// /// `CREATE TYPE "_foo" AS ENUM ('Bar', 'Baz');`
     /// #[derive(sqlx::Type)]

--- a/sqlx-postgres/src/types/array.rs
+++ b/sqlx-postgres/src/types/array.rs
@@ -242,6 +242,9 @@ where
                 // length of the array axis
                 let len = buf.get_i32();
 
+                let len = usize::try_from(len)
+                    .map_err(|_| format!("overflow converting array len ({len}) to usize"))?;
+
                 // the lower bound, we only support arrays starting from "1"
                 let lower = buf.get_i32();
 
@@ -249,14 +252,12 @@ where
                     return Err(format!("encountered an array with a lower bound of {lower} in the first dimension; only arrays starting at one are supported").into());
                 }
 
-                let mut elements = Vec::with_capacity(len as usize);
+                let mut elements = Vec::with_capacity(len);
 
                 for _ in 0..len {
-                    elements.push(T::decode(PgValueRef::get(
-                        &mut buf,
-                        format,
-                        element_type_info.clone(),
-                    ))?)
+                    let value_ref = PgValueRef::get(&mut buf, format, element_type_info.clone())?;
+
+                    elements.push(T::decode(value_ref)?);
                 }
 
                 Ok(elements)

--- a/sqlx-postgres/src/types/array.rs
+++ b/sqlx-postgres/src/types/array.rs
@@ -174,7 +174,14 @@ where
             }
         }
 
-        buf.extend(&(self.len() as i32).to_be_bytes()); // len
+        let array_len = i32::try_from(self.len()).map_err(|_| {
+            format!(
+                "encoded array length is too large for Postgres: {}",
+                self.len()
+            )
+        })?;
+
+        buf.extend(array_len.to_be_bytes()); // len
         buf.extend(&1_i32.to_be_bytes()); // lower bound
 
         for element in self.iter() {

--- a/sqlx-postgres/src/types/bigdecimal.rs
+++ b/sqlx-postgres/src/types/bigdecimal.rs
@@ -1,7 +1,6 @@
-use std::cmp;
-
 use bigdecimal::BigDecimal;
 use num_bigint::{BigInt, Sign};
+use std::cmp;
 
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
@@ -26,9 +25,17 @@ impl TryFrom<PgNumeric> for BigDecimal {
     type Error = BoxDynError;
 
     fn try_from(numeric: PgNumeric) -> Result<Self, BoxDynError> {
-        let (digits, sign, weight) = match numeric {
+        Self::try_from(&numeric)
+    }
+}
+
+impl TryFrom<&'_ PgNumeric> for BigDecimal {
+    type Error = BoxDynError;
+
+    fn try_from(numeric: &'_ PgNumeric) -> Result<Self, Self::Error> {
+        let (digits, sign, weight) = match *numeric {
             PgNumeric::Number {
-                digits,
+                ref digits,
                 sign,
                 weight,
                 ..
@@ -50,11 +57,27 @@ impl TryFrom<PgNumeric> for BigDecimal {
         };
 
         // weight is 0 if the decimal point falls after the first base-10000 digit
+        //
+        // `Vec` capacity cannot exceed `isize::MAX` bytes, so this cast can't wrap in practice.
+        #[allow(clippy::cast_possible_wrap)]
         let scale = (digits.len() as i64 - weight as i64 - 1) * 4;
 
         // no optimized algorithm for base-10 so use base-100 for faster processing
         let mut cents = Vec::with_capacity(digits.len() * 2);
-        for digit in &digits {
+
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_possible_wrap,
+            clippy::cast_sign_loss
+        )]
+        for (i, &digit) in digits.iter().enumerate() {
+            if !PgNumeric::is_valid_digit(digit) {
+                return Err(format!(
+                    "PgNumeric to BigDecimal: {i}th digit is out of range {digit}"
+                )
+                .into());
+            }
+
             cents.push((digit / 100) as u8);
             cents.push((digit % 100) as u8);
         }
@@ -79,9 +102,16 @@ impl TryFrom<&'_ BigDecimal> for PgNumeric {
         // FIXME: is there a way to iterate over the digits to avoid the Vec allocation
         let (sign, base_10) = integer.to_radix_be(10);
 
+        let base_10_len = i64::try_from(base_10.len()).map_err(|_| {
+            format!(
+                "BigDecimal base-10 length out of range for PgNumeric: {}",
+                base_10.len()
+            )
+        })?;
+
         // weight is positive power of 10000
         // exp is the negative power of 10
-        let weight_10 = base_10.len() as i64 - exp;
+        let weight_10 = base_10_len - exp;
 
         // scale is only nonzero when we have fractional digits
         // since `exp` is the _negative_ decimal exponent, it tells us
@@ -103,19 +133,34 @@ impl TryFrom<&'_ BigDecimal> for PgNumeric {
             base_10.len() / 4
         };
 
-        let offset = weight_10.rem_euclid(4) as usize;
+        // For efficiency, we want to process the base-10 digits in chunks of 4,
+        // but that means we need to deal with the non-divisible remainder first.
+        let offset = weight_10.rem_euclid(4);
+
+        // Do a checked conversion to the smallest integer,
+        // so we can widen arbitrarily without triggering lints.
+        let offset = u8::try_from(offset).unwrap_or_else(|_| {
+            panic!("BUG: `offset` should be in the range [0, 4) but is {offset}")
+        });
 
         let mut digits = Vec::with_capacity(digits_len);
 
-        if let Some(first) = base_10.get(..offset) {
+        if let Some(first) = base_10.get(..offset as usize) {
             if !first.is_empty() {
                 digits.push(base_10_to_10000(first));
             }
         } else if offset != 0 {
-            digits.push(base_10_to_10000(&base_10) * 10i16.pow((offset - base_10.len()) as u32));
+            // If we didn't hit the `if let Some` branch,
+            // then `base_10.len()` must strictly be smaller
+            #[allow(clippy::cast_possible_truncation)]
+            let power = (offset as usize - base_10.len()) as u32;
+
+            digits.push(base_10_to_10000(&base_10) * 10i16.pow(power));
         }
 
-        if let Some(rest) = base_10.get(offset..) {
+        if let Some(rest) = base_10.get(offset as usize..) {
+            // `chunk.len()` is always between 1 and 4
+            #[allow(clippy::cast_possible_truncation)]
             digits.extend(
                 rest.chunks(4)
                     .map(|chunk| base_10_to_10000(chunk) * 10i16.pow(4 - chunk.len() as u32)),
@@ -138,15 +183,13 @@ impl TryFrom<&'_ BigDecimal> for PgNumeric {
 #[doc=include_str!("bigdecimal-range.md")]
 impl Encode<'_, Postgres> for BigDecimal {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
-        PgNumeric::try_from(self)?.encode(buf);
+        PgNumeric::try_from(self)?.encode(buf)?;
 
         Ok(IsNull::No)
     }
 
     fn size_hint(&self) -> usize {
-        // BigDecimal::digits() gives us base-10 digits, so we divide by 4 to get base-10000 digits
-        // and since this is just a hint we just always round up
-        8 + (self.digits() / 4 + 1) as usize * 2
+        PgNumeric::size_hint(self.digits())
     }
 }
 

--- a/sqlx-postgres/src/types/bit_vec.rs
+++ b/sqlx-postgres/src/types/bit_vec.rs
@@ -8,6 +8,7 @@ use crate::{
 use bit_vec::BitVec;
 use sqlx_core::bytes::Buf;
 use std::{io, mem};
+use crate::arguments::value_size_int4_checked;
 
 impl Type<Postgres> for BitVec {
     fn type_info() -> PgTypeInfo {
@@ -31,7 +32,9 @@ impl PgHasArrayType for BitVec {
 
 impl Encode<'_, Postgres> for BitVec {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
-        buf.extend(&(self.len() as i32).to_be_bytes());
+        let len = value_size_int4_checked(self.len())?;
+
+        buf.extend(len.to_be_bytes());
         buf.extend(self.to_bytes());
 
         Ok(IsNull::No)

--- a/sqlx-postgres/src/types/bit_vec.rs
+++ b/sqlx-postgres/src/types/bit_vec.rs
@@ -1,3 +1,4 @@
+use crate::arguments::value_size_int4_checked;
 use crate::{
     decode::Decode,
     encode::{Encode, IsNull},
@@ -8,7 +9,6 @@ use crate::{
 use bit_vec::BitVec;
 use sqlx_core::bytes::Buf;
 use std::{io, mem};
-use crate::arguments::value_size_int4_checked;
 
 impl Type<Postgres> for BitVec {
     fn type_info() -> PgTypeInfo {

--- a/sqlx-postgres/src/types/chrono/date.rs
+++ b/sqlx-postgres/src/types/chrono/date.rs
@@ -23,7 +23,11 @@ impl PgHasArrayType for NaiveDate {
 impl Encode<'_, Postgres> for NaiveDate {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
         // DATE is encoded as the days since epoch
-        let days = (*self - postgres_epoch_date()).num_days() as i32;
+        let days: i32 = (*self - postgres_epoch_date())
+            .num_days()
+            .try_into()
+            .map_err(|_| format!("value {self:?} would overflow binary encoding for Postgres DATE"))?;
+
         Encode::<Postgres>::encode(days, buf)
     }
 

--- a/sqlx-postgres/src/types/chrono/date.rs
+++ b/sqlx-postgres/src/types/chrono/date.rs
@@ -26,7 +26,9 @@ impl Encode<'_, Postgres> for NaiveDate {
         let days: i32 = (*self - postgres_epoch_date())
             .num_days()
             .try_into()
-            .map_err(|_| format!("value {self:?} would overflow binary encoding for Postgres DATE"))?;
+            .map_err(|_| {
+                format!("value {self:?} would overflow binary encoding for Postgres DATE")
+            })?;
 
         Encode::<Postgres>::encode(days, buf)
     }

--- a/sqlx-postgres/src/types/cube.rs
+++ b/sqlx-postgres/src/types/cube.rs
@@ -3,22 +3,50 @@ use crate::encode::{Encode, IsNull};
 use crate::error::BoxDynError;
 use crate::types::Type;
 use crate::{PgArgumentBuffer, PgHasArrayType, PgTypeInfo, PgValueFormat, PgValueRef, Postgres};
+use sqlx_core::bytes::Buf;
 use sqlx_core::Error;
 use std::str::FromStr;
 
 const BYTE_WIDTH: usize = 8;
-const CUBE_TYPE_ZERO_VOLUME: usize = 128;
-const CUBE_TYPE_DEFAULT: usize = 0;
-const CUBE_DIMENSION_ONE: usize = 1;
-const DIMENSIONALITY_POSITION: usize = 3;
-const START_INDEX: usize = 4;
 
+/// <https://github.com/postgres/postgres/blob/e3ec9dc1bf4983fcedb6f43c71ea12ee26aefc7a/contrib/cube/cubedata.h#L7>
+const MAX_DIMENSIONS: usize = 100;
+
+const IS_POINT_FLAG: u32 = 1 << 31;
+
+// FIXME(breaking): these variants are confusingly named and structured
+// consider changing them or making this an opaque wrapper around `Vec<f64>`
 #[derive(Debug, Clone, PartialEq)]
 pub enum PgCube {
+    /// A one-dimensional point.
+    // FIXME: `Point1D(f64)
     Point(f64),
+    /// An N-dimensional point ("represented internally as a zero-volume cube").
+    // FIXME: `PointND(f64)`
     ZeroVolume(Vec<f64>),
+
+    /// A one-dimensional interval with starting and ending points.
+    // FIXME: `Interval1D { start: f64, end: f64 }`
     OneDimensionInterval(f64, f64),
+
+    // FIXME: add `Cube3D { lower_left: [f64; 3], upper_right: [f64; 3] }`?
+    /// An N-dimensional cube with points representing lower-left and upper-right corners, respectively.
+    // FIXME: CubeND { lower_left: Vec<f64>, upper_right: Vec<f64> }`
     MultiDimension(Vec<Vec<f64>>),
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct Header {
+    dimensions: usize,
+    is_point: bool,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("error decoding CUBE (is_point: {is_point}, dimensions: {dimensions})")]
+struct DecodeError {
+    is_point: bool,
+    dimensions: usize,
+    message: String,
 }
 
 impl Type<Postgres> for PgCube {
@@ -37,7 +65,7 @@ impl<'r> Decode<'r, Postgres> for PgCube {
     fn decode(value: PgValueRef<'r>) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         match value.format() {
             PgValueFormat::Text => Ok(PgCube::from_str(value.as_str()?)?),
-            PgValueFormat::Binary => Ok(pg_cube_from_bytes(value.as_bytes()?)?),
+            PgValueFormat::Binary => Ok(PgCube::from_bytes(value.as_bytes()?)?),
         }
     }
 }
@@ -50,6 +78,10 @@ impl<'q> Encode<'q, Postgres> for PgCube {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
         self.serialize(buf)?;
         Ok(IsNull::No)
+    }
+
+    fn size_hint(&self) -> usize {
+        self.header().encoded_size()
     }
 }
 
@@ -81,86 +113,84 @@ impl FromStr for PgCube {
     }
 }
 
-fn pg_cube_from_bytes(bytes: &[u8]) -> Result<PgCube, Error> {
-    let cube_type = bytes
-        .first()
-        .map(|&byte| byte as usize)
-        .ok_or(Error::Decode(
-            format!("Could not decode cube bytes: {:?}", bytes).into(),
-        ))?;
-
-    let dimensionality = bytes
-        .get(DIMENSIONALITY_POSITION)
-        .map(|&byte| byte as usize)
-        .ok_or(Error::Decode(
-            format!("Could not decode cube bytes: {:?}", bytes).into(),
-        ))?;
-
-    match (cube_type, dimensionality) {
-        (CUBE_TYPE_ZERO_VOLUME, CUBE_DIMENSION_ONE) => {
-            let point = get_f64_from_bytes(bytes, 4)?;
-            Ok(PgCube::Point(point))
-        }
-        (CUBE_TYPE_ZERO_VOLUME, _) => {
-            Ok(PgCube::ZeroVolume(deserialize_vector(bytes, START_INDEX)?))
-        }
-        (CUBE_TYPE_DEFAULT, CUBE_DIMENSION_ONE) => {
-            let x_start = 4;
-            let y_start = x_start + BYTE_WIDTH;
-            let x = get_f64_from_bytes(bytes, x_start)?;
-            let y = get_f64_from_bytes(bytes, y_start)?;
-            Ok(PgCube::OneDimensionInterval(x, y))
-        }
-        (CUBE_TYPE_DEFAULT, dim) => Ok(PgCube::MultiDimension(deserialize_matrix(
-            bytes,
-            START_INDEX,
-            dim,
-        )?)),
-        (flag, dimension) => Err(Error::Decode(
-            format!(
-                "Could not deserialise cube with flag {} and dimension {}: {:?}",
-                flag, dimension, bytes
-            )
-            .into(),
-        )),
-    }
-}
-
 impl PgCube {
-    fn serialize(&self, buff: &mut PgArgumentBuffer) -> Result<(), Error> {
+    fn header(&self) -> Header {
+        match self {
+            PgCube::Point(..) => Header {
+                is_point: true,
+                dimensions: 1,
+            },
+            PgCube::ZeroVolume(values) => Header {
+                is_point: true,
+                dimensions: values.len(),
+            },
+            PgCube::OneDimensionInterval(..) => Header {
+                is_point: false,
+                dimensions: 1,
+            },
+            PgCube::MultiDimension(multi_values) => Header {
+                is_point: false,
+                dimensions: multi_values.first().map(|arr| arr.len()).unwrap_or(0),
+            },
+        }
+    }
+
+    fn from_bytes(mut bytes: &[u8]) -> Result<Self, BoxDynError> {
+        let header = Header::try_read(&mut bytes)?;
+
+        if bytes.len() != header.data_size() {
+            return Err(DecodeError::new(
+                &header,
+                format!(
+                    "expected {} bytes after header, got {}",
+                    header.data_size(),
+                    bytes.len()
+                ),
+            )
+                .into());
+        }
+
+        match (header.is_point, header.dimensions) {
+            (true, 1) => Ok(PgCube::Point(bytes.get_f64())),
+            (true, _) => Ok(PgCube::ZeroVolume(
+                read_vec(&mut bytes).map_err(|e| DecodeError::new(&header, e))?,
+            )),
+            (false, 1) => Ok(PgCube::OneDimensionInterval(
+                bytes.get_f64(),
+                bytes.get_f64(),
+            )),
+            (false, _) => Ok(PgCube::MultiDimension(read_cube(&header, bytes)?)),
+        }
+    }
+
+    fn serialize(&self, buff: &mut PgArgumentBuffer) -> Result<(), String> {
+        let header = self.header();
+
+        buff.reserve(header.data_size());
+
+        header.try_write(buff)?;
+
         match self {
             PgCube::Point(value) => {
-                buff.extend(&[CUBE_TYPE_ZERO_VOLUME as u8, 0, 0, CUBE_DIMENSION_ONE as u8]);
                 buff.extend_from_slice(&value.to_be_bytes());
             }
             PgCube::ZeroVolume(values) => {
-                let dimension = values.len() as u8;
-                buff.extend_from_slice(&[CUBE_TYPE_ZERO_VOLUME as u8, 0, 0]);
-                buff.extend_from_slice(&dimension.to_be_bytes());
-                let bytes = values
-                    .iter()
-                    .flat_map(|v| v.to_be_bytes())
-                    .collect::<Vec<u8>>();
-                buff.extend_from_slice(&bytes);
+                buff.extend(values.iter().flat_map(|v| v.to_be_bytes()));
             }
             PgCube::OneDimensionInterval(x, y) => {
-                buff.extend_from_slice(&[0, 0, 0, CUBE_DIMENSION_ONE as u8]);
                 buff.extend_from_slice(&x.to_be_bytes());
                 buff.extend_from_slice(&y.to_be_bytes());
             }
             PgCube::MultiDimension(multi_values) => {
-                let dimension = multi_values
-                    .first()
-                    .map(|arr| arr.len() as u8)
-                    .unwrap_or(1_u8);
-                buff.extend_from_slice(&[0, 0, 0]);
-                buff.extend_from_slice(&dimension.to_be_bytes());
-                let bytes = multi_values
-                    .iter()
-                    .flatten()
-                    .flat_map(|v| v.to_be_bytes())
-                    .collect::<Vec<u8>>();
-                buff.extend_from_slice(&bytes);
+                if multi_values.len() != 2 {
+                    return Err(format!("invalid CUBE value: {self:?}"));
+                }
+
+                buff.extend(
+                    multi_values
+                        .iter()
+                        .flat_map(|point| point.iter().flat_map(|scalar| scalar.to_be_bytes())),
+                );
             }
         };
         Ok(())
@@ -174,41 +204,46 @@ impl PgCube {
     }
 }
 
-fn get_f64_from_bytes(bytes: &[u8], start: usize) -> Result<f64, Error> {
-    bytes
-        .get(start..start + BYTE_WIDTH)
-        .ok_or(Error::Decode(
-            format!("Could not decode cube bytes: {:?}", bytes).into(),
-        ))?
-        .try_into()
-        .map(f64::from_be_bytes)
-        .map_err(|err| Error::Decode(format!("Invalid bytes slice: {:?}", err).into()))
+fn read_vec(bytes: &mut &[u8]) -> Result<Vec<f64>, String> {
+    if bytes.len() % BYTE_WIDTH != 0 {
+        return Err(format!(
+            "data length not divisible by {BYTE_WIDTH}: {}",
+            bytes.len()
+        ));
+    }
+
+    let mut out = Vec::with_capacity(bytes.len() / BYTE_WIDTH);
+
+    while bytes.has_remaining() {
+        out.push(bytes.get_f64());
+    }
+
+    Ok(out)
 }
 
-fn deserialize_vector(bytes: &[u8], start_index: usize) -> Result<Vec<f64>, Error> {
-    let steps = (bytes.len() - start_index) / BYTE_WIDTH;
-    (0..steps)
-        .map(|i| get_f64_from_bytes(bytes, start_index + i * BYTE_WIDTH))
-        .collect()
-}
+fn read_cube(header: &Header, mut bytes: &[u8]) -> Result<Vec<Vec<f64>>, String> {
+    if bytes.len() != header.data_size() {
+        return Err(format!(
+            "expected {} bytes, got {}",
+            header.data_size(),
+            bytes.len()
+        ));
+    }
 
-fn deserialize_matrix(
-    bytes: &[u8],
-    start_index: usize,
-    dim: usize,
-) -> Result<Vec<Vec<f64>>, Error> {
-    let step = BYTE_WIDTH * dim;
-    let steps = (bytes.len() - start_index) / step;
+    let mut out = Vec::with_capacity(2);
 
-    (0..steps)
-        .map(|step_idx| {
-            (0..dim)
-                .map(|dim_idx| {
-                    get_f64_from_bytes(bytes, start_index + step_idx * step + dim_idx * BYTE_WIDTH)
-                })
-                .collect()
-        })
-        .collect()
+    // Expecting exactly 2 N-dimensional points
+    for _ in 0..2 {
+        let mut point = Vec::new();
+
+        for _ in 0..header.dimensions {
+            point.push(bytes.get_f64());
+        }
+
+        out.push(point);
+    }
+
+    Ok(out)
 }
 
 fn parse_float_from_str(s: &str, error_msg: &str) -> Result<f64, Error> {
@@ -268,12 +303,86 @@ fn remove_parentheses(s: &str) -> String {
     s.trim_matches(|c| c == '(' || c == ')').to_string()
 }
 
+impl Header {
+    const PACKED_WIDTH: usize = size_of::<u32>();
+
+    fn encoded_size(&self) -> usize {
+        Self::PACKED_WIDTH + self.data_size()
+    }
+
+    fn data_size(&self) -> usize {
+        if self.is_point {
+            self.dimensions * BYTE_WIDTH
+        } else {
+            self.dimensions * BYTE_WIDTH * 2
+        }
+    }
+
+    fn try_write(&self, buff: &mut PgArgumentBuffer) -> Result<(), String> {
+        if self.dimensions > MAX_DIMENSIONS {
+            return Err(format!(
+                "CUBE dimensionality exceeds allowed maximum ({} > {MAX_DIMENSIONS})",
+                self.dimensions
+            ));
+        }
+
+        // Cannot overflow thanks to the above check.
+        #[allow(clippy::cast_possible_truncation)]
+        let mut packed = self.dimensions as u32;
+
+        // https://github.com/postgres/postgres/blob/e3ec9dc1bf4983fcedb6f43c71ea12ee26aefc7a/contrib/cube/cubedata.h#L18-L24
+        if self.is_point {
+            packed |= IS_POINT_FLAG;
+        }
+
+        buff.extend(packed.to_be_bytes());
+
+        Ok(())
+    }
+
+    fn try_read(buf: &mut &[u8]) -> Result<Self, String> {
+        if buf.len() < Self::PACKED_WIDTH {
+            return Err(format!(
+                "expected CUBE data to contain at least {} bytes, got {}",
+                Self::PACKED_WIDTH,
+                buf.len()
+            ));
+        }
+
+        let packed = buf.get_u32();
+
+        let is_point = packed & IS_POINT_FLAG != 0;
+        let dimensions = packed & !IS_POINT_FLAG;
+
+        // can only overflow on 16-bit platforms
+        let dimensions = usize::try_from(dimensions)
+            .ok()
+            .filter(|&it| it <= MAX_DIMENSIONS)
+            .ok_or_else(|| format!("received CUBE data with higher than expected dimensionality: {dimensions} (is_point: {is_point})"))?;
+
+        Ok(Self {
+            is_point,
+            dimensions,
+        })
+    }
+}
+
+impl DecodeError {
+    fn new(header: &Header, message: String) -> Self {
+        DecodeError {
+            is_point: header.is_point,
+            dimensions: header.dimensions,
+            message,
+        }
+    }
+}
+
 #[cfg(test)]
 mod cube_tests {
 
     use std::str::FromStr;
 
-    use crate::types::{cube::pg_cube_from_bytes, PgCube};
+    use super::PgCube;
 
     const POINT_BYTES: &[u8] = &[128, 0, 0, 1, 64, 0, 0, 0, 0, 0, 0, 0];
     const ZERO_VOLUME_BYTES: &[u8] = &[
@@ -293,7 +402,7 @@ mod cube_tests {
 
     #[test]
     fn can_deserialise_point_type_byes() {
-        let cube = pg_cube_from_bytes(POINT_BYTES).unwrap();
+        let cube = PgCube::from_bytes(POINT_BYTES).unwrap();
         assert_eq!(cube, PgCube::Point(2.))
     }
 
@@ -311,7 +420,7 @@ mod cube_tests {
     }
     #[test]
     fn can_deserialise_zero_volume_bytes() {
-        let cube = pg_cube_from_bytes(ZERO_VOLUME_BYTES).unwrap();
+        let cube = PgCube::from_bytes(ZERO_VOLUME_BYTES).unwrap();
         assert_eq!(cube, PgCube::ZeroVolume(vec![2., 3.]));
     }
 
@@ -333,7 +442,7 @@ mod cube_tests {
 
     #[test]
     fn can_deserialise_one_dimension_interval_bytes() {
-        let cube = pg_cube_from_bytes(ONE_DIMENSIONAL_INTERVAL_BYTES).unwrap();
+        let cube = PgCube::from_bytes(ONE_DIMENSIONAL_INTERVAL_BYTES).unwrap();
         assert_eq!(cube, PgCube::OneDimensionInterval(7., 8.))
     }
 
@@ -355,7 +464,7 @@ mod cube_tests {
 
     #[test]
     fn can_deserialise_multi_dimension_2_dimension_byte() {
-        let cube = pg_cube_from_bytes(MULTI_DIMENSION_2_DIM_BYTES).unwrap();
+        let cube = PgCube::from_bytes(MULTI_DIMENSION_2_DIM_BYTES).unwrap();
         assert_eq!(
             cube,
             PgCube::MultiDimension(vec![vec![1., 2.], vec![3., 4.]])
@@ -396,7 +505,7 @@ mod cube_tests {
 
     #[test]
     fn can_deserialise_multi_dimension_3_dimension_bytes() {
-        let cube = pg_cube_from_bytes(MULTI_DIMENSION_3_DIM_BYTES).unwrap();
+        let cube = PgCube::from_bytes(MULTI_DIMENSION_3_DIM_BYTES).unwrap();
         assert_eq!(
             cube,
             PgCube::MultiDimension(vec![vec![2., 3., 4.], vec![5., 6., 7.]])

--- a/sqlx-postgres/src/types/cube.rs
+++ b/sqlx-postgres/src/types/cube.rs
@@ -147,7 +147,7 @@ impl PgCube {
                     bytes.len()
                 ),
             )
-                .into());
+            .into());
         }
 
         match (header.is_point, header.dimensions) {

--- a/sqlx-postgres/src/types/hstore.rs
+++ b/sqlx-postgres/src/types/hstore.rs
@@ -2,10 +2,8 @@ use std::{
     collections::{btree_map, BTreeMap},
     mem::size_of,
     ops::{Deref, DerefMut},
-    str::from_utf8,
+    str,
 };
-
-use serde::{Deserialize, Serialize};
 
 use crate::{
     decode::Decode,
@@ -14,6 +12,8 @@ use crate::{
     types::Type,
     PgArgumentBuffer, PgTypeInfo, PgValueRef, Postgres,
 };
+use serde::{Deserialize, Serialize};
+use sqlx_core::bytes::Buf;
 
 /// Key-value support (`hstore`) for Postgres.
 ///
@@ -143,20 +143,24 @@ impl<'r> Decode<'r, Postgres> for PgHstore {
         let mut buf = <&[u8] as Decode<Postgres>>::decode(value)?;
         let len = read_length(&mut buf)?;
 
-        if len < 0 {
-            Err(format!("hstore, invalid entry count: {len}"))?;
-        }
+        let len =
+            usize::try_from(len).map_err(|_| format!("PgHstore: length out of range: {len}"))?;
 
         let mut result = Self::default();
 
-        while !buf.is_empty() {
-            let key_len = read_length(&mut buf)?;
-            let key = read_value(&mut buf, key_len)?.ok_or("hstore, key not found")?;
+        for i in 0..len {
+            let key = read_string(&mut buf)
+                .map_err(|e| format!("PgHstore: error reading {i}th key: {e}"))?
+                .ok_or_else(|| format!("PgHstore: expected {i}th key, got nothing"))?;
 
-            let value_len = read_length(&mut buf)?;
-            let value = read_value(&mut buf, value_len)?;
+            let value = read_string(&mut buf)
+                .map_err(|e| format!("PgHstore: error reading value for key {key:?}: {e}"))?;
 
             result.insert(key, value);
+        }
+
+        if !buf.is_empty() {
+            tracing::warn!("{} unread bytes at the end of HSTORE value", buf.len());
         }
 
         Ok(result)
@@ -165,19 +169,38 @@ impl<'r> Decode<'r, Postgres> for PgHstore {
 
 impl Encode<'_, Postgres> for PgHstore {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
-        buf.extend_from_slice(&i32::to_be_bytes(self.0.len() as i32));
+        buf.extend_from_slice(&i32::to_be_bytes(
+            self.0
+                .len()
+                .try_into()
+                .map_err(|_| format!("PgHstore length out of range: {}", self.0.len()))?,
+        ));
 
-        for (key, val) in &self.0 {
+        for (i, (key, val)) in self.0.iter().enumerate() {
             let key_bytes = key.as_bytes();
 
-            buf.extend_from_slice(&i32::to_be_bytes(key_bytes.len() as i32));
+            let key_len = i32::try_from(key_bytes.len()).map_err(|_| {
+                // Doesn't make sense to print the key itself: it's more than 2 GiB long!
+                format!(
+                    "PgHstore: length of {i}th key out of range: {} bytes",
+                    key_bytes.len()
+                )
+            })?;
+
+            buf.extend_from_slice(&i32::to_be_bytes(key_len));
             buf.extend_from_slice(key_bytes);
 
             match val {
                 Some(val) => {
                     let val_bytes = val.as_bytes();
 
-                    buf.extend_from_slice(&i32::to_be_bytes(val_bytes.len() as i32));
+                    let val_len = i32::try_from(val_bytes.len()).map_err(|_| {
+                        format!(
+                            "PgHstore: value length for key {key:?} out of range: {} bytes",
+                            val_bytes.len()
+                        )
+                    })?;
+                    buf.extend_from_slice(&i32::to_be_bytes(val_len));
                     buf.extend_from_slice(val_bytes);
                 }
                 None => {
@@ -190,30 +213,36 @@ impl Encode<'_, Postgres> for PgHstore {
     }
 }
 
-fn read_length(buf: &mut &[u8]) -> Result<i32, BoxDynError> {
-    let (bytes, rest) = buf.split_at(size_of::<i32>());
+fn read_length(buf: &mut &[u8]) -> Result<i32, String> {
+    if buf.len() < size_of::<i32>() {
+        return Err(format!(
+            "expected {} bytes, got {}",
+            size_of::<i32>(),
+            buf.len()
+        ));
+    }
 
-    *buf = rest;
-
-    Ok(i32::from_be_bytes(
-        bytes
-            .try_into()
-            .map_err(|err| format!("hstore, reading length: {err}"))?,
-    ))
+    Ok(buf.get_i32())
 }
 
-fn read_value(buf: &mut &[u8], len: i32) -> Result<Option<String>, BoxDynError> {
-    match len {
-        len if len <= 0 => Ok(None),
-        len => {
-            let (val, rest) = buf.split_at(len as usize);
+fn read_string(buf: &mut &[u8]) -> Result<Option<String>, String> {
+    let len = read_length(buf)?;
 
+    match len {
+        -1 => Ok(None),
+        len => {
+            let len =
+                usize::try_from(len).map_err(|_| format!("string length out of range: {len}"))?;
+
+            if buf.len() < len {
+                return Err(format!("expected {len} bytes, got {}", buf.len()));
+            }
+
+            let (val, rest) = buf.split_at(len);
             *buf = rest;
 
             Ok(Some(
-                from_utf8(val)
-                    .map_err(|err| format!("hstore, reading value: {err}"))?
-                    .to_string(),
+                str::from_utf8(val).map_err(|e| e.to_string())?.to_string(),
             ))
         }
     }
@@ -258,7 +287,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "hstore, invalid entry count: -5")]
+    #[should_panic(expected = "PgHstore: length out of range: -5")]
     fn hstore_deserialize_buffer_length_error() {
         let buf = PgValueRef {
             value: Some(&[255, 255, 255, 251]),

--- a/sqlx-postgres/src/types/int.rs
+++ b/sqlx-postgres/src/types/int.rs
@@ -71,6 +71,8 @@ impl Decode<'_, Postgres> for i8 {
                     return Ok(i8::from_str_radix(text.trim_start_matches('\\'), 8)?);
                 }
 
+                // Wrapping is the whole idea.
+                #[allow(clippy::cast_possible_wrap)]
                 Ok(text.as_bytes()[0] as i8)
             }
         }

--- a/sqlx-postgres/src/types/numeric.rs
+++ b/sqlx-postgres/src/types/numeric.rs
@@ -75,6 +75,14 @@ impl PgNumericSign {
 }
 
 impl PgNumeric {
+    /// Equivalent value of `0::numeric`.
+    pub const ZERO: Self = PgNumeric::Number {
+        sign: PgNumericSign::Positive,
+        digits: vec![],
+        weight: 0,
+        scale: 0,
+    };
+
     pub(crate) fn decode(mut buf: &[u8]) -> Result<Self, BoxDynError> {
         // https://github.com/postgres/postgres/blob/bcd1c3630095e48bc3b1eb0fc8e8c8a7c851eba1/src/backend/utils/adt/numeric.c#L874
         let num_digits = buf.get_u16();

--- a/sqlx-postgres/src/types/numeric.rs
+++ b/sqlx-postgres/src/types/numeric.rs
@@ -151,8 +151,8 @@ impl PgNumeric {
                 buf.extend(&scale.to_be_bytes());
 
                 for (i, &digit) in digits.iter().enumerate() {
-                    if Self::is_valid_digit(digit) {
-                        return Err(format!("{i}th PgNumeric digit out of range {digit}"));
+                    if !Self::is_valid_digit(digit) {
+                        return Err(format!("{i}th PgNumeric digit out of range: {digit}"));
                     }
 
                     buf.extend(&digit.to_be_bytes());

--- a/sqlx-postgres/src/types/numeric.rs
+++ b/sqlx-postgres/src/types/numeric.rs
@@ -1,4 +1,5 @@
 use sqlx_core::bytes::Buf;
+use std::num::Saturating;
 
 use crate::error::BoxDynError;
 use crate::PgArgumentBuffer;
@@ -83,6 +84,27 @@ impl PgNumeric {
         scale: 0,
     };
 
+    pub(crate) fn is_valid_digit(digit: i16) -> bool {
+        (0..10_000).contains(&digit)
+    }
+
+    pub(crate) fn size_hint(decimal_digits: u64) -> usize {
+        let mut size_hint = Saturating(decimal_digits);
+
+        // BigDecimal::digits() gives us base-10 digits, so we divide by 4 to get base-10000 digits
+        // and since this is just a hint we just always round up
+        size_hint /= 4;
+        size_hint += 1;
+
+        // Times two bytes for each base-10000 digit
+        size_hint *= 2;
+
+        // Plus `weight` and `scale`
+        size_hint += 8;
+
+        usize::try_from(size_hint.0).unwrap_or(usize::MAX)
+    }
+
     pub(crate) fn decode(mut buf: &[u8]) -> Result<Self, BoxDynError> {
         // https://github.com/postgres/postgres/blob/bcd1c3630095e48bc3b1eb0fc8e8c8a7c851eba1/src/backend/utils/adt/numeric.c#L874
         let num_digits = buf.get_u16();
@@ -104,11 +126,11 @@ impl PgNumeric {
         }
     }
 
-    /// ### Panics
+    /// ### Errors
     ///
     /// * If `digits.len()` overflows `i16`
     /// * If any element in `digits` is greater than or equal to 10000
-    pub(crate) fn encode(&self, buf: &mut PgArgumentBuffer) {
+    pub(crate) fn encode(&self, buf: &mut PgArgumentBuffer) -> Result<(), String> {
         match *self {
             PgNumeric::Number {
                 ref digits,
@@ -116,18 +138,22 @@ impl PgNumeric {
                 scale,
                 weight,
             } => {
-                let digits_len: i16 = digits
-                    .len()
-                    .try_into()
-                    .expect("PgNumeric.digits.len() should not overflow i16");
+                let digits_len = i16::try_from(digits.len()).map_err(|_| {
+                    format!(
+                        "PgNumeric digits.len() ({}) should not overflow i16",
+                        digits.len()
+                    )
+                })?;
 
                 buf.extend(&digits_len.to_be_bytes());
                 buf.extend(&weight.to_be_bytes());
                 buf.extend(&(sign as i16).to_be_bytes());
                 buf.extend(&scale.to_be_bytes());
 
-                for digit in digits {
-                    debug_assert!(*digit < 10000, "PgNumeric digits must be in base-10000");
+                for (i, &digit) in digits.iter().enumerate() {
+                    if Self::is_valid_digit(digit) {
+                        return Err(format!("{i}th PgNumeric digit out of range {digit}"));
+                    }
 
                     buf.extend(&digit.to_be_bytes());
                 }
@@ -140,5 +166,7 @@ impl PgNumeric {
                 buf.extend(&0_i16.to_be_bytes());
             }
         }
+
+        Ok(())
     }
 }

--- a/sqlx-postgres/src/types/oid.rs
+++ b/sqlx-postgres/src/types/oid.rs
@@ -17,12 +17,6 @@ pub struct Oid(
     pub u32,
 );
 
-impl Oid {
-    pub(crate) fn incr_one(&mut self) {
-        self.0 = self.0.wrapping_add(1);
-    }
-}
-
 impl Type<Postgres> for Oid {
     fn type_info() -> PgTypeInfo {
         PgTypeInfo::OID

--- a/sqlx-postgres/src/types/range.rs
+++ b/sqlx-postgres/src/types/range.rs
@@ -350,7 +350,7 @@ where
 
                 if !flags.contains(RangeFlags::LB_INF) {
                     let value =
-                        T::decode(PgValueRef::get(&mut buf, value.format, element_ty.clone()))?;
+                        T::decode(PgValueRef::get(&mut buf, value.format, element_ty.clone())?)?;
 
                     start = if flags.contains(RangeFlags::LB_INC) {
                         Bound::Included(value)
@@ -361,7 +361,7 @@ where
 
                 if !flags.contains(RangeFlags::UB_INF) {
                     let value =
-                        T::decode(PgValueRef::get(&mut buf, value.format, element_ty.clone()))?;
+                        T::decode(PgValueRef::get(&mut buf, value.format, element_ty.clone())?)?;
 
                     end = if flags.contains(RangeFlags::UB_INC) {
                         Bound::Included(value)

--- a/sqlx-postgres/src/types/record.rs
+++ b/sqlx-postgres/src/types/record.rs
@@ -137,7 +137,7 @@ impl<'r> PgRecordDecoder<'r> {
 
                 self.ind += 1;
 
-                T::decode(PgValueRef::get(&mut self.buf, self.fmt, element_type))
+                T::decode(PgValueRef::get(&mut self.buf, self.fmt, element_type)?)
             }
 
             PgValueFormat::Text => {

--- a/sqlx-postgres/src/types/rust_decimal.rs
+++ b/sqlx-postgres/src/types/rust_decimal.rs
@@ -1,4 +1,4 @@
-use rust_decimal::{prelude::Zero, Decimal};
+use rust_decimal::Decimal;
 
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
@@ -25,9 +25,17 @@ impl TryFrom<PgNumeric> for Decimal {
     type Error = BoxDynError;
 
     fn try_from(numeric: PgNumeric) -> Result<Self, BoxDynError> {
-        let (digits, sign, mut weight, scale) = match numeric {
+        Decimal::try_from(&numeric)
+    }
+}
+
+impl TryFrom<&'_ PgNumeric> for Decimal {
+    type Error = BoxDynError;
+
+    fn try_from(numeric: &'_ PgNumeric) -> Result<Self, BoxDynError> {
+        let (digits, sign, mut weight, scale) = match *numeric {
             PgNumeric::Number {
-                digits,
+                ref digits,
                 sign,
                 weight,
                 scale,
@@ -40,13 +48,13 @@ impl TryFrom<PgNumeric> for Decimal {
 
         if digits.is_empty() {
             // Postgres returns an empty digit array for 0
-            return Ok(0u64.into());
+            return Ok(Decimal::ZERO);
         }
 
         let mut value = Decimal::ZERO;
 
         // Sum over `digits`, multiply each by its weight and add it to `value`.
-        for digit in digits {
+        for &digit in digits {
             let mul = Decimal::from(10_000i16)
                 .checked_powi(weight as i64)
                 .ok_or("value not representable as rust_decimal::Decimal")?;
@@ -71,40 +79,40 @@ impl TryFrom<PgNumeric> for Decimal {
     }
 }
 
+impl From<Decimal> for PgNumeric {
+    fn from(value: Decimal) -> Self {
+        PgNumeric::from(&value)
+    }
+}
+
 // This impl is effectively infallible because `NUMERIC` has a greater range than `Decimal`.
 impl From<&'_ Decimal> for PgNumeric {
+    // Impl has been manually validated.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
     fn from(decimal: &Decimal) -> Self {
-        // `Decimal` added `is_zero()` as an inherent method in a more recent version
-        if Zero::is_zero(decimal) {
-            PgNumeric::Number {
-                sign: PgNumericSign::Positive,
-                scale: 0,
-                weight: 0,
-                digits: vec![],
-            };
+        if Decimal::is_zero(decimal) {
+            return PgNumeric::ZERO;
         }
 
+        assert!(
+            (0u32..=28).contains(&decimal.scale()),
+            "decimal scale out of range {:?}",
+            decimal.unpack(),
+        );
+
+        // Cannot overflow: always in the range [0, 28]
         let scale = decimal.scale() as u16;
 
-        // A serialized version of the decimal number. The resulting byte array
-        // will have the following representation:
-        //
-        // Bytes 1-4: flags
-        // Bytes 5-8: lo portion of m
-        // Bytes 9-12: mid portion of m
-        // Bytes 13-16: high portion of m
-        let mut mantissa = u128::from_le_bytes(decimal.serialize());
+        let mut mantissa = decimal.mantissa().unsigned_abs();
 
-        // chop off the flags
-        mantissa >>= 32;
-
-        // If our scale is not a multiple of 4, we need to go to the next
-        // multiple.
+        // If our scale is not a multiple of 4, we need to go to the next multiple.
         let groups_diff = scale % 4;
         if groups_diff > 0 {
             let remainder = 4 - groups_diff as u32;
             let power = 10u32.pow(remainder) as u128;
 
+            // Impossible to overflow; 0 <= mantissa <= 2^96,
+            // and we're multiplying by at most 1,000 (giving us a result < 2^106)
             mantissa *= power;
         }
 
@@ -113,16 +121,32 @@ impl From<&'_ Decimal> for PgNumeric {
 
         // Convert to base-10000.
         while mantissa != 0 {
+            // Cannot overflow or wrap because of the modulus
             digits.push((mantissa % 10_000) as i16);
             mantissa /= 10_000;
         }
 
-        // Change the endianness.
+        // We started with the low digits first, but they should actually be at the end.
         digits.reverse();
 
-        // Weight is number of digits on the left side of the decimal.
-        let digits_after_decimal = (scale + 3) / 4;
-        let weight = digits.len() as i16 - digits_after_decimal as i16 - 1;
+        // Cannot overflow: strictly smaller than `scale`.
+        let digits_after_decimal = scale.div_ceil(4) as i16;
+
+        // `mantissa` contains at most 29 decimal digits (log10(2^96)),
+        // split into at most 8 4-digit segments.
+        assert!(
+            digits.len() <= 8,
+            "digits.len() out of range: {}; unpacked: {:?}",
+            digits.len(),
+            decimal.unpack()
+        );
+
+        // Cannot overflow; at most 8
+        let num_digits = digits.len() as i16;
+
+        // Find how many 4-digit segments should go before the decimal point.
+        // `weight = 0` puts just `digit[0]` before the decimal point, and the rest after.
+        let weight = num_digits - digits_after_decimal - 1;
 
         // Remove non-significant zeroes.
         while let Some(&0) = digits.last() {
@@ -134,6 +158,7 @@ impl From<&'_ Decimal> for PgNumeric {
                 false => PgNumericSign::Positive,
                 true => PgNumericSign::Negative,
             },
+            // Cannot overflow; between 0 and 28
             scale: scale as i16,
             weight,
             digits,
@@ -160,7 +185,7 @@ impl Decode<'_, Postgres> for Decimal {
 }
 
 #[cfg(test)]
-mod decimal_to_pgnumeric {
+mod tests {
     use super::{Decimal, PgNumeric, PgNumericSign};
     use std::convert::TryFrom;
 
@@ -169,13 +194,13 @@ mod decimal_to_pgnumeric {
         let zero: Decimal = "0".parse().unwrap();
 
         assert_eq!(
-            PgNumeric::try_from(&zero).unwrap(),
-            PgNumeric::Number {
-                sign: PgNumericSign::Positive,
-                scale: 0,
-                weight: 0,
-                digits: vec![]
-            }
+            PgNumeric::from(&zero),
+            PgNumeric::ZERO,
+        );
+
+        assert_eq!(
+            Decimal::try_from(&PgNumeric::ZERO).unwrap(),
+            Decimal::ZERO
         );
     }
 
@@ -344,6 +369,48 @@ mod decimal_to_pgnumeric {
     }
 
     #[test]
+    fn max_value() {
+        let expected_numeric = PgNumeric::Number {
+            sign: PgNumericSign::Positive,
+            scale: 0,
+            weight: 7,
+            digits: vec![7, 9228, 1625, 1426, 4337, 5935, 4395, 0335],
+        };
+        assert_eq!(
+            PgNumeric::try_from(&Decimal::MAX).unwrap(),
+            expected_numeric
+        );
+
+        let actual_decimal = Decimal::try_from(expected_numeric).unwrap();
+        assert_eq!(actual_decimal, Decimal::MAX);
+        // Value split by 10,000's to match the expected digits[]
+        assert_eq!(actual_decimal.mantissa(), 7_9228_1625_1426_4337_5935_4395_0335);
+        assert_eq!(actual_decimal.scale(), 0);
+    }
+
+    #[test]
+    fn max_value_max_scale() {
+        let mut max_value_max_scale = Decimal::MAX;
+        max_value_max_scale.set_scale(28).unwrap();
+
+        let expected_numeric = PgNumeric::Number {
+            sign: PgNumericSign::Positive,
+            scale: 28,
+            weight: 0,
+            digits: vec![7, 9228, 1625, 1426, 4337, 5935, 4395, 0335],
+        };
+        assert_eq!(
+            PgNumeric::try_from(&max_value_max_scale).unwrap(),
+            expected_numeric
+        );
+
+        let actual_decimal = Decimal::try_from(expected_numeric).unwrap();
+        assert_eq!(actual_decimal, max_value_max_scale);
+        assert_eq!(actual_decimal.mantissa(), 79_228_162_514_264_337_593_543_950_335);
+        assert_eq!(actual_decimal.scale(), 28);
+    }
+
+    #[test]
     fn issue_423_four_digit() {
         // This is a regression test for https://github.com/launchbadge/sqlx/issues/423
         let four_digit: Decimal = "1234".parse().unwrap();
@@ -420,7 +487,4 @@ mod decimal_to_pgnumeric {
         assert_eq!(actual_decimal.mantissa(), 10000);
         assert_eq!(actual_decimal.scale(), 2);
     }
-
-    #[test]
-    fn issue_666_trailing_zeroes_at_max_precision() {}
 }

--- a/sqlx-postgres/src/types/rust_decimal.rs
+++ b/sqlx-postgres/src/types/rust_decimal.rs
@@ -50,6 +50,9 @@ impl TryFrom<&'_ PgNumeric> for Decimal {
             // Postgres returns an empty digit array for 0
             return Ok(Decimal::ZERO);
         }
+        
+        let scale = u32::try_from(scale)
+            .map_err(|_| format!("invalid scale value for Pg NUMERIC: {scale}"))?;
 
         let mut value = Decimal::ZERO;
 
@@ -73,7 +76,7 @@ impl TryFrom<&'_ PgNumeric> for Decimal {
             PgNumericSign::Negative => value.set_sign_negative(true),
         }
 
-        value.rescale(scale as u32);
+        value.rescale(scale);
 
         Ok(value)
     }

--- a/sqlx-postgres/src/types/rust_decimal.rs
+++ b/sqlx-postgres/src/types/rust_decimal.rs
@@ -50,7 +50,7 @@ impl TryFrom<&'_ PgNumeric> for Decimal {
             // Postgres returns an empty digit array for 0
             return Ok(Decimal::ZERO);
         }
-        
+
         let scale = u32::try_from(scale)
             .map_err(|_| format!("invalid scale value for Pg NUMERIC: {scale}"))?;
 
@@ -171,7 +171,7 @@ impl From<&'_ Decimal> for PgNumeric {
 
 impl Encode<'_, Postgres> for Decimal {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
-        PgNumeric::from(self).encode(buf);
+        PgNumeric::from(self).encode(buf)?;
 
         Ok(IsNull::No)
     }

--- a/sqlx-postgres/src/types/rust_decimal.rs
+++ b/sqlx-postgres/src/types/rust_decimal.rs
@@ -193,15 +193,9 @@ mod tests {
     fn zero() {
         let zero: Decimal = "0".parse().unwrap();
 
-        assert_eq!(
-            PgNumeric::from(&zero),
-            PgNumeric::ZERO,
-        );
+        assert_eq!(PgNumeric::from(&zero), PgNumeric::ZERO,);
 
-        assert_eq!(
-            Decimal::try_from(&PgNumeric::ZERO).unwrap(),
-            Decimal::ZERO
-        );
+        assert_eq!(Decimal::try_from(&PgNumeric::ZERO).unwrap(), Decimal::ZERO);
     }
 
     #[test]
@@ -384,7 +378,10 @@ mod tests {
         let actual_decimal = Decimal::try_from(expected_numeric).unwrap();
         assert_eq!(actual_decimal, Decimal::MAX);
         // Value split by 10,000's to match the expected digits[]
-        assert_eq!(actual_decimal.mantissa(), 7_9228_1625_1426_4337_5935_4395_0335);
+        assert_eq!(
+            actual_decimal.mantissa(),
+            7_9228_1625_1426_4337_5935_4395_0335
+        );
         assert_eq!(actual_decimal.scale(), 0);
     }
 
@@ -406,7 +403,10 @@ mod tests {
 
         let actual_decimal = Decimal::try_from(expected_numeric).unwrap();
         assert_eq!(actual_decimal, max_value_max_scale);
-        assert_eq!(actual_decimal.mantissa(), 79_228_162_514_264_337_593_543_950_335);
+        assert_eq!(
+            actual_decimal.mantissa(),
+            79_228_162_514_264_337_593_543_950_335
+        );
         assert_eq!(actual_decimal.scale(), 28);
     }
 

--- a/sqlx-postgres/src/types/time/date.rs
+++ b/sqlx-postgres/src/types/time/date.rs
@@ -23,10 +23,9 @@ impl PgHasArrayType for Date {
 impl Encode<'_, Postgres> for Date {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
         // DATE is encoded as number of days since epoch (2000-01-01)
-        let days: i32 = (*self - PG_EPOCH)
-            .whole_days()
-            .try_into()
-            .map_err(|_| format!("value {self:?} would overflow binary encoding for Postgres DATE"))?;
+        let days: i32 = (*self - PG_EPOCH).whole_days().try_into().map_err(|_| {
+            format!("value {self:?} would overflow binary encoding for Postgres DATE")
+        })?;
         Encode::<Postgres>::encode(days, buf)
     }
 

--- a/sqlx-postgres/src/types/time/date.rs
+++ b/sqlx-postgres/src/types/time/date.rs
@@ -22,8 +22,11 @@ impl PgHasArrayType for Date {
 
 impl Encode<'_, Postgres> for Date {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
-        // DATE is encoded as the days since epoch
-        let days = (*self - PG_EPOCH).whole_days() as i32;
+        // DATE is encoded as number of days since epoch (2000-01-01)
+        let days: i32 = (*self - PG_EPOCH)
+            .whole_days()
+            .try_into()
+            .map_err(|_| format!("value {self:?} would overflow binary encoding for Postgres DATE"))?;
         Encode::<Postgres>::encode(days, buf)
     }
 

--- a/sqlx-postgres/src/types/time/datetime.rs
+++ b/sqlx-postgres/src/types/time/datetime.rs
@@ -37,7 +37,9 @@ impl PgHasArrayType for OffsetDateTime {
 impl Encode<'_, Postgres> for PrimitiveDateTime {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
         // TIMESTAMP is encoded as the microseconds since the epoch
-        let micros = (*self - PG_EPOCH.midnight()).whole_microseconds() as i64;
+        let micros: i64 = (*self - PG_EPOCH.midnight()).whole_microseconds()
+            .try_into()
+            .map_err(|_| format!("value {self:?} would overflow binary encoding for Postgres TIME"))?;
         Encode::<Postgres>::encode(micros, buf)
     }
 

--- a/sqlx-postgres/src/types/time/datetime.rs
+++ b/sqlx-postgres/src/types/time/datetime.rs
@@ -37,9 +37,12 @@ impl PgHasArrayType for OffsetDateTime {
 impl Encode<'_, Postgres> for PrimitiveDateTime {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
         // TIMESTAMP is encoded as the microseconds since the epoch
-        let micros: i64 = (*self - PG_EPOCH.midnight()).whole_microseconds()
+        let micros: i64 = (*self - PG_EPOCH.midnight())
+            .whole_microseconds()
             .try_into()
-            .map_err(|_| format!("value {self:?} would overflow binary encoding for Postgres TIME"))?;
+            .map_err(|_| {
+                format!("value {self:?} would overflow binary encoding for Postgres TIME")
+            })?;
         Encode::<Postgres>::encode(micros, buf)
     }
 

--- a/sqlx-postgres/src/types/time/time.rs
+++ b/sqlx-postgres/src/types/time/time.rs
@@ -21,8 +21,11 @@ impl PgHasArrayType for Time {
 
 impl Encode<'_, Postgres> for Time {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
-        // TIME is encoded as the microseconds since midnight
-        let micros = (*self - Time::MIDNIGHT).whole_microseconds() as i64;
+        // TIME is encoded as the microseconds since midnight.
+        //
+        // A truncating cast is fine because `self - Time::MIDNIGHT` cannot exceed a span of 24 hours.
+        #[allow(clippy::cast_possible_truncation)]
+        let micros: i64 = (*self - Time::MIDNIGHT).whole_microseconds() as i64;
         Encode::<Postgres>::encode(micros, buf)
     }
 

--- a/sqlx-sqlite/Cargo.toml
+++ b/sqlx-sqlite/Cargo.toml
@@ -16,7 +16,11 @@ json = ["sqlx-core/json", "serde"]
 offline = ["sqlx-core/offline", "serde"]
 migrate = ["sqlx-core/migrate"]
 
-chrono = ["dep:chrono"]
+# Type integrations
+chrono = ["dep:chrono", "sqlx-core/chrono"]
+time = ["dep:time", "sqlx-core/time"]
+uuid = ["dep:uuid", "sqlx-core/uuid"]
+
 regexp = ["dep:regex"]
 
 [dependencies]

--- a/sqlx-sqlite/Cargo.toml
+++ b/sqlx-sqlite/Cargo.toml
@@ -60,3 +60,6 @@ workspace = true
 
 [dev-dependencies]
 sqlx = { workspace = true, default-features = false, features = ["macros", "runtime-tokio", "tls-none"] }
+
+[lints]
+workspace = true

--- a/sqlx-sqlite/Cargo.toml
+++ b/sqlx-sqlite/Cargo.toml
@@ -63,7 +63,7 @@ features = [
 workspace = true
 
 [dev-dependencies]
-sqlx = { workspace = true, default-features = false, features = ["macros", "runtime-tokio", "tls-none"] }
+sqlx = { workspace = true, default-features = false, features = ["macros", "runtime-tokio", "tls-none", "sqlite"] }
 
 [lints]
 workspace = true

--- a/sqlx-sqlite/src/connection/explain.rs
+++ b/sqlx-sqlite/src/connection/explain.rs
@@ -1633,147 +1633,147 @@ fn test_root_block_columns_has_types() {
     {
         let table_db_block = table_block_nums["t"];
         assert_eq!(
-            ColumnType::Single {
+            Some(&ColumnType::Single {
                 datatype: DataType::Integer,
                 nullable: Some(true) //sqlite primary key columns are nullable unless declared not null
-            },
-            root_block_cols[&table_db_block][&0]
+            }),
+            root_block_cols[&table_db_block].get(&0)
         );
         assert_eq!(
-            ColumnType::Single {
+            Some(&ColumnType::Single {
                 datatype: DataType::Text,
                 nullable: Some(true)
-            },
-            root_block_cols[&table_db_block][&1]
+            }),
+            root_block_cols[&table_db_block].get(&1)
         );
         assert_eq!(
-            ColumnType::Single {
+            Some(&ColumnType::Single {
                 datatype: DataType::Text,
                 nullable: Some(false)
-            },
-            root_block_cols[&table_db_block][&2]
+            }),
+            root_block_cols[&table_db_block].get(&2)
         );
     }
 
     {
         let table_db_block = table_block_nums["i1"];
         assert_eq!(
-            ColumnType::Single {
+            Some(&ColumnType::Single {
                 datatype: DataType::Integer,
                 nullable: Some(true) //sqlite primary key columns are nullable unless declared not null
-            },
-            root_block_cols[&table_db_block][&0]
+            }),
+            root_block_cols[&table_db_block].get(&0)
         );
         assert_eq!(
-            ColumnType::Single {
+            Some(&ColumnType::Single {
                 datatype: DataType::Text,
                 nullable: Some(true)
-            },
-            root_block_cols[&table_db_block][&1]
+            }),
+            root_block_cols[&table_db_block].get(&1)
         );
     }
 
     {
         let table_db_block = table_block_nums["i2"];
         assert_eq!(
-            ColumnType::Single {
+            Some(&ColumnType::Single {
                 datatype: DataType::Integer,
                 nullable: Some(true) //sqlite primary key columns are nullable unless declared not null
-            },
-            root_block_cols[&table_db_block][&0]
+            }),
+            root_block_cols[&table_db_block].get(&0)
         );
         assert_eq!(
-            ColumnType::Single {
+            Some(&ColumnType::Single {
                 datatype: DataType::Text,
                 nullable: Some(true)
-            },
-            root_block_cols[&table_db_block][&1]
+            }),
+            root_block_cols[&table_db_block].get(&1)
         );
     }
 
     {
         let table_db_block = table_block_nums["t2"];
         assert_eq!(
-            ColumnType::Single {
+            Some(&ColumnType::Single {
                 datatype: DataType::Integer,
                 nullable: Some(false)
-            },
-            root_block_cols[&table_db_block][&0]
+            }),
+            root_block_cols[&table_db_block].get(&0)
         );
         assert_eq!(
-            ColumnType::Single {
+            Some(&ColumnType::Single {
                 datatype: DataType::Null,
                 nullable: Some(true)
-            },
-            root_block_cols[&table_db_block][&1]
+            }),
+            root_block_cols[&table_db_block].get(&1)
         );
         assert_eq!(
-            ColumnType::Single {
+            Some(&ColumnType::Single {
                 datatype: DataType::Null,
                 nullable: Some(false)
-            },
-            root_block_cols[&table_db_block][&2]
+            }),
+            root_block_cols[&table_db_block].get(&2)
         );
     }
 
     {
         let table_db_block = table_block_nums["t2i1"];
         assert_eq!(
-            ColumnType::Single {
+            Some(&ColumnType::Single {
                 datatype: DataType::Integer,
                 nullable: Some(false)
-            },
-            root_block_cols[&table_db_block][&0]
+            }),
+            root_block_cols[&table_db_block].get(&0)
         );
         assert_eq!(
-            ColumnType::Single {
+            Some(&ColumnType::Single {
                 datatype: DataType::Null,
                 nullable: Some(true)
-            },
-            root_block_cols[&table_db_block][&1]
+            }),
+            root_block_cols[&table_db_block].get(&1)
         );
     }
 
     {
         let table_db_block = table_block_nums["t2i2"];
         assert_eq!(
-            ColumnType::Single {
+            Some(&ColumnType::Single {
                 datatype: DataType::Integer,
                 nullable: Some(false)
-            },
-            root_block_cols[&table_db_block][&0]
+            }),
+            root_block_cols[&table_db_block].get(&0)
         );
         assert_eq!(
-            ColumnType::Single {
+            Some(&ColumnType::Single {
                 datatype: DataType::Null,
                 nullable: Some(false)
-            },
-            root_block_cols[&table_db_block][&1]
+            }),
+            root_block_cols[&table_db_block].get(&1)
         );
     }
 
     {
         let table_db_block = table_block_nums["t3"];
         assert_eq!(
-            ColumnType::Single {
+            Some(&ColumnType::Single {
                 datatype: DataType::Text,
                 nullable: Some(true)
-            },
-            root_block_cols[&table_db_block][&0]
+            }),
+            root_block_cols[&table_db_block].get(&0)
         );
         assert_eq!(
-            ColumnType::Single {
+            Some(&ColumnType::Single {
                 datatype: DataType::Float,
                 nullable: Some(false)
-            },
-            root_block_cols[&table_db_block][&1]
+            }),
+            root_block_cols[&table_db_block].get(&1)
         );
         assert_eq!(
-            ColumnType::Single {
+            Some(&ColumnType::Single {
                 datatype: DataType::Float,
                 nullable: Some(true)
-            },
-            root_block_cols[&table_db_block][&2]
+            }),
+            root_block_cols[&table_db_block].get(&2)
         );
     }
 }

--- a/sqlx-sqlite/src/connection/explain.rs
+++ b/sqlx-sqlite/src/connection/explain.rs
@@ -1,3 +1,10 @@
+// Bad casts in this module SHOULD NOT result in a SQL injection
+// https://github.com/launchbadge/sqlx/issues/3440
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss
+)]
 use crate::connection::intmap::IntMap;
 use crate::connection::{execute, ConnectionState};
 use crate::error::Error;

--- a/sqlx-sqlite/src/connection/intmap.rs
+++ b/sqlx-sqlite/src/connection/intmap.rs
@@ -1,3 +1,10 @@
+// Bad casts in this module SHOULD NOT result in a SQL injection
+// https://github.com/launchbadge/sqlx/issues/3440
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss
+)]
 use std::cmp::Ordering;
 use std::{fmt::Debug, hash::Hash};
 

--- a/sqlx-sqlite/src/logger.rs
+++ b/sqlx-sqlite/src/logger.rs
@@ -1,3 +1,11 @@
+// Bad casts in this module SHOULD NOT result in a SQL injection
+// https://github.com/launchbadge/sqlx/issues/3440
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss
+)]
+
 use crate::connection::intmap::IntMap;
 use std::collections::HashSet;
 use std::fmt::Debug;

--- a/sqlx-sqlite/src/migrate.rs
+++ b/sqlx-sqlite/src/migrate.rs
@@ -168,6 +168,7 @@ CREATE TABLE IF NOT EXISTS _sqlx_migrations (
             let elapsed = start.elapsed();
 
             // language=SQL
+            #[allow(clippy::cast_possible_truncation)]
             let _ = query(
                 r#"
     UPDATE _sqlx_migrations

--- a/sqlx-sqlite/src/options/parse.rs
+++ b/sqlx-sqlite/src/options/parse.rs
@@ -1,11 +1,13 @@
-use crate::error::Error;
-use crate::SqliteConnectOptions;
-use percent_encoding::{percent_decode_str, utf8_percent_encode, NON_ALPHANUMERIC};
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicUsize, Ordering};
+
+use percent_encoding::{percent_decode_str, percent_encode, AsciiSet};
 use url::Url;
+
+use crate::error::Error;
+use crate::SqliteConnectOptions;
 
 // https://www.sqlite.org/uri.html
 
@@ -114,10 +116,25 @@ impl SqliteConnectOptions {
     }
 
     pub(crate) fn build_url(&self) -> Url {
-        let filename =
-            utf8_percent_encode(&self.filename.to_string_lossy(), NON_ALPHANUMERIC).to_string();
-        let mut url =
-            Url::parse(&format!("sqlite://{}", filename)).expect("BUG: generated un-parseable URL");
+        // https://url.spec.whatwg.org/#path-percent-encode-set
+        static PATH_ENCODE_SET: AsciiSet = percent_encoding::CONTROLS
+            .add(b' ')
+            .add(b'"')
+            .add(b'#')
+            .add(b'<')
+            .add(b'>')
+            .add(b'?')
+            .add(b'`')
+            .add(b'{')
+            .add(b'}');
+
+        let filename_encoded = percent_encode(
+            self.filename.as_os_str().as_encoded_bytes(),
+            &PATH_ENCODE_SET,
+        );
+
+        let mut url = Url::parse(&format!("sqlite://{filename_encoded}"))
+            .expect("BUG: generated un-parseable URL");
 
         let mode = match (self.in_memory, self.create_if_missing, self.read_only) {
             (true, _, _) => "memory",
@@ -133,8 +150,9 @@ impl SqliteConnectOptions {
         };
         url.query_pairs_mut().append_pair("cache", cache);
 
-        url.query_pairs_mut()
-            .append_pair("immutable", &self.immutable.to_string());
+        if self.immutable {
+            url.query_pairs_mut().append_pair("immutable", "true");
+        }
 
         if let Some(vfs) = &self.vfs {
             url.query_pairs_mut().append_pair("vfs", vfs);

--- a/sqlx-sqlite/src/regexp.rs
+++ b/sqlx-sqlite/src/regexp.rs
@@ -170,7 +170,7 @@ unsafe extern "C" fn cleanup_arc_regex_pointer(ptr: *mut std::ffi::c_void) {
 
 #[cfg(test)]
 mod tests {
-    use sqlx::{ConnectOptions, Connection, Row};
+    use sqlx::{ConnectOptions, Row};
     use std::str::FromStr;
 
     async fn test_db() -> crate::SqliteConnection {

--- a/sqlx-sqlite/src/statement/handle.rs
+++ b/sqlx-sqlite/src/statement/handle.rs
@@ -34,6 +34,23 @@ pub(crate) struct StatementHandle(NonNull<sqlite3_stmt>);
 
 unsafe impl Send for StatementHandle {}
 
+macro_rules! expect_ret_valid {
+    ($fn_name:ident($($args:tt)*)) => {{
+        let val = $fn_name($($args)*);
+
+        TryFrom::try_from(val)
+            // This likely means UB in SQLite itself or our usage of it;
+            // signed integer overflow is UB in the C standard.
+            .unwrap_or_else(|_| panic!("{}() returned invalid value: {val:?}", stringify!($fn_name)))
+    }}
+}
+
+macro_rules! check_col_idx {
+    ($idx:ident) => {
+        c_int::try_from($idx).unwrap_or_else(|_| panic!("invalid column index: {}", $idx))
+    };
+}
+
 // might use some of this later
 #[allow(dead_code)]
 impl StatementHandle {
@@ -71,7 +88,7 @@ impl StatementHandle {
     #[inline]
     pub(crate) fn column_count(&self) -> usize {
         // https://sqlite.org/c3ref/column_count.html
-        unsafe { sqlite3_column_count(self.0.as_ptr()) as usize }
+        unsafe { expect_ret_valid!(sqlite3_column_count(self.0.as_ptr())) }
     }
 
     #[inline]
@@ -79,14 +96,14 @@ impl StatementHandle {
         // returns the number of changes of the *last* statement; not
         // necessarily this statement.
         // https://sqlite.org/c3ref/changes.html
-        unsafe { sqlite3_changes(self.db_handle()) as u64 }
+        unsafe { expect_ret_valid!(sqlite3_changes(self.db_handle())) }
     }
 
     #[inline]
     pub(crate) fn column_name(&self, index: usize) -> &str {
         // https://sqlite.org/c3ref/column_name.html
         unsafe {
-            let name = sqlite3_column_name(self.0.as_ptr(), index as c_int);
+            let name = sqlite3_column_name(self.0.as_ptr(), check_col_idx!(index));
             debug_assert!(!name.is_null());
 
             from_utf8_unchecked(CStr::from_ptr(name).to_bytes())
@@ -107,7 +124,7 @@ impl StatementHandle {
     #[inline]
     pub(crate) fn column_decltype(&self, index: usize) -> Option<SqliteTypeInfo> {
         unsafe {
-            let decl = sqlite3_column_decltype(self.0.as_ptr(), index as c_int);
+            let decl = sqlite3_column_decltype(self.0.as_ptr(), check_col_idx!(index));
             if decl.is_null() {
                 // If the Nth column of the result set is an expression or subquery,
                 // then a NULL pointer is returned.
@@ -123,6 +140,8 @@ impl StatementHandle {
 
     pub(crate) fn column_nullable(&self, index: usize) -> Result<Option<bool>, Error> {
         unsafe {
+            let index = check_col_idx!(index);
+
             // https://sqlite.org/c3ref/column_database_name.html
             //
             // ### Note
@@ -130,9 +149,9 @@ impl StatementHandle {
             // sqlite3_finalize() or until the statement is automatically reprepared by the
             // first call to sqlite3_step() for a particular run or until the same information
             // is requested again in a different encoding.
-            let db_name = sqlite3_column_database_name(self.0.as_ptr(), index as c_int);
-            let table_name = sqlite3_column_table_name(self.0.as_ptr(), index as c_int);
-            let origin_name = sqlite3_column_origin_name(self.0.as_ptr(), index as c_int);
+            let db_name = sqlite3_column_database_name(self.0.as_ptr(), index);
+            let table_name = sqlite3_column_table_name(self.0.as_ptr(), index);
+            let origin_name = sqlite3_column_origin_name(self.0.as_ptr(), index);
 
             if db_name.is_null() || table_name.is_null() || origin_name.is_null() {
                 return Ok(None);
@@ -174,7 +193,7 @@ impl StatementHandle {
     #[inline]
     pub(crate) fn bind_parameter_count(&self) -> usize {
         // https://www.sqlite.org/c3ref/bind_parameter_count.html
-        unsafe { sqlite3_bind_parameter_count(self.0.as_ptr()) as usize }
+        unsafe { expect_ret_valid!(sqlite3_bind_parameter_count(self.0.as_ptr())) }
     }
 
     // Name Of A Host Parameter
@@ -183,7 +202,7 @@ impl StatementHandle {
     pub(crate) fn bind_parameter_name(&self, index: usize) -> Option<&str> {
         unsafe {
             // https://www.sqlite.org/c3ref/bind_parameter_name.html
-            let name = sqlite3_bind_parameter_name(self.0.as_ptr(), index as c_int);
+            let name = sqlite3_bind_parameter_name(self.0.as_ptr(), check_col_idx!(index));
             if name.is_null() {
                 return None;
             }
@@ -200,7 +219,7 @@ impl StatementHandle {
         unsafe {
             sqlite3_bind_blob64(
                 self.0.as_ptr(),
-                index as c_int,
+                check_col_idx!(index),
                 v.as_ptr() as *const c_void,
                 v.len() as u64,
                 SQLITE_TRANSIENT(),
@@ -210,36 +229,39 @@ impl StatementHandle {
 
     #[inline]
     pub(crate) fn bind_text(&self, index: usize, v: &str) -> c_int {
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let encoding = SQLITE_UTF8 as u8;
+
         unsafe {
             sqlite3_bind_text64(
                 self.0.as_ptr(),
-                index as c_int,
+                check_col_idx!(index),
                 v.as_ptr() as *const c_char,
                 v.len() as u64,
                 SQLITE_TRANSIENT(),
-                SQLITE_UTF8 as u8,
+                encoding,
             )
         }
     }
 
     #[inline]
     pub(crate) fn bind_int(&self, index: usize, v: i32) -> c_int {
-        unsafe { sqlite3_bind_int(self.0.as_ptr(), index as c_int, v as c_int) }
+        unsafe { sqlite3_bind_int(self.0.as_ptr(), check_col_idx!(index), v as c_int) }
     }
 
     #[inline]
     pub(crate) fn bind_int64(&self, index: usize, v: i64) -> c_int {
-        unsafe { sqlite3_bind_int64(self.0.as_ptr(), index as c_int, v) }
+        unsafe { sqlite3_bind_int64(self.0.as_ptr(), check_col_idx!(index), v) }
     }
 
     #[inline]
     pub(crate) fn bind_double(&self, index: usize, v: f64) -> c_int {
-        unsafe { sqlite3_bind_double(self.0.as_ptr(), index as c_int, v) }
+        unsafe { sqlite3_bind_double(self.0.as_ptr(), check_col_idx!(index), v) }
     }
 
     #[inline]
     pub(crate) fn bind_null(&self, index: usize) -> c_int {
-        unsafe { sqlite3_bind_null(self.0.as_ptr(), index as c_int) }
+        unsafe { sqlite3_bind_null(self.0.as_ptr(), check_col_idx!(index)) }
     }
 
     // result values from the query
@@ -247,39 +269,41 @@ impl StatementHandle {
 
     #[inline]
     pub(crate) fn column_type(&self, index: usize) -> c_int {
-        unsafe { sqlite3_column_type(self.0.as_ptr(), index as c_int) }
+        unsafe { sqlite3_column_type(self.0.as_ptr(), check_col_idx!(index)) }
     }
 
     #[inline]
     pub(crate) fn column_int(&self, index: usize) -> i32 {
-        unsafe { sqlite3_column_int(self.0.as_ptr(), index as c_int) as i32 }
+        unsafe { sqlite3_column_int(self.0.as_ptr(), check_col_idx!(index)) as i32 }
     }
 
     #[inline]
     pub(crate) fn column_int64(&self, index: usize) -> i64 {
-        unsafe { sqlite3_column_int64(self.0.as_ptr(), index as c_int) as i64 }
+        unsafe { sqlite3_column_int64(self.0.as_ptr(), check_col_idx!(index)) as i64 }
     }
 
     #[inline]
     pub(crate) fn column_double(&self, index: usize) -> f64 {
-        unsafe { sqlite3_column_double(self.0.as_ptr(), index as c_int) }
+        unsafe { sqlite3_column_double(self.0.as_ptr(), check_col_idx!(index)) }
     }
 
     #[inline]
     pub(crate) fn column_value(&self, index: usize) -> *mut sqlite3_value {
-        unsafe { sqlite3_column_value(self.0.as_ptr(), index as c_int) }
+        unsafe { sqlite3_column_value(self.0.as_ptr(), check_col_idx!(index)) }
     }
 
     pub(crate) fn column_blob(&self, index: usize) -> &[u8] {
-        let index = index as c_int;
-        let len = unsafe { sqlite3_column_bytes(self.0.as_ptr(), index) } as usize;
+        let len = unsafe {
+            expect_ret_valid!(sqlite3_column_bytes(self.0.as_ptr(), check_col_idx!(index)))
+        };
 
         if len == 0 {
             // empty blobs are NULL so just return an empty slice
             return &[];
         }
 
-        let ptr = unsafe { sqlite3_column_blob(self.0.as_ptr(), index) } as *const u8;
+        let ptr =
+            unsafe { sqlite3_column_blob(self.0.as_ptr(), check_col_idx!(index)) } as *const u8;
         debug_assert!(!ptr.is_null());
 
         unsafe { from_raw_parts(ptr, len) }

--- a/sqlx-sqlite/src/statement/unlock_notify.rs
+++ b/sqlx-sqlite/src/statement/unlock_notify.rs
@@ -27,7 +27,8 @@ pub unsafe fn wait(conn: *mut sqlite3) -> Result<(), SqliteError> {
 
 unsafe extern "C" fn unlock_notify_cb(ptr: *mut *mut c_void, len: c_int) {
     let ptr = ptr as *mut &Notify;
-    let slice = slice::from_raw_parts(ptr, len as usize);
+    // We don't have a choice; we can't panic and unwind into FFI here.
+    let slice = slice::from_raw_parts(ptr, usize::try_from(len).unwrap_or(0));
 
     for notify in slice {
         notify.fire();

--- a/sqlx-sqlite/src/statement/virtual.rs
+++ b/sqlx-sqlite/src/statement/virtual.rs
@@ -163,7 +163,13 @@ fn prepare(
         let mut tail: *const c_char = null();
 
         let query_ptr = query.as_ptr() as *const c_char;
-        let query_len = query.len() as i32;
+        let query_len = i32::try_from(query.len()).map_err(|_| {
+            err_protocol!(
+                "query string too large for SQLite3 API ({} bytes); \
+                 try breaking it into smaller chunks (< 2 GiB), executed separately",
+                query.len()
+            )
+        })?;
 
         // <https://www.sqlite.org/c3ref/prepare.html>
         let status = unsafe {

--- a/sqlx-sqlite/src/types/float.rs
+++ b/sqlx-sqlite/src/types/float.rs
@@ -24,6 +24,8 @@ impl<'q> Encode<'q, Sqlite> for f32 {
 
 impl<'r> Decode<'r, Sqlite> for f32 {
     fn decode(value: SqliteValueRef<'r>) -> Result<f32, BoxDynError> {
+        // Truncation is intentional
+        #[allow(clippy::cast_possible_truncation)]
         Ok(value.double() as f32)
     }
 }

--- a/sqlx-test/Cargo.toml
+++ b/sqlx-test/Cargo.toml
@@ -9,3 +9,6 @@ sqlx = { default-features = false, path = ".." }
 env_logger = "0.11"
 dotenvy = "0.15.0"
 anyhow = "1.0.26"
+
+[lints]
+workspace = true

--- a/tests/mysql/error.rs
+++ b/tests/mysql/error.rs
@@ -57,7 +57,6 @@ async fn it_fails_with_not_null_violation() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg(mysql_8)]
 #[sqlx_macros::test]
 async fn it_fails_with_check_violation() -> anyhow::Result<()> {
     let mut conn = new::<MySql>().await?;

--- a/tests/mysql/rustsec.rs
+++ b/tests/mysql/rustsec.rs
@@ -1,0 +1,67 @@
+use sqlx::{Error, MySql};
+use std::io;
+
+use sqlx_test::new;
+
+// https://rustsec.org/advisories/RUSTSEC-2024-0363.html
+//
+// During the audit the MySQL driver was found to be *unlikely* to be vulnerable to the exploit,
+// so this just serves as a sanity check.
+#[sqlx::test]
+async fn rustsec_2024_0363() -> anyhow::Result<()> {
+    let overflow_len = 4 * 1024 * 1024 * 1024; // 4 GiB
+
+    let padding = " ".repeat(overflow_len);
+
+    let payload = "UPDATE injection_target SET message = 'you''ve been pwned!' WHERE id = 1";
+
+    let mut injected_value = String::with_capacity(overflow_len + payload.len());
+
+    injected_value.push_str(&padding);
+    injected_value.push_str(payload);
+
+    // Since this is so large, keeping it around until the end *can* lead to getting OOM-killed.
+    drop(padding);
+
+    let mut conn = new::<MySql>().await?;
+
+    sqlx::raw_sql(
+        "CREATE TEMPORARY TABLE injection_target(id INTEGER PRIMARY KEY AUTO_INCREMENT, message TEXT);\n\
+         INSERT INTO injection_target(message) VALUES ('existing message');",
+    )
+    .execute(&mut conn)
+    .await?;
+
+    // We can't concatenate a query string together like the other tests
+    // because it would just demonstrate a regular old SQL injection.
+    let res = sqlx::query("INSERT INTO injection_target(message) VALUES (?)")
+        .bind(&injected_value)
+        .execute(&mut conn)
+        .await;
+
+    if let Err(e) = res {
+        // Connection rejected the query; we're happy.
+        //
+        // Current observed behavior is that `mysqld` closes the connection before we're even done
+        // sending the message, giving us a "Broken pipe" error.
+        //
+        // As it turns out, MySQL has a tight limit on packet sizes (even after splitting)
+        // by default: https://dev.mysql.com/doc/refman/8.4/en/packet-too-large.html
+        if matches!(e, Error::Io(ref ioe) if ioe.kind() == io::ErrorKind::BrokenPipe) {
+            return Ok(());
+        }
+
+        panic!("unexpected error: {e:?}");
+    }
+
+    let messages: Vec<String> =
+        sqlx::query_scalar("SELECT message FROM injection_target ORDER BY id")
+            .fetch_all(&mut conn)
+            .await?;
+
+    assert_eq!(messages[0], "existing_message");
+    assert_eq!(messages[1].len(), injected_value.len());
+
+    // Injection didn't affect our database; we're happy.
+    Ok(())
+}

--- a/tests/postgres/fixtures/rustsec/2024_0363.sql
+++ b/tests/postgres/fixtures/rustsec/2024_0363.sql
@@ -1,0 +1,4 @@
+-- https://rustsec.org/advisories/RUSTSEC-2024-0363.html
+-- https://github.com/launchbadge/sqlx/issues/3440
+CREATE TABLE injection_target(id BIGSERIAL PRIMARY KEY, message TEXT);
+INSERT INTO injection_target(message) VALUES ('existing value');

--- a/tests/postgres/rustsec.rs
+++ b/tests/postgres/rustsec.rs
@@ -1,0 +1,146 @@
+use sqlx::{Error, PgPool};
+
+use std::{cmp, str};
+
+// https://rustsec.org/advisories/RUSTSEC-2024-0363.html
+#[sqlx::test(migrations = false, fixtures("./fixtures/rustsec/2024_0363.sql"))]
+async fn rustsec_2024_0363(pool: PgPool) -> anyhow::Result<()> {
+    let overflow_len = 4 * 1024 * 1024 * 1024; // 4 GiB
+
+    // These three strings concatenated together will be the first query the Postgres backend "sees"
+    //
+    // Rather contrived because this already represents an injection vulnerability,
+    // but it's easier to demonstrate the bug with a simple `Query` message
+    // than the `Prepare` -> `Bind` -> `Execute` flow.
+    let real_query_prefix = "INSERT INTO injection_target(message) VALUES ('";
+    let fake_message = "fake_msg') RETURNING id;\0";
+    let real_query_suffix = "') RETURNING id";
+
+    // Our payload is another simple `Query` message
+    let real_payload =
+        "Q\0\0\0\x4DUPDATE injection_target SET message = 'you''ve been pwned!' WHERE id = 1\0";
+
+    // This is the value we want the length prefix to overflow to (including the length of the prefix itself)
+    // This will leave the backend's buffer pointing at our real payload.
+    let fake_payload_len = real_query_prefix.len() + fake_message.len() + 4;
+
+    // Pretty easy to see that this should overflow to `fake_payload_len`
+    let target_payload_len = overflow_len + fake_payload_len;
+
+    // This is the length we expect `injected_value` to be
+    let expected_inject_len = target_payload_len
+        - 4 // Length prefix
+        - real_query_prefix.len()
+        - (real_query_suffix.len() + 1 /* NUL terminator */);
+
+    let pad_to_len = expected_inject_len - 5; // Header for FLUSH message that eats `real_query_suffix` (see below)
+
+    let expected_payload_len = 4 // length prefix
+        + real_query_prefix.len()
+        + expected_inject_len
+        + real_query_suffix.len()
+        + 1; // NUL terminator
+
+    let expected_wrapped_len = expected_payload_len % overflow_len;
+    assert_eq!(expected_wrapped_len, fake_payload_len);
+
+    // This will be the string we inject into the query.
+    let mut injected_value = String::with_capacity(expected_inject_len);
+
+    injected_value.push_str(fake_message);
+    injected_value.push_str(real_payload);
+
+    // The Postgres backend reads the `FLUSH` message but ignores its contents.
+    // This gives us a variable-length NOP that lets us pad to the length we want,
+    // as well as a way to eat `real_query_suffix` without breaking the connection.
+    let flush_fill = "\0".repeat(9996);
+
+    let flush_fmt_code = 'H'; // note: 'F' is `FunctionCall`.
+
+    'outer: while injected_value.len() < pad_to_len {
+        let remaining_len = pad_to_len - injected_value.len();
+
+        // The max length of a FLUSH message is 10,000, including the length prefix.
+        let flush_len = cmp::min(
+            remaining_len - 1, // minus format code
+            10000,
+        );
+
+        // We need `flush_len` to be valid UTF-8 when encoded in big-endian
+        // in order to push it to the string.
+        //
+        // Not every value is going to be valid though, so we search for one that is.
+        'inner: for flush_len in (4..=flush_len).rev() {
+            let flush_len_be = (flush_len as i32).to_be_bytes();
+
+            let Ok(flush_len_str) = str::from_utf8(&flush_len_be) else {
+                continue 'inner;
+            };
+
+            let fill_len = flush_len - 4;
+
+            injected_value.push(flush_fmt_code);
+            injected_value.push_str(flush_len_str);
+            injected_value.push_str(&flush_fill[..fill_len]);
+
+            continue 'outer;
+        }
+
+        panic!("unable to find a valid encoding/split for {flush_len}");
+    }
+
+    assert_eq!(injected_value.len(), pad_to_len);
+
+    // The amount of data the last FLUSH message has to eat
+    let eat_len = real_query_suffix.len() + 1; // plus NUL terminator
+
+    // Push the FLUSH message that will eat `real_query_suffix`
+    injected_value.push(flush_fmt_code);
+    injected_value.push_str(str::from_utf8(&(eat_len as i32).to_be_bytes()).unwrap());
+    // The value will be in the buffer already.
+
+    assert_eq!(expected_inject_len, injected_value.len());
+
+    let query = format!("{real_query_prefix}{injected_value}{real_query_suffix}");
+
+    // The length of the `Query` message we've created
+    let final_payload_len = 4 // length prefix
+        + query.len()
+        + 1; // NUL terminator
+
+    assert_eq!(expected_payload_len, final_payload_len);
+
+    let wrapped_len = final_payload_len % overflow_len;
+
+    assert_eq!(wrapped_len, fake_payload_len);
+
+    let res = sqlx::raw_sql(&query)
+        // Note: the connection may hang afterward
+        // because `pending_ready_for_query_count` will underflow.
+        .execute(&pool)
+        .await;
+
+    if let Err(e) = res {
+        // Connection rejected the query; we're happy.
+        if matches!(e, Error::Protocol(_)) {
+            return Ok(());
+        }
+
+        panic!("unexpected error: {e:?}");
+    }
+
+    let messages: Vec<String> =
+        sqlx::query_scalar("SELECT message FROM injection_target ORDER BY id")
+            .fetch_all(&pool)
+            .await?;
+
+    // If the injection succeeds, `messages` will look like:
+    // ["you've been pwned!'.to_string(), "fake_msg".to_string()]
+    assert_eq!(
+        messages,
+        ["existing message".to_string(), "fake_msg".to_string()]
+    );
+
+    // Injection didn't affect our database; we're happy.
+    Ok(())
+}

--- a/tests/sqlite/rustsec.rs
+++ b/tests/sqlite/rustsec.rs
@@ -1,0 +1,78 @@
+use sqlx::{Connection, Error, SqliteConnection};
+
+// https://rustsec.org/advisories/RUSTSEC-2024-0363.html
+//
+// Similar theory to the Postgres exploit in `tests/postgres/rustsec.rs` but much simpler
+// since we just want to overflow the query length itself.
+#[sqlx::test]
+async fn rustsec_2024_0363() -> anyhow::Result<()> {
+    let overflow_len = 4 * 1024 * 1024 * 1024; // 4 GiB
+
+    // `real_query_prefix` plus `fake_message` will be the first query that SQLite "sees"
+    //
+    // Rather contrived because this already represents a regular SQL injection,
+    // but this is the easiest way to demonstrate the exploit for SQLite.
+    let real_query_prefix = "INSERT INTO injection_target(message) VALUES ('";
+    let fake_message = "fake_msg') RETURNING id;";
+    let real_query_suffix = "') RETURNING id";
+
+    // Our actual payload is another query
+    let real_payload =
+        "\nUPDATE injection_target SET message = 'you''ve been pwned!' WHERE id = 1;\n--";
+
+    // This will parse the query up to `real_payload`.
+    let fake_payload_len = real_query_prefix.len() + fake_message.len();
+
+    // Pretty easy to see that this will overflow to `fake_payload_len`
+    let target_len = overflow_len + fake_payload_len;
+
+    let inject_len = target_len - real_query_prefix.len() - real_query_suffix.len();
+
+    let pad_len = inject_len - fake_message.len() - real_payload.len();
+
+    let mut injected_value = String::with_capacity(inject_len);
+    injected_value.push_str(fake_message);
+    injected_value.push_str(real_payload);
+
+    let padding = " ".repeat(pad_len);
+    injected_value.push_str(&padding);
+
+    let query = format!("{real_query_prefix}{injected_value}{real_query_suffix}");
+
+    assert_eq!(query.len(), target_len);
+
+    let mut conn = SqliteConnection::connect("sqlite://:memory:").await?;
+
+    sqlx::raw_sql(
+        "CREATE TABLE injection_target(id INTEGER PRIMARY KEY, message TEXT);\n\
+            INSERT INTO injection_target(message) VALUES ('existing message');",
+    )
+    .execute(&mut conn)
+    .await?;
+
+    let res = sqlx::raw_sql(&query).execute(&mut conn).await;
+
+    if let Err(e) = res {
+        // Connection rejected the query; we're happy.
+        if matches!(e, Error::Protocol(_)) {
+            return Ok(());
+        }
+
+        panic!("unexpected error: {e:?}");
+    }
+
+    let messages: Vec<String> =
+        sqlx::query_scalar("SELECT message FROM injection_target ORDER BY id")
+            .fetch_all(&mut conn)
+            .await?;
+
+    // If the injection succeeds, `messages` will look like:
+    // ["you've been pwned!'.to_string(), "fake_msg".to_string()]
+    assert_eq!(
+        messages,
+        ["existing message".to_string(), "fake_msg".to_string()]
+    );
+
+    // Injection didn't affect our database; we're happy.
+    Ok(())
+}


### PR DESCRIPTION
Fixes #3440 

Resolves https://rustsec.org/advisories/RUSTSEC-2024-0363.html

The last three commits may be cherry-picked against https://github.com/launchbadge/sqlx/commit/6f2905695b9606b5f51b40ce10af63ac9e696bb8 to see the exploit in action.

As of writing, only the Postgres driver actually appears to be exploitable before this patch, and appears to no longer be exploitable afterwards.