### PR TITLE
Postgres: force generic plan for better nullability inference.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,6 +1995,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "bindgen",
  "cc",
  "pkg-config",
  "vcpkg",

--- a/sqlx-postgres/src/connection/describe.rs
+++ b/sqlx-postgres/src/connection/describe.rs
@@ -11,12 +11,8 @@ use crate::types::Oid;
 use crate::HashMap;
 use crate::{PgColumn, PgConnection, PgTypeInfo};
 use futures_core::future::BoxFuture;
-use futures_util::TryFutureExt;
 use smallvec::SmallVec;
-use sqlx_core::executor::Executor;
-use sqlx_core::from_row::FromRow;
 use sqlx_core::query_builder::QueryBuilder;
-use sqlx_core::raw_sql::raw_sql;
 use std::sync::Arc;
 
 /// Describes the type of the `pg_type.typtype` column
@@ -523,22 +519,7 @@ WHERE rngtypid = $1
             .display()
             .ok_or_else(|| err_protocol!("cannot EXPLAIN unnamed statement: {stmt_id:?}"))?;
 
-        let mut explain = format!(
-            "
-            BEGIN;
-            DO $$
-            BEGIN
-              IF EXISTS (
-                SELECT 1
-                FROM pg_settings
-                WHERE name = 'plan_cache_mode'
-              ) THEN
-                SET LOCAL plan_cache_mode = 'force_generic_plan';
-              END IF;
-            END $$;
-            EXPLAIN (VERBOSE, FORMAT JSON) EXECUTE {stmt_id_display}
-        "
-        );
+        let mut explain = format!("EXPLAIN (VERBOSE, FORMAT JSON) EXECUTE {stmt_id_display}");
         let mut comma = false;
 
         if params_len > 0 {
@@ -554,15 +535,11 @@ WHERE rngtypid = $1
                 comma = true;
             }
 
-            explain += ");
-            ROLLBACK;
-            ";
+            explain += ")";
         }
 
-        let (Json(explains),): (Json<SmallVec<[Explain; 1]>>,) = self
-            .fetch_one(raw_sql(&explain))
-            .map_ok(|row| FromRow::from_row(&row))
-            .await??;
+        let (Json(explains),): (Json<SmallVec<[Explain; 1]>>,) =
+            query_as(&explain).fetch_one(self).await?;
 
         let mut nullables = Vec::new();
 

--- a/sqlx-postgres/src/connection/describe.rs
+++ b/sqlx-postgres/src/connection/describe.rs
@@ -12,6 +12,7 @@ use crate::HashMap;
 use crate::{PgColumn, PgConnection, PgTypeInfo};
 use futures_core::future::BoxFuture;
 use smallvec::SmallVec;
+use sqlx_core::executor::Executor;
 use sqlx_core::query_builder::QueryBuilder;
 use std::sync::Arc;
 
@@ -523,6 +524,8 @@ WHERE rngtypid = $1
         let mut comma = false;
 
         if params_len > 0 {
+            self.execute("set plan_cache_mode = force_generic_plan;").await?;
+
             explain += "(";
 
             // fill the arguments list with NULL, which should theoretically be valid

--- a/sqlx-postgres/src/connection/describe.rs
+++ b/sqlx-postgres/src/connection/describe.rs
@@ -524,7 +524,8 @@ WHERE rngtypid = $1
         let mut comma = false;
 
         if params_len > 0 {
-            self.execute("set plan_cache_mode = force_generic_plan;").await?;
+            self.execute("set plan_cache_mode = force_generic_plan;")
+                .await?;
 
             explain += "(";
 


### PR DESCRIPTION
Currently when using the `query!` and `query_as!` macro's sqlx uses `explain (verbose, format json) execute {statement_id}` to get the query plan of a prepared statement/query. Then looks through the plans and tries to be more accurate with the type inference.

If a prepared statement has query parameters it needs to fill then in with a valid argument and uses [`NULL`](https://github.com/launchbadge/sqlx/blob/19f40d87a669e41081a629a469359d341c9223d6/sqlx-postgres/src/connection/describe.rs#L525-L539) for every one because it is always a valid argument.

This causes the query planner to give a query plan back that is optimized when the function arguments are all `NULL`, this is not always correct.

This pr forces postgres to use a generic execution plan when describing a prepared statement with function arguments. That way it won't make optimizations based on the given parameters.

 
Fixes #3539, #1265, https://github.com/launchbadge/sqlx/issues/2796#issuecomment-1923456127, #3408, #2127
