### PR TITLE
CLi: made cli-lib modules publicly available for other crates

### DIFF
--- a/sqlx-cli/src/lib.rs
+++ b/sqlx-cli/src/lib.rs
@@ -1,3 +1,23 @@
+//! # SQLx CLI
+//!
+//! Command-line utility for the [SQLx](https://github.com/launchbadge/sqlx) ecosystem.
+//!
+//! This crate provides the core logic for the `sqlx` command-line interface, enabling database management,
+//! migrations, and offline query preparation for Rust projects using SQLx.
+//!
+//! ### Note: Semver Exempt API
+//! The API of this crate is not meant for general use and does *not* follow Semantic Versioning.
+//! The only crate that follows Semantic Versioning in the project is the `sqlx` crate itself.
+//! If you are building a custom SQLx driver, you should pin an exact version for `sqlx-cli` to
+//! avoid breakages:
+//!
+//! ```toml
+//! sqlx-cli = { version = "=0.9.0" }
+//! ```
+//!
+//! And then make releases in lockstep with `sqlx-cli`. We recommend all driver crates, in-tree
+//! or otherwise, use the same version numbers as `sqlx-cli` to avoid confusion.
+
 use std::future::Future;
 use std::io;
 use std::time::Duration;


### PR DESCRIPTION
Made modules `database`, `metadata`, ... publicly available for users that want to include sqlx-cli into their own helper binary or other library. (It's easier to use `migrate::run` directly without building `Opt`).

PR doesn't contain any significant changes.