### PR TITLE
Pgsql cube type compile fail

### DIFF
--- a/sqlx-postgres/src/types/cube.rs
+++ b/sqlx-postgres/src/types/cube.rs
@@ -5,8 +5,8 @@ use crate::types::Type;
 use crate::{PgArgumentBuffer, PgHasArrayType, PgTypeInfo, PgValueFormat, PgValueRef, Postgres};
 use sqlx_core::bytes::Buf;
 use sqlx_core::Error;
-use std::str::FromStr;
 use std::mem;
+use std::str::FromStr;
 
 const BYTE_WIDTH: usize = 8;
 

--- a/sqlx-postgres/src/types/cube.rs
+++ b/sqlx-postgres/src/types/cube.rs
@@ -6,6 +6,7 @@ use crate::{PgArgumentBuffer, PgHasArrayType, PgTypeInfo, PgValueFormat, PgValue
 use sqlx_core::bytes::Buf;
 use sqlx_core::Error;
 use std::str::FromStr;
+use std::mem;
 
 const BYTE_WIDTH: usize = 8;
 
@@ -304,7 +305,7 @@ fn remove_parentheses(s: &str) -> String {
 }
 
 impl Header {
-    const PACKED_WIDTH: usize = size_of::<u32>();
+    const PACKED_WIDTH: usize = mem::size_of::<u32>();
 
     fn encoded_size(&self) -> usize {
         Self::PACKED_WIDTH + self.data_size()

--- a/sqlx-postgres/src/types/hstore.rs
+++ b/sqlx-postgres/src/types/hstore.rs
@@ -1,8 +1,8 @@
 use std::{
     collections::{btree_map, BTreeMap},
-    mem::size_of,
     ops::{Deref, DerefMut},
     str,
+    mem,
 };
 
 use crate::{
@@ -214,10 +214,10 @@ impl Encode<'_, Postgres> for PgHstore {
 }
 
 fn read_length(buf: &mut &[u8]) -> Result<i32, String> {
-    if buf.len() < size_of::<i32>() {
+    if buf.len() < mem::size_of::<i32>() {
         return Err(format!(
             "expected {} bytes, got {}",
-            size_of::<i32>(),
+            mem::size_of::<i32>(),
             buf.len()
         ));
     }

--- a/sqlx-postgres/src/types/hstore.rs
+++ b/sqlx-postgres/src/types/hstore.rs
@@ -1,8 +1,8 @@
 use std::{
     collections::{btree_map, BTreeMap},
+    mem,
     ops::{Deref, DerefMut},
     str,
-    mem,
 };
 
 use crate::{


### PR DESCRIPTION
### Does your PR solve an issue?

Resolves #3461
Resolves #3460
Replaces #3457
Replaces #3456

The Postgresql cube type fails to compile in version 0.8.1:
```
.../sqlx-postgres-0.8.1/src/types/cube.rs:307:33
    |
307 |     const PACKED_WIDTH: usize = size_of::<u32>();
    |                                 ^^^^^^^ not found in this scope
    |
help: consider importing one of these items
    |
1   + use core::mem::size_of;
    |
1   + use std::mem::size_of;
```
The PR includes a patch for this as well as a scoping change for the hstore type to keep it consistent with the others.
