### PR TITLE
QueryBuilder: add debug_assert when `push_values` is passed an empty set of tuples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3582,7 +3582,6 @@ dependencies = [
  "rust_decimal",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "sha2",

--- a/sqlx-core/src/query_builder.rs
+++ b/sqlx-core/src/query_builder.rs
@@ -314,13 +314,23 @@ where
 
         let mut separated = self.separated(", ");
 
+        let mut empty_checker = false;
+
         for tuple in tuples {
+            if !empty_checker {
+                empty_checker = true;
+            }
+
             separated.push("(");
 
             // use a `Separated` with a separate (hah) internal state
             push_tuple(separated.query_builder.separated(", "), tuple);
 
             separated.push_unseparated(")");
+        }
+
+        if empty_checker {
+            tracing::warn!("Pushing empty values, QueryBuilder may not build correct sql query!");
         }
 
         separated.query_builder

--- a/sqlx-core/src/query_builder.rs
+++ b/sqlx-core/src/query_builder.rs
@@ -314,13 +314,7 @@ where
 
         let mut separated = self.separated(", ");
 
-        let mut empty_checker = false;
-
         for tuple in tuples {
-            if !empty_checker {
-                empty_checker = true;
-            }
-
             separated.push("(");
 
             // use a `Separated` with a separate (hah) internal state
@@ -329,9 +323,10 @@ where
             separated.push_unseparated(")");
         }
 
-        if empty_checker {
-            tracing::warn!("Pushing empty values, QueryBuilder may not build correct sql query!");
-        }
+        debug_assert!(
+            separated.push_separator,
+            "No value being pushed. QueryBuilder may not build correct sql query!"
+        );
 
         separated.query_builder
     }


### PR DESCRIPTION
### Does your PR solve an issue?
Yes

fixes #3733