### PR TITLE
fix: handle nullable values by printing NULL instead of panicking

### DIFF
--- a/sqlx-core/src/type_checking.rs
+++ b/sqlx-core/src/type_checking.rs
@@ -72,11 +72,17 @@ where
 
                 match T::decode(value.as_ref()) {
                     Ok(value) => Debug::fmt(&value, f),
-                    Err(e) => f.write_fmt(format_args!(
-                        "(error decoding SQL type {} as {}: {e:?})",
-                        info.name(),
-                        std::any::type_name::<T>()
-                    )),
+                    Err(e) => {
+                        if e.is::<crate::error::UnexpectedNullError>() {
+                            f.write_str("NULL")
+                        } else {
+                            f.write_fmt(format_args!(
+                                "(error decoding SQL type {} as {}: {e:?})",
+                                info.name(),
+                                std::any::type_name::<T>()
+                            ))
+                        }
+                    }
                 }
             },
         }


### PR DESCRIPTION
fixes #3683

Prints `NULL` in the debug impl for `Row` when an `UnexpectedNullError` is encountered.
A query like
 ```sql
 SELECT NULL::TEXT, 'test'
```
Prints
`Row {text: NULL, ?column?: "test"}`