### PR TITLE
chore: expose bstr feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ _unstable-all-types = [
     "mac_address",
     "uuid",
     "bit-vec",
+    "bstr"
 ]
 
 # Base runtime features without TLS
@@ -122,6 +123,7 @@ rust_decimal = ["sqlx-core/rust_decimal", "sqlx-macros?/rust_decimal", "sqlx-mys
 time = ["sqlx-core/time", "sqlx-macros?/time", "sqlx-mysql?/time", "sqlx-postgres?/time", "sqlx-sqlite?/time"]
 uuid = ["sqlx-core/uuid", "sqlx-macros?/uuid", "sqlx-mysql?/uuid", "sqlx-postgres?/uuid", "sqlx-sqlite?/uuid"]
 regexp = ["sqlx-sqlite?/regexp"]
+bstr = ["sqlx-core/bstr"]
 
 [workspace.dependencies]
 # Core Crates

--- a/sqlx-core/src/types/mod.rs
+++ b/sqlx-core/src/types/mod.rs
@@ -85,6 +85,9 @@ pub mod mac_address {
 pub use json::{Json, JsonRawValue, JsonValue};
 pub use text::Text;
 
+#[cfg(feature = "bstr")]
+pub use bstr::{BStr, BString};
+
 /// Indicates that a SQL type is supported for a database.
 ///
 /// ## Compile-time verification


### PR DESCRIPTION
This was removed in #2039, so I'm not sure if the feature should be removed completely or was forgotten about. This pr exposes the feature so it can be used, if it should be removed I'll update this pr.

Fixes #3702