### PR TITLE
Merge arguments

### DIFF
--- a/sqlx-core/src/any/arguments.rs
+++ b/sqlx-core/src/any/arguments.rs
@@ -28,6 +28,10 @@ impl<'q> Arguments<'q> for AnyArguments<'q> {
     fn len(&self) -> usize {
         self.values.0.len()
     }
+
+    fn merge(&mut self, other: Self) {
+        self.values.0.extend(other.values.0);
+    }
 }
 
 pub struct AnyArgumentBuffer<'q>(#[doc(hidden)] pub Vec<AnyValueKind<'q>>);

--- a/sqlx-core/src/arguments.rs
+++ b/sqlx-core/src/arguments.rs
@@ -27,6 +27,8 @@ pub trait Arguments<'q>: Send + Sized + Default {
     fn format_placeholder<W: Write>(&self, writer: &mut W) -> fmt::Result {
         writer.write_str("?")
     }
+
+    fn merge(&mut self, other: Self);
 }
 
 pub trait IntoArguments<'q, DB: Database>: Sized + Send {

--- a/sqlx-core/src/arguments.rs
+++ b/sqlx-core/src/arguments.rs
@@ -28,7 +28,7 @@ pub trait Arguments<'q>: Send + Sized + Default {
         writer.write_str("?")
     }
 
-    fn merge(&mut self, other: Self);
+    fn merge(mut self, other: Self);
 }
 
 pub trait IntoArguments<'q, DB: Database>: Sized + Send {

--- a/sqlx-core/src/arguments.rs
+++ b/sqlx-core/src/arguments.rs
@@ -28,7 +28,7 @@ pub trait Arguments<'q>: Send + Sized + Default {
         writer.write_str("?")
     }
 
-    fn merge(mut self, other: Self);
+    fn merge(&mut self, other: Self);
 }
 
 pub trait IntoArguments<'q, DB: Database>: Sized + Send {

--- a/sqlx-mysql/src/arguments.rs
+++ b/sqlx-mysql/src/arguments.rs
@@ -55,6 +55,13 @@ impl<'q> Arguments<'q> for MySqlArguments {
     fn len(&self) -> usize {
         self.types.len()
     }
+
+    fn merge(&mut self, other: Self) {
+        self.types.extend(other.types);
+        self.values.extend(other.values);
+        self.null_bitmap.bytes.extend(other.null_bitmap.bytes);
+        self.null_bitmap.length += other.null_bitmap.length;
+    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/sqlx-postgres/src/arguments.rs
+++ b/sqlx-postgres/src/arguments.rs
@@ -148,6 +148,9 @@ impl<'q> Arguments<'q> for PgArguments {
     fn merge(&mut self, other: Self) {
         self.types.extend(other.types);
         self.buffer.extend_from_slice(&other.buffer);
+        self.buffer.count += other.buffer.count;
+        self.buffer.patches.extend(other.buffer.patches);
+        self.buffer.type_holes.extend(other.buffer.type_holes);
     }
 
     #[inline(always)]

--- a/sqlx-postgres/src/arguments.rs
+++ b/sqlx-postgres/src/arguments.rs
@@ -145,6 +145,11 @@ impl<'q> Arguments<'q> for PgArguments {
         write!(writer, "${}", self.buffer.count)
     }
 
+    fn merge(&mut self, other: Self) {
+        self.types.extend(other.types);
+        self.buffer.extend_from_slice(&other.buffer);
+    }
+
     #[inline(always)]
     fn len(&self) -> usize {
         self.buffer.count

--- a/sqlx-sqlite/src/arguments.rs
+++ b/sqlx-sqlite/src/arguments.rs
@@ -72,6 +72,10 @@ impl<'q> Arguments<'q> for SqliteArguments<'q> {
     fn len(&self) -> usize {
         self.values.len()
     }
+
+    fn merge(&mut self, other: Self) {
+        self.values.extend(other.values);
+    }
 }
 
 impl SqliteArguments<'_> {


### PR DESCRIPTION
## Add argument merging
Currently, there is no convenient way to merge two sets of query builder arguments.

### Why?
In my use case, I need to combine arguments from multiple queries, but there's no existing method to do this. Adding a straightforward way to merge arguments would simplify this process.