### PR TITLE
Implement `Decode`, `Encode` and `Type` for `Box`, `Arc`, `Cow` and `Rc`

### DIFF
--- a/sqlx-core/src/decode.rs
+++ b/sqlx-core/src/decode.rs
@@ -82,16 +82,23 @@ where
     }
 }
 
-// implement `Decode` for Arc<T> for all SQL types
-impl<'r, DB, T> Decode<'r, DB> for Arc<T>
-where
-    DB: Database,
-    T: Decode<'r, DB>,
-{
-    fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
-        Ok(Arc::new(T::decode(value)?))
-    }
+macro_rules! impl_decode_for_smartpointer {
+    ($smart_pointer:ty) => {
+        impl<'r, DB, T> Decode<'r, DB> for $smart_pointer
+        where
+            DB: Database,
+            T: Decode<'r, DB>,
+        {
+            fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
+                Ok(Self::new(T::decode(value)?))
+            }
+        }
+    };
 }
+
+impl_decode_for_smartpointer!(Arc<T>);
+impl_decode_for_smartpointer!(Box<T>);
+impl_decode_for_smartpointer!(Rc<T>);
 
 // implement `Decode` for Cow<T> for all SQL types
 impl<'r, DB, T> Decode<'r, DB> for Cow<'_, T>
@@ -102,27 +109,5 @@ where
 {
     fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
         Ok(Cow::Owned(T::decode(value)?))
-    }
-}
-
-// implement `Decode` for Box<T> for all SQL types
-impl<'r, DB, T> Decode<'r, DB> for Box<T>
-where
-    DB: Database,
-    T: Decode<'r, DB>,
-{
-    fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
-        Ok(Box::new(T::decode(value)?))
-    }
-}
-
-// implement `Decode` for Rc<T> for all SQL types
-impl<'r, DB, T> Decode<'r, DB> for Rc<T>
-where
-    DB: Database,
-    T: Decode<'r, DB>,
-{
-    fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
-        Ok(Rc::new(T::decode(value)?))
     }
 }

--- a/sqlx-core/src/decode.rs
+++ b/sqlx-core/src/decode.rs
@@ -111,8 +111,10 @@ macro_rules! impl_decode_for_smartpointer {
             Vec<u8>: Decode<'r, DB>,
         {
             fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
-                let ref_str = <Vec<u8> as Decode<DB>>::decode(value)?;
-                Ok(ref_str.into())
+                // The `Postgres` implementation requires this to be decoded as an owned value because
+                // bytes can be sent in text format.
+                let bytes = <Vec<u8> as Decode<DB>>::decode(value)?;
+                Ok(bytes.into())
             }
         }
     };

--- a/sqlx-core/src/decode.rs
+++ b/sqlx-core/src/decode.rs
@@ -1,6 +1,7 @@
 //! Provides [`Decode`] for decoding values from the database.
 
 use std::borrow::Cow;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::database::Database;
@@ -112,5 +113,16 @@ where
 {
     fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
         Ok(Box::new(T::decode(value)?))
+    }
+}
+
+// implement `Decode` for Rc<T> for all SQL types
+impl<'r, DB, T> Decode<'r, DB> for Rc<T>
+where
+    DB: Database,
+    T: Decode<'r, DB>,
+{
+    fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
+        Ok(Rc::new(T::decode(value)?))
     }
 }

--- a/sqlx-core/src/decode.rs
+++ b/sqlx-core/src/decode.rs
@@ -133,6 +133,8 @@ where
     <T as ToOwned>::Owned: Decode<'r, DB>,
 {
     fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
+        // See https://github.com/launchbadge/sqlx/pull/3674#discussion_r2008611502 for more info
+        // about why decoding to a `Cow::Owned` was chosen.
         <<T as ToOwned>::Owned as Decode<DB>>::decode(value).map(Cow::Owned)
     }
 }

--- a/sqlx-core/src/decode.rs
+++ b/sqlx-core/src/decode.rs
@@ -129,32 +129,12 @@ impl<'r, 'a, DB, T> Decode<'r, DB> for Cow<'a, T>
 where
     DB: Database,
     // `ToOwned` is required here to satisfy `Cow`
-    T: ToOwned,
+    T: ToOwned + ?Sized,
     <T as ToOwned>::Owned: Decode<'r, DB>,
 {
     fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
         // See https://github.com/launchbadge/sqlx/pull/3674#discussion_r2008611502 for more info
         // about why decoding to a `Cow::Owned` was chosen.
         <<T as ToOwned>::Owned as Decode<DB>>::decode(value).map(Cow::Owned)
-    }
-}
-
-impl<'r, 'a, DB> Decode<'r, DB> for Cow<'a, str>
-where
-    DB: Database,
-    String: Decode<'r, DB>,
-{
-    fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
-        <String as Decode<DB>>::decode(value).map(Cow::Owned)
-    }
-}
-
-impl<'r, 'a, DB> Decode<'r, DB> for Cow<'a, [u8]>
-where
-    DB: Database,
-    Vec<u8>: Decode<'r, DB>,
-{
-    fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
-        <Vec<u8> as Decode<DB>>::decode(value).map(Cow::Owned)
     }
 }

--- a/sqlx-core/src/decode.rs
+++ b/sqlx-core/src/decode.rs
@@ -128,6 +128,7 @@ impl_decode_for_smartpointer!(Rc);
 impl<'r, 'a, DB, T> Decode<'r, DB> for Cow<'a, T>
 where
     DB: Database,
+    // `ToOwned` is required here to satisfy `Cow`
     T: ToOwned,
     <T as ToOwned>::Owned: Decode<'r, DB>,
 {

--- a/sqlx-core/src/encode.rs
+++ b/sqlx-core/src/encode.rs
@@ -172,7 +172,7 @@ impl_encode_for_smartpointer!(Arc<T>);
 impl_encode_for_smartpointer!(Box<T>);
 impl_encode_for_smartpointer!(Rc<T>);
 
-impl<'q, T, DB: Database> Encode<'q, DB> for Cow<'_, T>
+impl<'q, T, DB: Database> Encode<'q, DB> for Cow<'q, T>
 where
     T: Encode<'q, DB>,
     T: ToOwned,

--- a/sqlx-core/src/encode.rs
+++ b/sqlx-core/src/encode.rs
@@ -133,94 +133,49 @@ macro_rules! impl_encode_for_option {
     };
 }
 
