### PR TITLE
feat(sqlx-cli): Add flag to disable automatic loading of .env files

### DIFF
--- a/sqlx-cli/src/bin/cargo-sqlx.rs
+++ b/sqlx-cli/src/bin/cargo-sqlx.rs
@@ -13,8 +13,11 @@ enum Cli {
 
 #[tokio::main]
 async fn main() {
-    dotenvy::dotenv().ok();
     let Cli::Sqlx(opt) = Cli::parse();
+
+    if !opt.no_dotenv {
+        dotenvy::dotenv().ok();
+    }
 
     if let Err(error) = sqlx_cli::run(opt).await {
         println!("{} {}", style("error:").bold().red(), error);

--- a/sqlx-cli/src/bin/sqlx.rs
+++ b/sqlx-cli/src/bin/sqlx.rs
@@ -4,9 +4,14 @@ use sqlx_cli::Opt;
 
 #[tokio::main]
 async fn main() {
-    dotenvy::dotenv().ok();
+    let opt = Opt::parse();
+
+    if !opt.no_dotenv {
+        dotenvy::dotenv().ok();
+    }
+
     // no special handling here
-    if let Err(error) = sqlx_cli::run(Opt::parse()).await {
+    if let Err(error) = sqlx_cli::run(opt).await {
         println!("{} {}", style("error:").bold().red(), error);
         std::process::exit(1);
     }

--- a/sqlx-cli/src/opt.rs
+++ b/sqlx-cli/src/opt.rs
@@ -7,6 +7,10 @@ use clap_complete::Shell;
 #[derive(Parser, Debug)]
 #[clap(version, about, author)]
 pub struct Opt {
+    /// Do not automatically load `.env` files.
+    #[clap(long, default_value = "false")]
+    pub no_dotenv: bool,
+
     #[clap(subcommand)]
     pub command: Command,
 }

--- a/sqlx-cli/src/opt.rs
+++ b/sqlx-cli/src/opt.rs
@@ -8,7 +8,7 @@ use clap_complete::Shell;
 #[clap(version, about, author)]
 pub struct Opt {
     /// Do not automatically load `.env` files.
-    #[clap(long, default_value = "false")]
+    #[clap(long)]
     pub no_dotenv: bool,
 
     #[clap(subcommand)]


### PR DESCRIPTION
### Does your PR solve an issue?

https://github.com/launchbadge/sqlx/issues/3722

Automatic loading of `.env` files can be dangerous (and destructive).  It is possible to run an sqlx database command against a database that you did not expect just by virtue of there being a hidden `.env` file in the directory from which you ran the command.

This PR adds a top-level switch to the `sqlx` CLI `--no-dotenv` which will disable the automatic loading of `.env` files.  This makes it safer to use in scripts and allows developers to make loading `.env` files explicit if they want.