### PR TITLE
Fix: spawn task when opening new connection in acquire.

### DIFF
--- a/sqlx-core/src/pool/inner.rs
+++ b/sqlx-core/src/pool/inner.rs
@@ -290,7 +290,6 @@ impl<DB: Database> PoolInner<DB> {
                         }
                     };
 
-
                     // Attempt to connect...
                     let pool = self.clone();
                     return crate::rt::spawn(async move {

--- a/sqlx-core/src/pool/inner.rs
+++ b/sqlx-core/src/pool/inner.rs
@@ -295,9 +295,8 @@ impl<DB: Database> PoolInner<DB> {
                     return crate::rt::spawn(async move {
                         crate::rt::timeout(pool.options.connect_timeout, async move {
                             pool.connect(deadline, guard).await
-                        })
+                        }).await
                     }).await
-                    .await
                     .map_err(|_| Error::PoolTimedOut)?;
                 }
             }

--- a/sqlx-core/src/pool/options.rs
+++ b/sqlx-core/src/pool/options.rs
@@ -79,6 +79,7 @@ pub struct PoolOptions<DB: Database> {
     pub(crate) acquire_slow_level: LevelFilter,
     pub(crate) acquire_slow_threshold: Duration,
     pub(crate) acquire_timeout: Duration,
+    pub(crate) connect_timeout: Duration,
     pub(crate) min_connections: u32,
     pub(crate) max_lifetime: Option<Duration>,
     pub(crate) idle_timeout: Option<Duration>,
@@ -102,6 +103,7 @@ impl<DB: Database> Clone for PoolOptions<DB> {
             acquire_slow_threshold: self.acquire_slow_threshold,
             acquire_slow_level: self.acquire_slow_level,
             acquire_timeout: self.acquire_timeout,
+            connect_timeout: self.connect_timeout,
             min_connections: self.min_connections,
             max_lifetime: self.max_lifetime,
             idle_timeout: self.idle_timeout,
@@ -158,6 +160,7 @@ impl<DB: Database> PoolOptions<DB> {
             // to not flag typical time to add a new connection to a pool.
             acquire_slow_threshold: Duration::from_secs(2),
             acquire_timeout: Duration::from_secs(30),
+            connect_timeout: Duration::from_secs(30),
             idle_timeout: Some(Duration::from_secs(10 * 60)),
             max_lifetime: Some(Duration::from_secs(30 * 60)),
             fair: true,


### PR DESCRIPTION
### Does your PR solve an issue?
Fixes #3513,#3315,#3132,#2848

Ive read through the issues and I think this is the solution like proposed in #2848. However I don't think this is done yet. Should the connect_timeout be a part of the public api? Is 30 seconds a good default?