### PR TITLE
fix(postgres) use signed int for length prefix in `PgCopyIn`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3563,7 +3563,7 @@ version = "0.8.3"
 dependencies = [
  "async-io 1.13.0",
  "async-std",
- "base64 0.22.0",
+ "base64 0.22.1",
  "bigdecimal",
  "bit-vec",
  "bstr",

--- a/sqlx-postgres/src/copy.rs
+++ b/sqlx-postgres/src/copy.rs
@@ -230,10 +230,10 @@ impl<C: DerefMut<Target = PgConnection>> PgCopyIn<C> {
             }
 
             // Write the length
-            let read32 = u32::try_from(read)
-                .map_err(|_| err_protocol!("number of bytes read exceeds 2^32: {}", read))?;
+            let read32 = i32::try_from(read)
+                .map_err(|_| err_protocol!("number of bytes read exceeds 2^31 - 1: {}", read))?;
 
-            (&mut buf.get_mut()[1..]).put_u32(read32 + 4);
+            (&mut buf.get_mut()[1..]).put_i32(read32 + 4);
 
             conn.inner.stream.flush().await?;
         }


### PR DESCRIPTION
While looking into #3696 I noticed that `CopyData` uses an `i32` to represent the length prefix. However, the `AsyncRead` impl uses an `u32`. https://github.com/launchbadge/sqlx/blob/a83395a360296db1251e6e4138b6e6331912c3d4/sqlx-postgres/src/copy.rs#L233