### PR TITLE
Remove unused dependencies from sqlx-core, sqlx-cli and sqlx-postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1209,15 +1209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3375,12 +3366,10 @@ dependencies = [
  "glob",
  "openssl",
  "promptly",
- "serde",
  "serde_json",
  "sqlx",
  "tempfile",
  "tokio",
- "url",
 ]
 
 [[package]]
@@ -3389,36 +3378,28 @@ version = "0.8.2"
 dependencies = [
  "async-io 1.13.0",
  "async-std",
- "atoi",
  "bigdecimal",
  "bit-vec",
  "bstr",
- "byteorder",
  "bytes",
  "chrono",
  "crc",
  "crossbeam-queue",
- "digest",
  "either",
- "encoding_rs",
  "event-listener 5.2.0",
- "futures-channel",
  "futures-core",
  "futures-intrusive",
  "futures-io",
  "futures-util",
  "hashbrown 0.14.5",
  "hashlink",
- "hex",
  "indexmap 2.2.5",
  "ipnetwork",
  "log",
  "mac_address",
  "memchr",
  "native-tls",
- "num-bigint",
  "once_cell",
- "paste",
  "percent-encoding",
  "regex",
  "rust_decimal",
@@ -3426,7 +3407,6 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
- "sha1",
  "sha2",
  "smallvec",
  "sqlformat",
@@ -3665,7 +3645,6 @@ dependencies = [
  "etcetera",
  "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "hex",
  "hkdf",

--- a/sqlx-cli/Cargo.toml
+++ b/sqlx-cli/Cargo.toml
@@ -37,12 +37,10 @@ clap = { version = "4.3.10", features = ["derive", "env"] }
 clap_complete = { version = "4.3.1", optional = true }
 chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
 anyhow = "1.0.52"
-url = { version = "2.2.2", default-features = false }
 async-trait = "0.1.52"
 console = "0.15.0"
 promptly = "0.3.0"
 serde_json = "1.0.73"
-serde = { version = "1.0.132", features = ["derive"] }
 glob = "0.3.0"
 openssl = { version = "0.10.38", optional = true }
 cargo_metadata = "0.18.1"

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -52,32 +52,22 @@ mac_address = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }
 
 async-io = { version = "1.9.0", optional = true }
-paste = "1.0.6"
-atoi = "2.0"
-
 bytes = "1.1.0"
-byteorder = { version = "1.4.3", default-features = false, features = ["std"] }
 chrono = { version = "0.4.34", default-features = false, features = ["clock"], optional = true }
 crc = { version = "3", optional = true }
 crossbeam-queue = "0.3.2"
-digest = { version = "0.10.0", default-features = false, optional = true, features = ["std"] }
-encoding_rs = { version = "0.8.30", optional = true }
 either = "1.6.1"
-futures-channel = { version = "0.3.19", default-features = false, features = ["sink", "alloc", "std"] }
 futures-core = { version = "0.3.19", default-features = false }
 futures-io = "0.3.24"
 futures-intrusive = "0.5.0"
 futures-util = { version = "0.3.19", default-features = false, features = ["alloc", "sink", "io"] }
-hex = "0.4.3"
 log = { version = "0.4.18", default-features = false }
 memchr = { version = "2.4.1", default-features = false }
-num-bigint = { version = "0.4.0", default-features = false, optional = true, features = ["std"] }
 once_cell = "1.9.0"
 percent-encoding = "2.1.0"
 regex = { version = "1.5.5", optional = true }
 serde = { version = "1.0.132", features = ["derive", "rc"], optional = true }
 serde_json = { version = "1.0.73", features = ["raw_value"], optional = true }
-sha1 = { version = "0.10.1", default-features = false, optional = true }
 sha2 = { version = "0.10.0", default-features = false, optional = true }
 sqlformat = "0.2.0"
 thiserror = "1.0.30"

--- a/sqlx-postgres/Cargo.toml
+++ b/sqlx-postgres/Cargo.toml
@@ -29,7 +29,6 @@ uuid = ["dep:uuid", "sqlx-core/uuid"]
 # Futures crates
 futures-channel = { version = "0.3.19", default-features = false, features = ["sink", "alloc", "std"] }
 futures-core = { version = "0.3.19", default-features = false }
-futures-io = "0.3.24"
 futures-util = { version = "0.3.19", default-features = false, features = ["alloc", "sink", "io"] }
 
 # Cryptographic Primitives


### PR DESCRIPTION
There are quite some unused dependencies in sqlx-core and sqlx-cli. And one crate from sqlx-postgres.
Cargo builds with all features after removing these dependencies.
