### PR TITLE
Compile-time support for external drivers

### DIFF
--- a/sqlx-cli/src/bin/cargo-sqlx.rs
+++ b/sqlx-cli/src/bin/cargo-sqlx.rs
@@ -15,6 +15,8 @@ enum Cli {
 async fn main() {
     sqlx_cli::maybe_apply_dotenv();
 
+    sqlx::any::install_default_drivers();
+
     let Cli::Sqlx(opt) = Cli::parse();
 
     if let Err(error) = sqlx_cli::run(opt).await {

--- a/sqlx-cli/src/bin/sqlx.rs
+++ b/sqlx-cli/src/bin/sqlx.rs
@@ -7,6 +7,8 @@ async fn main() {
     // Checks for `--no-dotenv` before parsing.
     sqlx_cli::maybe_apply_dotenv();
 
+    sqlx::any::install_default_drivers();
+
     let opt = Opt::parse();
 
     // no special handling here

--- a/sqlx-cli/src/lib.rs
+++ b/sqlx-cli/src/lib.rs
@@ -204,8 +204,6 @@ where
     F: FnMut(&'a str) -> Fut,
     Fut: Future<Output = sqlx::Result<T>> + 'a,
 {
-    sqlx::any::install_default_drivers();
-
     let db_url = opts.expect_db_url()?;
 
     backoff::future::retry(

--- a/sqlx-macros-core/src/database/mod.rs
+++ b/sqlx-macros-core/src/database/mod.rs
@@ -33,6 +33,7 @@ pub struct CachingDescribeBlocking<DB: DatabaseExt> {
 
 #[allow(dead_code)]
 impl<DB: DatabaseExt> CachingDescribeBlocking<DB> {
+    #[allow(clippy::new_without_default, reason = "internal API")]
     pub const fn new() -> Self {
         CachingDescribeBlocking {
             connections: LazyLock::new(|| Mutex::new(HashMap::new())),

--- a/sqlx-macros-core/src/lib.rs
+++ b/sqlx-macros-core/src/lib.rs
@@ -27,7 +27,7 @@ pub type Error = Box<dyn std::error::Error>;
 pub type Result<T> = std::result::Result<T, Error>;
 
 mod common;
-mod database;
+pub mod database;
 
 #[cfg(feature = "derive")]
 pub mod derives;


### PR DESCRIPTION
### Does your PR solve an issue?
Not on this repo, but it would solve an issue for the `sqlx-exasol` driver: https://github.com/bobozaur/sqlx-exasol/issues/9.

With the changes here, the compile-time macros can be redefined by external drivers through usage of `sqlx_macros_core::query::expand_input()` with a custom `QueryDriver`. Furthermore, a `sqlx-cli` like binary can be exposed as well, since the `install_default_drivers()` call was moved to the `sqlx-cli` binaries. With these changes, the custom driver binary (that depends on `sqlx-cli` as a library) can install its own driver (this would panic with the current state of things).

### Is this a breaking change?
Nope, it's internal only. Should not affect anything else at all.