### PR TITLE
feat(Postgres): support nested domain types

### DIFF
--- a/sqlx-postgres/src/type_info.rs
+++ b/sqlx-postgres/src/type_info.rs
@@ -1013,7 +1013,7 @@ impl PgType {
     /// If `soft_eq` is true and `self` or `other` is `DeclareWithOid` but not both, return `true`
     /// before checking names.
     fn eq_impl(&self, other: &Self, soft_eq: bool) -> bool {
-        if let (Some(a), Some(b)) = (self.try_oid(), other.try_oid()) {
+        if let (Some(a), Some(b)) = (self.base_oid(), other.base_oid()) {
             // If there are OIDs available, use OIDs to perform a direct match
             return a == b;
         }
@@ -1034,6 +1034,17 @@ impl PgType {
 
         // Otherwise, perform a match on the name
         name_eq(self.name(), other.name())
+    }
+
+    // Returns the OID of the type, returns the OID of the base_type for Domain types
+    fn base_oid(&self) -> Option<Oid> {
+        match self {
+            PgType::Custom(custom) => match &custom.kind {
+                PgTypeKind::Domain(domain) => domain.base_oid(),
+                _ => Some(custom.oid),
+            },
+            ty => ty.try_oid(),
+        }
     }
 }
 

--- a/tests/postgres/setup.sql
+++ b/tests/postgres/setup.sql
@@ -63,3 +63,12 @@ CREATE SCHEMA IF NOT EXISTS foo;
 CREATE TYPE foo."Foo" as ENUM ('Bar', 'Baz');
 
 CREATE TABLE mytable(f HSTORE);
+
+CREATE DOMAIN positive_int AS integer CHECK (VALUE >= 0);
+CREATE DOMAIN percentage AS positive_int CHECK (VALUE < 100);
+
+CREATE TYPE person as (
+    id int,
+    age positive_int,
+    percent percentage
+);

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -657,3 +657,26 @@ CREATE TEMPORARY TABLE user_login (
 
     Ok(())
 }
+
+#[sqlx_macros::test]
+async fn test_nested_domain_types() -> anyhow::Result<()> {
+    #[derive(sqlx::Type)]
+    struct Person {
+        id: i32,
+        age: i32,
+        percent: i32,
+    }
+
+    let mut conn = new::<Postgres>().await?;
+
+    let p: Person = sqlx::query_scalar("select ROW(1, 21::positive_int, 50::percentage)::person")
+        .fetch_one(&mut conn)
+        .await
+        .unwrap();
+
+    assert!(p.id == 1);
+    assert!(p.age == 21);
+    assert!(p.percent == 50);
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds support for nested domain types. When comparing a `PgType` by `Oid` it compares the `Oid` of the base type when it is a domain.