### PR TITLE
feat: add Transaction type aliases

### DIFF
--- a/sqlx-mysql/src/lib.rs
+++ b/sqlx-mysql/src/lib.rs
@@ -60,6 +60,9 @@ pub type MySqlPoolOptions = crate::pool::PoolOptions<MySql>;
 pub trait MySqlExecutor<'c>: Executor<'c, Database = MySql> {}
 impl<'c, T: Executor<'c, Database = MySql>> MySqlExecutor<'c> for T {}
 
+/// An alias for [`Transaction`][crate::transaction::Transaction], specialized for MySQL.
+pub type MySqlTransaction<'c> = crate::transaction::Transaction<'c, MySql>;
+
 // NOTE: required due to the lack of lazy normalization
 impl_into_arguments_for_arguments!(MySqlArguments);
 impl_acquire!(MySql, MySqlConnection);

--- a/sqlx-postgres/src/lib.rs
+++ b/sqlx-postgres/src/lib.rs
@@ -70,6 +70,9 @@ pub type PgPoolOptions = crate::pool::PoolOptions<Postgres>;
 pub trait PgExecutor<'c>: Executor<'c, Database = Postgres> {}
 impl<'c, T: Executor<'c, Database = Postgres>> PgExecutor<'c> for T {}
 
+/// An alias for [`Transaction`][crate::transaction::Transaction], specialized for Postgres.
+pub type PgTransaction<'c> = crate::transaction::Transaction<'c, Postgres>;
+
 impl_into_arguments_for_arguments!(PgArguments);
 impl_acquire!(Postgres, PgConnection);
 impl_column_index_for_row!(PgRow);

--- a/sqlx-sqlite/src/lib.rs
+++ b/sqlx-sqlite/src/lib.rs
@@ -105,6 +105,9 @@ pub type SqlitePoolOptions = crate::pool::PoolOptions<Sqlite>;
 pub trait SqliteExecutor<'c>: Executor<'c, Database = Sqlite> {}
 impl<'c, T: Executor<'c, Database = Sqlite>> SqliteExecutor<'c> for T {}
 
+/// An alias for [`Transaction`][sqlx_core::transaction::Transaction], specialized for SQLite.
+pub type SqliteTransaction<'c> = sqlx_core::transaction::Transaction<'c, Sqlite>;
+
 // NOTE: required due to the lack of lazy normalization
 impl_into_arguments_for_arguments!(SqliteArguments<'q>);
 impl_column_index_for_row!(SqliteRow);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,17 +37,23 @@ pub use sqlx_core::migrate;
 #[cfg(feature = "mysql")]
 #[cfg_attr(docsrs, doc(cfg(feature = "mysql")))]
 #[doc(inline)]
-pub use sqlx_mysql::{self as mysql, MySql, MySqlConnection, MySqlExecutor, MySqlPool};
+pub use sqlx_mysql::{
+    self as mysql, MySql, MySqlConnection, MySqlExecutor, MySqlPool, MySqlTransaction,
+};
 
 #[cfg(feature = "postgres")]
 #[cfg_attr(docsrs, doc(cfg(feature = "postgres")))]
 #[doc(inline)]
-pub use sqlx_postgres::{self as postgres, PgConnection, PgExecutor, PgPool, Postgres};
+pub use sqlx_postgres::{
+    self as postgres, PgConnection, PgExecutor, PgPool, PgTransaction, Postgres,
+};
 
 #[cfg(feature = "_sqlite")]
 #[cfg_attr(docsrs, doc(cfg(feature = "_sqlite")))]
 #[doc(inline)]
-pub use sqlx_sqlite::{self as sqlite, Sqlite, SqliteConnection, SqliteExecutor, SqlitePool};
+pub use sqlx_sqlite::{
+    self as sqlite, Sqlite, SqliteConnection, SqliteExecutor, SqlitePool, SqliteTransaction,
+};
 
 #[cfg(feature = "any")]
 #[cfg_attr(docsrs, doc(cfg(feature = "any")))]


### PR DESCRIPTION
This pr adds `Transaction` type aliases. I feel like this would make sense since there are also aliases for `Pool`, `Executor` and `PoolOptions` and this is something I often try and reach for.