### PR TITLE
Proof of concept for `query_tuple!`, similar to `query!` but returns a tuple instead of an anonymous record

### DIFF
--- a/sqlx-macros-core/src/query/mod.rs
+++ b/sqlx-macros-core/src/query/mod.rs
@@ -200,7 +200,7 @@ pub fn expand_input<'a>(
             database_url_parsed,
             ..
         } => Err(format!(
-            "no database driver found matching URL scheme {:?}; the corresponding Cargo feature may need to be enabled", 
+            "no database driver found matching URL scheme {:?}; the corresponding Cargo feature may need to be enabled",
             database_url_parsed.scheme()
         ).into()),
         QueryDataSource::Cached(data) => {
@@ -315,6 +315,11 @@ where
                 ));
 
                 record_tokens
+            }
+            RecordType::Tuple => {
+                let columns = output::columns_to_rust::<DB>(&data.describe)?;
+
+                output::quote_query_tuple::<DB>(&input, &query_args, &columns)
             }
             RecordType::Given(ref out_ty) => {
                 let columns = output::columns_to_rust::<DB>(&data.describe)?;

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -48,7 +48,7 @@
 /// | At Least One   | `.fetch(...)`               | `impl Stream<Item = sqlx::Result<{adhoc struct}>>`  | Call `.try_next().await` to get each row result. |
 /// | Multiple   | `.fetch_all(...)`               | `sqlx::Result<Vec<{adhoc struct}>>`  | |
 ///
-/// \* All methods accept one of `&mut {connection type}`, `&mut Transaction` or `&Pool`.  
+/// \* All methods accept one of `&mut {connection type}`, `&mut Transaction` or `&Pool`.
 /// † Only callable if the query returns no columns; otherwise it's assumed the query *may* return at least one row.
 /// ## Requirements
 /// * The `DATABASE_URL` environment variable must be set at build-time to point to a database
@@ -672,6 +672,20 @@ macro_rules! query_scalar (
     );
     ($query:expr, $($args:tt)*) => (
         $crate::sqlx_macros::expand_query!(scalar = _, source = $query, args = [$($args)*])
+    )
+);
+
+/// A variant of [`query!`][`crate::query!`] which returns a tuple instead of an anonymous row type.
+///
+/// See [`query!`][`crate::query!`] for more information.
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+macro_rules! query_tuple (
+    ($query:expr) => (
+        $crate::sqlx_macros::expand_query!(tuple = _, source = $query)
+    );
+    ($query:expr, $($args:tt)*) => (
+        $crate::sqlx_macros::expand_query!(tuple = _, source = $query, args = [$($args)*])
     )
 );
 

--- a/tests/postgres/macros.rs
+++ b/tests/postgres/macros.rs
@@ -22,6 +22,23 @@ async fn test_query() -> anyhow::Result<()> {
 }
 
 #[sqlx_macros::test]
+async fn test_query_tuple() -> anyhow::Result<()> {
+    let mut conn = new::<Postgres>().await?;
+
+    let account = sqlx::query_tuple!(
+        "SELECT * from (VALUES (1, 'Herp Derpinson')) accounts(id, name) where id = $1",
+        1i32
+    )
+    .fetch_one(&mut conn)
+    .await?;
+
+    assert_eq!(account.0, Some(1));
+    assert_eq!(account.1.as_deref(), Some("Herp Derpinson"));
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
 async fn test_non_null() -> anyhow::Result<()> {
     let mut conn = new::<Postgres>().await?;
     let mut tx = conn.begin().await?;


### PR DESCRIPTION
<!-- 
PR AUTHOR INSTRUCTIONS; PLEASE READ.

Give your pull request an accurate and descriptive title. It should mention what component(s) or database driver(s) it touches.
Pull requests with undescriptive or inaccurate titles *may* be closed or have their titles changed before merging.

Fill out the fields below.

All pull requests *must* pass CI to be merged. Check your pull request frequently for build failures until all checks pass.
Address build failures by pushing new commits or amending existing ones. Feel free to ask for help if you get stuck.
If a failure seems spurious (timeout or cache failure), you may push a new commit to re-run it.

After addressing review comments, re-request review to show that you are ready for your PR to be looked at again.

Pull requests which sit for a long time with broken CI or unaddressed review comments will be closed to clear the backlog.
If this happens, you are welcome to open a new pull request, but please be sure to address the feedback you have received previously.

Bug fixes should include a regression test which fails before the fix and passes afterwards. If this is infeasible, please explain why.

New features *should* include unit or integration tests in the appropriate folders. Database specific tests should go in `tests/<database>`.

Note that unsolicited pull requests implementing large or complex changes may not be reviwed right away.
Maintainer time and energy is limited and massive unsolicited pull requests require an outsized effort to review.

To make the best use of your time and ours, search for and participate in existing discussion on the issue tracker before opening a pull request.
The solution you came up with may have already been rejected or postponed due to other work needing to be done first,
or there may be a pending solution going down a different direction that you hadn't considered.

Pull requests that take existing discussion into account are the most likely to be merged.

Delete this block comment before submission to show that you have read and understand these instructions.
-->

Currently I don't know of any way to get a tuple from a checked query, so I adapted some of the code for the anonymous record case (i.e. `query!`) and it seemed to work when I tried using it in my own project. See also [the discussion I started here](https://github.com/launchbadge/sqlx/discussions/3744).

Is there some caveats to this implementation that I'm not aware of? I'd love to see this functionality in sqlx and I'm a bit surprised that it doesn't exist yet seeing how easy it was to get this proof of concept, which is why I am suspecting there might be a problem with this? 😅 Please enlighten me!

### Is this a breaking change?
No, it only adds a feature.