### PR TITLE
build: drop unused `tempfile` dependency

### DIFF
--- a/sqlx-macros-core/Cargo.toml
+++ b/sqlx-macros-core/Cargo.toml
@@ -65,7 +65,6 @@ serde = { version = "1.0.132", features = ["derive"] }
 serde_json = { version = "1.0.73" }
 sha2 = { version = "0.10.0" }
 syn = { version = "2.0.52", default-features = false, features = ["full", "derive", "parsing", "printing", "clone-impls"] }
-tempfile = { version = "3.10.1" }
 quote = { version = "1.0.26", default-features = false }
 url = { version = "2.2.2" }
 


### PR DESCRIPTION
### Does your PR solve an issue?

No. I've just realized that my project depends on `tempfile` via `sqlx-macros-core`. `tempfile` is only needed for sqlx tests, so it's not necessary for the normal build to work.

### Is this a breaking change?

No