### PR TITLE
Add run_through_version method for versioned migrations

### DIFF
--- a/tests/mysql/migrate.rs
+++ b/tests/mysql/migrate.rs
@@ -33,8 +33,19 @@ async fn reversible(mut conn: PoolConnection<MySql>) -> anyhow::Result<()> {
 
     let migrator = Migrator::new(Path::new("tests/mysql/migrations_reversible")).await?;
 
+    // run only until first reversible migration
+    migrator
+        .run_through_version(&mut conn, 20220721124650)
+        .await?;
+
+    let latest_version = migrator.latest_version();
+    assert_eq!(latest_version, 20220721125033);
+
     // run migration
     migrator.run(&mut conn).await?;
+
+    let latest_applied_version = migrator.latest_applied_version(&mut conn).await?.unwrap();
+    assert_eq!(latest_applied_version, latest_version);
 
     // check outcome
     let res: i64 = conn

--- a/tests/sqlite/migrate.rs
+++ b/tests/sqlite/migrate.rs
@@ -33,8 +33,19 @@ async fn reversible(mut conn: PoolConnection<Sqlite>) -> anyhow::Result<()> {
 
     let migrator = Migrator::new(Path::new("tests/sqlite/migrations_reversible")).await?;
 
+    // run only until first reversible migration
+    migrator
+        .run_through_version(&mut conn, 20220721124650)
+        .await?;
+
+    let latest_version = migrator.latest_version();
+    assert_eq!(latest_version, 20220721125033);
+
     // run migration
     migrator.run(&mut conn).await?;
+
+    let latest_applied_version = migrator.latest_applied_version(&mut conn).await?.unwrap();
+    assert_eq!(latest_applied_version, latest_version);
 
     // check outcome
     let res: i64 = conn


### PR DESCRIPTION
### Description:
The sqlx library already has a feature in sqlx-cli https://github.com/launchbadge/sqlx/blob/main/sqlx-cli/src/migrate.rs
To run migration till a specific version. Unfortunately this functionality isn't yet exposed to the library. 

Therefore, this PR introduces three new public functions to the `Migrator` struct:
-   **`latest_version()`**: Returns the highest version number among all migrations defined in the `Migrator`'s source. 
-   **`latest_applied_version()`**: Retrieves the highest version number of migrations that have already been successfully applied to the database. 
-   **`run_through_version(target: i64)`**: Allows running "up" migrations against the database specifically up to a `target` version. This is enabling users to apply only a subset of pending migrations.

I also added tests to run the new functionality against different database backends.

### Is this a breaking change?
no, everything is backwards and forwards compatible. Only added function

