### PR TITLE
fix(mysql): validate parameter count for prepared statements

### DIFF
--- a/sqlx-mysql/src/connection/executor.rs
+++ b/sqlx-mysql/src/connection/executor.rs
@@ -124,11 +124,13 @@ impl MySqlConnection {
                         .await?;
 
                     if arguments.types.len() != metadata.parameters {
-                        return Err(Error::Protocol(format!(
-                                    "Prepared statement expected {} parameters but {} parameters were provided",
-                                    metadata.parameters,
-                                    arguments.types.len()
-                        )));
+                        return Err(
+                            err_protocol!(
+                                "prepared statement expected {} parameters but {} parameters were provided",
+                                metadata.parameters,
+                                arguments.types.len()
+                            )
+                        );
                     }
 
                     // https://dev.mysql.com/doc/internals/en/com-stmt-execute.html
@@ -146,11 +148,13 @@ impl MySqlConnection {
                         .await?;
 
                     if arguments.types.len() != metadata.parameters {
-                        return Err(Error::Protocol(format!(
-                                    "Prepared statement expected {} parameters but {} parameters were provided",
-                                    metadata.parameters,
-                                    arguments.types.len()
-                        )));
+                        return Err(
+                            err_protocol!(
+                                "prepared statement expected {} parameters but {} parameters were provided",
+                                metadata.parameters,
+                                arguments.types.len()
+                            )
+                        );
                     }
 
                     // https://dev.mysql.com/doc/internals/en/com-stmt-execute.html

--- a/sqlx-mysql/src/connection/executor.rs
+++ b/sqlx-mysql/src/connection/executor.rs
@@ -123,6 +123,14 @@ impl MySqlConnection {
                         .get_or_prepare_statement(sql)
                         .await?;
 
+                    if arguments.types.len() != metadata.parameters {
+                        return Err(Error::Protocol(format!(
+                                    "Prepared statement expected {} parameters but {} parameters were provided",
+                                    metadata.parameters,
+                                    arguments.types.len()
+                        )));
+                    }
+
                     // https://dev.mysql.com/doc/internals/en/com-stmt-execute.html
                     self.inner.stream
                         .send_packet(StatementExecute {
@@ -136,6 +144,14 @@ impl MySqlConnection {
                     let (id, metadata) = self
                         .prepare_statement(sql)
                         .await?;
+
+                    if arguments.types.len() != metadata.parameters {
+                        return Err(Error::Protocol(format!(
+                                    "Prepared statement expected {} parameters but {} parameters were provided",
+                                    metadata.parameters,
+                                    arguments.types.len()
+                        )));
+                    }
 
                     // https://dev.mysql.com/doc/internals/en/com-stmt-execute.html
                     self.inner.stream

--- a/tests/mysql/error.rs
+++ b/tests/mysql/error.rs
@@ -100,3 +100,50 @@ async fn it_fails_with_invalid_save_point_statement() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[sqlx_macros::test]
+async fn it_fails_with_parameter_count_mismatch_too_few() -> anyhow::Result<()> {
+    let mut conn = new::<MySql>().await?;
+    let res: Result<_, sqlx::Error> =
+        sqlx::query("SELECT * FROM tweet WHERE id = ? AND owner_id = ?")
+            .bind(1_i64)
+            .execute(&mut conn)
+            .await;
+
+    let err = res.unwrap_err();
+
+    assert!(matches!(err, Error::Protocol(_)), "{err}");
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
+async fn it_fails_with_parameter_count_mismatch_too_many() -> anyhow::Result<()> {
+    let mut conn = new::<MySql>().await?;
+    let res: Result<_, sqlx::Error> = sqlx::query("SELECT * FROM tweet WHERE id = ?")
+        .bind(1_i64)
+        .bind(2_i64)
+        .execute(&mut conn)
+        .await;
+
+    let err = res.unwrap_err();
+
+    assert!(matches!(err, Error::Protocol(_)), "{err}");
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
+async fn it_fails_with_parameter_count_mismatch_zero_expected() -> anyhow::Result<()> {
+    let mut conn = new::<MySql>().await?;
+    let res: Result<_, sqlx::Error> = sqlx::query("SELECT COUNT(*) FROM tweet")
+        .bind(1_i64)
+        .execute(&mut conn)
+        .await;
+
+    let err = res.unwrap_err();
+
+    assert!(matches!(err, Error::Protocol(_)), "{err}");
+
+    Ok(())
+}


### PR DESCRIPTION
### Does your PR solve an issue?
fixes #3774

### Is this a breaking change?
No. This PR adds proper error handling when the number of parameters provided doesn't match the number expected by a prepared statement in MySQL.
