### PR TITLE
feat: support `wasm` environments for postgresql

### DIFF
--- a/sqlx-postgres/Cargo.toml
+++ b/sqlx-postgres/Cargo.toml
@@ -57,7 +57,6 @@ bitflags = { version = "2", default-features = false }
 byteorder = { version = "1.4.3", default-features = false, features = ["std"] }
 dotenvy = { workspace = true }
 hex = "0.4.3"
-home = "0.5.5"
 itoa = "1.0.1"
 log = "0.4.18"
 memchr = { version = "2.4.1", default-features = false }
@@ -83,6 +82,9 @@ features = ["postgres", "derive"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
 etcetera = "0.8.0"
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+home = "0.5.5"
 
 [lints]
 workspace = true


### PR DESCRIPTION
This disables the home directory loading for WASM environments, as a filesystem to load files from is not available, as well as conditionally adding `home` on non WASM environments. With this, using `sqlx-postgres` is possible on `wasm32-unknown-unknown` targets.