### PR TITLE
Release 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.2 - 2024-09-02
+
+10 pull requests were merged this release cycle.
+
+This release addresses a few regressions that have occurred, and refines SQLx's MSRV policy (see [the FAQ](FAQ.md)).
+
+### Added
+* [[#3447]]: Clarify usage of Json/Jsonb in query macros [[@Lachstec]]
+
+### Changed
+* [[#3424]]: Remove deprecated feature-names from `Cargo.toml` files in examples [[@carschandler]]
+
+### Fixed
+* [[#3403]]: Fix (#3395) sqlx::test macro in 0.8 [[@joeydewaal]]
+* [[#3411]]: fix: Use rfc3339 to decode date from text [[@pierre-wehbe]]
+* [[#3453]]: fix(#3445): PgHasArrayType [[@joeydewaal]]
+    * Fixes `#[sqlx(no_pg_array)]` being forbidden on `#[derive(Type)]` structs. 
+* [[#3454]]: fix: non snake case warning [[@joeydewaal]]
+* [[#3459]]: Pgsql cube type compile fail [[@kdesjard]]
+* [[#3465]]: fix(postgres): max number of binds is 65535, not 32767 (regression) [[@abonander]]
+* [[#3467]]: fix cancellation issues with `PgListener`, `PgStream::recv()` [[@abonander]]
+    * Fixes cryptic `unknown message: "\\0"` error 
+* [[#3474]]: Fix try_get example in README.md [[@luveti]]
+
+[#3403]: https://github.com/launchbadge/sqlx/pull/3403
+[#3411]: https://github.com/launchbadge/sqlx/pull/3411
+[#3424]: https://github.com/launchbadge/sqlx/pull/3424
+[#3447]: https://github.com/launchbadge/sqlx/pull/3447
+[#3453]: https://github.com/launchbadge/sqlx/pull/3453
+[#3454]: https://github.com/launchbadge/sqlx/pull/3454
+[#3455]: https://github.com/launchbadge/sqlx/pull/3455
+[#3459]: https://github.com/launchbadge/sqlx/pull/3459
+[#3465]: https://github.com/launchbadge/sqlx/pull/3465
+[#3467]: https://github.com/launchbadge/sqlx/pull/3467
+[#3474]: https://github.com/launchbadge/sqlx/pull/3474
+
 ## 0.8.1 - 2024-08-23
 
 16 pull requests were merged this release cycle.
@@ -2543,3 +2579,8 @@ Fix docs.rs build by enabling a runtime feature in the docs.rs metadata in `Carg
 [@ods]: https://github.com/ods
 [@soucosmo]: https://github.com/soucosmo
 [@kolinfluence]: https://github.com/kolinfluence
+[@joeydewaal]: https://github.com/joeydewaal
+[@pierre-wehbe]: https://github.com/pierre-wehbe
+[@carschandler]: https://github.com/carschandler
+[@kdesjard]: https://github.com/kdesjard
+[@luveti]: https://github.com/luveti

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-std",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-cli"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3385,7 +3385,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-io 1.13.0",
  "async-std",
@@ -3569,7 +3569,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3580,7 +3580,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-std",
  "dotenvy",
@@ -3605,7 +3605,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "atoi",
  "base64 0.22.0",
@@ -3651,7 +3651,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "atoi",
  "base64 0.22.0",
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "atoi",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ authors = [
     "Chloe Ross <orangesnowfox@gmail.com>",
     "Daniel Akhterov <akhterovd@gmail.com>",
 ]
+# TODO: enable this for 0.9.0
+# rust-version = "1.80.0"
 
 [package]
 name = "sqlx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 repository = "https://github.com/launchbadge/sqlx"
@@ -120,17 +120,17 @@ regexp = ["sqlx-sqlite?/regexp"]
 
 [workspace.dependencies]
 # Core Crates
-sqlx-core = { version = "=0.8.1", path = "sqlx-core" }
-sqlx-macros-core = { version = "=0.8.1", path = "sqlx-macros-core" }
-sqlx-macros = { version = "=0.8.1", path = "sqlx-macros" }
+sqlx-core = { version = "=0.8.2", path = "sqlx-core" }
+sqlx-macros-core = { version = "=0.8.2", path = "sqlx-macros-core" }
+sqlx-macros = { version = "=0.8.2", path = "sqlx-macros" }
 
 # Driver crates
-sqlx-mysql = { version = "=0.8.1", path = "sqlx-mysql" }
-sqlx-postgres = { version = "=0.8.1", path = "sqlx-postgres" }
-sqlx-sqlite = { version = "=0.8.1", path = "sqlx-sqlite" }
+sqlx-mysql = { version = "=0.8.2", path = "sqlx-mysql" }
+sqlx-postgres = { version = "=0.8.2", path = "sqlx-postgres" }
+sqlx-sqlite = { version = "=0.8.2", path = "sqlx-sqlite" }
 
 # Facade crate (for reference from sqlx-cli)
-sqlx = { version = "=0.8.1", path = ".", default-features = false }
+sqlx = { version = "=0.8.2", path = ".", default-features = false }
 
 # Common type integrations shared by multiple driver crates.
 # These are optional unless enabled in a workspace crate.

--- a/FAQ.md
+++ b/FAQ.md
@@ -20,23 +20,14 @@ For each database and where applicable, we test against the latest and oldest ve
 -------------------------------------------------------------------
 ### What versions of Rust does SQLx support? What is SQLx's MSRV\*?
 
-Officially, we will only ever support the latest stable version of Rust. 
-It's just not something we consider to be worth keeping track of, given the current state of tooling.
+SQLx's MSRV is the second-to-latest stable release as of the beginning of the current release cycle (`0.x.0`).
+It will remain there until the next major release (`0.{x + 1}.0`).
 
-Cargo does support a [`rust-version`] field now in the package manifest, however that will only ensure
-that the user is using a `rustc` of that version or greater; it does not enforce that the crate's code is
-actually compatible with that version of Rust. That would need to be manually enforced and checked with CI,
-and we have enough CI passes already.
+This guarantees that SQLx will compile with a Rust version that is _at least_ six weeks old, which should be plenty
+of time for it to make it through any packaging system that is being actively kept up to date.
 
-In practice, we tend not to reach for language or library features that are *too* new, either because
-we don't need them or we just worked around their absence. There are language features we're waiting to be
-stabilized that we want to use (Generic Associated Types and Async Traits, to name a couple) which we will
-be utilizing when they're available, but that will be a major refactor with breaking API changes 
-which will then coincide with a major release.
-
-Thus, it is likely that a given SQLx release _will_ work with older versions of Rust. However,
-we make no guarantees about which exact versions it will work with besides the latest stable version,
-and we don't factor MSRV bumps into our semantic versioning.
+We do _not_ recommend installing Rust through operating system packages, 
+as they can often be a whole year or more out-of-date.
 
 \*Minimum Supported Rust Version
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -23,6 +23,9 @@ For each database and where applicable, we test against the latest and oldest ve
 SQLx's MSRV is the second-to-latest stable release as of the beginning of the current release cycle (`0.x.0`).
 It will remain there until the next major release (`0.{x + 1}.0`).
 
+For example, as of the `0.8.0` release of SQLx, the latest stable Rust version was `1.79.0`, so the MSRV for the
+`0.8.x` release cycle of SQLx is `1.78.0`.
+
 This guarantees that SQLx will compile with a Rust version that is _at least_ six weeks old, which should be plenty
 of time for it to make it through any packaging system that is being actively kept up to date.
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,4 @@
-# NOTE: this does NOT indicate a Minimum Supported Rust Version (MSRV) of SQLx.
-# We reserve the right to increase this version at any time without considering it to be a breaking change.
-# See the answer in FAQ.md for details.
+# Note: should NOT increase during a minor/patch release cycle
 [toolchain]
-channel = "1.80"
+channel = "1.78"
 profile = "minimal"

--- a/sqlx-mysql/src/io/buf_mut.rs
+++ b/sqlx-mysql/src/io/buf_mut.rs
@@ -16,12 +16,12 @@ impl MySqlBufMutExt for Vec<u8> {
         let encoded_le = v.to_le_bytes();
 
         match v {
-            ..251 => self.push(encoded_le[0]),
-            251..0x1_00_00 => {
+            0..=250 => self.push(encoded_le[0]),
+            251..=0xFF_FF => {
                 self.push(0xfc);
                 self.extend_from_slice(&encoded_le[..2]);
             }
-            0x1_00_00..0x1_00_00_00 => {
+            0x1_00_00..=0xFF_FF_FF => {
                 self.push(0xfd);
                 self.extend_from_slice(&encoded_le[..3]);
             }


### PR DESCRIPTION
Refines MSRV policy to prevent accidental breakage during a release cycle while still allowing us to use newer language/stdlib features.

Fixes #3472 