### PR TITLE
fix(Postgres) chunk pg_copy data

### DIFF
--- a/sqlx-postgres/src/copy.rs
+++ b/sqlx-postgres/src/copy.rs
@@ -129,6 +129,9 @@ impl PgPoolCopyExt for Pool<Postgres> {
     }
 }
 
+// (1 GiB - 1) - 1 - length prefix (4 bytes)
+pub const PG_COPY_MAX_DATA_LEN: usize = 0x3fffffff - 1 - 4;
+
 /// A connection in streaming `COPY FROM STDIN` mode.
 ///
 /// Created by [PgConnection::copy_in_raw] or [Pool::copy_out_raw].
@@ -186,11 +189,11 @@ impl<C: DerefMut<Target = PgConnection>> PgCopyIn<C> {
 
     /// Send a chunk of `COPY` data.
     ///
+    /// The data is sent in chunks if it exceeds the maximum length of a `CopyData` message (1 GiB - 6
+    /// bytes) and may be partially sent if this call is cancelled.
+    ///
     /// If you're copying data from an `AsyncRead`, maybe consider [Self::read_from] instead.
     pub async fn send(&mut self, data: impl Deref<Target = [u8]>) -> Result<&mut Self> {
-        // (1 GiB - 1) - command byte (1 byte) - length prefix (4 bytes)
-        const PG_COPY_MAX_DATA_LEN: usize = 1_073_741_824 - 1 - 1 - 4;
-
         for chunk in data.deref().chunks(PG_COPY_MAX_DATA_LEN) {
             self.conn
                 .as_deref_mut()

--- a/sqlx-postgres/src/lib.rs
+++ b/sqlx-postgres/src/lib.rs
@@ -34,6 +34,9 @@ mod value;
 #[doc(hidden)]
 pub mod any;
 
+#[doc(hidden)]
+pub use copy::PG_COPY_MAX_DATA_LEN;
+
 #[cfg(feature = "migrate")]
 mod migrate;
 

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -2042,3 +2042,26 @@ async fn test_issue_3052() {
         "expected encode error, got {too_large_error:?}",
     );
 }
+
+#[sqlx_macros::test]
+async fn test_pg_copy_chunked() -> anyhow::Result<()> {
+    let mut conn = new::<Postgres>().await?;
+
+    // (1 GiB - 1) - command byte (1 byte) - length prefix (4 bytes)
+    const COPY_MAX_DATA_LEN: usize = 1_073_741_824 - 1 - 1 - 4;
+
+    let mut row = "1".repeat(COPY_MAX_DATA_LEN / 10 - 1);
+    row.push_str("\n");
+
+    // creates a payload with COPY_MAX_DATA_LEN + 1 as size
+    let mut payload = row.repeat(10);
+    payload.push_str("12345678\n");
+
+    assert_eq!(payload.len(), COPY_MAX_DATA_LEN + 1);
+
+    let mut copy = conn.copy_in_raw("COPY products(name) FROM STDIN").await?;
+
+    assert!(copy.send(payload.as_bytes()).await.is_ok());
+    assert!(copy.finish().await.is_ok());
+    Ok(())
+}


### PR DESCRIPTION
Sends the data of `PgCopyIn` in chunks of `((1 GiB - 1) - 1) - 4`.

As for #3701, it looks like the data length will only be `8192` or smaller because that's the capacity of the `Vec<u8>` in `WriteBuffer` so no need to change anything there.

Fixes #3696