### PR TITLE
chore(mysql): create test for passwordless auth (#3484)

### DIFF
--- a/tests/mysql/mysql.rs
+++ b/tests/mysql/mysql.rs
@@ -1,14 +1,39 @@
+use anyhow::Context;
 use futures::TryStreamExt;
 use sqlx::mysql::{MySql, MySqlConnection, MySqlPool, MySqlPoolOptions, MySqlRow};
 use sqlx::{Column, Connection, Executor, Row, Statement, TypeInfo};
+use sqlx_core::connection::ConnectOptions;
+use sqlx_mysql::MySqlConnectOptions;
 use sqlx_test::{new, setup_if_needed};
 use std::env;
+use url::Url;
 
 #[sqlx_macros::test]
 async fn it_connects() -> anyhow::Result<()> {
     let mut conn = new::<MySql>().await?;
 
     conn.ping().await?;
+    conn.close().await?;
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
+async fn it_connects_without_password() -> anyhow::Result<()> {
+    setup_if_needed();
+
+    let mut url = Url::parse(&env::var("DATABASE_URL").context("expected DATABASE_URL")?)
+        .context("error parsing DATABASE_URL")?;
+
+    url.set_username("no_password").unwrap();
+    url.set_password(None).unwrap();
+
+    let mut conn = MySqlConnectOptions::from_url(&url)?.connect().await?;
+
+    let vars = sqlx::raw_sql("SHOW VARIABLES").fetch_all(&mut conn).await?;
+
+    assert!(!vars.is_empty());
+
     conn.close().await?;
 
     Ok(())

--- a/tests/mysql/setup.sql
+++ b/tests/mysql/setup.sql
@@ -22,3 +22,11 @@ CREATE TABLE products (
     name TEXT,
     price NUMERIC CHECK (price > 0)
 );
+
+-- Create a user without a password to test passwordless auth.
+CREATE USER 'no_password'@'%';
+
+-- The minimum privilege apparently needed to connect to a specific database.
+-- Granting no privileges, or just `GRANT USAGE`, gives an "access denied" error.
+-- https://github.com/launchbadge/sqlx/issues/3484#issuecomment-2350901546
+GRANT SELECT ON sqlx.* TO 'no_password'@'%';


### PR DESCRIPTION
This isn't a solution for #3484, as that seems to be an issue with privileges on the user's side. However, in the process of figuring that out, I realized we never explicitly test password-less auth.
