### PR TITLE
psql/migrations: when no-transaction is set, split multi-statement sql into individual statements and execute them separately 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2415,6 +2415,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pest"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3647,6 +3692,8 @@ dependencies = [
  "memchr",
  "num-bigint",
  "once_cell",
+ "pest",
+ "pest_derive",
  "rand",
  "rust_decimal",
  "serde",
@@ -4084,6 +4131,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-bidi"

--- a/sqlx-postgres/Cargo.toml
+++ b/sqlx-postgres/Cargo.toml
@@ -70,6 +70,8 @@ whoami = { version = "1.2.1", default-features = false }
 
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = { version = "1.0.85", features = ["raw_value"] }
+pest = "2.7.14"
+pest_derive = "2.7.14"
 
 [dependencies.sqlx-core]
 workspace = true

--- a/sqlx-postgres/src/lib.rs
+++ b/sqlx-postgres/src/lib.rs
@@ -18,6 +18,7 @@ mod message;
 mod options;
 mod query_result;
 mod row;
+mod split_sql;
 mod statement;
 mod transaction;
 mod type_checking;

--- a/sqlx-postgres/src/split_sql.rs
+++ b/sqlx-postgres/src/split_sql.rs
@@ -1,0 +1,130 @@
+use pest::Parser;
+use pest_derive::Parser;
+
+#[derive(Parser)]
+#[grammar_inline = r#"
+// The top-level rule matches the entire SQL input
+sql = { SOI ~ statement* ~ EOI }
+
+// A statement consists of optional leading comments and whitespace, content, and is terminated by a semicolon or end of input
+statement = { (WHITESPACE | COMMENT)* ~ statement_content ~ (semicolon | &EOI) }
+
+// Statement content is a sequence of constructs, comments, whitespace, or non-construct characters
+statement_content = { (construct | COMMENT | WHITESPACE | non_construct_char)+ }
+
+// Constructs that may contain semicolons internally
+construct = { DOLLAR_QUOTED_STRING | SINGLE_QUOTED_STRING | DOUBLE_QUOTED_IDENTIFIER }
+
+// Non-construct characters are any characters except semicolons
+non_construct_char = { !semicolon ~ ANY }
+
+// Semicolon outside constructs acts as a statement terminator
+semicolon = { ";" }
+
+// Single-quoted string literals, handling escaped quotes
+SINGLE_QUOTED_STRING = { "'" ~ SINGLE_QUOTED_CONTENT ~ ("'" | EOI) }
+SINGLE_QUOTED_CONTENT = { ( "''" | !("'" | EOI) ~ ANY )* }
+
+// Double-quoted identifiers, handling escaped quotes
+DOUBLE_QUOTED_IDENTIFIER = { "\"" ~ DOUBLE_QUOTED_IDENTIFIER_CONTENT ~ ("\"" | EOI) }
+DOUBLE_QUOTED_IDENTIFIER_CONTENT = { ( "\"\"" | !("\"" | EOI) ~ ANY )* }
+
+// Dollar-quoted strings, handling custom tags
+DOLLAR_QUOTED_STRING = { DOLLAR_QUOTE_START ~ DOLLAR_QUOTED_CONTENT ~ DOLLAR_QUOTE_END }
+DOLLAR_QUOTE_START = { "$" ~ DOLLAR_QUOTE_TAG ~ "$" }
+DOLLAR_QUOTE_TAG = { ASCII_ALPHANUMERIC* }
+DOLLAR_QUOTED_CONTENT = { ( !DOLLAR_QUOTE_END ~ ANY )* }
+DOLLAR_QUOTE_END = { "$" ~ DOLLAR_QUOTE_TAG ~ "$" }
+
+// Comments (single-line and multi-line)
+COMMENT = { SINGLE_LINE_COMMENT | MULTI_LINE_COMMENT }
+SINGLE_LINE_COMMENT = { "--" ~ (!NEWLINE ~ ANY)* ~ NEWLINE? }
+
+MULTI_LINE_COMMENT = { "/*" ~ MULTI_LINE_COMMENT_CONTENT* ~ ( "*/" | EOI ) }
+MULTI_LINE_COMMENT_CONTENT = { MULTI_LINE_COMMENT | (!"/*" ~ !"*/" ~ ANY) }
+
+// Whitespace rules
+WHITESPACE = { " " | "\t" | NEWLINE }
+NEWLINE = { "\r\n" | "\n" | "\r" }
+"#]
+struct PsqlSpliter;
+
+/// Splits a PostgreSQL query string into it's individual statements.
+///
+/// This function parses and splits a SQL input string into separate statements, handling
+/// PostgreSQL-specific syntax elements such as:
+///
+/// - **Dollar-quoted strings**: Supports custom dollar-quoted tags (e.g., `$$`, `$tag$`).
+/// - **Single and double-quoted strings**: Handles escaped quotes inside strings.
+/// - **Comments**: Supports single-line (`--`) and multi-line (`/* ... */`) comments, preserving them as part of the statement.
+/// - **Whitespace**: Retains all leading and trailing whitespace and comments around each statement.
+/// - **Semicolons**: Recognizes semicolons as statement terminators, while ignoring them inside strings or comments.
+///
+/// If parsing fails or only one statement is found, the input is returned in full.
+///
+/// ```no_run
+/// use sql_split_pest::split_psql;
+/// let sql = r#"
+///     -- First query
+///     INSERT INTO users (name) VALUES ('Alice; Bob');
+///
+///     -- Second query
+///     SELECT * FROM posts;
+///
+///     /* Multi-line
+///     comment */
+///     CREATE FUNCTION test_function()
+///     RETURNS VOID AS $$
+///     BEGIN
+///         -- Multiple statements inside the function
+///         INSERT INTO table_a VALUES (1);
+///         INSERT INTO table_b VALUES (2);
+///     END;
+///     $$ LANGUAGE plpgsql;
+///
+///     -- invalid sql
+///     SELECT 'This is an unterminated string FROM users;
+///     SELECT * FROM users WHERE name = AND email = 'john@example.com';
+///     SELECT * FROM users JOIN other_table ON;
+///
+/// "#;
+///
+/// let statements = split_psql(sql);
+/// dbg!(&statements);
+/// assert_eq!(statements.len(), 4);
+/// assert!(statements[0].contains("INSERT INTO users"));
+/// assert!(statements[1].contains("SELECT * FROM posts"));
+/// assert!(statements[2].contains("CREATE FUNCTION"));
+/// assert!(statements[2].contains("plpgsql"));
+/// assert!(statements[3].contains("other_table"));
+/// ```
+pub fn split_sql<S: AsRef<str>>(sql: S) -> Vec<String> {
+    let sql_str = sql.as_ref();
+
+    PsqlSpliter::parse(Rule::sql, sql_str).map_or_else(
+        |_| vec![sql_str.to_string()],
+        |mut parsed| match parsed.next() {
+            // this should never happen
+            None => vec![sql_str.to_string()],
+            Some(sql) => {
+                let mut statements = Vec::new();
+                let mut statement = String::new();
+                for pair in sql.into_inner() {
+                    match pair.as_rule() {
+                        Rule::WHITESPACE | Rule::COMMENT => statement.push_str(pair.as_str()),
+                        Rule::statement | Rule::EOI => {
+                            statement.push_str(pair.as_str());
+                            // omit empty whitespace at the end of sql
+                            if !statement.is_empty() && !statement.chars().all(char::is_whitespace)
+                            {
+                                statements.push(std::mem::take(&mut statement));
+                            }
+                        }
+                        _ => unreachable!(),
+                    }
+                }
+                statements
+            }
+        },
+    )
+}

