### PR TITLE
docs(pool): recommend actix-web ThinData over Data to avoid two Arcs

### DIFF
--- a/sqlx-core/src/pool/mod.rs
+++ b/sqlx-core/src/pool/mod.rs
@@ -109,7 +109,8 @@ mod options;
 /// application/daemon/web server/etc. and then shared with all tasks throughout the process'
 /// lifetime. How best to accomplish this depends on your program architecture.
 ///
-/// In Actix-Web, for example, you can share a single pool with all request handlers using [web::Data].
+/// In Actix-Web, for example, you can efficiently share a single pool with all request handlers
+/// using [web::ThinData].
 ///
 /// Cloning `Pool` is cheap as it is simply a reference-counted handle to the inner pool state.
 /// When the last remaining handle to the pool is dropped, the connections owned by the pool are
@@ -131,7 +132,7 @@ mod options;
 /// * [PgPool][crate::postgres::PgPool] (PostgreSQL)
 /// * [SqlitePool][crate::sqlite::SqlitePool] (SQLite)
 ///
-/// [web::Data]: https://docs.rs/actix-web/3/actix_web/web/struct.Data.html
+/// [web::ThinData]: https://docs.rs/actix-web/4.9.0/actix_web/web/struct.ThinData.html
 ///
 /// ### Note: Drop Behavior
 /// Due to a lack of async `Drop`, dropping the last `Pool` handle may not immediately clean


### PR DESCRIPTION
Both actix_web::web::Data and sqlx::PgPool internally wrap an Arc. Thus, using Data<PgPool> as an extractor in an actix-web route handler results in two Arcs wrapping the data of interest, which isn't ideal.

Actix-web 4.9.0 introduced a new web::ThinData extractor for cases like this, where the data is already wrapped in an `Arc` (or is otherwise similarly cheap and sensible to simply clone), which doesn't wrap the inner value in a (second) Arc.

Since the new extractor is better suited to the task, suggest it in place of web::Data when giving an example on how to share a pool.

### Does your PR solve an (open) issue?
No.

### Is this a breaking change?
No.