### PR TITLE
fix(ci): breakage from Rustup 1.28

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -14,20 +14,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use latest Rust
-        run: rustup override set stable
+      - name: Setup Rust
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup override set stable
 
       - uses: Swatinem/rust-cache@v2
-        with:
-          key: sqlx-cli
 
       - run: >
-            cargo build
-            -p sqlx-cli
-            --bin sqlx
-            --release
-            --no-default-features
-            --features mysql,postgres,sqlite
+          cargo build
+          -p sqlx-cli
+          --bin sqlx
+          --release
+          --no-default-features
+          --features mysql,postgres,sqlite
 
       - uses: actions/upload-artifact@v4
         with:
@@ -63,9 +63,10 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Setup Rust
+        run: rustup show active-toolchain || rustup toolchain install
+
       - uses: Swatinem/rust-cache@v2
-        with:
-          key: mysql-examples
 
       - name: Todos (Setup)
         working-directory: examples/mysql/todos
@@ -98,7 +99,7 @@ jobs:
           name: sqlx-cli
           path: /home/runner/.local/bin
 
-      - run:  |
+      - run: |
           ls -R /home/runner/.local/bin
           chmod +x $HOME/.local/bin/sqlx
           echo $HOME/.local/bin >> $GITHUB_PATH
@@ -106,9 +107,8 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: pg-examples
+      - name: Setup Rust
+        run: rustup show active-toolchain || rustup toolchain install
 
       - name: Axum Social with Tests (Setup)
         working-directory: examples/postgres/axum-social-with-tests
@@ -217,9 +217,10 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Setup Rust
+        run: rustup show active-toolchain || rustup toolchain install
+
       - uses: Swatinem/rust-cache@v2
-        with:
-          key: sqlite-examples
 
       - name: TODOs (Setup)
         env:

--- a/.github/workflows/sqlx-cli.yml
+++ b/.github/workflows/sqlx-cli.yml
@@ -15,8 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - run: |
-          rustup update
+      - name: Setup Rust
+        run: |
+          rustup show active-toolchain || rustup toolchain install
           rustup component add clippy
           rustup toolchain install beta
           rustup component add --toolchain beta clippy
@@ -40,18 +41,19 @@ jobs:
       matrix:
         # Note: macOS-latest uses M1 Silicon (ARM64)
         os:
-         - ubuntu-latest
-         # FIXME: migrations tests fail on Windows for whatever reason
-         # - windows-latest
-         - macOS-13
-         - macOS-latest
+          - ubuntu-latest
+          # FIXME: migrations tests fail on Windows for whatever reason
+          # - windows-latest
+          - macOS-13
+          - macOS-latest
 
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Rust
+        run: rustup show active-toolchain || rustup toolchain install
+
       - uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ runner.os }}-test
 
       - run: cargo test --manifest-path sqlx-cli/Cargo.toml
 
@@ -85,12 +87,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use latest Rust
-        run: rustup override set stable
+      - name: Setup Rust
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup override set stable
 
       - uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ runner.os }}-cli
 
       - run: cargo build --manifest-path sqlx-cli/Cargo.toml --bin cargo-sqlx ${{ matrix.args }}
 

--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   format:
     name: Format
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - run: rustup component add rustfmt
@@ -18,7 +18,7 @@ jobs:
 
   check:
     name: Check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         runtime: [ async-std, tokio ]
@@ -53,7 +53,7 @@ jobs:
 
   check-minimal-versions:
     name: Check build using minimal versions
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust
@@ -65,7 +65,7 @@ jobs:
 
   test:
     name: Unit Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -115,7 +115,7 @@ jobs:
 
   sqlite:
     name: SQLite
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         runtime: [ async-std, tokio ]
@@ -183,7 +183,7 @@ jobs:
 
   postgres:
     name: Postgres
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         postgres: [ 17, 13 ]
@@ -284,7 +284,7 @@ jobs:
 
   mysql:
     name: MySQL
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         mysql: [ 8 ]
@@ -373,7 +373,7 @@ jobs:
 
   mariadb:
     name: MariaDB
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         mariadb: [ verylatest, 11_4, 10_11, 10_4 ]

