### PR TITLE
Avoid privilege requirements by using an advisory lock in test setup (postgres).

### DIFF
--- a/sqlx-postgres/src/testing/mod.rs
+++ b/sqlx-postgres/src/testing/mod.rs
@@ -134,9 +134,9 @@ async fn test_context(args: &TestArgs) -> Result<TestContext<Postgres>, Error> {
         // I couldn't find a bug on the mailing list for `CREATE SCHEMA` specifically,
         // but a clearly related bug with `CREATE TABLE` has been known since 2007:
         // https://www.postgresql.org/message-id/200710222037.l9MKbCJZ098744%40wwwmaster.postgresql.org
-        // magic constant 0x73716c7874657374 is just 8 ascii bytes 'sqlxtest'.
+        // magic constant 8318549251334697844 is just 8 ascii bytes 'sqlxtest'.
         r#"
-        select pg_advisory_xact_lock(0x73716c7874657374);
+        select pg_advisory_xact_lock(8318549251334697844);
 
         create schema if not exists _sqlx_test;
 

--- a/sqlx-postgres/src/testing/mod.rs
+++ b/sqlx-postgres/src/testing/mod.rs
@@ -134,8 +134,9 @@ async fn test_context(args: &TestArgs) -> Result<TestContext<Postgres>, Error> {
         // I couldn't find a bug on the mailing list for `CREATE SCHEMA` specifically,
         // but a clearly related bug with `CREATE TABLE` has been known since 2007:
         // https://www.postgresql.org/message-id/200710222037.l9MKbCJZ098744%40wwwmaster.postgresql.org
+        // magic constant 0x73716c7874657374 is just 8 ascii bytes 'sqlxtest'.
         r#"
-        lock table pg_catalog.pg_namespace in share row exclusive mode;
+        select pg_advisory_xact_lock(0x73716c7874657374);
 
         create schema if not exists _sqlx_test;
 


### PR DESCRIPTION
We use serverless Postgres provider [Neon](https://neon.tech/home), which limits the privileges available for security reasons. This means that locking `pg_namespace` as is currently done isn't possible, and so it is impossible to use `sqlx::test` with Neon (likely other providers are similar).

Fortunately, this lock exists to avoid a race condition when setting up the test environment, and it can be replaced with an advisory lock. This is also suggested by [a more recent StackOverflow answer to the referenced question](https://stackoverflow.com/a/75698561).

The downside of this approach is that other code (including older sqlx versions) will not honor the lock when trying to make `_sqlx_test` objects. This seems unlikely, and is both data-safe and ephemeral when it happens (it just results in an error).

This PR accepts that tradeoff and implements the advisory lock approach. I have confirmed that it allows `sqlx::test` to be used with Neon.
