### PR TITLE
Escape PostgreSQL options

### DIFF
--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -721,10 +721,11 @@ fn test_options_formatting() {
         Some("-c geqo=off -c statement_timeout=5min".to_string())
     );
     // https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-OPTIONS
-    let options = PgConnectOptions::new().options([("passfile", r"/back\slash/ and\ spaces")]);
+    let options =
+        PgConnectOptions::new().options([("application_name", r"/back\slash/ and\ spaces")]);
     assert_eq!(
         options.options,
-        Some(r"-c passfile=/back\\slash/\ and\\\ spaces".to_string())
+        Some(r"-c application_name=/back\\slash/\ and\\\ spaces".to_string())
     );
     let options = PgConnectOptions::new();
     assert_eq!(options.options, None);

--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -495,6 +495,9 @@ impl PgConnectOptions {
 
     /// Set additional startup options for the connection as a list of key-value pairs.
     ///
+    /// Escapes the options’ backslash and space characters as per
+    /// https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-OPTIONS
+    ///
     /// # Example
     ///
     /// ```rust

--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -693,10 +693,10 @@ fn test_options_formatting() {
         Some("-c geqo=off -c statement_timeout=5min".to_string())
     );
     // https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-OPTIONS
-    let options = PgConnectOptions::new().options([("passfile", "/back\\slash/ and\\ spaces")]);
+    let options = PgConnectOptions::new().options([("passfile", r"/back\slash/ and\ spaces")]);
     assert_eq!(
         options.options,
-        Some("-c passfile=/back\\\\slash/\\ and\\\\\\ spaces".to_string())
+        Some(r"-c passfile=/back\\slash/\ and\\\ spaces".to_string())
     );
     let options = PgConnectOptions::new();
     assert_eq!(options.options, None);


### PR DESCRIPTION
Properly escape PostgreSQL options containing spaces and backslash characters as specified under https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-OPTIONS.

Fixes #2027 

### Is this a breaking change?
~~No, this change fixes behavior that I consider a minor edge case.~~

Yes,

> anyone who's already manually escaping options will get different, likely incorrect, results after this patch