--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -21,20 +21,21 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        runtime: [async-std, tokio]
-        tls: [native-tls, rustls, none]
+        runtime: [ async-std, tokio ]
+        tls: [ native-tls, rustls, none ]
     steps:
       - uses: actions/checkout@v4
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: "${{ runner.os }}-check-${{ matrix.runtime }}-${{ matrix.tls }}"
-
-      - run: |
-          rustup update
+      # Swatinem/rust-cache recommends setting up the rust toolchain first because it's used in cache keys
+      - name: Setup Rust
+        # https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html
+        run: |
+          rustup show active-toolchain || rustup toolchain install
           rustup component add clippy
           rustup toolchain install beta
           rustup component add --toolchain beta clippy
+
+      - uses: Swatinem/rust-cache@v2
 
       - run: >
           cargo clippy
@@ -55,8 +56,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - run: rustup update
-      - run: rustup toolchain install nightly
+      - name: Setup Rust
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup toolchain install nightly
       - run: cargo +nightly generate-lockfile -Z minimal-versions
       - run: cargo build --all-features
 
@@ -66,12 +69,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ runner.os }}-test
+      # https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html
+      - name: Setup Rust
+        run: rustup show active-toolchain || rustup toolchain install
 
-      - name: Install Rust
-        run: rustup update
+      - uses: Swatinem/rust-cache@v2
 
       - name: Test sqlx-core
         run: >
@@ -116,17 +118,19 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        runtime: [async-std, tokio]
-        linking: [sqlite, sqlite-unbundled]
+        runtime: [ async-std, tokio ]
+        linking: [ sqlite, sqlite-unbundled ]
     needs: check
     steps:
       - uses: actions/checkout@v4
 
       - run: mkdir /tmp/sqlite3-lib && wget -O /tmp/sqlite3-lib/ipaddr.so https://github.com/nalgeon/sqlean/releases/download/0.15.2/ipaddr.so
 
+      # https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html
+      - name: Setup Rust
+        run: rustup show active-toolchain || rustup toolchain install
+
       - uses: Swatinem/rust-cache@v2
-        with:
-          key: "${{ runner.os }}-${{ matrix.linking }}-${{ matrix.runtime }}-${{ matrix.tls }}"
 
       - name: Install system sqlite library
         if: ${{ matrix.linking == 'sqlite-unbundled' }}
@@ -182,16 +186,17 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        postgres: [17, 13]
-        runtime: [async-std, tokio]
-        tls: [native-tls, rustls-aws-lc-rs, rustls-ring, none]
+        postgres: [ 17, 13 ]
+        runtime: [ async-std, tokio ]
+        tls: [ native-tls, rustls-aws-lc-rs, rustls-ring, none ]
     needs: check
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Rust
+        run: rustup show active-toolchain || rustup toolchain install
+
       - uses: Swatinem/rust-cache@v2
-        with:
-          key: "${{ runner.os }}-postgres-${{ matrix.runtime }}-${{ matrix.tls }}"
 
       - env:
           # FIXME: needed to disable `ltree` tests in Postgres 9.6
@@ -282,16 +287,17 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        mysql: [8]
-        runtime: [async-std, tokio]
-        tls: [native-tls, rustls-aws-lc-rs, rustls-ring, none]
+        mysql: [ 8 ]
+        runtime: [ async-std, tokio ]
+        tls: [ native-tls, rustls-aws-lc-rs, rustls-ring, none ]
     needs: check
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Rust
+        run: rustup show active-toolchain || rustup toolchain install
+
       - uses: Swatinem/rust-cache@v2
-        with:
-          key: "${{ runner.os }}-mysql-${{ matrix.runtime }}-${{ matrix.tls }}"
 
       - run: cargo build --features mysql,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }}
 
@@ -370,16 +376,17 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        mariadb: [verylatest, 11_4, 10_11, 10_4]
-        runtime: [async-std, tokio]
-        tls: [native-tls, rustls-aws-lc-rs, rustls-ring, none]
+        mariadb: [ verylatest, 11_4, 10_11, 10_4 ]
+        runtime: [ async-std, tokio ]
+        tls: [ native-tls, rustls-aws-lc-rs, rustls-ring, none ]
     needs: check
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Rust
+        run: rustup show active-toolchain || rustup toolchain install
+
       - uses: Swatinem/rust-cache@v2
-        with:
-          key: "${{ runner.os }}-mysql-${{ matrix.runtime }}-${{ matrix.tls }}"
 
       - run: cargo build --features mysql,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }}
 


### PR DESCRIPTION
* Fix breakage from Rustup 1.28 <https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html>
* Let `Swatinem/rust-cache` generate cache keys
* Upgrade Ubuntu jobs to 24.04