-impl<'q, T, DB: Database> Encode<'q, DB> for Arc<T>
-where
-    T: Encode<'q, DB>,
-{
-    #[inline]
-    fn encode(self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> Result<IsNull, BoxDynError> {
-        <T as Encode<DB>>::encode_by_ref(self.as_ref(), buf)
-    }
+macro_rules! impl_encode_for_smartpointer {
+    ($smart_pointer:ty) => {
+        impl<'q, T, DB: Database> Encode<'q, DB> for $smart_pointer
+        where
+            T: Encode<'q, DB>,
+        {
+            #[inline]
+            fn encode(
+                self,
+                buf: &mut <DB as Database>::ArgumentBuffer<'q>,
+            ) -> Result<IsNull, BoxDynError> {
+                <T as Encode<DB>>::encode_by_ref(self.as_ref(), buf)
+            }
 
-    #[inline]
-    fn encode_by_ref(
-        &self,
-        buf: &mut <DB as Database>::ArgumentBuffer<'q>,
-    ) -> Result<IsNull, BoxDynError> {
-        <&T as Encode<DB>>::encode(self, buf)
-    }
+            #[inline]
+            fn encode_by_ref(
+                &self,
+                buf: &mut <DB as Database>::ArgumentBuffer<'q>,
+            ) -> Result<IsNull, BoxDynError> {
+                <&T as Encode<DB>>::encode(self, buf)
+            }
 
-    #[inline]
-    fn produces(&self) -> Option<DB::TypeInfo> {
-        (**self).produces()
-    }
+            #[inline]
+            fn produces(&self) -> Option<DB::TypeInfo> {
+                (**self).produces()
+            }
 
-    #[inline]
-    fn size_hint(&self) -> usize {
-        (**self).size_hint()
-    }
+            #[inline]
+            fn size_hint(&self) -> usize {
+                (**self).size_hint()
+            }
+        }
+    };
 }
+
+impl_encode_for_smartpointer!(Arc<T>);
+impl_encode_for_smartpointer!(Box<T>);
+impl_encode_for_smartpointer!(Rc<T>);
 
 impl<'q, T, DB: Database> Encode<'q, DB> for Cow<'_, T>
 where
     T: Encode<'q, DB>,
     T: ToOwned<Owned = T>,
-{
-    #[inline]
-    fn encode(self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> Result<IsNull, BoxDynError> {
-        <T as Encode<DB>>::encode_by_ref(self.as_ref(), buf)
-    }
-
-    #[inline]
-    fn encode_by_ref(
-        &self,
-        buf: &mut <DB as Database>::ArgumentBuffer<'q>,
-    ) -> Result<IsNull, BoxDynError> {
-        <&T as Encode<DB>>::encode(self, buf)
-    }
-
-    #[inline]
-    fn produces(&self) -> Option<DB::TypeInfo> {
-        (**self).produces()
-    }
-
-    #[inline]
-    fn size_hint(&self) -> usize {
-        (**self).size_hint()
-    }
-}
-
-impl<'q, T, DB: Database> Encode<'q, DB> for Box<T>
-where
-    T: Encode<'q, DB>,
-{
-    #[inline]
-    fn encode(self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> Result<IsNull, BoxDynError> {
-        <T as Encode<DB>>::encode_by_ref(self.as_ref(), buf)
-    }
-
-    #[inline]
-    fn encode_by_ref(
-        &self,
-        buf: &mut <DB as Database>::ArgumentBuffer<'q>,
-    ) -> Result<IsNull, BoxDynError> {
-        <&T as Encode<DB>>::encode(self, buf)
-    }
-
-    #[inline]
-    fn produces(&self) -> Option<DB::TypeInfo> {
-        (**self).produces()
-    }
-
-    #[inline]
-    fn size_hint(&self) -> usize {
-        (**self).size_hint()
-    }
-}
-
-impl<'q, T, DB: Database> Encode<'q, DB> for Rc<T>
-where
-    T: Encode<'q, DB>,
 {
     #[inline]
     fn encode(self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> Result<IsNull, BoxDynError> {

--- a/sqlx-core/src/encode.rs
+++ b/sqlx-core/src/encode.rs
@@ -175,11 +175,11 @@ impl_encode_for_smartpointer!(Rc<T>);
 impl<'q, T, DB: Database> Encode<'q, DB> for Cow<'_, T>
 where
     T: Encode<'q, DB>,
-    T: ToOwned<Owned = T>,
+    T: ToOwned,
 {
     #[inline]
     fn encode(self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> Result<IsNull, BoxDynError> {
-        <T as Encode<DB>>::encode_by_ref(self.as_ref(), buf)
+        <&T as Encode<DB>>::encode_by_ref(&self.as_ref(), buf)
     }
 
     #[inline]
@@ -187,16 +187,16 @@ where
         &self,
         buf: &mut <DB as Database>::ArgumentBuffer<'q>,
     ) -> Result<IsNull, BoxDynError> {
-        <&T as Encode<DB>>::encode(self, buf)
+        <&T as Encode<DB>>::encode_by_ref(&self.as_ref(), buf)
     }
 
     #[inline]
     fn produces(&self) -> Option<DB::TypeInfo> {
-        (**self).produces()
+        <&T as Encode<DB>>::produces(&self.as_ref())
     }
 
     #[inline]
     fn size_hint(&self) -> usize {
-        (**self).size_hint()
+        <&T as Encode<DB>>::size_hint(&self.as_ref())
     }
 }

--- a/sqlx-core/src/encode.rs
+++ b/sqlx-core/src/encode.rs
@@ -1,6 +1,8 @@
 //! Provides [`Encode`] for encoding values for the database.
 
+use std::borrow::Cow;
 use std::mem;
+use std::sync::Arc;
 
 use crate::database::Database;
 use crate::error::BoxDynError;
@@ -128,4 +130,89 @@ macro_rules! impl_encode_for_option {
             }
         }
     };
+}
+
+impl<'q, T, DB: Database> Encode<'q, DB> for Arc<T>
+where
+    T: Encode<'q, DB>,
+{
+    #[inline]
+    fn encode(self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> Result<IsNull, BoxDynError> {
+        <T as Encode<DB>>::encode_by_ref(self.as_ref(), buf)
+    }
+
+    #[inline]
+    fn encode_by_ref(
+        &self,
+        buf: &mut <DB as Database>::ArgumentBuffer<'q>,
+    ) -> Result<IsNull, BoxDynError> {
+        <&T as Encode<DB>>::encode(self, buf)
+    }
+
+    #[inline]
+    fn produces(&self) -> Option<DB::TypeInfo> {
+        (**self).produces()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> usize {
+        (**self).size_hint()
+    }
+}
+
+impl<'q, T, DB: Database> Encode<'q, DB> for Cow<'_, T>
+where
+    T: Encode<'q, DB>,
+    T: ToOwned<Owned = T>,
+{
+    #[inline]
+    fn encode(self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> Result<IsNull, BoxDynError> {
+        <T as Encode<DB>>::encode_by_ref(self.as_ref(), buf)
+    }
+
+    #[inline]
+    fn encode_by_ref(
+        &self,
+        buf: &mut <DB as Database>::ArgumentBuffer<'q>,
+    ) -> Result<IsNull, BoxDynError> {
+        <&T as Encode<DB>>::encode(self, buf)
+    }
+
+    #[inline]
+    fn produces(&self) -> Option<DB::TypeInfo> {
+        (**self).produces()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> usize {
+        (**self).size_hint()
+    }
+}
+
+impl<'q, T, DB: Database> Encode<'q, DB> for Box<T>
+where
+    T: Encode<'q, DB>,
+{
+    #[inline]
+    fn encode(self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> Result<IsNull, BoxDynError> {
+        <T as Encode<DB>>::encode_by_ref(self.as_ref(), buf)
+    }
+
+    #[inline]
+    fn encode_by_ref(
+        &self,
+        buf: &mut <DB as Database>::ArgumentBuffer<'q>,
+    ) -> Result<IsNull, BoxDynError> {
+        <&T as Encode<DB>>::encode(self, buf)
+    }
+
+    #[inline]
+    fn produces(&self) -> Option<DB::TypeInfo> {
+        (**self).produces()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> usize {
+        (**self).size_hint()
+    }
 }

--- a/sqlx-core/src/types/mod.rs
+++ b/sqlx-core/src/types/mod.rs
@@ -17,7 +17,7 @@
 //! To represent nullable SQL types, `Option<T>` is supported where `T` implements `Type`.
 //! An `Option<T>` represents a potentially `NULL` value from SQL.
 
-use std::{borrow::Cow, sync::Arc};
+use std::{borrow::Cow, rc::Rc, sync::Arc};
 
 use crate::database::Database;
 use crate::type_info::TypeInfo;
@@ -280,6 +280,16 @@ where
 }
 
 impl<T: Type<DB>, DB: Database> Type<DB> for Box<T> {
+    fn type_info() -> DB::TypeInfo {
+        <T as Type<DB>>::type_info()
+    }
+
+    fn compatible(ty: &DB::TypeInfo) -> bool {
+        ty.is_null() || <T as Type<DB>>::compatible(ty)
+    }
+}
+
+impl<T: Type<DB>, DB: Database> Type<DB> for Rc<T> {
     fn type_info() -> DB::TypeInfo {
         <T as Type<DB>>::type_info()
     }

--- a/sqlx-core/src/types/mod.rs
+++ b/sqlx-core/src/types/mod.rs
@@ -276,7 +276,7 @@ impl_type_for_smartpointer!(Rc<T>);
 impl<T, DB: Database> Type<DB> for Cow<'_, T>
 where
     T: Type<DB>,
-    T: ToOwned<Owned = T>,
+    T: ToOwned,
     T: ?Sized,
 {
     fn type_info() -> DB::TypeInfo {

--- a/sqlx-core/src/types/mod.rs
+++ b/sqlx-core/src/types/mod.rs
@@ -17,6 +17,8 @@
 //! To represent nullable SQL types, `Option<T>` is supported where `T` implements `Type`.
 //! An `Option<T>` represents a potentially `NULL` value from SQL.
 
+use std::{borrow::Cow, sync::Arc};
+
 use crate::database::Database;
 use crate::type_info::TypeInfo;
 
@@ -240,6 +242,44 @@ impl<T: ?Sized + Type<DB>, DB: Database> Type<DB> for &'_ T {
 
 // for optionals, the underlying SQL type is identical
 impl<T: Type<DB>, DB: Database> Type<DB> for Option<T> {
+    fn type_info() -> DB::TypeInfo {
+        <T as Type<DB>>::type_info()
+    }
+
+    fn compatible(ty: &DB::TypeInfo) -> bool {
+        ty.is_null() || <T as Type<DB>>::compatible(ty)
+    }
+}
+
+impl<T, DB: Database> Type<DB> for Arc<T>
+where
+    T: Type<DB>,
+    T: ?Sized,
+{
+    fn type_info() -> DB::TypeInfo {
+        <T as Type<DB>>::type_info()
+    }
+
+    fn compatible(ty: &DB::TypeInfo) -> bool {
+        ty.is_null() || <T as Type<DB>>::compatible(ty)
+    }
+}
+
+impl<T, DB: Database> Type<DB> for Cow<'_, T>
+where
+    T: Type<DB>,
+    T: ToOwned<Owned = T>,
+{
+    fn type_info() -> DB::TypeInfo {
+        <T as Type<DB>>::type_info()
+    }
+
+    fn compatible(ty: &DB::TypeInfo) -> bool {
+        ty.is_null() || <T as Type<DB>>::compatible(ty)
+    }
+}
+
+impl<T: Type<DB>, DB: Database> Type<DB> for Box<T> {
     fn type_info() -> DB::TypeInfo {
         <T as Type<DB>>::type_info()
     }

--- a/sqlx-core/src/types/mod.rs
+++ b/sqlx-core/src/types/mod.rs
@@ -251,19 +251,27 @@ impl<T: Type<DB>, DB: Database> Type<DB> for Option<T> {
     }
 }
 
-impl<T, DB: Database> Type<DB> for Arc<T>
-where
-    T: Type<DB>,
-    T: ?Sized,
-{
-    fn type_info() -> DB::TypeInfo {
-        <T as Type<DB>>::type_info()
-    }
+macro_rules! impl_type_for_smartpointer {
+    ($smart_pointer:ty) => {
+        impl<T, DB: Database> Type<DB> for $smart_pointer
+        where
+            T: Type<DB>,
+            T: ?Sized,
+        {
+            fn type_info() -> DB::TypeInfo {
+                <T as Type<DB>>::type_info()
+            }
 
-    fn compatible(ty: &DB::TypeInfo) -> bool {
-        ty.is_null() || <T as Type<DB>>::compatible(ty)
-    }
+            fn compatible(ty: &DB::TypeInfo) -> bool {
+                <T as Type<DB>>::compatible(ty)
+            }
+        }
+    };
 }
+
+impl_type_for_smartpointer!(Arc<T>);
+impl_type_for_smartpointer!(Box<T>);
+impl_type_for_smartpointer!(Rc<T>);
 
 impl<T, DB: Database> Type<DB> for Cow<'_, T>
 where
@@ -275,26 +283,6 @@ where
     }
 
     fn compatible(ty: &DB::TypeInfo) -> bool {
-        ty.is_null() || <T as Type<DB>>::compatible(ty)
-    }
-}
-
-impl<T: Type<DB>, DB: Database> Type<DB> for Box<T> {
-    fn type_info() -> DB::TypeInfo {
-        <T as Type<DB>>::type_info()
-    }
-
-    fn compatible(ty: &DB::TypeInfo) -> bool {
-        ty.is_null() || <T as Type<DB>>::compatible(ty)
-    }
-}
-
-impl<T: Type<DB>, DB: Database> Type<DB> for Rc<T> {
-    fn type_info() -> DB::TypeInfo {
-        <T as Type<DB>>::type_info()
-    }
-
-    fn compatible(ty: &DB::TypeInfo) -> bool {
-        ty.is_null() || <T as Type<DB>>::compatible(ty)
+        <T as Type<DB>>::compatible(ty)
     }
 }

--- a/sqlx-core/src/types/mod.rs
+++ b/sqlx-core/src/types/mod.rs
@@ -255,8 +255,7 @@ macro_rules! impl_type_for_smartpointer {
     ($smart_pointer:ty) => {
         impl<T, DB: Database> Type<DB> for $smart_pointer
         where
-            T: Type<DB>,
-            T: ?Sized,
+            T: Type<DB> + ?Sized,
         {
             fn type_info() -> DB::TypeInfo {
                 <T as Type<DB>>::type_info()
@@ -275,9 +274,8 @@ impl_type_for_smartpointer!(Rc<T>);
 
 impl<T, DB: Database> Type<DB> for Cow<'_, T>
 where
-    T: Type<DB>,
-    T: ToOwned,
-    T: ?Sized,
+    // `ToOwned` is required here to satisfy `Cow`
+    T: Type<DB> + ToOwned + ?Sized,
 {
     fn type_info() -> DB::TypeInfo {
         <T as Type<DB>>::type_info()

--- a/sqlx-core/src/types/mod.rs
+++ b/sqlx-core/src/types/mod.rs
@@ -277,6 +277,7 @@ impl<T, DB: Database> Type<DB> for Cow<'_, T>
 where
     T: Type<DB>,
     T: ToOwned<Owned = T>,
+    T: ?Sized,
 {
     fn type_info() -> DB::TypeInfo {
         <T as Type<DB>>::type_info()

--- a/sqlx-mysql/src/types/bytes.rs
+++ b/sqlx-mysql/src/types/bytes.rs
@@ -46,12 +46,6 @@ impl Encode<'_, MySql> for Box<[u8]> {
     }
 }
 
-impl<'r> Decode<'r, MySql> for Box<[u8]> {
-    fn decode(value: MySqlValueRef<'r>) -> Result<Self, BoxDynError> {
-        <&[u8] as Decode<MySql>>::decode(value).map(Box::from)
-    }
-}
-
 impl Type<MySql> for Vec<u8> {
     fn type_info() -> MySqlTypeInfo {
         <[u8] as Type<MySql>>::type_info()

--- a/sqlx-mysql/src/types/bytes.rs
+++ b/sqlx-mysql/src/types/bytes.rs
@@ -40,16 +40,6 @@ impl<'r> Decode<'r, MySql> for &'r [u8] {
     }
 }
 
-impl Type<MySql> for Box<[u8]> {
-    fn type_info() -> MySqlTypeInfo {
-        <&[u8] as Type<MySql>>::type_info()
-    }
-
-    fn compatible(ty: &MySqlTypeInfo) -> bool {
-        <&[u8] as Type<MySql>>::compatible(ty)
-    }
-}
-
 impl Encode<'_, MySql> for Box<[u8]> {
     fn encode_by_ref(&self, buf: &mut Vec<u8>) -> Result<IsNull, BoxDynError> {
         <&[u8] as Encode<MySql>>::encode(self.as_ref(), buf)

--- a/sqlx-mysql/src/types/bytes.rs
+++ b/sqlx-mysql/src/types/bytes.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
 use crate::error::BoxDynError;
@@ -65,5 +67,11 @@ impl Encode<'_, MySql> for Vec<u8> {
 impl Decode<'_, MySql> for Vec<u8> {
     fn decode(value: MySqlValueRef<'_>) -> Result<Self, BoxDynError> {
         <&[u8] as Decode<MySql>>::decode(value).map(ToOwned::to_owned)
+    }
+}
+
+impl Encode<'_, MySql> for Cow<'_, [u8]> {
+    fn encode_by_ref(&self, buf: &mut Vec<u8>) -> Result<IsNull, BoxDynError> {
+        <&[u8] as Encode<MySql>>::encode(self.as_ref(), buf)
     }
 }

--- a/sqlx-mysql/src/types/str.rs
+++ b/sqlx-mysql/src/types/str.rs
@@ -83,9 +83,3 @@ impl Encode<'_, MySql> for Cow<'_, str> {
         }
     }
 }
-
-impl Encode<'_, MySql> for Cow<'_, [u8]> {
-    fn encode_by_ref(&self, buf: &mut Vec<u8>) -> Result<IsNull, BoxDynError> {
-        <&[u8] as Encode<MySql>>::encode(self.as_ref(), buf)
-    }
-}

--- a/sqlx-mysql/src/types/str.rs
+++ b/sqlx-mysql/src/types/str.rs
@@ -46,16 +46,6 @@ impl<'r> Decode<'r, MySql> for &'r str {
     }
 }
 
-impl Type<MySql> for Box<str> {
-    fn type_info() -> MySqlTypeInfo {
-        <&str as Type<MySql>>::type_info()
-    }
-
-    fn compatible(ty: &MySqlTypeInfo) -> bool {
-        <&str as Type<MySql>>::compatible(ty)
-    }
-}
-
 impl Encode<'_, MySql> for Box<str> {
     fn encode_by_ref(&self, buf: &mut Vec<u8>) -> Result<IsNull, BoxDynError> {
         <&str as Encode<MySql>>::encode(&**self, buf)
@@ -87,16 +77,6 @@ impl Encode<'_, MySql> for String {
 impl Decode<'_, MySql> for String {
     fn decode(value: MySqlValueRef<'_>) -> Result<Self, BoxDynError> {
         <&str as Decode<MySql>>::decode(value).map(ToOwned::to_owned)
-    }
-}
-
-impl Type<MySql> for Cow<'_, str> {
-    fn type_info() -> MySqlTypeInfo {
-        <&str as Type<MySql>>::type_info()
-    }
-
-    fn compatible(ty: &MySqlTypeInfo) -> bool {
-        <&str as Type<MySql>>::compatible(ty)
     }
 }
 

--- a/sqlx-mysql/src/types/str.rs
+++ b/sqlx-mysql/src/types/str.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
 use crate::error::BoxDynError;
@@ -5,7 +7,6 @@ use crate::io::MySqlBufMutExt;
 use crate::protocol::text::{ColumnFlags, ColumnType};
 use crate::types::Type;
 use crate::{MySql, MySqlTypeInfo, MySqlValueRef};
-use std::borrow::Cow;
 
 impl Type<MySql> for str {
     fn type_info() -> MySqlTypeInfo {
@@ -52,12 +53,6 @@ impl Encode<'_, MySql> for Box<str> {
     }
 }
 
-impl<'r> Decode<'r, MySql> for Box<str> {
-    fn decode(value: MySqlValueRef<'r>) -> Result<Self, BoxDynError> {
-        <&str as Decode<MySql>>::decode(value).map(Box::from)
-    }
-}
-
 impl Type<MySql> for String {
     fn type_info() -> MySqlTypeInfo {
         <str as Type<MySql>>::type_info()
@@ -89,8 +84,8 @@ impl Encode<'_, MySql> for Cow<'_, str> {
     }
 }
 
-impl<'r> Decode<'r, MySql> for Cow<'r, str> {
-    fn decode(value: MySqlValueRef<'r>) -> Result<Self, BoxDynError> {
-        value.as_str().map(Cow::Borrowed)
+impl Encode<'_, MySql> for Cow<'_, [u8]> {
+    fn encode_by_ref(&self, buf: &mut Vec<u8>) -> Result<IsNull, BoxDynError> {
+        <&[u8] as Encode<MySql>>::encode(self.as_ref(), buf)
     }
 }

--- a/sqlx-postgres/src/types/bytes.rs
+++ b/sqlx-postgres/src/types/bytes.rs
@@ -80,15 +80,6 @@ fn text_hex_decode_input(value: PgValueRef<'_>) -> Result<&[u8], BoxDynError> {
         .map_err(Into::into)
 }
 
-impl Decode<'_, Postgres> for Box<[u8]> {
-    fn decode(value: PgValueRef<'_>) -> Result<Self, BoxDynError> {
-        Ok(match value.format() {
-            PgValueFormat::Binary => Box::from(value.as_bytes()?),
-            PgValueFormat::Text => Box::from(hex::decode(text_hex_decode_input(value)?)?),
-        })
-    }
-}
-
 impl Decode<'_, Postgres> for Vec<u8> {
     fn decode(value: PgValueRef<'_>) -> Result<Self, BoxDynError> {
         Ok(match value.format() {

--- a/sqlx-postgres/src/types/bytes.rs
+++ b/sqlx-postgres/src/types/bytes.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::decode::Decode;
 use crate::encode::{Encode, IsNull};
 use crate::error::BoxDynError;
@@ -99,5 +101,11 @@ impl<const N: usize> Decode<'_, Postgres> for [u8; N] {
             PgValueFormat::Text => hex::decode_to_slice(text_hex_decode_input(value)?, &mut bytes)?,
         };
         Ok(bytes)
+    }
+}
+
+impl Encode<'_, Postgres> for Cow<'_, [u8]> {
+    fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
+        <&[u8] as Encode<Postgres>>::encode(self.as_ref(), buf)
     }
 }

--- a/sqlx-postgres/src/types/str.rs
+++ b/sqlx-postgres/src/types/str.rs
@@ -24,16 +24,6 @@ impl Type<Postgres> for str {
     }
 }
 
-impl Type<Postgres> for Cow<'_, str> {
-    fn type_info() -> PgTypeInfo {
-        <&str as Type<Postgres>>::type_info()
-    }
-
-    fn compatible(ty: &PgTypeInfo) -> bool {
-        <&str as Type<Postgres>>::compatible(ty)
-    }
-}
-
 impl Type<Postgres> for String {
     fn type_info() -> PgTypeInfo {
         <&str as Type<Postgres>>::type_info()

--- a/sqlx-postgres/src/types/str.rs
+++ b/sqlx-postgres/src/types/str.rs
@@ -82,15 +82,6 @@ impl Encode<'_, Postgres> for &'_ str {
     }
 }
 
-impl Encode<'_, Postgres> for Cow<'_, str> {
-    fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
-        match self {
-            Cow::Borrowed(str) => <&str as Encode<Postgres>>::encode(*str, buf),
-            Cow::Owned(str) => <&str as Encode<Postgres>>::encode(&**str, buf),
-        }
-    }
-}
-
 impl Encode<'_, Postgres> for Box<str> {
     fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
         <&str as Encode<Postgres>>::encode(&**self, buf)
@@ -109,20 +100,23 @@ impl<'r> Decode<'r, Postgres> for &'r str {
     }
 }
 
-impl<'r> Decode<'r, Postgres> for Cow<'r, str> {
-    fn decode(value: PgValueRef<'r>) -> Result<Self, BoxDynError> {
-        Ok(Cow::Borrowed(value.as_str()?))
-    }
-}
-
-impl<'r> Decode<'r, Postgres> for Box<str> {
-    fn decode(value: PgValueRef<'r>) -> Result<Self, BoxDynError> {
-        Ok(Box::from(value.as_str()?))
-    }
-}
-
 impl Decode<'_, Postgres> for String {
     fn decode(value: PgValueRef<'_>) -> Result<Self, BoxDynError> {
         Ok(value.as_str()?.to_owned())
+    }
+}
+
+impl Encode<'_, Postgres> for Cow<'_, str> {
+    fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
+        match self {
+            Cow::Borrowed(str) => <&str as Encode<Postgres>>::encode(*str, buf),
+            Cow::Owned(str) => <&str as Encode<Postgres>>::encode(&**str, buf),
+        }
+    }
+}
+
+impl Encode<'_, Postgres> for Cow<'_, [u8]> {
+    fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
+        <&[u8] as Encode<Postgres>>::encode(self.as_ref(), buf)
     }
 }

--- a/sqlx-postgres/src/types/str.rs
+++ b/sqlx-postgres/src/types/str.rs
@@ -34,16 +34,6 @@ impl Type<Postgres> for Cow<'_, str> {
     }
 }
 
-impl Type<Postgres> for Box<str> {
-    fn type_info() -> PgTypeInfo {
-        <&str as Type<Postgres>>::type_info()
-    }
-
-    fn compatible(ty: &PgTypeInfo) -> bool {
-        <&str as Type<Postgres>>::compatible(ty)
-    }
-}
-
 impl Type<Postgres> for String {
     fn type_info() -> PgTypeInfo {
         <&str as Type<Postgres>>::type_info()

--- a/sqlx-sqlite/src/types/bytes.rs
+++ b/sqlx-sqlite/src/types/bytes.rs
@@ -85,3 +85,20 @@ impl<'r> Decode<'r, Sqlite> for Vec<u8> {
         Ok(value.blob().to_owned())
     }
 }
+
+impl<'q> Encode<'q, Sqlite> for Cow<'q, [u8]> {
+    fn encode(self, args: &mut Vec<SqliteArgumentValue<'q>>) -> Result<IsNull, BoxDynError> {
+        args.push(SqliteArgumentValue::Blob(self));
+
+        Ok(IsNull::No)
+    }
+
+    fn encode_by_ref(
+        &self,
+        args: &mut Vec<SqliteArgumentValue<'q>>,
+    ) -> Result<IsNull, BoxDynError> {
+        args.push(SqliteArgumentValue::Blob(self.clone()));
+
+        Ok(IsNull::No)
+    }
+}

--- a/sqlx-sqlite/src/types/bytes.rs
+++ b/sqlx-sqlite/src/types/bytes.rs
@@ -34,16 +34,6 @@ impl<'r> Decode<'r, Sqlite> for &'r [u8] {
     }
 }
 
