### PR TITLE
feat(postgres): add PgAdvisoryLockGuardOwned

### DIFF
--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -1834,6 +1834,72 @@ async fn test_advisory_locks() -> anyhow::Result<()> {
 }
 
 #[sqlx_macros::test]
+async fn test_advisory_locks_with_owned_guards() -> anyhow::Result<()> {
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&dotenvy::var("DATABASE_URL")?)
+        .await?;
+
+    let lock1 = Arc::new(PgAdvisoryLock::new("sqlx-postgres-tests-1"));
+    let lock2 = Arc::new(PgAdvisoryLock::new("sqlx-postgres-tests-2"));
+
+    let conn1 = pool.acquire().await?;
+    let mut conn1_lock1 = lock1.clone().acquire_owned(conn1).await?;
+
+    // try acquiring a recursive lock through a mutable reference then dropping
+    drop(lock1.clone().acquire_owned(&mut conn1_lock1).await?);
+
+    let conn2 = pool.acquire().await?;
+    let conn2_lock2 = lock2.clone().acquire_owned(conn2).await?;
+
+    sqlx_core::rt::spawn({
+        let lock1 = lock1.clone();
+        let lock2 = lock2.clone();
+
+        async move {
+            let conn2_lock2 = lock1
+                .clone()
+                .try_acquire_owned(conn2_lock2)
+                .await?
+                .right_or_else(|_| {
+                    panic!(
+                        "acquired lock but wasn't supposed to! Key: {:?}",
+                        lock1.key()
+                    )
+                });
+
+            let (conn2, released) = lock2.force_release(conn2_lock2).await?;
+            assert!(released);
+
+            // acquire both locks but let the pool release them
+            let conn2_lock1 = lock1.acquire_owned(conn2).await?;
+            let _conn2_lock1and2 = lock2.acquire_owned(conn2_lock1).await?;
+
+            anyhow::Ok(())
+        }
+    });
+
+    // acquire lock2 on conn1, we leak the lock1 guard so we can manually release it before lock2
+    let conn1_lock1and2 = lock2.clone().acquire_owned(conn1_lock1.leak()).await?;
+
+    // release lock1 while holding lock2
+    let (conn1_lock2, released) = lock1.force_release(conn1_lock1and2).await?;
+    assert!(released);
+
+    let conn1 = conn1_lock2.release_now().await?;
+
+    // acquire both locks to be sure they were released
+    {
+        let conn1_lock1 = lock1.acquire_owned(conn1).await?;
+        let _conn1_lock1and2 = lock2.acquire_owned(conn1_lock1).await?;
+    }
+
+    pool.close().await;
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
 async fn test_postgres_bytea_hex_deserialization_errors() -> anyhow::Result<()> {
     let mut conn = new::<Postgres>().await?;
     conn.execute("SET bytea_output = 'escape';").await?;


### PR DESCRIPTION
This new lock guard can own an `Arc<PgAdvisoryLock>` without any lifetime, allowing it to be moved into spawned tasks.

Fixes #3429 