### PR TITLE
Warn when migration was inferred as non-reversible and user set rever…

### DIFF
--- a/sqlx-cli/src/migrate.rs
+++ b/sqlx-cli/src/migrate.rs
@@ -113,6 +113,9 @@ pub async fn add(
     // Type of newly created migration will be the same as the first one
     // or reversible flag if this is the first migration
     let migration_type = MigrationType::infer(&migrator, reversible);
+    if reversible && !migration_type.is_reversible() {
+        println!("Cannot create reversible migration since prior migrations are not reversible.");
+    }
 
     let ordering = MigrationOrdering::infer(sequential, timestamp, &migrator);
     let file_prefix = ordering.file_prefix();


### PR DESCRIPTION
This PR prints a warning when trying to add a reversible migration on top of non-reversible migrations. This behavior was added along with the PR that added inference: https://github.com/launchbadge/sqlx/pull/2664.

First time contributor here - I read the code and it's not clear why reversible migrations can't be stacked on top of non-reversible ones. Obviously this would limit which versions one could revert, which seems fine.

I'm in the spot where I was lazy in the beginning of a project and used non-reversible migrations. But now I'd like to start using reversible ones.

### Does your PR solve an issue?

Running `sqlx migrate add -r something` after previously adding non-reversible migrations ignores the `-r` flag and creates a non-reversible migration.  I was confused for a bit.

https://github.com/launchbadge/sqlx/issues/3598
