### PR TITLE
Add json(nullable) macro attribute

### DIFF
--- a/sqlx-core/src/from_row.rs
+++ b/sqlx-core/src/from_row.rs
@@ -271,6 +271,32 @@ use crate::{error::Error, row::Row};
 ///     }
 /// }
 /// ```
+///
+/// By default the `#[sqlx(json)]` attribute will assume that the underlying database row is
+/// _not_ NULL. This can cause issues when your field type is an `Option<T>` because this would be
+/// represented as the _not_ NULL (in terms of DB) JSON value of `null`.
+///
+/// If you wish to describe a database row which _is_ NULLable but _cannot_ contain the JSON value `null`,
+/// use the `#[sqlx(json(nullable))]` attrubute.
+///
+/// For example
+/// ```rust,ignore
+/// #[derive(serde::Deserialize)]
+/// struct Data {
+///     field1: String,
+///     field2: u64
+/// }
+///
+/// #[derive(sqlx::FromRow)]
+/// struct User {
+///     id: i32,
+///     name: String,
+///     #[sqlx(json(nullable))]
+///     metadata: Option<Data>
+/// }
+/// ```
+/// Would describe a database field which _is_ NULLable but if it exists it must be the JSON representation of `Data`
+/// and cannot be the JSON value `null`
 pub trait FromRow<'r, R: Row>: Sized {
     fn from_row(row: &'r R) -> Result<Self, Error>;
 }

--- a/sqlx-macros-core/src/derives/attributes.rs
+++ b/sqlx-macros-core/src/derives/attributes.rs
@@ -61,8 +61,8 @@ pub struct SqlxContainerAttributes {
 }
 
 pub enum JsonAttribute {
-    Mandatory,
-    Optional
+    NonNullable,
+    Nullable
 }
 
 pub struct SqlxChildAttributes {
@@ -170,10 +170,10 @@ pub fn parse_child_attributes(input: &[Attribute]) -> syn::Result<SqlxChildAttri
                 if meta.input.peek(syn::token::Paren) {
                     let content;
                     parenthesized!(content in meta.input);
-                    let literal: Token![optional] = content.parse()?;
-                    json = Some(JsonAttribute::Optional);
+                    let literal: Token![nullable] = content.parse()?;
+                    json = Some(JsonAttribute::Nullable);
                 } else {
-                    json = Some(JsonAttribute::Mandatory);
+                    json = Some(JsonAttribute::NonNullable);
                 }
             }
 