-impl Type<Sqlite> for Box<[u8]> {
-    fn type_info() -> SqliteTypeInfo {
-        <&[u8] as Type<Sqlite>>::type_info()
-    }
-
-    fn compatible(ty: &SqliteTypeInfo) -> bool {
-        <&[u8] as Type<Sqlite>>::compatible(ty)
-    }
-}
-
 impl Encode<'_, Sqlite> for Box<[u8]> {
     fn encode(self, args: &mut Vec<SqliteArgumentValue<'_>>) -> Result<IsNull, BoxDynError> {
         args.push(SqliteArgumentValue::Blob(Cow::Owned(self.into_vec())));

--- a/sqlx-sqlite/src/types/bytes.rs
+++ b/sqlx-sqlite/src/types/bytes.rs
@@ -53,12 +53,6 @@ impl Encode<'_, Sqlite> for Box<[u8]> {
     }
 }
 
-impl Decode<'_, Sqlite> for Box<[u8]> {
-    fn decode(value: SqliteValueRef<'_>) -> Result<Self, BoxDynError> {
-        Ok(Box::from(value.blob()))
-    }
-}
-
 impl Type<Sqlite> for Vec<u8> {
     fn type_info() -> SqliteTypeInfo {
         <&[u8] as Type<Sqlite>>::type_info()

--- a/sqlx-sqlite/src/types/str.rs
+++ b/sqlx-sqlite/src/types/str.rs
@@ -49,12 +49,6 @@ impl Encode<'_, Sqlite> for Box<str> {
     }
 }
 
