### PR TITLE
fix: executor arg of RawSql methods can have looser bound

### DIFF
--- a/sqlx-core/src/raw_sql.rs
+++ b/sqlx-core/src/raw_sql.rs
@@ -139,11 +139,12 @@ impl<'q, DB: Database> Execute<'q, DB> for RawSql<'q> {
 impl<'q> RawSql<'q> {
     /// Execute the SQL string and return the total number of rows affected.
     #[inline]
-    pub async fn execute<'c, E>(
+    pub async fn execute<'e, 'c: 'e, E>(
         self,
         executor: E,
     ) -> crate::Result<<E::Database as Database>::QueryResult>
     where
+        'q: 'e,
         E: Executor<'c>,
     {
         executor.execute(self).await
@@ -151,12 +152,11 @@ impl<'q> RawSql<'q> {
 
     /// Execute the SQL string. Returns a stream which gives the number of rows affected for each statement in the string.
     #[inline]
-    pub fn execute_many<'c, 'e, E>(
+    pub fn execute_many<'e, 'c: 'e, E>(
         self,
         executor: E,
     ) -> BoxStream<'e, crate::Result<<E::Database as Database>::QueryResult>>
     where
-        'c: 'e,
         'q: 'e,
         E: Executor<'c>,
     {
@@ -167,12 +167,11 @@ impl<'q> RawSql<'q> {
     ///
     /// If the string contains multiple statements, their results will be concatenated together.
     #[inline]
-    pub fn fetch<'c, 'e, E>(
+    pub fn fetch<'e, 'c: 'e, E>(
         self,
         executor: E,
     ) -> BoxStream<'e, Result<<E::Database as Database>::Row, Error>>
     where
-        'c: 'e,
         'q: 'e,
         E: Executor<'c>,
     {
@@ -184,7 +183,7 @@ impl<'q> RawSql<'q> {
     /// For each query in the stream, any generated rows are returned first,
     /// then the `QueryResult` with the number of rows affected.
     #[inline]
-    pub fn fetch_many<'c, 'e, E>(
+    pub fn fetch_many<'e, 'c: 'e, E>(
         self,
         executor: E,
     ) -> BoxStream<
@@ -195,7 +194,6 @@ impl<'q> RawSql<'q> {
         >,
     >
     where
-        'c: 'e,
         'q: 'e,
         E: Executor<'c>,
     {
@@ -210,12 +208,11 @@ impl<'q> RawSql<'q> {
     /// To avoid exhausting available memory, ensure the result set has a known upper bound,
     /// e.g. using `LIMIT`.
     #[inline]
-    pub async fn fetch_all<'c, 'e, E>(
+    pub async fn fetch_all<'e, 'c: 'e, E>(
         self,
         executor: E,
     ) -> crate::Result<Vec<<E::Database as Database>::Row>>
     where
-        'c: 'e,
         'q: 'e,
         E: Executor<'e>,
     {
@@ -235,12 +232,11 @@ impl<'q> RawSql<'q> {
     ///
     /// Otherwise, you might want to add `LIMIT 1` to your query.
     #[inline]
-    pub async fn fetch_one<'c, 'e, E>(
+    pub async fn fetch_one<'e, 'c: 'e, E>(
         self,
         executor: E,
     ) -> crate::Result<<E::Database as Database>::Row>
     where
-        'c: 'e,
         'q: 'e,
         E: Executor<'c>,
     {
@@ -260,12 +256,11 @@ impl<'q> RawSql<'q> {
     ///
     /// Otherwise, you might want to add `LIMIT 1` to your query.
     #[inline]
-    pub async fn fetch_optional<'c, 'e, E>(
+    pub async fn fetch_optional<'e, 'c: 'e, E>(
         self,
         executor: E,
     ) -> crate::Result<<E::Database as Database>::Row>
     where
-        'c: 'e,
         'q: 'e,
         E: Executor<'c>,
     {

--- a/sqlx-core/src/raw_sql.rs
+++ b/sqlx-core/src/raw_sql.rs
@@ -139,26 +139,26 @@ impl<'q, DB: Database> Execute<'q, DB> for RawSql<'q> {
 impl<'q> RawSql<'q> {
     /// Execute the SQL string and return the total number of rows affected.
     #[inline]
-    pub async fn execute<'e, E>(
+    pub async fn execute<'c, E>(
         self,
         executor: E,
     ) -> crate::Result<<E::Database as Database>::QueryResult>
     where
-        'q: 'e,
-        E: Executor<'e>,
+        E: Executor<'c>,
     {
         executor.execute(self).await
     }
 
     /// Execute the SQL string. Returns a stream which gives the number of rows affected for each statement in the string.
     #[inline]
-    pub fn execute_many<'e, E>(
+    pub fn execute_many<'c, 'e, E>(
         self,
         executor: E,
     ) -> BoxStream<'e, crate::Result<<E::Database as Database>::QueryResult>>
     where
+        'c: 'e,
         'q: 'e,
-        E: Executor<'e>,
+        E: Executor<'c>,
     {
         executor.execute_many(self)
     }
@@ -167,13 +167,14 @@ impl<'q> RawSql<'q> {
     ///
     /// If the string contains multiple statements, their results will be concatenated together.
     #[inline]
-    pub fn fetch<'e, E>(
+    pub fn fetch<'c, 'e, E>(
         self,
         executor: E,
     ) -> BoxStream<'e, Result<<E::Database as Database>::Row, Error>>
     where
+        'c: 'e,
         'q: 'e,
-        E: Executor<'e>,
+        E: Executor<'c>,
     {
         executor.fetch(self)
     }
@@ -183,7 +184,7 @@ impl<'q> RawSql<'q> {
     /// For each query in the stream, any generated rows are returned first,
     /// then the `QueryResult` with the number of rows affected.
     #[inline]
-    pub fn fetch_many<'e, E>(
+    pub fn fetch_many<'c, 'e, E>(
         self,
         executor: E,
     ) -> BoxStream<
@@ -194,8 +195,9 @@ impl<'q> RawSql<'q> {
         >,
     >
     where
+        'c: 'e,
         'q: 'e,
-        E: Executor<'e>,
+        E: Executor<'c>,
     {
         executor.fetch_many(self)
     }
@@ -208,11 +210,12 @@ impl<'q> RawSql<'q> {
     /// To avoid exhausting available memory, ensure the result set has a known upper bound,
     /// e.g. using `LIMIT`.
     #[inline]
-    pub async fn fetch_all<'e, E>(
+    pub async fn fetch_all<'c, 'e, E>(
         self,
         executor: E,
     ) -> crate::Result<Vec<<E::Database as Database>::Row>>
     where
+        'c: 'e,
         'q: 'e,
         E: Executor<'e>,
     {
@@ -232,13 +235,14 @@ impl<'q> RawSql<'q> {
     ///
     /// Otherwise, you might want to add `LIMIT 1` to your query.
     #[inline]
-    pub async fn fetch_one<'e, E>(
+    pub async fn fetch_one<'c, 'e, E>(
         self,
         executor: E,
     ) -> crate::Result<<E::Database as Database>::Row>
     where
+        'c: 'e,
         'q: 'e,
-        E: Executor<'e>,
+        E: Executor<'c>,
     {
         executor.fetch_one(self).await
     }
@@ -256,13 +260,14 @@ impl<'q> RawSql<'q> {
     ///
     /// Otherwise, you might want to add `LIMIT 1` to your query.
     #[inline]
-    pub async fn fetch_optional<'e, E>(
+    pub async fn fetch_optional<'c, 'e, E>(
         self,
         executor: E,
     ) -> crate::Result<<E::Database as Database>::Row>
     where
+        'c: 'e,
         'q: 'e,
-        E: Executor<'e>,
+        E: Executor<'c>,
     {
         executor.fetch_one(self).await
     }


### PR DESCRIPTION
The original code has an unnecessary lifetime bound `'q: 'e`.

We have a code snippet like:

```rust
    let res = sqlx::raw_sql(&insert_sql)
        .execute(&mut **txn)
        .await
        .change_context_lazy(make_error)?;
```

failed with: ```implementation of `std::marker::Send` is not general enough``` in several caller layers outside.

while change to:

```rust
    let res = txn
        .execute(&insert_sql)
        .await
        .change_context_lazy(make_error)?;
```

works.

A brief is that the `txn`'s lifetime bound to the outer struct, so as long as the returned future is bound to that lifetime, rustc knows it's send for all outer struct's lifetime.

However, with `.execute(&mut **txn)`, the new lifetime `c` is resolved to `e` where `'q: 'e` and then the return future lifetime is `'e`. Now rustc doesn't know the relation of the lifetimes, and failed to compile.