### PR TITLE
Clarify usage of Json/Jsonb in query macros

### DIFF
--- a/sqlx-core/src/types/json.rs
+++ b/sqlx-core/src/types/json.rs
@@ -54,7 +54,7 @@ use crate::types::Type;
 ///
 /// If the query macros are used, it is necessary to tell the macro to use
 /// the `Json` adapter by using the type override syntax
-/// ```rust,no_run
+/// ```rust,ignore
 /// # async fn example3() -> sqlx::Result<()> {
 /// # let mut conn: sqlx::PgConnection = unimplemented!();
 /// #[derive(sqlx::FromRow)]

--- a/sqlx-core/src/types/json.rs
+++ b/sqlx-core/src/types/json.rs
@@ -51,7 +51,7 @@ use crate::types::Type;
 ///   dewey_decimal: sqlx::types::Json<HashMap<String, Book>>
 /// }
 /// ```
-/// 
+///
 /// If the query macros are used, it is necessary to tell the macro to use
 /// the `Json` adapter by using the type override syntax
 /// ```

--- a/sqlx-core/src/types/json.rs
+++ b/sqlx-core/src/types/json.rs
@@ -54,7 +54,9 @@ use crate::types::Type;
 ///
 /// If the query macros are used, it is necessary to tell the macro to use
 /// the `Json` adapter by using the type override syntax
-/// ```
+/// ```rust,no_run
+/// # async fn example3() -> sqlx::Result<()> {
+/// # let mut conn: sqlx::PgConnection = unimplemented!();
 /// #[derive(sqlx::FromRow)]
 /// struct Book {
 ///     title: String,
@@ -73,9 +75,10 @@ use crate::types::Type;
 /// FROM authors
 ///     "#
 /// )
-/// .fetch_all(pool)
+/// .fetch_all(&mut conn)
 /// .await?;
-///
+/// # Ok(())
+/// # }
 /// ```
 #[derive(
     Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize,

--- a/sqlx-core/src/types/json.rs
+++ b/sqlx-core/src/types/json.rs
@@ -55,7 +55,7 @@ use crate::types::Type;
 /// If the query macros are used, it is necessary to tell the macro to use
 /// the `Json` adapter by using the type override syntax
 /// ```
-/// #[derive(sqlx::FromRow]
+/// #[derive(sqlx::FromRow)]
 /// struct Book {
 ///     title: String,
 /// }

--- a/sqlx-core/src/types/json.rs
+++ b/sqlx-core/src/types/json.rs
@@ -51,6 +51,32 @@ use crate::types::Type;
 ///   dewey_decimal: sqlx::types::Json<HashMap<String, Book>>
 /// }
 /// ```
+/// 
+/// If the query macros are used, it is necessary to tell the macro to use
+/// the `Json` adapter by using the type override syntax
+/// ```
+/// #[derive(sqlx::FromRow]
+/// struct Book {
+///     title: String,
+/// }
+///
+/// #[derive(sqlx::FromRow)]
+/// struct Author {
+///     name: String,
+///     books: sqlx::types::Json<Book>,
+/// }
+/// // Note the type override in the query string
+/// let authors = sqlx::query_as!(
+///     Author,
+///     r#"
+/// SELECT name, books as "books: Json<Book>"
+/// FROM authors
+///     "#
+/// )
+/// .fetch_all(pool)
+/// .await?;
+///
+/// ```
 #[derive(
     Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize,
 )]


### PR DESCRIPTION
fixes #3153 by providing an example on how to use the `Json` adapter by using type override syntax.
