### PR TITLE
fix: non snake case warning

### DIFF
--- a/sqlx-macros-core/src/query/mod.rs
+++ b/sqlx-macros-core/src/query/mod.rs
@@ -301,10 +301,13 @@ where
 
                 let mut record_tokens = quote! {
                     #[derive(Debug)]
+                    #[allow(non_snake_case)]
                     struct #record_name {
                         #(#record_fields)*
                     }
                 };
+
+
 
                 record_tokens.extend(output::quote_query_as::<DB>(
                     &input,

--- a/sqlx-macros-core/src/query/mod.rs
+++ b/sqlx-macros-core/src/query/mod.rs
@@ -307,8 +307,6 @@ where
                     }
                 };
 
-
-
                 record_tokens.extend(output::quote_query_as::<DB>(
                     &input,
                     &record_name,

--- a/sqlx-macros-core/src/query/output.rs
+++ b/sqlx-macros-core/src/query/output.rs
@@ -143,15 +143,25 @@ pub fn quote_query_as<DB: DatabaseExt>(
                     // binding to a `let` avoids confusing errors about
                     // "try expression alternatives have incompatible types"
                     // it doesn't seem to hurt inference in the other branches
+                    #[allow(non_snake_case)]
                     let #var_name = row.try_get_unchecked::<#type_, _>(#i)?.into();
                 },
                 // type was overridden to be a wildcard so we fallback to the runtime check
-                (true, ColumnType::Wildcard) => quote! ( let #var_name = row.try_get(#i)?; ),
+                (true, ColumnType::Wildcard) => quote! (
+                    #[allow(non_snake_case)]
+                    let #var_name = row.try_get(#i)?; 
+                    ),
                 (true, ColumnType::OptWildcard) => {
-                    quote! ( let #var_name = row.try_get::<::std::option::Option<_>, _>(#i)?; )
+                    quote! (
+                        #[allow(non_snake_case)]
+                        let #var_name = row.try_get::<::std::option::Option<_>, _>(#i)?;
+                        )
                 }
                 // macro is the `_unchecked!()` variant so this will die in decoding if it's wrong
-                (false, _) => quote!( let #var_name = row.try_get_unchecked(#i)?; ),
+                (false, _) => quote!(
+                    #[allow(non_snake_case)]
+                    let #var_name = row.try_get_unchecked(#i)?;
+                    ),
             }
         },
     );

--- a/sqlx-macros-core/src/query/output.rs
+++ b/sqlx-macros-core/src/query/output.rs
@@ -148,20 +148,20 @@ pub fn quote_query_as<DB: DatabaseExt>(
                 },
                 // type was overridden to be a wildcard so we fallback to the runtime check
                 (true, ColumnType::Wildcard) => quote! (
-                    #[allow(non_snake_case)]
-                    let #var_name = row.try_get(#i)?; 
-                    ),
+                #[allow(non_snake_case)]
+                let #var_name = row.try_get(#i)?;
+                ),
                 (true, ColumnType::OptWildcard) => {
                     quote! (
-                        #[allow(non_snake_case)]
-                        let #var_name = row.try_get::<::std::option::Option<_>, _>(#i)?;
-                        )
+                    #[allow(non_snake_case)]
+                    let #var_name = row.try_get::<::std::option::Option<_>, _>(#i)?;
+                    )
                 }
                 // macro is the `_unchecked!()` variant so this will die in decoding if it's wrong
                 (false, _) => quote!(
-                    #[allow(non_snake_case)]
-                    let #var_name = row.try_get_unchecked(#i)?;
-                    ),
+                #[allow(non_snake_case)]
+                let #var_name = row.try_get_unchecked(#i)?;
+                ),
             }
         },
     );


### PR DESCRIPTION
### Does your PR solve an issue?
This fixes a rust-analyzer warning when a query has a non snake-case name. It simply adds a `#[allow(non_snake_case)]` lint to the generated struct and variables.
Fixes: #3361
