### PR TITLE
fix: PgConnectOptions docs

### DIFF
--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -134,6 +134,19 @@ impl PgConnectOptions {
     /// # use sqlx_postgres::PgConnectOptions;
     /// let options = PgConnectOptions::new();
     /// ```
+    ///
+    /// Note: that unlike `libpq` the environment variables:
+    ///
+    /// * `PGSSLROOTCERT`
+    /// * `PGSSLCERT`
+    /// * `PGSSLKEY`
+    ///
+    /// Must not exclusively be path, ´sqlx-postgres` supports these variables
+    /// encode the certificates / keys directly. Content snooping is done via
+    /// `CertificateInput::from`.
+    ///
+    /// Note: Putting key material in environment variables can be subjected to risk as on
+    /// some platforms environment variables can be recovered by other (non root) users.
     pub fn new() -> Self {
         Self::new_without_pgpass().apply_pgpass()
     }


### PR DESCRIPTION
Note I'm PRing this to document the *current* behavior, I'm not sure if it was the intention of the original author to support MORE behavior than `libpq` offers.

If I look at `pub fn ssl_client_key(self, key: impl AsRef<Path>) -> PgConnectOptions` there is no way to "set" the inline version of `CertificateInput`, it only accepts the file version. This potentially should be lifted for symmetry with the environment variables.

This may not be the intention? But also I seen no reason to artificially constrain `sqlx-postgres` to libpq behavior, in lots of scenarios (single file lambda binary) its much better to be able to set the certificate inline.

Regardless of what the desired final behavior is: This PR just documents the status quo, even if we wish to change it in the future.

### Is this a breaking change?

no