### PR TITLE
Add `begin_with` methods to support database-specific transaction options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,6 +187,7 @@ rand_xoshiro = "0.6.0"
 hex = "0.4.3"
 tempfile = "3.10.1"
 criterion = { version = "0.5.1", features = ["async_tokio"] }
+libsqlite3-sys = { version = "0.30.1" }
 
 # If this is an unconditional dev-dependency then Cargo will *always* try to build `libsqlite3-sys`,
 # even when SQLite isn't the intended test target, and fail if the build environment is not set up for compiling C code.

--- a/sqlx-core/src/acquire.rs
+++ b/sqlx-core/src/acquire.rs
@@ -93,7 +93,7 @@ impl<'a, DB: Database> Acquire<'a> for &'_ Pool<DB> {
         let conn = self.acquire();
 
         Box::pin(async move {
-            Transaction::begin(MaybePoolConnection::PoolConnection(conn.await?)).await
+            Transaction::begin(MaybePoolConnection::PoolConnection(conn.await?), None).await
         })
     }
 }
@@ -121,7 +121,7 @@ macro_rules! impl_acquire {
                 'c,
                 Result<$crate::transaction::Transaction<'c, $DB>, $crate::error::Error>,
             > {
-                $crate::transaction::Transaction::begin(self)
+                $crate::transaction::Transaction::begin(self, None)
             }
         }
     };

--- a/sqlx-core/src/any/connection/backend.rs
+++ b/sqlx-core/src/any/connection/backend.rs
@@ -3,6 +3,7 @@ use crate::describe::Describe;
 use either::Either;
 use futures_core::future::BoxFuture;
 use futures_core::stream::BoxStream;
+use std::borrow::Cow;
 use std::fmt::Debug;
 
 pub trait AnyConnectionBackend: std::any::Any + Debug + Send + 'static {
@@ -26,7 +27,13 @@ pub trait AnyConnectionBackend: std::any::Any + Debug + Send + 'static {
     fn ping(&mut self) -> BoxFuture<'_, crate::Result<()>>;
 
     /// Begin a new transaction or establish a savepoint within the active transaction.
