### PR TITLE
Fix NoHostnameTlsVerifier for rustls 0.23.24 and above

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3123,9 +3123,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.21"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -3150,15 +3150,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -48,7 +48,7 @@ tokio = { workspace = true, optional = true }
 # TLS
 native-tls = { version = "0.2.10", optional = true }
 
-rustls = { version = "0.23.15", default-features = false, features = ["std", "tls12"], optional = true }
+rustls = { version = "0.23.24", default-features = false, features = ["std", "tls12"], optional = true }
 webpki-roots = { version = "0.26", optional = true }
 rustls-native-certs = { version = "0.8.0", optional = true }
 

--- a/sqlx-core/src/net/tls/tls_rustls.rs
+++ b/sqlx-core/src/net/tls/tls_rustls.rs
@@ -309,9 +309,9 @@ impl ServerCertVerifier for NoHostnameTlsVerifier {
             ocsp_response,
             now,
         ) {
-            Err(TlsError::InvalidCertificate(CertificateError::NotValidForName)) => {
-                Ok(ServerCertVerified::assertion())
-            }
+            Err(TlsError::InvalidCertificate(
+                CertificateError::NotValidForName | CertificateError::NotValidForNameContext { .. },
+            )) => Ok(ServerCertVerified::assertion()),
             res => res,
         }
     }


### PR DESCRIPTION
From [Rustls 0.23.24 release](https://github.com/rustls/rustls/releases/tag/v%2F0.23.24):
> New feature: More detailed and helpful error reporting for common certificate errors, such as name mismatches and certificate expiry. Users who std::fmt::Display the rustls Error type will take advantage of this automatically. Users handling CertificateError variants individually should note the new variants, such as CertificateError::NotValidForNameContext (compare CertificateError::NotValidForName).

This fixes the `NoHostnameTlsVerifier` by also matching on this new variant.

Fixes #3793