### PR TITLE
Added missing special casing for encoding embedded arrays of custom types

### DIFF
--- a/sqlx-postgres/src/types/record.rs
+++ b/sqlx-postgres/src/types/record.rs
@@ -41,13 +41,13 @@ impl<'a> PgRecordEncoder<'a> {
     {
         let ty = value.produces().unwrap_or_else(T::type_info);
 
-        if let PgType::DeclareWithName(name) = ty.0 {
+        match ty.0 {
             // push a hole for this type ID
             // to be filled in on query execution
-            self.buf.patch_type_by_name(&name);
-        } else {
+            PgType::DeclareWithName(name) => self.buf.patch_type_by_name(&name),
+            PgType::DeclareArrayOf(array) => self.buf.patch_array_type(array),
             // write type id
-            self.buf.extend(&ty.0.oid().0.to_be_bytes());
+            pg_type => self.buf.extend(&pg_type.oid().0.to_be_bytes()),
         }
 
         self.buf.encode(value)?;

--- a/tests/postgres/derives.rs
+++ b/tests/postgres/derives.rs
@@ -810,3 +810,69 @@ async fn test_custom_pg_array() -> anyhow::Result<()> {
     }
     Ok(())
 }
+
+#[sqlx_macros::test]
+async fn test_record_array_type() -> anyhow::Result<()> {
+    let mut conn = new::<Postgres>().await?;
+
+    conn.execute(
+        r#"
+DROP TABLE IF EXISTS responses;
+
+DROP TYPE IF EXISTS http_response CASCADE;
+DROP TYPE IF EXISTS header_pair CASCADE;
+
+CREATE TYPE header_pair AS (
+    name TEXT,
+    value TEXT
+);
+
+CREATE TYPE http_response AS (
+    headers header_pair[]
+);
+
+CREATE TABLE responses (
+    response http_response NOT NULL
+);
+    "#,
+    )
+    .await?;
+
+    #[derive(Debug, sqlx::Type)]
+    #[sqlx(type_name = "http_response")]
+    struct HttpResponseRecord {
+        headers: Vec<HeaderPairRecord>,
+    }
+
+    #[derive(Debug, sqlx::Type)]
+    #[sqlx(type_name = "header_pair")]
+    struct HeaderPairRecord {
+        name: String,
+        value: String,
+    }
+
+    let value = HttpResponseRecord {
+        headers: vec![
+            HeaderPairRecord {
+                name: "Content-Type".to_owned(),
+                value: "text/html; charset=utf-8".to_owned()
+            },
+            HeaderPairRecord {
+                name: "Cache-Control".to_owned(),
+                value: "max-age=0".to_owned()
+            }
+        ],
+    };
+
+    sqlx::query(
+        "
+INSERT INTO responses (response)
+VALUES ($1)
+        ",
+    )
+    .bind(&value)
+    .execute(&mut conn)
+    .await?;
+
+    Ok(())
+}

--- a/tests/postgres/derives.rs
+++ b/tests/postgres/derives.rs
@@ -855,12 +855,12 @@ CREATE TABLE responses (
         headers: vec![
             HeaderPairRecord {
                 name: "Content-Type".to_owned(),
-                value: "text/html; charset=utf-8".to_owned()
+                value: "text/html; charset=utf-8".to_owned(),
             },
             HeaderPairRecord {
                 name: "Cache-Control".to_owned(),
-                value: "max-age=0".to_owned()
-            }
+                value: "max-age=0".to_owned(),
+            },
         ],
     };
 


### PR DESCRIPTION
fixes #1672 - or at least [my last comment](https://github.com/launchbadge/sqlx/issues/1672#issuecomment-2483639488) on the ticket, as I now realise the person originally reported a decoding issue, and this is about encoding, as decoding already worked fine. My specific scenario has been added to the test suite to confirm this fixes it.

This fix is inspired by this similar bit of code:
https://github.com/launchbadge/sqlx/blob/82d332f4b487440b4c2bd5d54a5f17dcc1abc92c/sqlx-postgres/src/types/array.rs#L168-L175

With this fix in, it's now perfectly fine to store (and retrieve) nested structures in Postgres, without any additional boilerplate, such as:
```rust
#[derive(Debug, sqlx::Type)]
#[sqlx(type_name = "http_response")]
struct HttpResponseRecord {
    status_code: i16,
    headers: Vec<HeaderPairRecord>,
    body: Vec<u8>,
}

#[derive(Debug, sqlx::Type)]
#[sqlx(type_name = "header_pair")]
struct HeaderPairRecord {
    name: String,
    value: Vec<u8>,
}

[...]

sqlx::query!(
    r#"
    INSERT INTO idempotency (user_id, idempotency_key, response, created_at)
    VALUES ($1, $2, $3, NOW())
    "#,
    &user_id,
    &idempotency_key,
    &http_response_record as _,
)
.execute(connection)
.await?;

let saved_response = sqlx::query!(
    r#"
    SELECT response AS "response: HttpResponseRecord"
    FROM idempotency
    WHERE user_id = $1
    AND idempotency_key = $2
    "#,
    &user_id,
    &idempotency_key
)
.fetch_optional(connection)
.await?;
```

By the way, I've seen comments pointing to using the *newtype* pattern to map embedded arrays of custom types; but it's no longer necessary after this fix, so it might be worth updating the official documentation with an example.