### PR TITLE
fix: stop dead branch in proc macro from emitting clippy::missing_panics_doc

### DIFF
--- a/sqlx-macros-core/src/query/args.rs
+++ b/sqlx-macros-core/src/query/args.rs
@@ -89,7 +89,9 @@ pub fn quote_args<DB: DatabaseExt>(
                             _ty_check = match_borrow.match_borrow();
 
                             // this causes move-analysis to effectively ignore this block
-                            ::std::panic!();
+                            // `panic!` would be enough here but we would then get a warning on `clippy::missing_panics_doc`
+                            // SAFETY: this branch is never reached.
+                            unsafe { ::std::hint::unreachable_unchecked() }
                         }
                     ))
                 })


### PR DESCRIPTION
fixes #3594