### PR TITLE
fix: using sqlx::test macro inside macro's

### DIFF
--- a/sqlx-macros-core/src/test_attr.rs
+++ b/sqlx-macros-core/src/test_attr.rs
@@ -257,7 +257,7 @@ fn parse_args(attr_args: AttributeArgs) -> syn::Result<Args> {
                 }
 
                 let Some(lit) = recurse_lit_lookup(value.value) else {
-                    return Err(syn::Error::new_spanned(path, "expected string for `false`"));
+                    return Err(syn::Error::new_spanned(path, "expected string or `false`"));
                 };
 
                 migrations = match lit {

--- a/sqlx-macros-core/src/test_attr.rs
+++ b/sqlx-macros-core/src/test_attr.rs
@@ -244,7 +244,19 @@ fn parse_args(attr_args: AttributeArgs) -> syn::Result<Args> {
                     ));
                 }
 
-                let Expr::Lit(syn::ExprLit { lit, .. }) = value.value else {
+                fn recurse_lit_lookup(expr: Expr) -> Option<Lit> {
+                    match expr {
+                        Expr::Lit(syn::ExprLit { lit, .. }) => {
+                            return Some(lit);
+                        }
+                        Expr::Group(syn::ExprGroup { expr, .. }) => {
+                            return recurse_lit_lookup(*expr);
+                        }
+                        _ => return None,
+                    }
+                }
+
+                let Some(lit) = recurse_lit_lookup(value.value) else {
                     return Err(syn::Error::new_spanned(path, "expected string for `false`"));
                 };
 

--- a/tests/postgres/test-attr.rs
+++ b/tests/postgres/test-attr.rs
@@ -186,3 +186,16 @@ async fn it_gets_comments(pool: PgPool) -> sqlx::Result<()> {
 async fn this_should_compile(_pool: PgPool) -> sqlx::Result<()> {
     Ok(())
 }
+
+macro_rules! macro_using_test {
+    ($migrations: literal) => {
+        #[sqlx::test(
+                            migrations = $migrations,
+                            fixtures(path = "../fixtures/postgres", scripts("users", "posts"))
+                        )]
+        async fn macro_using_macro(_pool: PgPool) -> sqlx::Result<()> {
+            Ok(())
+        }
+    };
+}
+macro_using_test!("tests/postgres/migrations");


### PR DESCRIPTION
### Does your PR solve an issue?
fixes #3534

This fixes a regression in the `sqlx::test` macro, this pr makes it work inside macro's. The error message seems to also have been changed by accident between version `0.7.4` and `0.8.0` so I changed it back.