### PR TITLE
fix(macros): slightly improve unsupported type error message

### DIFF
--- a/sqlx-macros-core/src/query/args.rs
+++ b/sqlx-macros-core/src/query/args.rs
@@ -66,7 +66,12 @@ pub fn quote_args<DB: DatabaseExt>(
                                         i + 1,
                                     )
                                 } else {
-                                    format!("unsupported type {} for param #{}", param_ty, i + 1)
+                                    format!(
+                                        "no built in mapping found for type {} for param #{}; \
+                                        a type override may be required, see documentation for details",
+                                        param_ty,
+                                        i + 1
+                                    )
                                 }
                             })?
                             .parse::<TokenStream>()

--- a/sqlx-macros-core/src/query/output.rs
+++ b/sqlx-macros-core/src/query/output.rs
@@ -236,7 +236,7 @@ fn get_column_type<DB: DatabaseExt>(i: usize, column: &DB::Column) -> TokenStrea
             let message =
                 if let Some(feature_gate) = <DB as TypeChecking>::get_feature_gate(type_info) {
                     format!(
-                        "optional sqlx feature `{feat}` required for type {ty} of {col}",
+                        "SQLx feature `{feat}` required for type {ty} of {col}",
                         ty = &type_info,
                         feat = feature_gate,
                         col = DisplayColumn {
@@ -246,7 +246,8 @@ fn get_column_type<DB: DatabaseExt>(i: usize, column: &DB::Column) -> TokenStrea
                     )
                 } else {
                     format!(
-                        "unsupported type {ty} of {col}",
+                        "no built in mapping found for type {ty} of {col}; \
+                        a type override may be required, see documentation for details",
                         ty = type_info,
                         col = DisplayColumn {
                             idx: i,


### PR DESCRIPTION

### Does your PR solve an issue?
This PR makes a small improvement to the "unsupported type" error message to suggest a potential solution to the user.

I just spent a couple hours on an issue forgetting that type overrides exist and I wished that the message nudged me in that direction. 
Perhaps the message could be made even more intelligent.

### Is this a breaking change?
No. It's a minor DX improvement.
