### PR TITLE
fix(Sqlite): stop sending rows after first error

### DIFF
--- a/sqlx-sqlite/src/connection/worker.rs
+++ b/sqlx-sqlite/src/connection/worker.rs
@@ -151,7 +151,8 @@ impl ConnectionWorker {
                             match limit {
                                 None => {
                                     for res in iter {
-                                        if tx.send(res).is_err() {
+                                        let has_error = res.is_err();
+                                        if tx.send(res).is_err() || has_error {
                                             break;
                                         }
                                     }
@@ -171,7 +172,8 @@ impl ConnectionWorker {
                                                 }
                                             }
                                         }
-                                        if tx.send(res).is_err() {
+                                        let has_error = res.is_err();
+                                        if tx.send(res).is_err() || has_error {
                                             break;
                                         }
                                     }


### PR DESCRIPTION
Unfortunately this fix could not be one line because the order of the expressions matter.

Fixes #3662
