### PR TITLE
fix: URL decode database name when parsing connection url

### DIFF
--- a/sqlx-postgres/src/options/parse.rs
+++ b/sqlx-postgres/src/options/parse.rs
@@ -40,7 +40,11 @@ impl PgConnectOptions {
 
         let path = url.path().trim_start_matches('/');
         if !path.is_empty() {
-            options = options.database(path);
+            options = options.database(
+                &percent_decode_str(path)
+                    .decode_utf8()
+                    .map_err(Error::config)?,
+            );
         }
 
         for (key, value) in url.query_pairs().into_iter() {


### PR DESCRIPTION
# The problem

Connecting to databases with non-standard characters in the db name fails.

```rust
    let connection_uri = "postgres://postgres:postgres@localhost:5432/test db";

    let mut connection = PgConnection::connect(connection_uri).await?;

    let results = sqlx::query("SELECT * FROM test")
        .fetch_all(&mut connection)
        .await?;
```

Fails with `database "test%20db" does not exist`

Creating a connection configuration, and then setting the db name explicitly, fixes the issue:

```rust
    let connection_uri = "postgres://postgres:postgres@localhost:5432/test db";

    let connect_options = PgConnectOptions::from_url(&connection_uri.parse()?)?;
    let connect_options = connect_options.database("test db");

    let mut connection = PgConnection::connect_with(&connect_options).await?;
    
    let results = sqlx::query("SELECT * FROM test")
        .fetch_all(&mut connection)
        .await?;
```

Additionally, setting the db name with a query parameter also fixes the problem:

```rust
    let connection_uri = "postgres://postgres:postgres@localhost:5432?dbname=test db";
```

# Background

When parsing a connection string, the various parts are [url decoded](https://github.com/launchbadge/sqlx/blob/main/sqlx-postgres/src/options/parse.rs#L12-L18) before being stored in the connection configuration struct.

The [one exception is the database name](https://github.com/launchbadge/sqlx/blob/main/sqlx-postgres/src/options/parse.rs#L41-L44).

When we [get the name from the `dbname` query param](https://github.com/launchbadge/sqlx/blob/main/sqlx-postgres/src/options/parse.rs#L80), it seems the values are decoded.

When [building back a URL](https://github.com/launchbadge/sqlx/blob/main/sqlx-postgres/src/options/parse.rs#L132), it seems we rely on the behavior of the `set_path` path method which will encode the string if needed, (if we passed the name using the dbname query param), or leave it as is if already percent encoded (if we passed it using the url path)

However, it looks like the `establish` method [does not handle](https://github.com/launchbadge/sqlx/blob/main/sqlx-postgres/src/connection/establish.rs#L50) getting a url encoded database name, and sends it as-is. Hence our problem.

# Fix

URL decode the db name when extracted from the path of a connection string

