### PR TITLE
docs: add some missing backticks

### DIFF
--- a/sqlx-mysql/src/testing/mod.rs
+++ b/sqlx-mysql/src/testing/mod.rs
@@ -30,7 +30,7 @@ impl TestSupport for MySql {
         Box::pin(async move {
             let mut conn = MASTER_POOL
                 .get()
-                .expect("cleanup_test() invoked outside `#[sqlx::test]")
+                .expect("cleanup_test() invoked outside `#[sqlx::test]`")
                 .acquire()
                 .await?;
 

--- a/sqlx-postgres/src/testing/mod.rs
+++ b/sqlx-postgres/src/testing/mod.rs
@@ -30,7 +30,7 @@ impl TestSupport for Postgres {
         Box::pin(async move {
             let mut conn = MASTER_POOL
                 .get()
-                .expect("cleanup_test() invoked outside `#[sqlx::test]")
+                .expect("cleanup_test() invoked outside `#[sqlx::test]`")
                 .acquire()
                 .await?;
 

--- a/sqlx-postgres/src/types/cube.rs
+++ b/sqlx-postgres/src/types/cube.rs
@@ -20,7 +20,7 @@ const IS_POINT_FLAG: u32 = 1 << 31;
 #[derive(Debug, Clone, PartialEq)]
 pub enum PgCube {
     /// A one-dimensional point.
-    // FIXME: `Point1D(f64)
+    // FIXME: `Point1D(f64)`
     Point(f64),
     /// An N-dimensional point ("represented internally as a zero-volume cube").
     // FIXME: `PointND(f64)`
@@ -32,7 +32,7 @@ pub enum PgCube {
 
     // FIXME: add `Cube3D { lower_left: [f64; 3], upper_right: [f64; 3] }`?
     /// An N-dimensional cube with points representing lower-left and upper-right corners, respectively.
-    // FIXME: CubeND { lower_left: Vec<f64>, upper_right: Vec<f64> }`
+    // FIXME: `CubeND { lower_left: Vec<f64>, upper_right: Vec<f64> }`
     MultiDimension(Vec<Vec<f64>>),
 }
 

--- a/sqlx-postgres/src/types/mod.rs
+++ b/sqlx-postgres/src/types/mod.rs
@@ -21,10 +21,10 @@
 //! | [`PgLQuery`]                          | LQUERY                                               |
 //! | [`PgCiText`]                          | CITEXT<sup>1</sup>                                   |
 //! | [`PgCube`]                            | CUBE                                                 |
-//! | [`PgPoint]                            | POINT                                                |
-//! | [`PgLine]                             | LINE                                                 |
-//! | [`PgLSeg]                             | LSEG                                                 |
-//! | [`PgBox]                              | BOX                                                  |
+//! | [`PgPoint`]                            | POINT                                                |
+//! | [`PgLine`]                             | LINE                                                 |
+//! | [`PgLSeg`]                             | LSEG                                                 |
+//! | [`PgBox`]                              | BOX                                                  |
 //! | [`PgHstore`]                          | HSTORE                                               |
 //!
 //! <sup>1</sup> SQLx generally considers `CITEXT` to be compatible with `String`, `&str`, etc.,

--- a/sqlx-postgres/src/types/mod.rs
+++ b/sqlx-postgres/src/types/mod.rs
@@ -21,10 +21,10 @@
 //! | [`PgLQuery`]                          | LQUERY                                               |
 //! | [`PgCiText`]                          | CITEXT<sup>1</sup>                                   |
 //! | [`PgCube`]                            | CUBE                                                 |
-//! | [`PgPoint`]                            | POINT                                                |
-//! | [`PgLine`]                             | LINE                                                 |
-//! | [`PgLSeg`]                             | LSEG                                                 |
-//! | [`PgBox`]                              | BOX                                                  |
+//! | [`PgPoint`]                           | POINT                                                |
+//! | [`PgLine`]                            | LINE                                                 |
+//! | [`PgLSeg`]                            | LSEG                                                 |
+//! | [`PgBox`]                             | BOX                                                  |
 //! | [`PgHstore`]                          | HSTORE                                               |
 //!
 //! <sup>1</sup> SQLx generally considers `CITEXT` to be compatible with `String`, `&str`, etc.,


### PR DESCRIPTION
very minor but noticed some backticks were not properly delimited in the docs for `sqlx_postgres`, so this fixes that formatting.

running ``rg -P '^[^`]*\`[\`]*$'`` found a few more places that should likely have delimiting backticks, so fixed up those as well. 