### PR TITLE
sqlx-core: impl IntoArguments for Arguments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -302,6 +302,11 @@ path = "benches/sqlite/describe.rs"
 harness = false
 required-features = ["sqlite"]
 
+[[test]]
+name = "generic-sqlite"
+path = "tests/generic/sqlite.rs"
+required-features = ["sqlite", "macros"]
+
 #
 # MySQL
 #
@@ -350,6 +355,11 @@ required-features = ["mysql", "macros", "migrate"]
 name = "mysql-rustsec"
 path = "tests/mysql/rustsec.rs"
 required-features = ["mysql"]
+
+[[test]]
+name = "generic-mysql"
+path = "tests/generic/mysql.rs"
+required-features = ["mysql", "macros"]
 
 #
 # PostgreSQL
@@ -405,3 +415,8 @@ required-features = ["postgres"]
 name = "postgres-rustsec"
 path = "tests/postgres/rustsec.rs"
 required-features = ["postgres", "macros", "migrate"]
+
+[[test]]
+name = "generic-postgres"
+path = "tests/generic/postgres.rs"
+required-features = ["postgres", "macros"]

--- a/sqlx-core/src/arguments.rs
+++ b/sqlx-core/src/arguments.rs
@@ -37,17 +37,27 @@ pub trait IntoArguments<'q, DB: Database>: Sized + Send {
 #[macro_export]
 macro_rules! impl_into_arguments_for_arguments {
     ($Arguments:path) => {
-        impl<'q>
-            $crate::arguments::IntoArguments<
-                'q,
-                <$Arguments as $crate::arguments::Arguments<'q>>::Database,
-            > for $Arguments
-        {
-            fn into_arguments(self) -> $Arguments {
-                self
-            }
-        }
+        // impl<'q>
+        //     $crate::arguments::IntoArguments<
+        //         'q,
+        //         <$Arguments as $crate::arguments::Arguments<'q>>::Database,
+        //     > for $Arguments
+        // {
+        //     fn into_arguments(self) -> $Arguments {
+        //         self
+        //     }
+        // }
     };
+}
+
+impl<'q, DB, T> IntoArguments<'q, DB> for T
+where
+    DB: Database,
+    T: Arguments<'q, Database = DB> + Into<<DB as Database>::Arguments<'q>>,
+{
+    fn into_arguments(self) -> <DB as Database>::Arguments<'q> {
+        self.into()
+    }
 }
 
 /// used by the query macros to prevent supernumerary `.bind()` calls

--- a/sqlx-postgres/src/arguments.rs
+++ b/sqlx-postgres/src/arguments.rs
@@ -9,7 +9,7 @@ use crate::types::Type;
 use crate::{PgConnection, PgTypeInfo, Postgres};
 
 use crate::type_info::PgArrayOf;
-pub(crate) use sqlx_core::arguments::{Arguments, IntoArguments};
+pub(crate) use sqlx_core::arguments::Arguments;
 use sqlx_core::error::BoxDynError;
 
 // TODO: buf.patch(|| ...) is a poor name, can we think of a better name? Maybe `buf.lazy(||)` ?

--- a/sqlx-postgres/src/arguments.rs
+++ b/sqlx-postgres/src/arguments.rs
@@ -9,7 +9,7 @@ use crate::types::Type;
 use crate::{PgConnection, PgTypeInfo, Postgres};
 
 use crate::type_info::PgArrayOf;
-pub(crate) use sqlx_core::arguments::Arguments;
+pub(crate) use sqlx_core::arguments::{Arguments, IntoArguments};
 use sqlx_core::error::BoxDynError;
 
 // TODO: buf.patch(|| ...) is a poor name, can we think of a better name? Maybe `buf.lazy(||)` ?

