### PR TITLE
Fix docs.rs build of sqlx-sqlite

### DIFF
--- a/sqlx-sqlite/Cargo.toml
+++ b/sqlx-sqlite/Cargo.toml
@@ -72,3 +72,6 @@ sqlx = { workspace = true, default-features = false, features = ["macros", "runt
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+features = ["bundled", "any", "json", "chrono", "time", "uuid"]


### PR DESCRIPTION
The documentation of (at least) `sqlx-sqlite` is [not been available on docs.rs](https://docs.rs/crate/sqlx-sqlite/0.8.5) - it also doesn't work to run `cargo doc` without specifying features locally.

This patch fixes the docs.rs issue.