### PR TITLE
Add PgListener::next_buffered(), to support batch processing of notifications

### DIFF
--- a/sqlx-postgres/src/listener.rs
+++ b/sqlx-postgres/src/listener.rs
@@ -235,7 +235,7 @@ impl PgListener {
     pub async fn try_recv(&mut self) -> Result<Option<PgNotification>, Error> {
         // Flush the buffer first, if anything
         // This would only fill up if this listener is used as a connection
-        if let Some(notification) = self.try_recv_buffered() {
+        if let Some(notification) = self.next_buffered() {
             return Ok(Some(notification));
         }
 
@@ -300,7 +300,7 @@ impl PgListener {
     /// This is similar to `try_recv`, except it will not wait if the connection has not yet received a notification.
     ///
     /// This is helpful if you want to retrieve all buffered notifications and process them in batches.
-    pub fn try_recv_buffered(&mut self) -> Option<PgNotification> {
+    pub fn next_buffered(&mut self) -> Option<PgNotification> {
         if let Ok(Some(notification)) = self.buffer_rx.try_next() {
             Some(PgNotification(notification))
         } else {

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -1100,10 +1100,7 @@ async fn test_listener_try_recv_buffered() -> anyhow::Result<()> {
     assert!(listener.try_recv_buffered().is_none());
 
     // Should receive one notification.
-    assert!(
-        try_recv(&mut listener).await?,
-        "Notification not received"
-    );
+    assert!(try_recv(&mut listener).await?, "Notification not received");
 
     // The next four should be buffered.
     for _ in (0..4) {
@@ -1114,10 +1111,7 @@ async fn test_listener_try_recv_buffered() -> anyhow::Result<()> {
     assert!(listener.try_recv_buffered().is_none());
 
     // Even if we wait.
-    assert!(
-        !try_recv(&mut listener).await?,
-        "Notification received"
-    );
+    assert!(!try_recv(&mut listener).await?, "Notification received");
 
     Ok(())
 }

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -1092,7 +1092,7 @@ async fn test_listener_try_recv_buffered() -> anyhow::Result<()> {
     assert!(listener.try_recv_buffered().is_none());
 
     // Send five notifications.
-    for _ in (0..5) {
+    for _ in 0..5 {
         notify_conn.execute("NOTIFY test_channel").await?;
     }
 
@@ -1103,7 +1103,7 @@ async fn test_listener_try_recv_buffered() -> anyhow::Result<()> {
     assert!(try_recv(&mut listener).await?, "Notification not received");
 
     // The next four should be buffered.
-    for _ in (0..4) {
+    for _ in 0..4 {
         assert!(listener.try_recv_buffered().is_some());
     }
 

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -1089,7 +1089,7 @@ async fn test_listener_try_recv_buffered() -> anyhow::Result<()> {
     }
 
     // Check no notification is buffered, since we haven't sent one.
-    assert!(listener.try_recv_buffered().is_none());
+    assert!(listener.next_buffered().is_none());
 
     // Send five notifications transactionally, so they all arrive at once.
     {
@@ -1102,7 +1102,7 @@ async fn test_listener_try_recv_buffered() -> anyhow::Result<()> {
     }
 
     // Still no notifications buffered, since we haven't awaited the listener yet.
-    assert!(listener.try_recv_buffered().is_none());
+    assert!(listener.next_buffered().is_none());
 
     // Activate connection.
     sqlx::query!("SELECT 1 AS one")
@@ -1112,13 +1112,13 @@ async fn test_listener_try_recv_buffered() -> anyhow::Result<()> {
     // The next five notifications should now be buffered.
     for i in 0..5 {
         assert!(
-            listener.try_recv_buffered().is_some(),
+            listener.next_buffered().is_some(),
             "Notification {i} was not buffered"
         );
     }
 
     // Should be no more.
-    assert!(listener.try_recv_buffered().is_none());
+    assert!(listener.next_buffered().is_none());
 
     // Even if we wait.
     assert!(!try_recv(&mut listener).await?, "Notification received");


### PR DESCRIPTION
Hello! I wanted to support batch processing of notifications when there is a lot of them, so it made sense to grab whatever notifications might be readily available. `try_next()` is unsuitable for that, since if the buffer is empty, I don't want to wait for a new NOTIFY to happen before progressing with the batch. So, it seemed to make sense to add a new non-async method that is essentially the first buffer check of `try_recv()`, and then call that in a loop to build up a batch until it returns None (or a batch limit is released).

I updated `try_recv()` to call the new function, just to make things as DRY as possible, but it isn't a huge improvement. Happy to revert that part if you prefer.

Also happy to bikeshed the new method's name/interface. A couple options I considered were:

```rust
// Similar to `read_to_end()` and `read_to_string()` in the Read trait 
pub fn fill_notification_buffer(&mut self, buffer: &mut Vec<PgNotification>) -> usize {
  // Add all notifications in the buffer to the vec and return the number of notifications we added.
  // UnboundedReceiver doesn't support receiving multiple messages at the same time, though,
  // so there doesn't seem to be any performance benefit the way there would be with the Read trait.
}
```

```rust
// Just implement the loop behavior for the caller. This isn't anything they couldn't implement
// themselves on top of try_recv_buffered(), though, and it doesn't let them reuse a buffer vec.
pub async fn try_recv_multiple(&mut self, limit: usize) -> Result<Vec<PgNotification>, Error> {
  let vec =
    if let Some(first) = self.try_recv().await? {
      vec![first]
    } else {
      return Ok(vec![]);
    };
  loop {
    if vec.len() >= limit {
      return Ok(vec)
    }
    if let Some(n) = self.try_recv_buffered() {
      vec.push(n);
    } else {
      return Ok(vec);
    }
  }
```

Anyway, ran the tests with `cargo test -p sqlx-postgres --all-features`, please let me know if you think there's anything else worth testing/running.

Thanks!