### PR TITLE
chore: replace rustls-pemfile with rustls-pki-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3144,15 +3144,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3591,7 +3582,7 @@ dependencies = [
  "rust_decimal",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "sha2",

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -25,7 +25,7 @@ _tls-native-tls = ["native-tls"]
 _tls-rustls-aws-lc-rs = ["_tls-rustls", "rustls/aws-lc-rs", "webpki-roots"]
 _tls-rustls-ring-webpki = ["_tls-rustls", "rustls/ring", "webpki-roots"]
 _tls-rustls-ring-native-roots = ["_tls-rustls", "rustls/ring", "rustls-native-certs"]
-_tls-rustls = ["rustls", "rustls-pemfile"]
+_tls-rustls = ["rustls"]
 _tls-none = []
 
 # support offline/decoupled building (enables serialization of `Describe`)
@@ -39,8 +39,7 @@ tokio = { workspace = true, optional = true }
 # TLS
 native-tls = { version = "0.2.10", optional = true }
 
-rustls = { version = "0.23.11", default-features = false, features = ["std", "tls12"], optional = true }
-rustls-pemfile = { version = "2", optional = true }
+rustls = { version = "0.23.15", default-features = false, features = ["std", "tls12"], optional = true }
 webpki-roots = { version = "0.26", optional = true }
 rustls-native-certs = { version = "0.8.0", optional = true }
 


### PR DESCRIPTION
Replaces rustls-pemfile crate with rustls-pki-types api.