### PR TITLE
fix E0425

### DIFF
--- a/sqlx-postgres/src/types/cube.rs
+++ b/sqlx-postgres/src/types/cube.rs
@@ -5,7 +5,7 @@ use crate::types::Type;
 use crate::{PgArgumentBuffer, PgHasArrayType, PgTypeInfo, PgValueFormat, PgValueRef, Postgres};
 use sqlx_core::bytes::Buf;
 use sqlx_core::Error;
-use std::str::FromStr;
+use std::{mem, str::FromStr};
 
 const BYTE_WIDTH: usize = 8;
 
@@ -304,7 +304,7 @@ fn remove_parentheses(s: &str) -> String {
 }
 
 impl Header {
-    const PACKED_WIDTH: usize = size_of::<u32>();
+    const PACKED_WIDTH: usize = mem::size_of::<u32>();
 
     fn encoded_size(&self) -> usize {
         Self::PACKED_WIDTH + self.data_size()


### PR DESCRIPTION
On Arch Linux x86_64, rustc 1.79.0 (129f3b996 2024-06-10) there is E0425 while building sqlx-postgres. Fixed the error.