### PR TITLE
Use unnamed statement in pg when not persistent

### DIFF
--- a/sqlx-postgres/src/message/parse.rs
+++ b/sqlx-postgres/src/message/parse.rs
@@ -77,3 +77,19 @@ fn test_encode_parse() {
 
     assert_eq!(buf, EXPECTED);
 }
+
+#[test]
+fn test_encode_parse_unnamed_statement() {
+    const EXPECTED: &[u8] = b"P\0\0\0\x15\0SELECT $1\0\0\x01\0\0\0\x19";
+
+    let mut buf = Vec::new();
+    let m = Parse {
+        statement: StatementId::UNNAMED,
+        query: "SELECT $1",
+        param_types: &[Oid(25)],
+    };
+
+    m.encode_msg(&mut buf).unwrap();
+
+    assert_eq!(buf, EXPECTED);
+}


### PR DESCRIPTION
This change makes Postgres use the unnamed statement when preparing statements and `persistent = false`.

This means Postgres will automatically close the prepared statement when another query is run – as per the [docs](https://www.postgresql.org/docs/13/protocol-flow.html) – avoiding a memory leak.

### Does your PR solve an issue?

fixes #3850

### Is this a breaking change?

No.

it fixes a bug, and makes it behave as documented.
