### PR TITLE
expose relation_id and relation_attribution_no on PgColumn

### DIFF
--- a/sqlx-postgres/src/column.rs
+++ b/sqlx-postgres/src/column.rs
@@ -20,6 +20,12 @@ impl PgColumn {
         self.relation_id.map(|oid| oid.0)
     }
 
+    /// Returns the 1-based index of this column in its parent table, if applicable.
+    ///
+    /// This will be `None` if the column is the result of an expression.
+    ///
+    /// Corresponds to column `attnum` of the `pg_catalog.pg_attribute` table:
+    /// <https://www.postgresql.org/docs/current/catalog-pg-attribute.html>
     pub fn relation_attribute_no(&self) -> Option<i16> {
         self.relation_attribute_no
     }

--- a/sqlx-postgres/src/column.rs
+++ b/sqlx-postgres/src/column.rs
@@ -22,8 +22,8 @@ impl PgColumn {
     ///
     /// Corresponds to column `attrelid` of the `pg_catalog.pg_attribute` table:
     /// <https://www.postgresql.org/docs/current/catalog-pg-attribute.html>
-    pub fn relation_id(&self) -> Option<Oid> {
-        self.relation_id.map(|oid| oid.0)
+    pub fn relation_id(&self) -> Option<crate::types::Oid> {
+        self.relation_id
     }
 
     /// Returns the 1-based index of this column in its parent table, if applicable.

--- a/sqlx-postgres/src/column.rs
+++ b/sqlx-postgres/src/column.rs
@@ -16,7 +16,13 @@ pub struct PgColumn {
 }
 
 impl PgColumn {
-    pub fn relation_id(&self) -> Option<u32> {
+    /// Returns the OID of the table this column is from, if applicable.
+    ///
+    /// This will be `None` if the column is the result of an expression.
+    ///
+    /// Corresponds to column `attrelid` of the `pg_catalog.pg_attribute` table:
+    /// <https://www.postgresql.org/docs/current/catalog-pg-attribute.html>
+    pub fn relation_id(&self) -> Option<Oid> {
         self.relation_id.map(|oid| oid.0)
     }
 

--- a/sqlx-postgres/src/column.rs
+++ b/sqlx-postgres/src/column.rs
@@ -10,9 +10,19 @@ pub struct PgColumn {
     pub(crate) name: UStr,
     pub(crate) type_info: PgTypeInfo,
     #[cfg_attr(feature = "offline", serde(skip))]
-    pub(crate) relation_id: Option<i32>,
+    pub(crate) relation_id: Option<crate::types::Oid>,
     #[cfg_attr(feature = "offline", serde(skip))]
     pub(crate) relation_attribute_no: Option<i16>,
+}
+
+impl PgColumn {
+    pub fn relation_id(&self) -> Option<u32> {
+        self.relation_id.map(|oid| oid.0)
+    }
+
+    pub fn relation_attribute_no(&self) -> Option<i16> {
+        self.relation_attribute_no
+    }
 }
 
 impl Column for PgColumn {

--- a/sqlx-postgres/src/message/row_description.rs
+++ b/sqlx-postgres/src/message/row_description.rs
@@ -17,7 +17,7 @@ pub struct Field {
 
     /// If the field can be identified as a column of a specific table, the
     /// object ID of the table; otherwise zero.
-    pub relation_id: Option<i32>,
+    pub relation_id: Option<Oid>,
 
     /// If the field can be identified as a column of a specific table, the attribute number of
     /// the column; otherwise zero.
@@ -65,7 +65,7 @@ impl BackendMessage for RowDescription {
                 ));
             }
 
-            let relation_id = buf.get_i32();
+            let relation_id = Oid(buf.get_u32());
             let relation_attribute_no = buf.get_i16();
             let data_type_id = Oid(buf.get_u32());
             let data_type_size = buf.get_i16();
@@ -74,7 +74,7 @@ impl BackendMessage for RowDescription {
 
             fields.push(Field {
                 name,
-                relation_id: if relation_id == 0 {
+                relation_id: if relation_id.0 == 0 {
                     None
                 } else {
                     Some(relation_id)

--- a/sqlx-postgres/src/message/row_description.rs
+++ b/sqlx-postgres/src/message/row_description.rs
@@ -74,7 +74,7 @@ impl BackendMessage for RowDescription {
 
             fields.push(Field {
                 name,
-                relation_id: if relation_id.0 == 0 {
+                relation_id: if relation_id == 0 {
                     None
                 } else {
                     Some(Oid(relation_id))

--- a/sqlx-postgres/src/message/row_description.rs
+++ b/sqlx-postgres/src/message/row_description.rs
@@ -65,7 +65,7 @@ impl BackendMessage for RowDescription {
                 ));
             }
 
-            let relation_id = Oid(buf.get_u32());
+            let relation_id = buf.get_u32();
             let relation_attribute_no = buf.get_i16();
             let data_type_id = Oid(buf.get_u32());
             let data_type_size = buf.get_i16();

--- a/sqlx-postgres/src/message/row_description.rs
+++ b/sqlx-postgres/src/message/row_description.rs
@@ -77,7 +77,7 @@ impl BackendMessage for RowDescription {
                 relation_id: if relation_id.0 == 0 {
                     None
                 } else {
-                    Some(relation_id)
+                    Some(Oid(relation_id))
                 },
                 relation_attribute_no: if relation_attribute_no == 0 {
                     None


### PR DESCRIPTION
I'm building a tool that does introspection on queries that requires reading relation_id and attribute number from postgres queries. Today, sqlx keeps those fields private.

This PR exposes those fields, along with a small data type correction to relation_id - it's an Oid, which is a u32, not a i32.