### PR TITLE
doc(sqlite): show how to turn options into a pool

### DIFF
--- a/sqlx-sqlite/src/options/mod.rs
+++ b/sqlx-sqlite/src/options/mod.rs
@@ -41,13 +41,19 @@ use sqlx_core::IndexMap;
 /// ```rust,no_run
 /// # async fn example() -> sqlx::Result<()> {
 /// use sqlx::ConnectOptions;
-/// use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
+/// use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePool};
 /// use std::str::FromStr;
 ///
-/// let conn = SqliteConnectOptions::from_str("sqlite://data.db")?
+/// let opts = SqliteConnectOptions::from_str("sqlite://data.db")?
 ///     .journal_mode(SqliteJournalMode::Wal)
-///     .read_only(true)
-///     .connect().await?;
+///     .read_only(true);
+///
+/// // use in a pool
+/// let pool = SqlitePool::connect_with(opts).await?;
+///
+/// // or connect directly
+/// # let opts = SqliteConnectOptions::from_str("sqlite://data.db")?;
+/// let conn = opts.connect().await?;
 /// #
 /// # Ok(())
 /// # }


### PR DESCRIPTION
It took me 15 minutes of messing around and googling to find `.connect_with()`.

Took me also a couple of minutes to find the SqliteConnectOptions, but I wouldn't know where to mention that in the docs.