-impl Decode<'_, Sqlite> for Box<str> {
-    fn decode(value: SqliteValueRef<'_>) -> Result<Self, BoxDynError> {
-        value.text().map(Box::from)
-    }
-}
-
 impl Type<Sqlite> for String {
     fn type_info() -> SqliteTypeInfo {
         <&str as Type<Sqlite>>::type_info()
@@ -101,8 +95,19 @@ impl<'q> Encode<'q, Sqlite> for Cow<'q, str> {
     }
 }
 
-impl<'r> Decode<'r, Sqlite> for Cow<'r, str> {
-    fn decode(value: SqliteValueRef<'r>) -> Result<Self, BoxDynError> {
-        value.text().map(Cow::Borrowed)
+impl<'q> Encode<'q, Sqlite> for Cow<'q, [u8]> {
+    fn encode(self, args: &mut Vec<SqliteArgumentValue<'q>>) -> Result<IsNull, BoxDynError> {
+        args.push(SqliteArgumentValue::Blob(self));
+
+        Ok(IsNull::No)
+    }
+
+    fn encode_by_ref(
+        &self,
+        args: &mut Vec<SqliteArgumentValue<'q>>,
+    ) -> Result<IsNull, BoxDynError> {
+        args.push(SqliteArgumentValue::Blob(self.clone()));
+
+        Ok(IsNull::No)
     }
 }

