### PR TITLE
Use the date and time format based on the standard from SQLite

### DIFF
--- a/sqlx-sqlite/src/types/chrono.rs
+++ b/sqlx-sqlite/src/types/chrono.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-
 use crate::value::ValueRef;
 use crate::{
     decode::Decode,
@@ -10,9 +8,7 @@ use crate::{
     Sqlite, SqliteArgumentValue, SqliteTypeInfo, SqliteValueRef,
 };
 use chrono::FixedOffset;
-use chrono::{
-    DateTime, Local, NaiveDate, NaiveDateTime, NaiveTime, Offset, SecondsFormat, TimeZone, Utc,
-};
+use chrono::{DateTime, Local, NaiveDate, NaiveDateTime, NaiveTime, Offset, TimeZone, Utc};
 
 impl<Tz: TimeZone> Type<Sqlite> for DateTime<Tz> {
     fn type_info() -> SqliteTypeInfo {
@@ -61,12 +57,21 @@ impl Type<Sqlite> for NaiveTime {
     }
 }
 
-impl<Tz: TimeZone> Encode<'_, Sqlite> for DateTime<Tz>
-where
-    Tz::Offset: Display,
-{
+impl Encode<'_, Sqlite> for DateTime<Utc> {
     fn encode_by_ref(&self, buf: &mut Vec<SqliteArgumentValue<'_>>) -> Result<IsNull, BoxDynError> {
-        Encode::<Sqlite>::encode(self.to_rfc3339_opts(SecondsFormat::AutoSi, false), buf)
+        Encode::<Sqlite>::encode(self.format("%F %T%.f").to_string(), buf)
+    }
+}
+
+impl Encode<'_, Sqlite> for DateTime<Local> {
+    fn encode_by_ref(&self, buf: &mut Vec<SqliteArgumentValue<'_>>) -> Result<IsNull, BoxDynError> {
+        Encode::<Sqlite>::encode(self.format("%F %T%.f%:z").to_string(), buf)
+    }
+}
+
+impl Encode<'_, Sqlite> for DateTime<FixedOffset> {
+    fn encode_by_ref(&self, buf: &mut Vec<SqliteArgumentValue<'_>>) -> Result<IsNull, BoxDynError> {
+        Encode::<Sqlite>::encode(self.format("%F %T%.f%:z").to_string(), buf)
     }
 }
 


### PR DESCRIPTION
This commit changes the date and time format used in SQLite to the standard format specified in the SQLite documentation.
Based on the SQLite docs, the date and time format is a variation of ISO 8601. See: https://www.sqlite.org/lang_datefunc.html
This also aligns the format to the format used for the [NaiveDateTime format](https://github.com/launchbadge/sqlx/blob/a892ebc6e283f443145f92bbc7fce4ae44547331/sqlx-sqlite/src/types/chrono.rs#L73).


The current format prevents, e.g., the comparison between CURRENT_TIMESTAMP and the value.
Additionally, it causes compatibility issues with other applications using the same database.
