### PR TITLE
Fix: Cannot query Postgres `INTERVAL[]`

### DIFF
--- a/sqlx-postgres/src/type_checking.rs
+++ b/sqlx-postgres/src/type_checking.rs
@@ -24,6 +24,8 @@ impl_type_checking!(
 
         sqlx::postgres::types::PgInterval,
 
+        Vec<sqlx::postgres::types::PgInterval> | &[sqlx::postgres::types::PgInterval],
+
         sqlx::postgres::types::PgMoney,
 
         sqlx::postgres::types::PgLTree,

--- a/sqlx-postgres/src/type_checking.rs
+++ b/sqlx-postgres/src/type_checking.rs
@@ -24,8 +24,6 @@ impl_type_checking!(
 
         sqlx::postgres::types::PgInterval,
 
-        Vec<sqlx::postgres::types::PgInterval> | &[sqlx::postgres::types::PgInterval],
-
         sqlx::postgres::types::PgMoney,
 
         sqlx::postgres::types::PgLTree,
@@ -99,6 +97,7 @@ impl_type_checking!(
         Vec<f64> | &[f64],
         Vec<sqlx::postgres::types::Oid> | &[sqlx::postgres::types::Oid],
         Vec<sqlx::postgres::types::PgMoney> | &[sqlx::postgres::types::PgMoney],
+        Vec<sqlx::postgres::types::PgInterval> | &[sqlx::postgres::types::PgInterval],
 
         #[cfg(feature = "uuid")]
         Vec<sqlx::types::Uuid> | &[sqlx::types::Uuid],


### PR DESCRIPTION
```
    error: unsupported type INTERVAL[] of column #2 ("event_offsets")
```

Hello, I'm querying array of intervals, but sqlx give that error. 

That PR fixes it