### PR TITLE
Demote `.pgpass` file warning to a debug message.

### DIFF
--- a/sqlx-postgres/src/options/pgpass.rs
+++ b/sqlx-postgres/src/options/pgpass.rs
@@ -43,10 +43,20 @@ fn load_password_from_file(
 ) -> Option<String> {
     let file = File::open(&path)
         .map_err(|e| {
-            tracing::warn!(
-                path = %path.display(),
-                "Failed to open `.pgpass` file: {e:?}",
-            );
+            match e.kind() {
+                std::io::ErrorKind::NotFound => {
+                    tracing::debug!(
+                        path = %path.display(),
+                        "`.pgpass` file not found",
+                    );
+                }
+                _ => {
+                    tracing::warn!(
+                        path = %path.display(),
+                        "Failed to open `.pgpass` file: {e:?}",
+                    );
+                }
+            };
         })
         .ok()?;
 


### PR DESCRIPTION
As per the discussion in that issue, let's make this a `debug` warning. And I hope @jajcus doesn't mind me jumping on this - but I noticed it yesterday, and had to submit a PR. :)

Fixes #3531