### PR TITLE
Support PgHstore by default in macros

### DIFF
--- a/sqlx-postgres/src/type_checking.rs
+++ b/sqlx-postgres/src/type_checking.rs
@@ -83,6 +83,7 @@ impl_type_checking!(
         #[cfg(feature = "bit-vec")]
         sqlx::types::BitVec,
 
+        sqlx::postgres::types::PgHstore,
         // Arrays
 
         Vec<bool> | &[bool],
@@ -138,6 +139,8 @@ impl_type_checking!(
 
         #[cfg(feature = "json")]
         Vec<sqlx::types::JsonValue> | &[sqlx::types::JsonValue],
+
+        Vec<sqlx::postgres::types::PgHstore> | &[sqlx::postgres::types::PgHstore],
 
         // Ranges
 

--- a/sqlx-postgres/src/types/hstore.rs
+++ b/sqlx-postgres/src/types/hstore.rs
@@ -10,7 +10,7 @@ use crate::{
     encode::{Encode, IsNull},
     error::BoxDynError,
     types::Type,
-    PgArgumentBuffer, PgTypeInfo, PgValueRef, Postgres,
+    PgArgumentBuffer, PgHasArrayType, PgTypeInfo, PgValueRef, Postgres,
 };
 use serde::{Deserialize, Serialize};
 use sqlx_core::bytes::Buf;
@@ -135,6 +135,12 @@ impl IntoIterator for PgHstore {
 impl Type<Postgres> for PgHstore {
     fn type_info() -> PgTypeInfo {
         PgTypeInfo::with_name("hstore")
+    }
+}
+
+impl PgHasArrayType for PgHstore {
+    fn array_type_info() -> PgTypeInfo {
+        PgTypeInfo::array_of("hstore")
     }
 }
 

--- a/tests/postgres/macros.rs
+++ b/tests/postgres/macros.rs
@@ -1,4 +1,4 @@
-use sqlx::{Connection, PgConnection, PgPool, Postgres, Transaction};
+use sqlx::{Connection, PgConnection, Postgres, Transaction};
 use sqlx_postgres::types::PgHstore;
 use sqlx_test::new;
 

--- a/tests/postgres/macros.rs
+++ b/tests/postgres/macros.rs
@@ -638,21 +638,23 @@ async fn test_to_from_citext() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[sqlx_macros::test(migrations = "tests/postgres/migrations")]
-async fn pghstore_tests(pool: PgPool) -> Result<(), sqlx::Error> {
+#[sqlx_macros::test]
+async fn pghstore_tests() -> anyhow::Result<()> {
+    let mut conn = new::<Postgres>().await?;
+
     let mut store = PgHstore::default();
     let stores = vec![store.clone(), store.clone()];
 
     store.insert("key".into(), Some("value".to_string()));
     sqlx::query!("         insert into mytable(f) values ($1)", store)
-        .execute(&pool)
+        .execute(&mut conn)
         .await?;
 
     sqlx::query!(
         "         insert into mytable(f) select * from unnest($1::hstore[])",
         &stores
     )
-    .execute(&pool)
+    .execute(&mut conn)
     .await?;
 
     Ok(())

--- a/tests/postgres/migrations/4_hstore.sql
+++ b/tests/postgres/migrations/4_hstore.sql
@@ -1,0 +1,2 @@
+CREATE EXTENSION hstore WITH SCHEMA public;
+CREATE TABLE mytable(f HSTORE);

--- a/tests/postgres/migrations/4_hstore.sql
+++ b/tests/postgres/migrations/4_hstore.sql
@@ -1,2 +1,0 @@
-CREATE EXTENSION hstore WITH SCHEMA public;
-CREATE TABLE mytable(f HSTORE);

--- a/tests/postgres/setup.sql
+++ b/tests/postgres/setup.sql
@@ -7,6 +7,9 @@ CREATE EXTENSION IF NOT EXISTS cube;
 -- https://www.postgresql.org/docs/current/citext.html
 CREATE EXTENSION IF NOT EXISTS citext;
 
+-- https://www.postgresql.org/docs/current/hstore.html
+CREATE EXTENSION IF NOT EXISTS hstore;
+
 -- https://www.postgresql.org/docs/current/sql-createtype.html
 CREATE TYPE status AS ENUM ('new', 'open', 'closed');
 
@@ -58,3 +61,5 @@ CREATE TABLE test_citext (
 CREATE SCHEMA IF NOT EXISTS foo;
 
 CREATE TYPE foo."Foo" as ENUM ('Bar', 'Baz');
+
+CREATE TABLE mytable(f HSTORE);


### PR DESCRIPTION
### Does your PR solve an issue?
This allows the use of `PgHstore` in the query macros.

Fixes: #3488
