### PR TITLE
Fix of sqlx-cli/sqlite WAL code due to mismatch in cargo feature names

### DIFF
--- a/sqlx-cli/src/database.rs
+++ b/sqlx-cli/src/database.rs
@@ -11,7 +11,7 @@ pub async fn create(connect_opts: &ConnectOpts) -> anyhow::Result<()> {
     let exists = crate::retry_connect_errors(connect_opts, Any::database_exists).await?;
 
     if !exists {
-        #[cfg(feature = "_sqlite")]
+        #[cfg(any(feature = "sqlite", feature = "sqlite-unbundled"))]
         sqlx::sqlite::CREATE_DB_WAL.store(
             connect_opts.sqlite_create_db_wal,
             std::sync::atomic::Ordering::Release,

--- a/sqlx-cli/src/opt.rs
+++ b/sqlx-cli/src/opt.rs
@@ -262,7 +262,7 @@ pub struct ConnectOpts {
     /// However, if your application sets a `journal_mode` on `SqliteConnectOptions` to something
     /// other than `Wal`, then it will have to take the database file out of WAL mode on connecting,
     /// which requires an exclusive lock and may return a `database is locked` (`SQLITE_BUSY`) error.
-    #[cfg(feature = "_sqlite")]
+    #[cfg(any(feature = "sqlite", feature = "sqlite-unbundled"))]
     #[clap(long, action = clap::ArgAction::Set, default_value = "true")]
     pub sqlite_create_db_wal: bool,
 }


### PR DESCRIPTION
This is not a breaking change.