--- a/tests/postgres/migrate.rs
+++ b/tests/postgres/migrate.rs
@@ -74,13 +74,20 @@ async fn no_tx(mut conn: PoolConnection<Postgres>) -> anyhow::Result<()> {
     // run migration
     migrator.run(&mut conn).await?;
 
-    // check outcome
+    // check outcomes
     let res: String = conn
         .fetch_one("SELECT datname FROM pg_database WHERE datname = 'test_db'")
         .await?
         .get(0);
 
     assert_eq!(res, "test_db");
+
+    let res: String = conn
+        .fetch_one("SELECT email FROM users WHERE username = 'test_user'")
+        .await?
+        .get(0);
+
+    assert_eq!(res, "test_user@example.com");
 
     Ok(())
 }

--- a/tests/postgres/migrations_no_tx/0_create_db.sql
+++ b/tests/postgres/migrations_no_tx/0_create_db.sql
@@ -1,3 +1,14 @@
 -- no-transaction
 
 CREATE DATABASE test_db;
+
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    username VARCHAR(50) NOT NULL,
+    email VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX CONCURRENTLY idx_users_email ON users(email);
+
+INSERT INTO users (username, email) VALUES ('test_user', 'test_user@example.com');


### PR DESCRIPTION
This is going to be a controversial one. 

Recently, support for adding `-- no-transaction` at the beginning of migration files was introduced, which will execute the migration without creating a transaction. This is useful for certain commands, such as `CREATE INDEX CONCURRENTLY`, which are not allowed to run inside transactions. 

However, postgres will _implicitly_ create a transaction block when a query contains multiple statements. This means that the  `-- no-transaction` flag has inconsistent behavior depending on whether the migration contains just one statement or multiple ones, and that commands that are not allowed to run inside transactions will fail if part of a larger migration. 

I propose to split the sql into individual statements when `no_tx` is set and to execute them separately, resulting in consistent behavior in line with how many sql tools handle this case. This was implemented using a custom `pest` grammar, which is very low overhead and performant (but does add a dependency). 

One could argue that the current behavior is good (albeit lacking a clear error message) and that users should be encouraged to create small migrations with only one statement at a time when opting out of the safety of transactions. I would counter that a user that opts out of transactions usually has a reason for that and is aware that extra care has to be taken to ensure that migration is sound and tested, that an error during a `no_tx` migration will always require manual cleanup anyway, and that there are production cases where forcing the user to split up a logical migration into potentially many individual files can add complexity and make it harder to manage and audit (we recently had such case).  