--- a/sqlx-sqlite/src/types/str.rs
+++ b/sqlx-sqlite/src/types/str.rs
@@ -30,12 +30,6 @@ impl<'r> Decode<'r, Sqlite> for &'r str {
     }
 }
 
-impl Type<Sqlite> for Box<str> {
-    fn type_info() -> SqliteTypeInfo {
-        <&str as Type<Sqlite>>::type_info()
-    }
-}
-
 impl Encode<'_, Sqlite> for Box<str> {
     fn encode(self, args: &mut Vec<SqliteArgumentValue<'_>>) -> Result<IsNull, BoxDynError> {
         args.push(SqliteArgumentValue::Text(Cow::Owned(self.into_string())));
@@ -87,16 +81,6 @@ impl<'q> Encode<'q, Sqlite> for String {
 impl<'r> Decode<'r, Sqlite> for String {
     fn decode(value: SqliteValueRef<'r>) -> Result<Self, BoxDynError> {
         value.text().map(ToOwned::to_owned)
-    }
-}
-
-impl Type<Sqlite> for Cow<'_, str> {
-    fn type_info() -> SqliteTypeInfo {
-        <&str as Type<Sqlite>>::type_info()
-    }
-
-    fn compatible(ty: &SqliteTypeInfo) -> bool {
-        <&str as Type<Sqlite>>::compatible(ty)
     }
 }
 

--- a/sqlx-sqlite/src/types/str.rs
+++ b/sqlx-sqlite/src/types/str.rs
@@ -94,20 +94,3 @@ impl<'q> Encode<'q, Sqlite> for Cow<'q, str> {
         Ok(IsNull::No)
     }
 }
