### PR TITLE
Derive Copy where possible for database-specific types

### DIFF
--- a/sqlx-postgres/src/types/interval.rs
+++ b/sqlx-postgres/src/types/interval.rs
@@ -10,7 +10,7 @@ use crate::{PgArgumentBuffer, PgHasArrayType, PgTypeInfo, PgValueFormat, PgValue
 
 // `PgInterval` is available for direct access to the INTERVAL type
 
-#[derive(Debug, Eq, PartialEq, Clone, Hash, Default)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash, Default)]
 pub struct PgInterval {
     pub months: i32,
     pub days: i32,

--- a/sqlx-postgres/src/types/range.rs
+++ b/sqlx-postgres/src/types/range.rs
@@ -26,7 +26,7 @@ bitflags! {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct PgRange<T> {
     pub start: Bound<T>,
     pub end: Bound<T>,


### PR DESCRIPTION
I looked for them in `sqlx-postgres`, `sqlx-mysql`, `sqlx-sqlite` and `sqlx-core`.
I would assume this change is desirable.