### PR TITLE
Raise libsqlite3-sys dependency from 0.30 to 0.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,7 +354,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "923ded50f602b3007e5e63e3f094c479d9c8a9b42d7f4034e4afe456aa48bfd2"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.5",
  "cc",
  "cmake",
  "dunce",
@@ -499,10 +499,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.96",
  "which",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags 2.7.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2082,11 +2100,11 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "ad8935b44e7c13394a179a438e0cebba0fe08fe01b54f152e29a93b5cf993fd4"
 dependencies = [
- "bindgen",
+ "bindgen 0.71.1",
  "cc",
  "pkg-config",
  "vcpkg",
@@ -2985,6 +3003,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,13 +192,13 @@ rand_xoshiro = "0.6.0"
 hex = "0.4.3"
 tempfile = "3.10.1"
 criterion = { version = "0.5.1", features = ["async_tokio"] }
-libsqlite3-sys = { version = "0.30.1" }
+libsqlite3-sys = { version = "0.31.0" }
 
 # If this is an unconditional dev-dependency then Cargo will *always* try to build `libsqlite3-sys`,
 # even when SQLite isn't the intended test target, and fail if the build environment is not set up for compiling C code.
 [target.'cfg(sqlite_test_sqlcipher)'.dev-dependencies]
 # Enable testing with SQLCipher if specifically requested.
-libsqlite3-sys = { version = "0.30.1", features = ["bundled-sqlcipher"] }
+libsqlite3-sys = { version = "0.31.0", features = ["bundled-sqlcipher"] }
 
 # Common lint settings for the workspace
 [workspace.lints.clippy]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 # Note: should NOT increase during a minor/patch release cycle
 [toolchain]
-channel = "1.78"
+channel = "1.82"
 profile = "minimal"

--- a/sqlx-sqlite/Cargo.toml
+++ b/sqlx-sqlite/Cargo.toml
@@ -56,7 +56,7 @@ serde = { version = "1.0.145", features = ["derive"], optional = true }
 regex = { version = "1.5.5", optional = true }
 
 [dependencies.libsqlite3-sys]
-version = "0.30.1"
+version = "0.31.0"
 default-features = false
 features = [
     "pkg-config",


### PR DESCRIPTION
This makes it possible to use sqlx and the most recent versions of the `cargo` crate in the same dependency graph. Cargo depends on rusqlite 0.33 which uses libsqlite3-sys 0.31. Without this PR, this dependency graph doesn't work.

```console
error: failed to select a version for `libsqlite3-sys`.
    ... required by package `sqlx-sqlite v0.8.5`
    ... which satisfies dependency `sqlx-sqlite = "=0.8.5"` of package `sqlx v0.8.5`
    ... which satisfies dependency `sqlx = "^0.8.5"` of package `repro v0.0.0`
versions that meet the requirements `^0.30.1` are: 0.30.1

the package `libsqlite3-sys` links to the native library `sqlite3`, but it conflicts with a previous package which links to `sqlite3` as well:
package `libsqlite3-sys v0.31.0`
    ... which satisfies dependency `libsqlite3-sys = "^0.31.0"` of package `rusqlite v0.33.0`
    ... which satisfies dependency `rusqlite = "^0.33.0"` of package `cargo v0.87.1`
    ... which satisfies dependency `cargo = "^0.87"` of package `repro v0.0.0`
Only one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the `links = "sqlite3"` value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.

failed to select a version for `libsqlite3-sys` which could resolve this conflict
```

### Is this a breaking change?

The libsqlite3-sys update: no, previous precedent is that these are semver-exempt and anyone using libsqlite3-sys through some other dependency needs to have pinned their sqlx version and be updating in lockstep.

https://github.com/launchbadge/sqlx/blob/91d26bad4d5e2b05fab1c86d0fbe11586d30f29d/CHANGELOG.md#L888-L890

However, for this specific update, libsqlite3-sys requires a version of bindgen that only supports Rust 1.82+, and sqlx considers this a breaking change.

https://github.com/launchbadge/sqlx/blob/91d26bad4d5e2b05fab1c86d0fbe11586d30f29d/FAQ.md#L23-L24

If a new major version of sqlx is not imminent, I am still interested in libsqlite3-sys 0.31 in sqlx 0.8 and can make it not a breaking change by improving bindgen to generate Rust 1.78-compatible code when run by a toolchain older than 1.82.