-
-impl<'q> Encode<'q, Sqlite> for Cow<'q, [u8]> {
-    fn encode(self, args: &mut Vec<SqliteArgumentValue<'q>>) -> Result<IsNull, BoxDynError> {
-        args.push(SqliteArgumentValue::Blob(self));
-
-        Ok(IsNull::No)
-    }
-
-    fn encode_by_ref(
-        &self,
-        args: &mut Vec<SqliteArgumentValue<'q>>,
-    ) -> Result<IsNull, BoxDynError> {
-        args.push(SqliteArgumentValue::Blob(self.clone()));
-
-        Ok(IsNull::No)
-    }
-}

--- a/tests/mysql/types.rs
+++ b/tests/mysql/types.rs
@@ -15,7 +15,7 @@ use sqlx::types::Text;
 use sqlx::mysql::types::MySqlTime;
 use sqlx_mysql::types::MySqlTimeSign;
 
-use sqlx_test::{new, test_type};
+use sqlx_test::{new, test_prepared_type, test_type};
 
 test_type!(bool(MySql, "false" == false, "true" == true));
 
@@ -303,6 +303,17 @@ mod json_tests {
     ));
 }
 
+test_type!(test_arc<Arc<i32>>(MySql, "1" == Arc::new(1i32)));
+test_type!(test_cow<Cow<'_, i32>>(MySql, "1" == Cow::<i32>::Owned(1i32)));
+test_type!(test_box<Box<i32>>(MySql, "1" == Box::new(1i32)));
+test_type!(test_rc<Rc<i32>>(MySql, "1" == Rc::new(1i32)));
+
+test_type!(test_box_str<Box<str>>(MySql, "'John'" == Box::<str>::from("John")));
+test_type!(test_cow_str<Cow<'_, str>>(MySql, "'Phil'" == Cow::<'static, str>::from("Phil")));
+
+test_prepared_type!(test_box_slice<Box<[u8]>>(MySql, "X'01020304'" == Box::<[u8]>::from([1,2,3,4])));
+test_prepared_type!(test_cow_slice<Cow<'_, [u8]>>(MySql, "X'01020304'" == Cow::<'static, [u8]>::from(&[1,2,3,4])));
+
 #[sqlx_macros::test]
 async fn test_bits() -> anyhow::Result<()> {
     let mut conn = new::<MySql>().await?;
@@ -385,51 +396,5 @@ CREATE TEMPORARY TABLE user_login (
     assert_eq!(last_login.user_id, user_id);
     assert_eq!(*last_login.socket_addr, socket_addr);
 
-    Ok(())
-}
-
-#[sqlx_macros::test]
-async fn test_smartpointers() -> anyhow::Result<()> {
-    let mut conn = new::<MySql>().await?;
-
-    let user_age: (Arc<i32>, Cow<'static, i32>, Box<i32>, i32) =
-        sqlx::query_as("SELECT ?, ?, ?, ?")
-            .bind(Arc::new(1i32))
-            .bind(Cow::<'_, i32>::Borrowed(&2i32))
-            .bind(Box::new(3i32))
-            .bind(Rc::new(4i32))
-            .fetch_one(&mut conn)
-            .await?;
-
-    assert!(user_age.0.as_ref() == &1);
-    assert!(user_age.1.as_ref() == &2);
-    assert!(user_age.2.as_ref() == &3);
-    assert!(user_age.3 == 4);
-    Ok(())
-}
-
-#[sqlx_macros::test]
-async fn test_str_slice() -> anyhow::Result<()> {
-    let mut conn = new::<MySql>().await?;
-
-    let box_str: Box<str> = "John".into();
-    let box_slice: Box<[u8]> = [1, 2, 3, 4].into();
-    let cow_str: Cow<'static, str> = "Phil".into();
-    let cow_slice: Cow<'static, [u8]> = Cow::Borrowed(&[1, 2, 3, 4]);
-
-    let row = sqlx::query("SELECT ?, ?, ?, ?")
-        .bind(&box_str)
-        .bind(&box_slice)
-        .bind(&cow_str)
-        .bind(&cow_slice)
-        .fetch_one(&mut conn)
-        .await?;
-
-    let data: (Box<str>, Box<[u8]>, Cow<'_, str>, Cow<'_, [u8]>) = FromRow::from_row(&row)?;
-
-    assert!(data.0 == box_str);
-    assert!(data.1 == box_slice);
-    assert!(data.2 == cow_str);
-    assert!(data.3 == cow_slice);
     Ok(())
 }

--- a/tests/mysql/types.rs
+++ b/tests/mysql/types.rs
@@ -1,11 +1,14 @@
 extern crate time_ as time;
 
+use std::borrow::Cow;
 use std::net::SocketAddr;
+use std::rc::Rc;
 #[cfg(feature = "rust_decimal")]
 use std::str::FromStr;
+use std::sync::Arc;
 
 use sqlx::mysql::MySql;
-use sqlx::{Executor, Row};
+use sqlx::{Executor, FromRow, Row};
 
 use sqlx::types::Text;
 
@@ -382,5 +385,51 @@ CREATE TEMPORARY TABLE user_login (
     assert_eq!(last_login.user_id, user_id);
     assert_eq!(*last_login.socket_addr, socket_addr);
 
+    Ok(())
+}
+
+#[sqlx_macros::test]
+async fn test_smartpointers() -> anyhow::Result<()> {
+    let mut conn = new::<MySql>().await?;
+
+    let user_age: (Arc<i32>, Cow<'static, i32>, Box<i32>, i32) =
+        sqlx::query_as("SELECT ?, ?, ?, ?")
+            .bind(Arc::new(1i32))
+            .bind(Cow::<'_, i32>::Borrowed(&2i32))
+            .bind(Box::new(3i32))
+            .bind(Rc::new(4i32))
+            .fetch_one(&mut conn)
+            .await?;
+
+    assert!(user_age.0.as_ref() == &1);
+    assert!(user_age.1.as_ref() == &2);
+    assert!(user_age.2.as_ref() == &3);
+    assert!(user_age.3 == 4);
+    Ok(())
+}
+
+#[sqlx_macros::test]
+async fn test_str_slice() -> anyhow::Result<()> {
+    let mut conn = new::<MySql>().await?;
+
+    let box_str: Box<str> = "John".into();
+    let box_slice: Box<[u8]> = [1, 2, 3, 4].into();
+    let cow_str: Cow<'static, str> = "Phil".into();
+    let cow_slice: Cow<'static, [u8]> = Cow::Borrowed(&[1, 2, 3, 4]);
+
+    let row = sqlx::query("SELECT ?, ?, ?, ?")
+        .bind(&box_str)
+        .bind(&box_slice)
+        .bind(&cow_str)
+        .bind(&cow_slice)
+        .fetch_one(&mut conn)
+        .await?;
+
+    let data: (Box<str>, Box<[u8]>, Cow<'_, str>, Cow<'_, [u8]>) = FromRow::from_row(&row)?;
+
+    assert!(data.0 == box_str);
+    assert!(data.1 == box_slice);
+    assert!(data.2 == cow_str);
+    assert!(data.3 == cow_slice);
     Ok(())
 }

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -3,8 +3,8 @@ extern crate time_ as time;
 use std::borrow::Cow;
 use std::net::SocketAddr;
 use std::ops::Bound;
-use std::str::FromStr;
 use std::rc::Rc;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use sqlx::postgres::types::{Oid, PgCiText, PgInterval, PgMoney, PgRange};

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use sqlx::postgres::types::{Oid, PgCiText, PgInterval, PgMoney, PgRange};
 use sqlx::postgres::Postgres;
+use sqlx::FromRow;
 use sqlx_test::{new, test_decode_type, test_prepared_type, test_type};
 
 use sqlx_core::executor::Executor;
@@ -741,7 +742,7 @@ CREATE TEMPORARY TABLE user_login (
 }
 
 #[sqlx_macros::test]
-async fn test_arc() -> anyhow::Result<()> {
+async fn test_smartpointers() -> anyhow::Result<()> {
     let mut conn = new::<Postgres>().await?;
 
     let user_age: (Arc<i32>, Cow<'static, i32>, Box<i32>, i32) =
@@ -757,5 +758,31 @@ async fn test_arc() -> anyhow::Result<()> {
     assert!(user_age.1.as_ref() == &2);
     assert!(user_age.2.as_ref() == &3);
     assert!(user_age.3 == 4);
+    Ok(())
+}
+
+#[sqlx_macros::test]
+async fn test_str_slice() -> anyhow::Result<()> {
+    let mut conn = new::<Postgres>().await?;
+
+    let box_str: Box<str> = "John".into();
+    let box_slice: Box<[u8]> = [1, 2, 3, 4].into();
+    let cow_str: Cow<'static, str> = "Phil".into();
+    let cow_slice: Cow<'static, [u8]> = Cow::Borrowed(&[1, 2, 3, 4]);
+
+    let row = sqlx::query("SELECT $1, $2, $3, $4")
+        .bind(&box_str)
+        .bind(&box_slice)
+        .bind(&cow_str)
+        .bind(&cow_slice)
+        .fetch_one(&mut conn)
+        .await?;
+
+    let data: (Box<str>, Box<[u8]>, Cow<'_, str>, Cow<'_, [u8]>) = FromRow::from_row(&row)?;
+
+    assert!(data.0 == box_str);
+    assert!(data.1 == box_slice);
+    assert!(data.2 == cow_str);
+    assert!(data.3 == cow_slice);
     Ok(())
 }

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -747,11 +747,12 @@ async fn test_arc() -> anyhow::Result<()> {
     let user_age: (Arc<i32>, Cow<'static, i32>, Box<i32>, i32) =
         sqlx::query_as("SELECT $1, $2, $3, $4")
             .bind(Arc::new(1i32))
-            .bind(Cow::<'_, i32>::Owned(2i32))
+            .bind(Cow::<'_, i32>::Borrowed(&2i32))
             .bind(Box::new(3i32))
             .bind(Rc::new(4i32))
             .fetch_one(&mut conn)
             .await?;
+
     assert!(user_age.0.as_ref() == &1);
     assert!(user_age.1.as_ref() == &2);
     assert!(user_age.2.as_ref() == &3);

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -744,51 +744,17 @@ CREATE TEMPORARY TABLE user_login (
 async fn test_arc() -> anyhow::Result<()> {
     let mut conn = new::<Postgres>().await?;
 
-    let user_age: Arc<i32> = sqlx::query_scalar("SELECT $1 AS age ")
-        .bind(Arc::new(1i32))
-        .fetch_one(&mut conn)
-        .await?;
-    assert!(user_age.as_ref() == &1);
-    Ok(())
-}
-
-#[sqlx_macros::test]
-async fn test_cow() -> anyhow::Result<()> {
-    let mut conn = new::<Postgres>().await?;
-
-    let age: Cow<'_, i32> = Cow::Owned(1i32);
-
-    let user_age: Cow<'static, i32> = sqlx::query_scalar("SELECT $1 AS age ")
-        .bind(age)
-        .fetch_one(&mut conn)
-        .await?;
-
-    assert!(user_age.as_ref() == &1);
-    Ok(())
-}
-
-#[sqlx_macros::test]
-async fn test_box() -> anyhow::Result<()> {
-    let mut conn = new::<Postgres>().await?;
-
-    let user_age: Box<i32> = sqlx::query_scalar("SELECT $1 AS age ")
-        .bind(Box::new(1))
-        .fetch_one(&mut conn)
-        .await?;
-
-    assert!(user_age.as_ref() == &1);
-    Ok(())
-}
-
-#[sqlx_macros::test]
-async fn test_rc() -> anyhow::Result<()> {
-    let mut conn = new::<Postgres>().await?;
-
-    let user_age: i32 = sqlx::query_scalar("SELECT $1 AS age")
-        .bind(Rc::new(1i32))
-        .fetch_one(&mut conn)
-        .await?;
-
-    assert!(user_age == 1);
+    let user_age: (Arc<i32>, Cow<'static, i32>, Box<i32>, i32) =
+        sqlx::query_as("SELECT $1, $2, $3, $4")
+            .bind(Arc::new(1i32))
+            .bind(Cow::<'_, i32>::Owned(2i32))
+            .bind(Box::new(3i32))
+            .bind(Rc::new(4i32))
+            .fetch_one(&mut conn)
+            .await?;
+    assert!(user_age.0.as_ref() == &1);
+    assert!(user_age.1.as_ref() == &2);
+    assert!(user_age.2.as_ref() == &3);
+    assert!(user_age.3 == 4);
     Ok(())
 }

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -9,7 +9,6 @@ use std::sync::Arc;
 
 use sqlx::postgres::types::{Oid, PgCiText, PgInterval, PgMoney, PgRange};
 use sqlx::postgres::Postgres;
-use sqlx::FromRow;
 use sqlx_test::{new, test_decode_type, test_prepared_type, test_type};
 
 use sqlx_core::executor::Executor;
@@ -698,6 +697,17 @@ test_type!(ltree_vec<Vec<sqlx::postgres::types::PgLTree>>(Postgres,
         ]
 ));
 
+test_type!(test_arc<Arc<i32>>(Postgres, "1::INT4" == Arc::new(1i32)));
+test_type!(test_cow<Cow<'_, i32>>(Postgres, "1::INT4" == Cow::<i32>::Owned(1i32)));
+test_type!(test_box<Box<i32>>(Postgres, "1::INT4" == Box::new(1i32)));
+test_type!(test_rc<Rc<i32>>(Postgres, "1::INT4" == Rc::new(1i32)));
+
+test_type!(test_box_str<Box<str>>(Postgres, "'John'::TEXT" == Box::<str>::from("John")));
+test_type!(test_cow_str<Cow<'_, str>>(Postgres, "'Phil'::TEXT" == Cow::<'static, str>::from("Phil")));
+
+test_prepared_type!(test_box_slice<Box<[u8]>>(Postgres, "'\\x01020304'::BYTEA" == Box::<[u8]>::from([1,2,3,4])));
+test_prepared_type!(test_cow_slice<Cow<'_, [u8]>>(Postgres, "'\\x01020304'::BYTEA" == Cow::<'static, [u8]>::from(&[1,2,3,4])));
+
 #[sqlx_macros::test]
 async fn test_text_adapter() -> anyhow::Result<()> {
     #[derive(sqlx::FromRow, Debug, PartialEq, Eq)]
@@ -738,51 +748,5 @@ CREATE TEMPORARY TABLE user_login (
     assert_eq!(last_login.user_id, user_id);
     assert_eq!(*last_login.socket_addr, socket_addr);
 
-    Ok(())
-}
-
-#[sqlx_macros::test]
-async fn test_smartpointers() -> anyhow::Result<()> {
-    let mut conn = new::<Postgres>().await?;
-
-    let user_age: (Arc<i32>, Cow<'static, i32>, Box<i32>, i32) =
-        sqlx::query_as("SELECT $1, $2, $3, $4")
-            .bind(Arc::new(1i32))
-            .bind(Cow::<'_, i32>::Borrowed(&2i32))
-            .bind(Box::new(3i32))
-            .bind(Rc::new(4i32))
-            .fetch_one(&mut conn)
-            .await?;
-
-    assert!(user_age.0.as_ref() == &1);
-    assert!(user_age.1.as_ref() == &2);
-    assert!(user_age.2.as_ref() == &3);
-    assert!(user_age.3 == 4);
-    Ok(())
-}
-
-#[sqlx_macros::test]
-async fn test_str_slice() -> anyhow::Result<()> {
-    let mut conn = new::<Postgres>().await?;
-
-    let box_str: Box<str> = "John".into();
-    let box_slice: Box<[u8]> = [1, 2, 3, 4].into();
-    let cow_str: Cow<'static, str> = "Phil".into();
-    let cow_slice: Cow<'static, [u8]> = Cow::Borrowed(&[1, 2, 3, 4]);
-
-    let row = sqlx::query("SELECT $1, $2, $3, $4")
-        .bind(&box_str)
-        .bind(&box_slice)
-        .bind(&cow_str)
-        .bind(&cow_slice)
-        .fetch_one(&mut conn)
-        .await?;
-
-    let data: (Box<str>, Box<[u8]>, Cow<'_, str>, Cow<'_, [u8]>) = FromRow::from_row(&row)?;
-
-    assert!(data.0 == box_str);
-    assert!(data.1 == box_slice);
-    assert!(data.2 == cow_str);
-    assert!(data.3 == cow_slice);
     Ok(())
 }


### PR DESCRIPTION
fixes #3100

Implements `Decode`, `Encode` and `Type` for `Box<T>`, `Arc<T>`, `Cow<'_,T>` and `Rc<T>`. I left out the `Decode` impl for `Rc<T>` because of the `Send` trait bounds in `QueryAs` and `QueryScalar` (which makes it impossible to use `Rc`).