-    fn begin(&mut self) -> BoxFuture<'_, crate::Result<()>>;
+    ///
+    /// If this is a new transaction, `statement` may be used instead of the
+    /// default "BEGIN" statement.
+    ///
+    /// If we are already inside a transaction and `statement.is_some()`, then
+    /// `Error::InvalidSavePoint` is returned without running any statements.
+    fn begin(&mut self, statement: Option<Cow<'static, str>>) -> BoxFuture<'_, crate::Result<()>>;
 
     fn commit(&mut self) -> BoxFuture<'_, crate::Result<()>>;
 

--- a/sqlx-core/src/any/connection/mod.rs
+++ b/sqlx-core/src/any/connection/mod.rs
@@ -1,4 +1,5 @@
 use futures_core::future::BoxFuture;
+use std::borrow::Cow;
 
 use crate::any::{Any, AnyConnectOptions};
 use crate::connection::{ConnectOptions, Connection};
@@ -87,7 +88,17 @@ impl Connection for AnyConnection {
     where
         Self: Sized,
     {
-        Transaction::begin(self)
+        Transaction::begin(self, None)
+    }
+
+    fn begin_with(
+        &mut self,
+        statement: impl Into<Cow<'static, str>>,
+    ) -> BoxFuture<'_, Result<Transaction<'_, Self::Database>, Error>>
+    where
+        Self: Sized,
+    {
+        Transaction::begin(self, Some(statement.into()))
     }
 
     fn cached_statements_size(&self) -> usize {

--- a/sqlx-core/src/any/transaction.rs
+++ b/sqlx-core/src/any/transaction.rs
@@ -1,4 +1,5 @@
 use futures_util::future::BoxFuture;
+use std::borrow::Cow;
 
 use crate::any::{Any, AnyConnection};
 use crate::error::Error;
@@ -9,8 +10,11 @@ pub struct AnyTransactionManager;
 impl TransactionManager for AnyTransactionManager {
     type Database = Any;
 
-    fn begin(conn: &mut AnyConnection) -> BoxFuture<'_, Result<(), Error>> {
-        conn.backend.begin()
+    fn begin<'conn>(
+        conn: &'conn mut AnyConnection,
+        statement: Option<Cow<'static, str>>,
+    ) -> BoxFuture<'conn, Result<(), Error>> {
+        conn.backend.begin(statement)
     }
 
     fn commit(conn: &mut AnyConnection) -> BoxFuture<'_, Result<(), Error>> {

--- a/sqlx-core/src/connection.rs
+++ b/sqlx-core/src/connection.rs
@@ -61,7 +61,10 @@ pub trait Connection: Send {
         statement: impl Into<Cow<'static, str>>,
     ) -> BoxFuture<'_, Result<Transaction<'_, Self::Database>, Error>>
     where
-        Self: Sized;
+        Self: Sized,
+    {
+        Transaction::begin(self, Some(statement.into()))
+    }
 
     /// Execute the function inside a transaction.
     ///

--- a/sqlx-core/src/connection.rs
+++ b/sqlx-core/src/connection.rs
@@ -4,6 +4,7 @@ use crate::error::Error;
 use crate::transaction::Transaction;
 use futures_core::future::BoxFuture;
 use log::LevelFilter;
+use std::borrow::Cow;
 use std::fmt::Debug;
 use std::str::FromStr;
 use std::time::Duration;
@@ -46,6 +47,16 @@ pub trait Connection: Send {
     ///
     /// Returns a [`Transaction`] for controlling and tracking the new transaction.
     fn begin(&mut self) -> BoxFuture<'_, Result<Transaction<'_, Self::Database>, Error>>
+    where
+        Self: Sized;
+
+    /// Begin a new transaction with a custom statement.
+    ///
+    /// Returns a [`Transaction`] for controlling and tracking the new transaction.
+    fn begin_with(
+        &mut self,
+        statement: impl Into<Cow<'static, str>>,
+    ) -> BoxFuture<'_, Result<Transaction<'_, Self::Database>, Error>>
     where
         Self: Sized;
 

--- a/sqlx-core/src/connection.rs
+++ b/sqlx-core/src/connection.rs
@@ -53,6 +53,9 @@ pub trait Connection: Send {
     /// Begin a new transaction with a custom statement.
     ///
     /// Returns a [`Transaction`] for controlling and tracking the new transaction.
+    ///
+    /// Returns an error if the connection is already in a transaction or if
+    /// `statement` does not put the connection into a transaction.
     fn begin_with(
         &mut self,
         statement: impl Into<Cow<'static, str>>,

--- a/sqlx-core/src/error.rs
+++ b/sqlx-core/src/error.rs
@@ -114,6 +114,9 @@ pub enum Error {
 
     #[error("attempted to call begin_with at non-zero transaction depth")]
     InvalidSavePointStatement,
+
+    #[error("got unexpected connection status after attempting to begin transaction")]
+    BeginFailed,
 }
 
 impl StdError for Box<dyn DatabaseError> {}

--- a/sqlx-core/src/error.rs
+++ b/sqlx-core/src/error.rs
@@ -111,6 +111,9 @@ pub enum Error {
     #[cfg(feature = "migrate")]
     #[error("{0}")]
     Migrate(#[source] Box<crate::migrate::MigrateError>),
+
+    #[error("attempted to call begin_with at non-zero transaction depth")]
+    InvalidSavePointStatement,
 }
 
 impl StdError for Box<dyn DatabaseError> {}

--- a/sqlx-core/src/pool/connection.rs
+++ b/sqlx-core/src/pool/connection.rs
@@ -191,7 +191,7 @@ impl<'c, DB: Database> crate::acquire::Acquire<'c> for &'c mut PoolConnection<DB
         self,
     ) -> futures_core::future::BoxFuture<'c, Result<crate::transaction::Transaction<'c, DB>, Error>>
     {
-        crate::transaction::Transaction::begin(&mut **self)
+        crate::transaction::Transaction::begin(&mut **self, None)
     }
 }
 

--- a/sqlx-core/src/pool/mod.rs
+++ b/sqlx-core/src/pool/mod.rs
@@ -54,6 +54,7 @@
 //! [`Pool::acquire`] or
 //! [`Pool::begin`].
 
+use std::borrow::Cow;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
@@ -380,6 +381,36 @@ impl<DB: Database> Pool<DB> {
             Some(conn) => Transaction::begin(MaybePoolConnection::PoolConnection(conn), None)
                 .await
                 .map(Some),
+
+            None => Ok(None),
+        }
+    }
+
+    /// Retrieves a connection and immediately begins a new transaction using `statement`.
+    pub async fn begin_with(
+        &self,
+        statement: impl Into<Cow<'static, str>>,
+    ) -> Result<Transaction<'static, DB>, Error> {
+        Transaction::begin(
+            MaybePoolConnection::PoolConnection(self.acquire().await?),
+            Some(statement.into()),
+        )
+        .await
+    }
+
+    /// Attempts to retrieve a connection and, if successful, immediately begins a new
+    /// transaction using `statement`.
+    pub async fn try_begin_with(
+        &self,
+        statement: impl Into<Cow<'static, str>>,
+    ) -> Result<Option<Transaction<'static, DB>>, Error> {
+        match self.try_acquire() {
+            Some(conn) => Transaction::begin(
+                MaybePoolConnection::PoolConnection(conn),
+                Some(statement.into()),
+            )
+            .await
+            .map(Some),
 
             None => Ok(None),
         }

--- a/sqlx-core/src/pool/mod.rs
+++ b/sqlx-core/src/pool/mod.rs
@@ -367,13 +367,17 @@ impl<DB: Database> Pool<DB> {
 
     /// Retrieves a connection and immediately begins a new transaction.
     pub async fn begin(&self) -> Result<Transaction<'static, DB>, Error> {
-        Transaction::begin(MaybePoolConnection::PoolConnection(self.acquire().await?)).await
+        Transaction::begin(
+            MaybePoolConnection::PoolConnection(self.acquire().await?),
+            None,
+        )
+        .await
     }
 
     /// Attempts to retrieve a connection and immediately begins a new transaction if successful.
     pub async fn try_begin(&self) -> Result<Option<Transaction<'static, DB>>, Error> {
         match self.try_acquire() {
-            Some(conn) => Transaction::begin(MaybePoolConnection::PoolConnection(conn))
+            Some(conn) => Transaction::begin(MaybePoolConnection::PoolConnection(conn), None)
                 .await
                 .map(Some),
 

--- a/sqlx-mysql/src/any.rs
+++ b/sqlx-mysql/src/any.rs
@@ -16,6 +16,7 @@ use sqlx_core::database::Database;
 use sqlx_core::describe::Describe;
 use sqlx_core::executor::Executor;
 use sqlx_core::transaction::TransactionManager;
+use std::borrow::Cow;
 use std::future;
 
 sqlx_core::declare_driver_with_optional_migrate!(DRIVER = MySql);
@@ -37,8 +38,11 @@ impl AnyConnectionBackend for MySqlConnection {
         Connection::ping(self)
     }
 
-    fn begin(&mut self) -> BoxFuture<'_, sqlx_core::Result<()>> {
-        MySqlTransactionManager::begin(self)
+    fn begin(
+        &mut self,
+        statement: Option<Cow<'static, str>>,
+    ) -> BoxFuture<'_, sqlx_core::Result<()>> {
+        MySqlTransactionManager::begin(self, statement)
     }
 
     fn commit(&mut self) -> BoxFuture<'_, sqlx_core::Result<()>> {

--- a/sqlx-mysql/src/connection/establish.rs
+++ b/sqlx-mysql/src/connection/establish.rs
@@ -27,6 +27,7 @@ impl MySqlConnection {
             inner: Box::new(MySqlConnectionInner {
                 stream,
                 transaction_depth: 0,
+                status_flags: Default::default(),
                 cache_statement: StatementCache::new(options.statement_cache_capacity),
                 log_settings: options.log_settings.clone(),
             }),

--- a/sqlx-mysql/src/connection/executor.rs
+++ b/sqlx-mysql/src/connection/executor.rs
@@ -166,6 +166,8 @@ impl MySqlConnection {
                     // this indicates either a successful query with no rows at all or a failed query
                     let ok = packet.ok()?;
 
+                    self.inner.status_flags = ok.status;
+
                     let rows_affected = ok.affected_rows;
                     logger.increase_rows_affected(rows_affected);
                     let done = MySqlQueryResult {
@@ -207,6 +209,8 @@ impl MySqlConnection {
 
                     if packet[0] == 0xfe && packet.len() < 9 {
                         let eof = packet.eof(self.inner.stream.capabilities)?;
+
+                        self.inner.status_flags = eof.status;
 
                         r#yield!(Either::Left(MySqlQueryResult {
                             rows_affected: 0,

--- a/sqlx-mysql/src/connection/mod.rs
+++ b/sqlx-mysql/src/connection/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt::{self, Debug, Formatter};
 
 use futures_core::future::BoxFuture;
@@ -111,7 +112,17 @@ impl Connection for MySqlConnection {
     where
         Self: Sized,
     {
-        Transaction::begin(self)
+        Transaction::begin(self, None)
+    }
+
+    fn begin_with(
+        &mut self,
+        statement: impl Into<Cow<'static, str>>,
+    ) -> BoxFuture<'_, Result<Transaction<'_, Self::Database>, Error>>
+    where
+        Self: Sized,
+    {
+        Transaction::begin(self, Some(statement.into()))
     }
 
     fn shrink_buffers(&mut self) {

--- a/sqlx-mysql/src/connection/mod.rs
+++ b/sqlx-mysql/src/connection/mod.rs
@@ -8,6 +8,7 @@ pub(crate) use stream::{MySqlStream, Waiting};
 
 use crate::common::StatementCache;
 use crate::error::Error;
+use crate::protocol::response::Status;
 use crate::protocol::statement::StmtClose;
 use crate::protocol::text::{Ping, Quit};
 use crate::statement::MySqlStatementMetadata;
@@ -35,11 +36,20 @@ pub(crate) struct MySqlConnectionInner {
 
     // transaction status
     pub(crate) transaction_depth: usize,
+    status_flags: Status,
 
     // cache by query string to the statement id and metadata
     cache_statement: StatementCache<(u32, MySqlStatementMetadata)>,
 
     log_settings: LogSettings,
+}
+
+impl MySqlConnection {
+    pub(crate) fn in_transaction(&self) -> bool {
+        self.inner
+            .status_flags
+            .intersects(Status::SERVER_STATUS_IN_TRANS)
+    }
 }
 
 impl Debug for MySqlConnection {

--- a/sqlx-mysql/src/protocol/response/status.rs
+++ b/sqlx-mysql/src/protocol/response/status.rs
@@ -1,7 +1,7 @@
 // https://dev.mysql.com/doc/dev/mysql-server/8.0.12/mysql__com_8h.html#a1d854e841086925be1883e4d7b4e8cad
 // https://mariadb.com/kb/en/library/mariadb-connectorc-types-and-definitions/#server-status
 bitflags::bitflags! {
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
     pub struct Status: u16 {
         // Is raised when a multi-statement transaction has been started, either explicitly,
         // by means of BEGIN or COMMIT AND CHAIN, or implicitly, by the first

--- a/sqlx-mysql/src/transaction.rs
+++ b/sqlx-mysql/src/transaction.rs
@@ -27,6 +27,9 @@ impl TransactionManager for MySqlTransactionManager {
             }
             let statement = statement.unwrap_or_else(|| begin_ansi_transaction_sql(depth));
             conn.execute(&*statement).await?;
+            if !conn.in_transaction() {
+                return Err(Error::BeginFailed);
+            }
             conn.inner.transaction_depth += 1;
 
             Ok(())

--- a/sqlx-postgres/src/any.rs
+++ b/sqlx-postgres/src/any.rs
@@ -5,6 +5,7 @@ use crate::{
 use futures_core::future::BoxFuture;
 use futures_core::stream::BoxStream;
 use futures_util::{stream, StreamExt, TryFutureExt, TryStreamExt};
+use std::borrow::Cow;
 use std::future;
 
 use sqlx_core::any::{
@@ -39,8 +40,11 @@ impl AnyConnectionBackend for PgConnection {
         Connection::ping(self)
     }
 
-    fn begin(&mut self) -> BoxFuture<'_, sqlx_core::Result<()>> {
-        PgTransactionManager::begin(self)
+    fn begin(
+        &mut self,
+        statement: Option<Cow<'static, str>>,
+    ) -> BoxFuture<'_, sqlx_core::Result<()>> {
+        PgTransactionManager::begin(self, statement)
     }
 
     fn commit(&mut self) -> BoxFuture<'_, sqlx_core::Result<()>> {

--- a/sqlx-postgres/src/connection/mod.rs
+++ b/sqlx-postgres/src/connection/mod.rs
@@ -128,6 +128,13 @@ impl PgConnection {
 
         Ok(())
     }
+
+    pub(crate) fn in_transaction(&self) -> bool {
+        match self.inner.transaction_status {
+            TransactionStatus::Transaction => true,
+            TransactionStatus::Error | TransactionStatus::Idle => false,
+        }
+    }
 }
 
 impl Debug for PgConnection {

--- a/sqlx-postgres/src/connection/mod.rs
+++ b/sqlx-postgres/src/connection/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt::{self, Debug, Formatter};
 use std::sync::Arc;
 
@@ -179,7 +180,17 @@ impl Connection for PgConnection {
     where
         Self: Sized,
     {
-        Transaction::begin(self)
+        Transaction::begin(self, None)
+    }
+
+    fn begin_with(
+        &mut self,
+        statement: impl Into<Cow<'static, str>>,
+    ) -> BoxFuture<'_, Result<Transaction<'_, Self::Database>, Error>>
+    where
+        Self: Sized,
+    {
+        Transaction::begin(self, Some(statement.into()))
     }
 
     fn cached_statements_size(&self) -> usize {

--- a/sqlx-postgres/src/transaction.rs
+++ b/sqlx-postgres/src/transaction.rs
@@ -20,10 +20,13 @@ impl TransactionManager for PgTransactionManager {
     ) -> BoxFuture<'conn, Result<(), Error>> {
         Box::pin(async move {
             let depth = conn.inner.transaction_depth;
-            if statement.is_some() && depth > 0 {
-                return Err(Error::InvalidSavePointStatement);
-            }
-            let statement = statement.unwrap_or_else(|| begin_ansi_transaction_sql(depth));
+            let statement = match statement {
+                // custom `BEGIN` statements are not allowed if we're already in
+                // a transaction (we need to issue a `SAVEPOINT` instead)
+                Some(_) if depth > 0 => return Err(Error::InvalidSavePointStatement),
+                Some(statement) => statement,
+                None => begin_ansi_transaction_sql(depth),
+            };
 
             let rollback = Rollback::new(conn);
             rollback.conn.queue_simple_query(&statement)?;

--- a/sqlx-sqlite/src/any.rs
+++ b/sqlx-sqlite/src/any.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::{
     Either, Sqlite, SqliteArgumentValue, SqliteArguments, SqliteColumn, SqliteConnectOptions,
     SqliteConnection, SqliteQueryResult, SqliteRow, SqliteTransactionManager, SqliteTypeInfo,
@@ -37,8 +39,11 @@ impl AnyConnectionBackend for SqliteConnection {
         Connection::ping(self)
     }
 
-    fn begin(&mut self) -> BoxFuture<'_, sqlx_core::Result<()>> {
-        SqliteTransactionManager::begin(self)
+    fn begin(
+        &mut self,
+        statement: Option<Cow<'static, str>>,
+    ) -> BoxFuture<'_, sqlx_core::Result<()>> {
+        SqliteTransactionManager::begin(self, statement)
     }
 
     fn commit(&mut self) -> BoxFuture<'_, sqlx_core::Result<()>> {

--- a/sqlx-sqlite/src/connection/mod.rs
+++ b/sqlx-sqlite/src/connection/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::ffi::CStr;
 use std::fmt::Write;
@@ -252,7 +253,17 @@ impl Connection for SqliteConnection {
     where
         Self: Sized,
     {
-        Transaction::begin(self)
+        Transaction::begin(self, None)
+    }
+
+    fn begin_with(
+        &mut self,
+        statement: impl Into<Cow<'static, str>>,
+    ) -> BoxFuture<'_, Result<Transaction<'_, Self::Database>, Error>>
+    where
+        Self: Sized,
+    {
+        Transaction::begin(self, Some(statement.into()))
     }
 
     fn cached_statements_size(&self) -> usize {

--- a/sqlx-sqlite/src/connection/mod.rs
+++ b/sqlx-sqlite/src/connection/mod.rs
@@ -558,29 +558,6 @@ impl LockedSqliteHandle<'_> {
         let ret = unsafe { sqlite3_get_autocommit(self.as_raw_handle().as_ptr()) };
         ret == 0
     }
-
-    /// Calls `sqlite3_txn_state` on this handle.
-    pub fn transaction_state(&mut self) -> Result<SqliteTransactionState, Error> {
-        use libsqlite3_sys::{
-            sqlite3_txn_state, SQLITE_TXN_NONE, SQLITE_TXN_READ, SQLITE_TXN_WRITE,
-        };
-
-        let state =
-            match unsafe { sqlite3_txn_state(self.as_raw_handle().as_ptr(), std::ptr::null()) } {
-                SQLITE_TXN_NONE => SqliteTransactionState::None,
-                SQLITE_TXN_READ => SqliteTransactionState::Read,
-                SQLITE_TXN_WRITE => SqliteTransactionState::Write,
-                _ => return Err(Error::Protocol("Invalid transaction state".into())),
-            };
-        Ok(state)
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum SqliteTransactionState {
-    None,
-    Read,
-    Write,
 }
 
 impl Drop for ConnectionState {

--- a/sqlx-sqlite/src/connection/mod.rs
+++ b/sqlx-sqlite/src/connection/mod.rs
@@ -12,8 +12,8 @@ use futures_core::future::BoxFuture;
 use futures_intrusive::sync::MutexGuard;
 use futures_util::future;
 use libsqlite3_sys::{
-    sqlite3, sqlite3_commit_hook, sqlite3_progress_handler, sqlite3_rollback_hook,
-    sqlite3_update_hook, SQLITE_DELETE, SQLITE_INSERT, SQLITE_UPDATE,
+    sqlite3, sqlite3_commit_hook, sqlite3_get_autocommit, sqlite3_progress_handler,
+    sqlite3_rollback_hook, sqlite3_update_hook, SQLITE_DELETE, SQLITE_INSERT, SQLITE_UPDATE,
 };
 #[cfg(feature = "preupdate-hook")]
 pub use preupdate_hook::*;
@@ -552,6 +552,11 @@ impl LockedSqliteHandle<'_> {
 
     pub fn remove_rollback_hook(&mut self) {
         self.guard.remove_rollback_hook();
+    }
+
+    pub(crate) fn in_transaction(&mut self) -> bool {
+        let ret = unsafe { sqlite3_get_autocommit(self.as_raw_handle().as_ptr()) };
+        ret == 0
     }
 }
 

--- a/sqlx-sqlite/src/connection/mod.rs
+++ b/sqlx-sqlite/src/connection/mod.rs
@@ -558,6 +558,29 @@ impl LockedSqliteHandle<'_> {
         let ret = unsafe { sqlite3_get_autocommit(self.as_raw_handle().as_ptr()) };
         ret == 0
     }
+
+    /// Calls `sqlite3_txn_state` on this handle.
+    pub fn transaction_state(&mut self) -> Result<SqliteTransactionState, Error> {
+        use libsqlite3_sys::{
+            sqlite3_txn_state, SQLITE_TXN_NONE, SQLITE_TXN_READ, SQLITE_TXN_WRITE,
+        };
+
+        let state =
+            match unsafe { sqlite3_txn_state(self.as_raw_handle().as_ptr(), std::ptr::null()) } {
+                SQLITE_TXN_NONE => SqliteTransactionState::None,
+                SQLITE_TXN_READ => SqliteTransactionState::Read,
+                SQLITE_TXN_WRITE => SqliteTransactionState::Write,
+                _ => return Err(Error::Protocol("Invalid transaction state".into())),
+            };
+        Ok(state)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SqliteTransactionState {
+    None,
+    Read,
+    Write,
 }
 
 impl Drop for ConnectionState {

--- a/sqlx-sqlite/src/lib.rs
+++ b/sqlx-sqlite/src/lib.rs
@@ -48,9 +48,7 @@ pub use arguments::{SqliteArgumentValue, SqliteArguments};
 pub use column::SqliteColumn;
 #[cfg(feature = "preupdate-hook")]
 pub use connection::PreupdateHookResult;
-pub use connection::{
-    LockedSqliteHandle, SqliteConnection, SqliteOperation, SqliteTransactionState, UpdateHookResult,
-};
+pub use connection::{LockedSqliteHandle, SqliteConnection, SqliteOperation, UpdateHookResult};
 pub use database::Sqlite;
 pub use error::SqliteError;
 pub use options::{

--- a/sqlx-sqlite/src/lib.rs
+++ b/sqlx-sqlite/src/lib.rs
@@ -48,7 +48,9 @@ pub use arguments::{SqliteArgumentValue, SqliteArguments};
 pub use column::SqliteColumn;
 #[cfg(feature = "preupdate-hook")]
 pub use connection::PreupdateHookResult;
-pub use connection::{LockedSqliteHandle, SqliteConnection, SqliteOperation, UpdateHookResult};
+pub use connection::{
+    LockedSqliteHandle, SqliteConnection, SqliteOperation, SqliteTransactionState, UpdateHookResult,
+};
 pub use database::Sqlite;
 pub use error::SqliteError;
 pub use options::{

--- a/sqlx-sqlite/src/transaction.rs
+++ b/sqlx-sqlite/src/transaction.rs
@@ -1,4 +1,5 @@
 use futures_core::future::BoxFuture;
+use std::borrow::Cow;
 
 use crate::{Sqlite, SqliteConnection};
 use sqlx_core::error::Error;
@@ -10,8 +11,11 @@ pub struct SqliteTransactionManager;
 impl TransactionManager for SqliteTransactionManager {
     type Database = Sqlite;
 
-    fn begin(conn: &mut SqliteConnection) -> BoxFuture<'_, Result<(), Error>> {
-        Box::pin(conn.worker.begin())
+    fn begin<'conn>(
+        conn: &'conn mut SqliteConnection,
+        statement: Option<Cow<'static, str>>,
+    ) -> BoxFuture<'conn, Result<(), Error>> {
+        Box::pin(conn.worker.begin(statement))
     }
 
     fn commit(conn: &mut SqliteConnection) -> BoxFuture<'_, Result<(), Error>> {

--- a/tests/mysql/error.rs
+++ b/tests/mysql/error.rs
@@ -86,3 +86,17 @@ async fn it_fails_with_begin_failed() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[sqlx_macros::test]
+async fn it_fails_with_invalid_save_point_statement() -> anyhow::Result<()> {
+    let mut conn = new::<MySql>().await?;
+    let mut txn = conn.begin().await?;
+    let txn_conn = sqlx::Acquire::acquire(&mut txn).await?;
+    let res = txn_conn.begin_with("BEGIN").await;
+
+    let err = res.unwrap_err();
+
+    assert!(matches!(err, Error::InvalidSavePointStatement), "{err}");
+
+    Ok(())
+}

--- a/tests/mysql/error.rs
+++ b/tests/mysql/error.rs
@@ -1,4 +1,4 @@
-use sqlx::{error::ErrorKind, mysql::MySql, Connection};
+use sqlx::{error::ErrorKind, mysql::MySql, Connection, Error};
 use sqlx_test::new;
 
 #[sqlx_macros::test]
@@ -71,6 +71,18 @@ async fn it_fails_with_check_violation() -> anyhow::Result<()> {
     let err = err.into_database_error().unwrap();
 
     assert_eq!(err.kind(), ErrorKind::CheckViolation);
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
+async fn it_fails_with_begin_failed() -> anyhow::Result<()> {
+    let mut conn = new::<MySql>().await?;
+    let res = conn.begin_with("SELECT * FROM tweet").await;
+
+    let err = res.unwrap_err();
+
+    assert!(matches!(err, Error::BeginFailed), "{err:?}");
 
     Ok(())
 }

--- a/tests/postgres/error.rs
+++ b/tests/postgres/error.rs
@@ -86,3 +86,17 @@ async fn it_fails_with_begin_failed() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[sqlx_macros::test]
+async fn it_fails_with_invalid_save_point_statement() -> anyhow::Result<()> {
+    let mut conn = new::<Postgres>().await?;
+    let mut txn = conn.begin().await?;
+    let txn_conn = sqlx::Acquire::acquire(&mut txn).await?;
+    let res = txn_conn.begin_with("BEGIN").await;
+
+    let err = res.unwrap_err();
+
+    assert!(matches!(err, Error::InvalidSavePointStatement), "{err}");
+
+    Ok(())
+}

--- a/tests/postgres/error.rs
+++ b/tests/postgres/error.rs
@@ -1,4 +1,4 @@
-use sqlx::{error::ErrorKind, postgres::Postgres, Connection};
+use sqlx::{error::ErrorKind, postgres::Postgres, Connection, Error};
 use sqlx_test::new;
 
 #[sqlx_macros::test]
@@ -71,6 +71,18 @@ async fn it_fails_with_check_violation() -> anyhow::Result<()> {
     let err = err.into_database_error().unwrap();
 
     assert_eq!(err.kind(), ErrorKind::CheckViolation);
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
+async fn it_fails_with_begin_failed() -> anyhow::Result<()> {
+    let mut conn = new::<Postgres>().await?;
+    let res = conn.begin_with("SELECT * FROM tweet").await;
+
+    let err = res.unwrap_err();
+
+    assert!(matches!(err, Error::BeginFailed), "{err:?}");
 
     Ok(())
 }

--- a/tests/sqlite/error.rs
+++ b/tests/sqlite/error.rs
@@ -1,4 +1,4 @@
-use sqlx::{error::ErrorKind, sqlite::Sqlite, Connection, Executor};
+use sqlx::{error::ErrorKind, sqlite::Sqlite, Connection, Error, Executor};
 use sqlx_test::new;
 
 #[sqlx_macros::test]
@@ -67,6 +67,18 @@ async fn it_fails_with_check_violation() -> anyhow::Result<()> {
     let err = err.into_database_error().unwrap();
 
     assert_eq!(err.kind(), ErrorKind::CheckViolation);
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
+async fn it_fails_with_begin_failed() -> anyhow::Result<()> {
+    let mut conn = new::<Sqlite>().await?;
+    let res = conn.begin_with("SELECT * FROM tweet").await;
+
+    let err = res.unwrap_err();
+
+    assert!(matches!(err, Error::BeginFailed), "{err:?}");
 
     Ok(())
 }

--- a/tests/sqlite/error.rs
+++ b/tests/sqlite/error.rs
@@ -82,3 +82,17 @@ async fn it_fails_with_begin_failed() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[sqlx_macros::test]
+async fn it_fails_with_invalid_save_point_statement() -> anyhow::Result<()> {
+    let mut conn = new::<Sqlite>().await?;
+    let mut txn = conn.begin().await?;
+    let txn_conn = sqlx::Acquire::acquire(&mut txn).await?;
+    let res = txn_conn.begin_with("BEGIN").await;
+
+    let err = res.unwrap_err();
+
+    assert!(matches!(err, Error::InvalidSavePointStatement), "{err}");
+
+    Ok(())
+}

--- a/tests/sqlite/sqlite.rs
+++ b/tests/sqlite/sqlite.rs
@@ -8,6 +8,7 @@ use sqlx::{
     SqliteConnection, SqlitePool, Statement, TypeInfo,
 };
 use sqlx::{Value, ValueRef};
+use sqlx_sqlite::LockedSqliteHandle;
 use sqlx_test::new;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -1175,15 +1176,9 @@ async fn test_multiple_set_preupdate_hook_calls_drop_old_handler() -> anyhow::Re
 
 #[sqlx_macros::test]
 async fn it_can_use_transaction_options() -> anyhow::Result<()> {
-    use sqlx_sqlite::SqliteTransactionState;
-
-    async fn check_txn_state(
-        conn: &mut SqliteConnection,
-        expected: SqliteTransactionState,
-    ) -> Result<(), sqlx::Error> {
-        let state = conn.lock_handle().await?.transaction_state()?;
+    async fn check_txn_state(conn: &mut SqliteConnection, expected: SqliteTransactionState) {
+        let state = transaction_state(&mut conn.lock_handle().await.unwrap());
         assert_eq!(state, expected);
-        Ok(())
     }
 
     let mut conn = SqliteConnectOptions::new()
@@ -1192,19 +1187,39 @@ async fn it_can_use_transaction_options() -> anyhow::Result<()> {
         .await
         .unwrap();
 
-    check_txn_state(&mut conn, SqliteTransactionState::None).await?;
+    check_txn_state(&mut conn, SqliteTransactionState::None).await;
 
     let mut tx = conn.begin_with("BEGIN DEFERRED").await?;
-    check_txn_state(&mut tx, SqliteTransactionState::None).await?;
+    check_txn_state(&mut tx, SqliteTransactionState::None).await;
     drop(tx);
 
     let mut tx = conn.begin_with("BEGIN IMMEDIATE").await?;
-    check_txn_state(&mut tx, SqliteTransactionState::Write).await?;
+    check_txn_state(&mut tx, SqliteTransactionState::Write).await;
     drop(tx);
 
     let mut tx = conn.begin_with("BEGIN EXCLUSIVE").await?;
-    check_txn_state(&mut tx, SqliteTransactionState::Write).await?;
+    check_txn_state(&mut tx, SqliteTransactionState::Write).await;
     drop(tx);
 
     Ok(())
+}
+
+fn transaction_state(handle: &mut LockedSqliteHandle) -> SqliteTransactionState {
+    use libsqlite3_sys::{sqlite3_txn_state, SQLITE_TXN_NONE, SQLITE_TXN_READ, SQLITE_TXN_WRITE};
+
+    let unchecked_state =
+        unsafe { sqlite3_txn_state(handle.as_raw_handle().as_ptr(), std::ptr::null()) };
+    match unchecked_state {
+        SQLITE_TXN_NONE => SqliteTransactionState::None,
+        SQLITE_TXN_READ => SqliteTransactionState::Read,
+        SQLITE_TXN_WRITE => SqliteTransactionState::Write,
+        _ => panic!("unknown txn state: {unchecked_state}"),
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SqliteTransactionState {
+    None,
+    Read,
+    Write,
 }


### PR DESCRIPTION
Fixes #481 