--- a/sqlx-macros-core/src/derives/attributes.rs
+++ b/sqlx-macros-core/src/derives/attributes.rs
@@ -1,7 +1,8 @@
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote_spanned;
 use syn::{
-    parenthesized, punctuated::Punctuated, token::Comma, Attribute, DeriveInput, Field, LitStr, Meta, Token, Type, Variant
+    parenthesized, punctuated::Punctuated, token::Comma, Attribute, DeriveInput, Field, LitStr,
+    Meta, Token, Type, Variant,
 };
 
 macro_rules! assert_attribute {
@@ -62,7 +63,7 @@ pub struct SqlxContainerAttributes {
 
 pub enum JsonAttribute {
     NonNullable,
-    Nullable
+    Nullable,
 }
 
 pub struct SqlxChildAttributes {

--- a/sqlx-macros-core/src/derives/attributes.rs
+++ b/sqlx-macros-core/src/derives/attributes.rs
@@ -1,7 +1,7 @@
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote_spanned;
 use syn::{
-    parenthesized, parse::discouraged::AnyDelimiter, punctuated::Punctuated, token::{self, Comma}, Attribute, DeriveInput, Field, LitStr, Meta, Token, Type, Variant
+    parenthesized, punctuated::Punctuated, token::Comma, Attribute, DeriveInput, Field, LitStr, Meta, Token, Type, Variant
 };
 
 macro_rules! assert_attribute {
@@ -170,7 +170,8 @@ pub fn parse_child_attributes(input: &[Attribute]) -> syn::Result<SqlxChildAttri
                 if meta.input.peek(syn::token::Paren) {
                     let content;
                     parenthesized!(content in meta.input);
-                    let literal: Token![nullable] = content.parse()?;
+                    let literal: Ident = content.parse()?;
+                    assert_eq!(literal.to_string(), "nullable", "Unrecognized `json` attribute. Valid values are `json` or `json(nullable)`");
                     json = Some(JsonAttribute::Nullable);
                 } else {
                     json = Some(JsonAttribute::NonNullable);
@@ -180,7 +181,7 @@ pub fn parse_child_attributes(input: &[Attribute]) -> syn::Result<SqlxChildAttri
             Ok(())
         })?;
 
-        if json && flatten {
+        if json.is_some() && flatten {
             fail!(
                 attr,
                 "Cannot use `json` and `flatten` together on the same field"

--- a/sqlx-macros-core/src/derives/row.rs
+++ b/sqlx-macros-core/src/derives/row.rs
@@ -6,7 +6,7 @@ use syn::{
 };
 
 use super::{
-    attributes::{parse_child_attributes, parse_container_attributes},
+    attributes::{parse_child_attributes, parse_container_attributes, JsonAttribute},
     rename_all,
 };
 
@@ -99,7 +99,7 @@ fn expand_derive_from_row_struct(
 
             let expr: Expr = match (attributes.flatten, attributes.try_from, attributes.json) {
                 // <No attributes>
-                (false, None, false) => {
+                (false, None, None) => {
                     predicates
                         .push(parse_quote!(#ty: ::sqlx::decode::Decode<#lifetime, R::Database>));
                     predicates.push(parse_quote!(#ty: ::sqlx::types::Type<R::Database>));
@@ -107,12 +107,12 @@ fn expand_derive_from_row_struct(
                     parse_quote!(__row.try_get(#id_s))
                 }
                 // Flatten
-                (true, None, false) => {
+                (true, None, None) => {
                     predicates.push(parse_quote!(#ty: ::sqlx::FromRow<#lifetime, R>));
                     parse_quote!(<#ty as ::sqlx::FromRow<#lifetime, R>>::from_row(__row))
                 }
                 // Flatten + Try from
-                (true, Some(try_from), false) => {
+                (true, Some(try_from), None) => {
                     predicates.push(parse_quote!(#try_from: ::sqlx::FromRow<#lifetime, R>));
                     parse_quote!(
                         <#try_from as ::sqlx::FromRow<#lifetime, R>>::from_row(__row)
@@ -130,11 +130,11 @@ fn expand_derive_from_row_struct(
                     )
                 }
                 // Flatten + Json
-                (true, _, true) => {
+                (true, _, Some(_)) => {
                     panic!("Cannot use both flatten and json")
                 }
                 // Try from
-                (false, Some(try_from), false) => {
+                (false, Some(try_from), None) => {
                     predicates
                         .push(parse_quote!(#try_from: ::sqlx::decode::Decode<#lifetime, R::Database>));
                     predicates.push(parse_quote!(#try_from: ::sqlx::types::Type<R::Database>)); 
@@ -154,8 +154,8 @@ fn expand_derive_from_row_struct(
                             })
                     )
                 }
-                // Try from + Json
-                (false, Some(try_from), true) => {
+                // Try from + Json mandatory
+                (false, Some(try_from), Some(JsonAttribute::Mandatory)) => {
                     predicates
                         .push(parse_quote!(::sqlx::types::Json<#try_from>: ::sqlx::decode::Decode<#lifetime, R::Database>));
                     predicates.push(parse_quote!(::sqlx::types::Json<#try_from>: ::sqlx::types::Type<R::Database>));
@@ -175,13 +175,24 @@ fn expand_derive_from_row_struct(
                             })
                     )
                 },
+                // Try from + Json optional
+                (false, Some(try_from), Some(JsonAttribute::Optional)) => {
+                    panic!("Cannot use both try from and json optional")
+                },
                 // Json
-                (false, None, true) => {
+                (false, None, Some(JsonAttribute::Mandatory)) => {
                     predicates
                         .push(parse_quote!(::sqlx::types::Json<#ty>: ::sqlx::decode::Decode<#lifetime, R::Database>));
                     predicates.push(parse_quote!(::sqlx::types::Json<#ty>: ::sqlx::types::Type<R::Database>));
 
                     parse_quote!(__row.try_get::<::sqlx::types::Json<_>, _>(#id_s).map(|x| x.0))
+                },
+                (false, None, Some(JsonAttribute::Optional)) => {
+                    predicates
+                        .push(parse_quote!(::core::Option<::sqlx::types::Json<#ty>>: ::sqlx::decode::Decode<#lifetime, R::Database>));
+                    predicates.push(parse_quote!(::core::Option<::sqlx::types::Json<#ty>>: ::sqlx::types::Type<R::Database>));
+
+                    parse_quote!(__row.try_get::<::core::Option<::sqlx::types::Json<_>>, _>(#id_s).map(|x| x.map(|y| y.0)))
                 },
             };
 

--- a/sqlx-macros-core/src/derives/row.rs
+++ b/sqlx-macros-core/src/derives/row.rs
@@ -155,7 +155,7 @@ fn expand_derive_from_row_struct(
                     )
                 }
                 // Try from + Json mandatory
-                (false, Some(try_from), Some(JsonAttribute::Mandatory)) => {
+                (false, Some(try_from), Some(JsonAttribute::NonNullable)) => {
                     predicates
                         .push(parse_quote!(::sqlx::types::Json<#try_from>: ::sqlx::decode::Decode<#lifetime, R::Database>));
                     predicates.push(parse_quote!(::sqlx::types::Json<#try_from>: ::sqlx::types::Type<R::Database>));
@@ -175,24 +175,24 @@ fn expand_derive_from_row_struct(
                             })
                     )
                 },
-                // Try from + Json optional
-                (false, Some(try_from), Some(JsonAttribute::Optional)) => {
-                    panic!("Cannot use both try from and json optional")
+                // Try from + Json nullable
+                (false, Some(try_from), Some(JsonAttribute::Nullable)) => {
+                    panic!("Cannot use both try from and json nullable")
                 },
                 // Json
-                (false, None, Some(JsonAttribute::Mandatory)) => {
+                (false, None, Some(JsonAttribute::NonNullable)) => {
                     predicates
                         .push(parse_quote!(::sqlx::types::Json<#ty>: ::sqlx::decode::Decode<#lifetime, R::Database>));
                     predicates.push(parse_quote!(::sqlx::types::Json<#ty>: ::sqlx::types::Type<R::Database>));
 
                     parse_quote!(__row.try_get::<::sqlx::types::Json<_>, _>(#id_s).map(|x| x.0))
                 },
-                (false, None, Some(JsonAttribute::Optional)) => {
+                (false, None, Some(JsonAttribute::Nullable)) => {
                     predicates
                         .push(parse_quote!(::core::Option<::sqlx::types::Json<#ty>>: ::sqlx::decode::Decode<#lifetime, R::Database>));
                     predicates.push(parse_quote!(::core::Option<::sqlx::types::Json<#ty>>: ::sqlx::types::Type<R::Database>));
 
-                    parse_quote!(__row.try_get::<::core::Option<::sqlx::types::Json<_>>, _>(#id_s).map(|x| x.map(|y| y.0)))
+                    parse_quote!(__row.try_get::<::core::Option<::sqlx::types::Json<_>>, _>(#id_s).map(|x| x.flatten().map(|y| y.0)))
                 },
             };
 

--- a/sqlx-macros-core/src/derives/row.rs
+++ b/sqlx-macros-core/src/derives/row.rs
@@ -176,7 +176,7 @@ fn expand_derive_from_row_struct(
                     )
                 },
                 // Try from + Json nullable
-                (false, Some(try_from), Some(JsonAttribute::Nullable)) => {
+                (false, Some(_), Some(JsonAttribute::Nullable)) => {
                     panic!("Cannot use both try from and json nullable")
                 },
                 // Json

--- a/sqlx-macros-core/src/derives/row.rs
+++ b/sqlx-macros-core/src/derives/row.rs
@@ -189,10 +189,10 @@ fn expand_derive_from_row_struct(
                 },
                 (false, None, Some(JsonAttribute::Nullable)) => {
                     predicates
-                        .push(parse_quote!(::core::Option<::sqlx::types::Json<#ty>>: ::sqlx::decode::Decode<#lifetime, R::Database>));
-                    predicates.push(parse_quote!(::core::Option<::sqlx::types::Json<#ty>>: ::sqlx::types::Type<R::Database>));
+                        .push(parse_quote!(::core::option::Option<::sqlx::types::Json<#ty>>: ::sqlx::decode::Decode<#lifetime, R::Database>));
+                    predicates.push(parse_quote!(::core::option::Option<::sqlx::types::Json<#ty>>: ::sqlx::types::Type<R::Database>));
 
-                    parse_quote!(__row.try_get::<::core::Option<::sqlx::types::Json<_>>, _>(#id_s).map(|x| x.flatten().map(|y| y.0)))
+                    parse_quote!(__row.try_get::<::core::option::Option<::sqlx::types::Json<_>>, _>(#id_s).map(|x| x.and_then(|y| y.0)))
                 },
             };
 

--- a/tests/mysql/macros.rs
+++ b/tests/mysql/macros.rs
@@ -497,6 +497,7 @@ async fn test_from_row_json_attr() -> anyhow::Result<()> {
 #[sqlx_macros::test]
 async fn test_from_row_json_attr_nullable() -> anyhow::Result<()> {
     #[derive(serde::Deserialize)]
+    #[allow(dead_code)]
     struct J {
         a: u32,
         b: u32,

--- a/tests/mysql/macros.rs
+++ b/tests/mysql/macros.rs
@@ -495,6 +495,30 @@ async fn test_from_row_json_attr() -> anyhow::Result<()> {
 }
 
 #[sqlx_macros::test]
+async fn test_from_row_json_attr_nullable() -> anyhow::Result<()> {
+    #[derive(serde::Deserialize)]
+    struct J {
+        a: u32,
+        b: u32,
+    }
+
+    #[derive(sqlx::FromRow)]
+    struct Record {
+        #[sqlx(json(nullable))]
+        j: Option<J>,
+    }
+
+    let mut conn = new::<MySql>().await?;
+
+    let record = sqlx::query_as::<_, Record>("select null as j")
+        .fetch_one(&mut conn)
+        .await?;
+
+    assert_eq!(record.j, None);
+    Ok(())
+}
+
+#[sqlx_macros::test]
 async fn test_from_row_json_try_from_attr() -> anyhow::Result<()> {
     #[derive(serde::Deserialize)]
     struct J {

--- a/tests/mysql/macros.rs
+++ b/tests/mysql/macros.rs
@@ -510,11 +510,11 @@ async fn test_from_row_json_attr_nullable() -> anyhow::Result<()> {
 
     let mut conn = new::<MySql>().await?;
 
-    let record = sqlx::query_as::<_, Record>("select null as j")
+    let record = sqlx::query_as::<_, Record>("select NULL as j")
         .fetch_one(&mut conn)
         .await?;
 
-    assert_eq!(record.j, None);
+    assert!(record.j.is_none());
     Ok(())
 }
 


### PR DESCRIPTION
### Does your PR solve an issue?

fixes #2849

This MR introduces a `#[sqlx(json(nullable))]` attribute which allows for the correct behaviour on

```rust
#[derive(Serialize, Deserialize)]
enum Foo {
  Bar,
  Baz
}

struct Test {
  #[sqlx(json(nullable))]
  hello: Option<Foo>
}
```

by allowing the underlying row value to be null
