### PR TITLE
allow using hstore in macros

### DIFF
--- a/sqlx-postgres/src/type_checking.rs
+++ b/sqlx-postgres/src/type_checking.rs
@@ -209,6 +209,9 @@ impl_type_checking!(
         #[cfg(feature = "time")]
         Vec<sqlx::postgres::types::PgRange<sqlx::types::time::OffsetDateTime>> |
             &[sqlx::postgres::types::PgRange<sqlx::types::time::OffsetDateTime>],
+
+        sqlx::postgres::types::PgHstore,
+        Vec<sqlx::postgres::types::PgHstore> | &[sqlx::postgres::types::PgHstore],
     },
     ParamChecking::Strong,
     feature-types: info => info.__type_feature_gate(),

--- a/sqlx-postgres/src/types/hstore.rs
+++ b/sqlx-postgres/src/types/hstore.rs
@@ -15,6 +15,8 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use sqlx_core::bytes::Buf;
 
+use super::PgHasArrayType;
+
 /// Key-value support (`hstore`) for Postgres.
 ///
 /// SQLx currently maps `hstore` to a `BTreeMap<String, Option<String>>` but this may be expanded in
@@ -135,6 +137,12 @@ impl IntoIterator for PgHstore {
 impl Type<Postgres> for PgHstore {
     fn type_info() -> PgTypeInfo {
         PgTypeInfo::with_name("hstore")
+    }
+}
+
+impl PgHasArrayType for PgHstore {
+    fn array_type_info() -> PgTypeInfo {
+        PgTypeInfo::array_of("hstore")
     }
 }
 

--- a/tests/postgres/setup.sql
+++ b/tests/postgres/setup.sql
@@ -7,6 +7,9 @@ CREATE EXTENSION IF NOT EXISTS cube;
 -- https://www.postgresql.org/docs/current/citext.html
 CREATE EXTENSION IF NOT EXISTS citext;
 
+-- https://www.postgresql.org/docs/current/hstore.html
+CREATE EXTENSION IF NOT EXISTS hstore;
+
 -- https://www.postgresql.org/docs/current/sql-createtype.html
 CREATE TYPE status AS ENUM ('new', 'open', 'closed');
 
@@ -58,3 +61,6 @@ CREATE TABLE test_citext (
 CREATE SCHEMA IF NOT EXISTS foo;
 
 CREATE TYPE foo."Foo" as ENUM ('Bar', 'Baz');
+
+CREATE TABLE test_hstore(id_test_hstore SERIAL, store HSTORE);
+CREATE TABLE test_hstores(id_test_hstores SERIAL, stores HSTORE[]);


### PR DESCRIPTION
### Does your PR solve an issue?
fixes #3488

This still does not allow `HSTORE[]` in macros.  This needs ``PgHstore` to implement the `PgHasArrayType` trait.  I'll look into it.