### PR TITLE
Use `UNION ALL` instead of `UNION` in nullable check

### DIFF
--- a/sqlx-postgres/src/connection/describe.rs
+++ b/sqlx-postgres/src/connection/describe.rs
@@ -448,26 +448,45 @@ WHERE rngtypid = $1
         // This will include columns that don't have a `relation_id` (are not from a table);
         // assuming those are a minority of columns, it's less code to _not_ work around it
         // and just let Postgres return `NULL`.
-        let mut nullable_query = QueryBuilder::new("SELECT NOT pg_attribute.attnotnull FROM ( ");
+        //
+        // Use `UNION ALL` syntax instead of `VALUES` due to frequent lack of
+        // support for `VALUES` in pgwire supported databases.
+        let mut nullable_query = QueryBuilder::new("SELECT NOT attnotnull FROM ( ");
+        let mut separated = nullable_query.separated("UNION ALL ");
 
-        nullable_query.push_values(meta.columns.iter().zip(0i32..), |mut tuple, (column, i)| {
-            // ({i}::int4, {column.relation_id}::int4, {column.relation_attribute_no}::int2)
-            tuple.push_bind(i).push_unseparated("::int4");
-            tuple
-                .push_bind(column.relation_id)
-                .push_unseparated("::int4");
-            tuple
-                .push_bind(column.relation_attribute_no)
-                .push_unseparated("::int2");
-        });
+        let mut column_iter = meta.columns.iter().zip(0i32..);
+        if let Some((column, i)) = column_iter.next() {
+            separated.push("( SELECT ");
+            separated
+                .push_bind_unseparated(i)
+                .push_unseparated("::int4 AS idx, ");
+            separated
+                .push_bind_unseparated(column.relation_id)
+                .push_unseparated("::int4 AS table_id, ");
+            separated
+                .push_bind_unseparated(column.relation_attribute_no)
+                .push_unseparated("::int2 AS col_idx ) ");
+        }
+
+        for (column, i) in column_iter {
+            separated.push("( SELECT ");
+            separated
+                .push_bind_unseparated(i)
+                .push_unseparated("::int4, ");
+            separated
+                .push_bind_unseparated(column.relation_id)
+                .push_unseparated("::int4, ");
+            separated
+                .push_bind_unseparated(column.relation_attribute_no)
+                .push_unseparated("::int2 ) ");
+        }
 
         nullable_query.push(
-            ") as col(idx, table_id, col_idx) \
-            LEFT JOIN pg_catalog.pg_attribute \
+            ") AS col LEFT JOIN pg_catalog.pg_attribute \
                 ON table_id IS NOT NULL \
                AND attrelid = table_id \
                AND attnum = col_idx \
-            ORDER BY col.idx",
+            ORDER BY idx",
         );
 
         let mut nullables: Vec<Option<bool>> = nullable_query


### PR DESCRIPTION
Instead of generating nullable query using `VALUES`, use `UNION ALL` syntax.

Current query:
```
SELECT NOT attnotnull FROM (
  VALUES
    ( $1::int4, $2::int4, $3::int2 ),
    ( $3::int4, $4::int4, $5::int2 ),
) AS col(idx, table_id, col_idx) ...
```

Becomes:
```
SELECT NOT attnotnull FROM (
  ( SELECT $1::int4 AS idx, $2::int4 AS table_id, $3::int2 AS col_idx )
  UNION ALL ( SELECT $1::int4, $2::int4, $3::int2 )
) AS col ...
```

This change allows better support for databases that support a `pgwire` interface but with limited SQL syntax. In particular, timeseries databases such as QuestDB and kdb are unsupported.