--- a/tests/generic/ansi.rs
+++ b/tests/generic/ansi.rs
@@ -1,0 +1,11 @@
+pub async fn generic_it_connects<'q, 'e, E>(e: E) -> sqlx::Result<i32>
+where
+    E: sqlx::Executor<'e>,
+    E::Database: sqlx::Database,
+    i32: sqlx::Type<Database = E::Database> + sqlx::Decode<'q, Database = E::Database>,
+{
+    sqlx::query("select 1 + 1")
+        .try_map(|row: PgRow| row.try_get::<i32, _>(0))
+        .fetch_one(e)
+        .await
+}

--- a/tests/generic/mysql.rs
+++ b/tests/generic/mysql.rs
@@ -1,0 +1,15 @@
+mod ansi;
+
+use sqlx::MySql;
+use sqlx_test::{new, pool, setup_if_needed};
+
+#[sqlx_macros::test]
+async fn it_connects() -> anyhow::Result<()> {
+    let mut conn = new::<MySql>().await?;
+
+    let value = ansi::generic_it_connects(&mut conn).await?;
+
+    assert_eq!(2i32, value);
+
+    Ok(())
+}

--- a/tests/generic/postgres.rs
+++ b/tests/generic/postgres.rs
@@ -1,0 +1,15 @@
+mod ansi;
+
+use sqlx::Postgres;
+use sqlx_test::{new, pool, setup_if_needed};
+
+#[sqlx_macros::test]
+async fn it_connects() -> anyhow::Result<()> {
+    let mut conn = new::<Postgres>().await?;
+
+    let value = ansi::generic_it_connects(&mut conn).await?;
+
+    assert_eq!(2i32, value);
+
+    Ok(())
+}

--- a/tests/generic/sqlite.rs
+++ b/tests/generic/sqlite.rs
@@ -1,0 +1,15 @@
+mod ansi;
+
+use sqlx::Sqlite;
+use sqlx_test::{new, pool, setup_if_needed};
+
+#[sqlx_macros::test]
+async fn it_connects() -> anyhow::Result<()> {
+    let mut conn = new::<Sqlite>().await?;
+
+    let value = ansi::generic_it_connects(&mut conn).await?;
+
+    assert_eq!(2i32, value);
+
+    Ok(())
+}


### PR DESCRIPTION

<!-- 
PR AUTHOR INSTRUCTIONS; PLEASE READ.

Give your pull request an accurate and descriptive title. It should mention what component(s) or database driver(s) it touches.
Pull requests with undescriptive or inaccurate titles *may* be closed or have their titles changed before merging.

Fill out the fields below.

All pull requests *must* pass CI to be merged. Check your pull request frequently for build failures until all checks pass.
Address build failures by pushing new commits or amending existing ones. Feel free to ask for help if you get stuck.
If a failure seems spurious (timeout or cache failure), you may push a new commit to re-run it.

After addressing review comments, re-request review to show that you are ready for your PR to be looked at again.

Pull requests which sit for a long time with broken CI or unaddressed review comments will be closed to clear the backlog.
If this happens, you are welcome to open a new pull request, but please be sure to address the feedback you have received previously.

Bug fixes should include a regression test which fails before the fix and passes afterwards. If this is infeasible, please explain why.

New features *should* include unit or integration tests in the appropriate folders. Database specific tests should go in `tests/<database>`.

Note that unsolicited pull requests implementing large or complex changes may not be reviwed right away.
Maintainer time and energy is limited and massive unsolicited pull requests require an outsized effort to review.

To make the best use of your time and ours, search for and participate in existing discussion on the issue tracker before opening a pull request.
The solution you came up with may have already been rejected or postponed due to other work needing to be done first,
or there may be a pending solution going down a different direction that you hadn't considered.

Pull requests that take existing discussion into account are the most likely to be merged.

Delete this block comment before submission to show that you have read and understand these instructions.
-->

### Does your PR solve an issue?
fixes #3834 

### Is this a breaking change?

struct which impl both `Arguments` and `IntoArguments` will conflict now.
