### PR TITLE
Bump ipnetwork to v0.21.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,12 +1933,9 @@ checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "ipnetwork"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
-dependencies = [
- "serde",
-]
+checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
 
 [[package]]
 name = "is-terminal"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ bigdecimal = "0.4.0"
 bit-vec = "0.6.3"
 chrono = { version = "0.4.34", default-features = false, features = ["std", "clock"] }
 ipnet = "2.3.0"
-ipnetwork = "0.20.0"
+ipnetwork = "0.21.1"
 mac_address = "1.1.5"
 rust_decimal = { version = "1.26.1", default-features = false, features = ["std"] }
 time = { version = "0.3.36", features = ["formatting", "parsing", "macros"] }


### PR DESCRIPTION
See [the release notes](https://github.com/achanda/ipnetwork/releases/tag/v0.21.0).