### PR TITLE
Add support for `Box<JsonRawValue>` types.

### DIFF
--- a/sqlx-core/src/types/json.rs
+++ b/sqlx-core/src/types/json.rs
@@ -196,9 +196,33 @@ where
     }
 }
 
+impl<DB> Type<DB> for Box<JsonRawValue>
+where
+    for<'a> Json<&'a Self>: Type<DB>,
+    DB: Database,
+{
+    fn type_info() -> DB::TypeInfo {
+        <Json<&Self> as Type<DB>>::type_info()
+    }
+
+    fn compatible(ty: &DB::TypeInfo) -> bool {
+        <Json<&Self> as Type<DB>>::compatible(ty)
+    }
+}
+
 // We don't have to implement Encode for JsonRawValue because that's covered by the default
 // implementation for Encode
 impl<'r, DB> Decode<'r, DB> for &'r JsonRawValue
+where
+    Json<Self>: Decode<'r, DB>,
+    DB: Database,
+{
+    fn decode(value: <DB as Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
+        <Json<Self> as Decode<DB>>::decode(value).map(|item| item.0)
+    }
+}
+
+impl<'r, DB> Decode<'r, DB> for Box<JsonRawValue>
 where
     Json<Self>: Decode<'r, DB>,
     DB: Database,

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -465,7 +465,9 @@ mod json {
             .await?;
 
         let value: &JsonRawValue = row.try_get(0)?;
+        assert_eq!(value.get(), "{\"hello\": \"world\"}");
 
+        let value: Box<JsonRawValue> = row.try_get(0)?;
         assert_eq!(value.get(), "{\"hello\": \"world\"}");
 
         // prepared, binary API
@@ -474,7 +476,9 @@ mod json {
             .await?;
 
         let value: &JsonRawValue = row.try_get(0)?;
+        assert_eq!(value.get(), "{\"hello\": \"world\"}");
 
+        let value: Box<JsonRawValue> = row.try_get(0)?;
         assert_eq!(value.get(), "{\"hello\": \"world\"}");
 
         Ok(())


### PR DESCRIPTION
This allows keeping structs that implement FromRow lifetime-free,
previously you had to use `&'a JsonRawValue`.

```rust
struct Foo {
    bar: Box<JsonRawValue>,
}
```
