### PR TITLE
fix(cli): running tests on 32bit platforms

### DIFF
--- a/sqlx-cli/tests/add.rs
+++ b/sqlx-cli/tests/add.rs
@@ -17,7 +17,7 @@ fn add_migration_ambiguous() -> anyhow::Result<()> {
 
 #[derive(Debug, PartialEq, Eq)]
 struct FileName {
-    id: usize,
+    id: u64,
     description: String,
     suffix: String,
 }
@@ -50,7 +50,7 @@ impl From<PathBuf> for FileName {
     fn from(path: PathBuf) -> Self {
         let filename = path.file_name().unwrap().to_string_lossy();
         let (id, rest) = filename.split_once("_").unwrap();
-        let id: usize = id.parse().unwrap();
+        let id: u64 = id.parse().unwrap();
         let (description, suffix) = rest.split_once(".").unwrap();
         Self {
             id,


### PR DESCRIPTION
This fixes a regression introduced by #3352 that make tests fail to build on 32 bit platforms, caused by this function [^1] trying to compare a number bigger than what `usize` can represent on those platforms.

I've also suggested clippy add a lint [^2] for this kind of things.

[^1]: https://github.com/launchbadge/sqlx/blob/9d74aeae5253a5bcdf07c5e3f581a6282e609eac/sqlx-cli/tests/add.rs#L36-L46
[^2]: https://github.com/rust-lang/rust-clippy/issues/13943