### PR TITLE
sqlx-postgres: Bump etcetera to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,13 +1240,13 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
 dependencies = [
  "cfg-if",
  "home",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3030,7 +3030,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3653,7 +3653,6 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn 2.0.96",
- "tempfile",
  "tokio",
  "url",
 ]

--- a/sqlx-postgres/Cargo.toml
+++ b/sqlx-postgres/Cargo.toml
@@ -83,7 +83,7 @@ workspace = true
 features = ["postgres", "derive"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
-etcetera = "0.8.0"
+etcetera = "0.10.0"
 
 [lints]
 workspace = true


### PR DESCRIPTION
This bumps the underlying version of windows-sys used by this crate. 

I've only compile tested this by crosscompiling from Linux.

### Does your PR solve an issue?

No

### Is this a breaking change?

Yes, but a workaround for users is available

MSRV increases to 1.81.0, while sqlx-postgres 0.8.5 has an MSRV of 1.75.0

Users can pin `home` to version 0.5.9 or older 1.70.0 if home is pinned to 0.5.9 or older, which would solve the issue. 

Alternatives are:
- Bumping to etcetera 0.9.0 which has an MSRV of 1.70.0
- Merging this after 3821, which increases MSRV to 1.85.0, removing this concern
