### PR TITLE
close listener connection on TimedOut and BrokenPipe errors

### DIFF
--- a/sqlx-postgres/src/listener.rs
+++ b/sqlx-postgres/src/listener.rs
@@ -280,7 +280,10 @@ impl PgListener {
                 // update self state, and loop to try again.
                 Err(Error::Io(err))
                     if (err.kind() == io::ErrorKind::ConnectionAborted
-                        || err.kind() == io::ErrorKind::UnexpectedEof) =>
+                        || err.kind() == io::ErrorKind::UnexpectedEof
+                        // see ERRORS section in tcp(7) man page (https://man7.org/linux/man-pages/man7/tcp.7.html)
+                        || err.kind() == io::ErrorKind::TimedOut
+                        || err.kind() == io::ErrorKind::BrokenPipe) =>
                 {
                     if let Some(mut conn) = self.connection.take() {
                         self.buffer_tx = conn.inner.stream.notifications.take();

--- a/sqlx-postgres/src/listener.rs
+++ b/sqlx-postgres/src/listener.rs
@@ -279,11 +279,14 @@ impl PgListener {
                 // The connection is dead, ensure that it is dropped,
                 // update self state, and loop to try again.
                 Err(Error::Io(err))
-                    if (err.kind() == io::ErrorKind::ConnectionAborted
-                        || err.kind() == io::ErrorKind::UnexpectedEof
+                    if matches!(
+                        err.kind(),
+                        io::ErrorKind::ConnectionAborted |
+                        io::ErrorKind::UnexpectedEof |
                         // see ERRORS section in tcp(7) man page (https://man7.org/linux/man-pages/man7/tcp.7.html)
-                        || err.kind() == io::ErrorKind::TimedOut
-                        || err.kind() == io::ErrorKind::BrokenPipe) =>
+                        io::ErrorKind::TimedOut |
+                        io::ErrorKind::BrokenPipe
+                    ) =>
                 {
                     if let Some(mut conn) = self.connection.take() {
                         self.buffer_tx = conn.inner.stream.notifications.take();


### PR DESCRIPTION
This PR handles `TimedOut` and `BrokerPipe` errors that could be returned by [tcp](https://man7.org/linux/man-pages/man7/tcp.7.html) layer:

```
EPIPE  The other end closed the socket unexpectedly or a read is
              executed on a shut down socket.

ETIMEDOUT
      The other end didn't acknowledge retransmitted data after
      some time.
```

In these cases it makes sense to close listener connection proactively.