### PR TITLE
feat: support urlbased config for sqlite

### DIFF
--- a/sqlx-sqlite/src/options/parse.rs
+++ b/sqlx-sqlite/src/options/parse.rs
@@ -2,12 +2,15 @@ use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
 use percent_encoding::{percent_decode_str, percent_encode, AsciiSet};
 use url::Url;
 
 use crate::error::Error;
 use crate::SqliteConnectOptions;
+
+use super::SqliteJournalMode;
 
 // https://www.sqlite.org/uri.html
 
@@ -102,6 +105,31 @@ impl SqliteConnectOptions {
 
                     "vfs" => options.vfs = Some(Cow::Owned(value.into_owned())),
 
+                    // The journal_mode query parameter specifies the journal mode to use for the database.
+                    // The default is DELETE, but WAL is recommended for most use cases.
+                    // See https://www.sqlite.org/pragma.html#pragma_journal_mode
+                    // as journal_mode is not a standard query parameter, we prefix it with `_`
+                    "_journal_mode" => {
+                        if SqliteJournalMode::from_str(&value).is_err() {
+                            return Err(Error::Configuration(
+                                format!("unknown value {value:?} for `journal_mode`").into(),
+                            ));
+                        }
+                        options
+                            .pragmas
+                            .insert("journal_mode".into(), Some(value.into_owned().into()));
+                    }
+
+                    // The busy_timeout query parameter specifies the timeout to use when the database is busy.
+                    // the default is 5 seconds, but this can be changed to a shorter or longer duration.
+                    // See https://www.sqlite.org/pragma.html#pragma_busy_timeout
+                    // as busy_timeout is not a standard query parameter, we prefix it with `_`
+                    "_busy_timeout" => {
+                        if let Some(timeout) = parse_duration(&value) {
+                            options.busy_timeout = timeout;
+                        }
+                    }
+
                     _ => {
                         return Err(Error::Configuration(
                             format!("unknown query parameter `{key}` while parsing connection URL")
@@ -149,13 +177,22 @@ impl SqliteConnectOptions {
             false => "private",
         };
         url.query_pairs_mut().append_pair("cache", cache);
-
         if self.immutable {
             url.query_pairs_mut().append_pair("immutable", "true");
         }
 
         if let Some(vfs) = &self.vfs {
             url.query_pairs_mut().append_pair("vfs", vfs);
+        }
+
+        if let Some(Some(journal_mode)) = self.pragmas.get("journal_mode") {
+            url.query_pairs_mut()
+                .append_pair("_journal_mode", journal_mode);
+        }
+
+        if !self.busy_timeout.is_zero() {
+            url.query_pairs_mut()
+                .append_pair("_busy_timeout", &format_duration(self.busy_timeout));
         }
 
         url
@@ -177,6 +214,30 @@ impl FromStr for SqliteConnectOptions {
         let params = database_and_params.next();
 
         Self::from_db_and_params(database, params)
+    }
+}
+
+type TimeUnitParser = (&'static str, fn(u64) -> Duration);
+
+// This function is used to parse the busy timeout from the URL query parameters.
+// as busy timeout should be short, we only support milliseconds and seconds
+fn parse_duration(s: &str) -> Option<Duration> {
+    static UNITS: [TimeUnitParser; 2] = [("ms", Duration::from_millis), ("s", Duration::from_secs)];
+    for (suffix, func) in UNITS.iter() {
+        let Some(suffix) = s.strip_suffix(suffix) else {
+            continue;
+        };
+        let value = suffix.parse::<u64>().ok()?;
+        return Some(func(value));
+    }
+    None
+}
+
+fn format_duration(duration: Duration) -> String {
+    if duration.subsec_millis() == 0 {
+        format!("{}s", duration.as_secs())
+    } else {
+        format!("{}ms", duration.as_millis())
     }
 }
 
@@ -221,11 +282,55 @@ fn test_parse_shared_in_memory() -> Result<(), Error> {
 
 #[test]
 fn it_returns_the_parsed_url() -> Result<(), Error> {
-    let url = "sqlite://test.db?mode=rw&cache=shared";
+    let url = "sqlite://test.db?mode=rw&cache=shared&_busy_timeout=5s";
     let options: SqliteConnectOptions = url.parse()?;
 
     let expected_url = Url::parse(url).unwrap();
     assert_eq!(options.build_url(), expected_url);
 
+    Ok(())
+}
+
+#[test]
+fn it_parse_journal_mode() -> Result<(), Error> {
+    let url = "sqlite://test.db?_journal_mode=WAL";
+    let options: SqliteConnectOptions = url.parse()?;
+
+    let val = options.pragmas.get("journal_mode").cloned().flatten();
+    assert_eq!(val, Some(Cow::Owned("WAL".to_string())));
+
+    let format_url = options.build_url();
+    assert_eq!(
+        format_url.as_str(),
+        "sqlite://test.db?mode=rw&cache=private&_journal_mode=WAL&_busy_timeout=5s"
+    );
+    Ok(())
+}
+
+#[test]
+fn it_should_return_error_for_invalid_journal_mode() -> Result<(), Error> {
+    let url = "sqlite://test.db?_journal_mode=invalid";
+    let options: Result<SqliteConnectOptions, Error> = url.parse();
+
+    assert!(options.is_err());
+    assert_eq!(
+        options.unwrap_err().to_string(),
+        "error with configuration: unknown value \"invalid\" for `journal_mode`"
+    );
+    Ok(())
+}
+
+#[test]
+fn it_should_parse_busy_timeout() -> Result<(), Error> {
+    let url = "sqlite://test.db?_busy_timeout=1000ms";
+    let options: SqliteConnectOptions = url.parse()?;
+
+    assert_eq!(options.busy_timeout, Duration::from_millis(1000));
+
+    let format_url = options.build_url();
+    assert_eq!(
+        format_url.as_str(),
+        "sqlite://test.db?mode=rw&cache=private&_busy_timeout=1s"
+    );
     Ok(())
 }


### PR DESCRIPTION
Does your PR solve an issue?
This PR introduces support for configuring journal_mode and busy_timeout via the SQLite database URL, improving ergonomics and aligning with behavior in other ecosystems.

Currently, libraries like SeaORM do not expose journal_mode and busy_timeout through DatabaseConfig, which requires users to manually run PRAGMA commands after establishing a connection. This adds complexity and boilerplate. By allowing these settings to be specified in the URL itself, usage becomes much simpler and declarative.

This feature mirrors existing functionality in other SQLite libraries such as the Go SQLite driver [mattn/go-sqlite3](https://github.com/mattn/go-sqlite3/blob/master/README.md), which supports these parameters in the DSN.

Example usage:
```
sqlite://app.db?_journal_mode=WAL&_busy_timeout=5000
```
Is this a breaking change?
No, this is not a breaking change. Existing URLs will continue to work as before, and the new configuration options are optional and additive.

Additional context
This change improves developer experience by eliminating the need to execute manual PRAGMA statements by using sea-orm and allows consistent configuration via connection string.

Unit and/or integration tests have been added to verify that journal_mode and busy_timeout are correctly parsed and applied from the URL configuration.