### PR TITLE
Postgres: adds SystemTime conversion from/to TIMESTAMPZ

### DIFF
--- a/sqlx-postgres/src/type_checking.rs
+++ b/sqlx-postgres/src/type_checking.rs
@@ -19,6 +19,7 @@ impl_type_checking!(
         f32,
         f64,
         Vec<u8> | &[u8],
+        std::time::SystemTime,
 
         sqlx::postgres::types::Oid,
 

--- a/sqlx-postgres/src/types/mod.rs
+++ b/sqlx-postgres/src/types/mod.rs
@@ -23,6 +23,7 @@
 //! | [`PgCube`]                            | CUBE                                                 |
 //! | [`PgPoint]                            | POINT                                                |
 //! | [`PgHstore`]                          | HSTORE                                               |
+//! | [`SystemTime`](std::time::SystemTime) | TIMESTAMPTZ                                          |
 //!
 //! <sup>1</sup> SQLx generally considers `CITEXT` to be compatible with `String`, `&str`, etc.,
 //! but this wrapper type is available for edge cases, such as `CITEXT[]` which Postgres
@@ -201,6 +202,7 @@ mod oid;
 mod range;
 mod record;
 mod str;
+mod system_time;
 mod text;
 mod tuple;
 mod void;

--- a/sqlx-postgres/src/types/range.rs
+++ b/sqlx-postgres/src/types/range.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Debug, Display, Formatter};
 use std::ops::{Bound, Range, RangeBounds, RangeFrom, RangeInclusive, RangeTo, RangeToInclusive};
-
+use std::time::SystemTime;
 use bitflags::bitflags;
 use sqlx_core::bytes::Buf;
 
@@ -132,6 +132,16 @@ impl Type<Postgres> for PgRange<i64> {
     }
 }
 
+impl Type<Postgres> for PgRange<SystemTime> {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::TSTZ_RANGE
+    }
+
+    fn compatible(ty: &PgTypeInfo) -> bool {
+        range_compatible::<SystemTime>(ty)
+    }
+}
+
 #[cfg(feature = "bigdecimal")]
 impl Type<Postgres> for PgRange<bigdecimal::BigDecimal> {
     fn type_info() -> PgTypeInfo {
@@ -229,6 +239,12 @@ impl PgHasArrayType for PgRange<i32> {
 impl PgHasArrayType for PgRange<i64> {
     fn array_type_info() -> PgTypeInfo {
         PgTypeInfo::INT8_RANGE_ARRAY
+    }
+}
+
+impl PgHasArrayType for PgRange<SystemTime> {
+    fn array_type_info() -> PgTypeInfo {
+        PgTypeInfo::TSTZ_RANGE_ARRAY
     }
 }
 

--- a/sqlx-postgres/src/types/system_time.rs
+++ b/sqlx-postgres/src/types/system_time.rs
@@ -1,0 +1,65 @@
+use crate::decode::Decode;
+use crate::encode::{Encode, IsNull};
+use crate::error::BoxDynError;
+use crate::types::Type;
+use crate::{PgArgumentBuffer, PgHasArrayType, PgTypeInfo, PgValueFormat, PgValueRef, Postgres};
+use std::time::{Duration, SystemTime};
+
+impl Type<Postgres> for SystemTime {
+    fn type_info() -> PgTypeInfo {
+        PgTypeInfo::TIMESTAMPTZ
+    }
+}
+
+impl PgHasArrayType for SystemTime {
+    fn array_type_info() -> PgTypeInfo {
+        PgTypeInfo::TIMESTAMPTZ_ARRAY
+    }
+}
+
+impl Encode<'_, Postgres> for SystemTime {
+    fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
+        // TIMESTAMP is encoded as the microseconds since the epoch
+        let micros = self.duration_since(SystemTime::UNIX_EPOCH)?.as_micros();
+        let micros = i64::try_from(micros)
+            .map_err(|_| format!("SystemTime out of range for Postgres: {self:?}"))?;
+        Encode::<Postgres>::encode(micros, buf)
+    }
+
+    fn size_hint(&self) -> usize {
+        size_of::<i64>()
+    }
+}
+
+impl<'r> Decode<'r, Postgres> for SystemTime {
+    fn decode(value: PgValueRef<'r>) -> Result<Self, BoxDynError> {
+        Ok(match value.format() {
+            PgValueFormat::Binary => {
+                // TIMESTAMP is encoded as the microseconds since the epoch
+                let us: i64 = Decode::<Postgres>::decode(value)?;
+                let us = u64::try_from(us)
+                    .map_err(|_| "Postgres TIMESTAMPTZ out of range for SystemTime (SystemTime only supports timestamps after UNIX epoch)")?;
+                SystemTime::UNIX_EPOCH
+                    .checked_add(Duration::from_micros(us))
+                    .ok_or("Postgres TIMESTAMPTZ out of range for SystemTime")?
+            }
+            PgValueFormat::Text => {
+                // std has no datetime parsing
+                // We rely on chrono or time if they are available
+                #[cfg(feature = "chrono")]
+                {
+                    chrono::DateTime::<chrono::Utc>::decode(value)?.into()
+                }
+                #[cfg(all(not(feature = "chrono"), feature = "time"))]
+                {
+                    time::OffsetDateTime::decode(value)?.into()
+                }
+                #[cfg(all(not(feature = "chrono"), not(feature = "time")))]
+                return Err(
+                    "not implemented: decode to SystemTime in text mode (unprepared queries)"
+                        .into(),
+                );
+            }
+        })
+    }
+}


### PR DESCRIPTION
Text decoding relies on time or chrono if they are available or fails

issue #2304 