### PR TITLE
Fix: Enable Json type when db feature isn't enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ sqlite-unbundled = ["_sqlite", "sqlx-sqlite/unbundled", "sqlx-macros?/sqlite-unb
 sqlite-preupdate-hook = ["sqlx-sqlite/preupdate-hook"]
 
 # types
-json = ["sqlx-macros?/json", "sqlx-mysql?/json", "sqlx-postgres?/json", "sqlx-sqlite?/json"]
+json = ["sqlx-core/json", "sqlx-macros?/json", "sqlx-mysql?/json", "sqlx-postgres?/json", "sqlx-sqlite?/json"]
 
 bigdecimal = ["sqlx-core/bigdecimal", "sqlx-macros?/bigdecimal", "sqlx-mysql?/bigdecimal", "sqlx-postgres?/bigdecimal"]
 bit-vec = ["sqlx-core/bit-vec", "sqlx-macros?/bit-vec", "sqlx-postgres?/bit-vec"]


### PR DESCRIPTION
Fixes #3797 to ensure json type is imported even when a database feature isn't enabled. This is not a breaking change.