### PR TITLE
fix(logs): Correct spelling of aquired_after_secs tracing field

### DIFF
--- a/sqlx-core/src/pool/inner.rs
+++ b/sqlx-core/src/pool/inner.rs
@@ -308,7 +308,7 @@ impl<DB: Database> PoolInner<DB> {
             private_tracing_dynamic_event!(
                 target: "sqlx::pool::acquire",
                 level,
-                aquired_after_secs = acquired_after.as_secs_f64(),
+                acquired_after_secs = acquired_after.as_secs_f64(),
                 slow_acquire_threshold_secs = self.options.acquire_slow_threshold.as_secs_f64(),
                 "acquired connection, but time to acquire exceeded slow threshold"
             );
@@ -316,7 +316,7 @@ impl<DB: Database> PoolInner<DB> {
             private_tracing_dynamic_event!(
                 target: "sqlx::pool::acquire",
                 level,
-                aquired_after_secs = acquired_after.as_secs_f64(),
+                acquired_after_secs = acquired_after.as_secs_f64(),
                 "acquired connection"
             );
         }


### PR DESCRIPTION
Logging of slow connection acquires was added with https://github.com/launchbadge/sqlx/pull/3073 and included tracing fields. One of those fields has an incorrect spelling of `acquire` in its name; this PR corrects the spelling.

Some users of the crate were interested in collecting metrics or building alerts based on this and related tracing fields. If we simply rename the field, this would be a breaking change. @abonander has mentioned he is open to including both the old spelling and the corrected spelling if there is concern about a breaking change to the log field naming.

Due to previous interest in this or https://github.com/launchbadge/sqlx/pull/3004:

cc @jqphu / @Matthias247 / @kukabi