### PR TITLE
feat: Unify `Debug` implementations across `PgRow`, `MySqlRow` and `SqliteRow`

### DIFF
--- a/sqlx-mysql/src/row.rs
+++ b/sqlx-mysql/src/row.rs
@@ -9,7 +9,6 @@ use crate::HashMap;
 use crate::{protocol, MySql, MySqlColumn, MySqlValueFormat, MySqlValueRef};
 
 /// Implementation of [`Row`] for MySQL.
-#[derive(Debug)]
 pub struct MySqlRow {
     pub(crate) row: protocol::Row,
     pub(crate) format: MySqlValueFormat,
@@ -47,5 +46,11 @@ impl ColumnIndex<MySqlRow> for &'_ str {
             .get(*self)
             .ok_or_else(|| Error::ColumnNotFound((*self).into()))
             .copied()
+    }
+}
+
+impl std::fmt::Debug for MySqlRow {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        debug_row(self, f)
     }
 }

--- a/sqlx-postgres/src/row.rs
+++ b/sqlx-postgres/src/row.rs
@@ -4,10 +4,8 @@ use crate::message::DataRow;
 use crate::statement::PgStatementMetadata;
 use crate::value::PgValueFormat;
 use crate::{PgColumn, PgValueRef, Postgres};
+use sqlx_core::row::debug_row;
 pub(crate) use sqlx_core::row::Row;
-use sqlx_core::type_checking::TypeChecking;
-use sqlx_core::value::ValueRef;
-use std::fmt::Debug;
 use std::sync::Arc;
 
 /// Implementation of [`Row`] for PostgreSQL.
@@ -51,25 +49,8 @@ impl ColumnIndex<PgRow> for &'_ str {
     }
 }
 
-impl Debug for PgRow {
+impl std::fmt::Debug for PgRow {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "PgRow ")?;
-
-        let mut debug_map = f.debug_map();
-        for (index, column) in self.columns().iter().enumerate() {
-            match self.try_get_raw(index) {
-                Ok(value) => {
-                    debug_map.entry(
-                        &column.name,
-                        &Postgres::fmt_value_debug(&<PgValueRef as ValueRef>::to_owned(&value)),
-                    );
-                }
-                Err(error) => {
-                    debug_map.entry(&column.name, &format!("decode error: {error:?}"));
-                }
-            }
-        }
-
-        debug_map.finish()
+        debug_row(self, f)
     }
 }

--- a/sqlx-sqlite/src/row.rs
+++ b/sqlx-sqlite/src/row.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use sqlx_core::column::ColumnIndex;
 use sqlx_core::error::Error;
 use sqlx_core::ext::ustr::UStr;
-use sqlx_core::row::Row;
+use sqlx_core::row::{debug_row, Row};
 use sqlx_core::HashMap;
 
 use crate::statement::StatementHandle;
@@ -74,6 +74,12 @@ impl ColumnIndex<SqliteRow> for &'_ str {
             .get(*self)
             .ok_or_else(|| Error::ColumnNotFound((*self).into()))
             .copied()
+    }
+}
+
+impl std::fmt::Debug for SqliteRow {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        debug_row(self, f)
     }
 }
 


### PR DESCRIPTION
### Context

In a personal code base I currently maintain a `Row` implementation called `DebugRow` as a catch-all type for queries so that I can use its `Debug` implementation for snapshot testing (using the great [insta](https://lib.rs/crates/insta) crate). 

While upgrading the version of sqlx I noticed there was now a useful `Debug` implementation for `PgRow` (#2917) which had me hoping there was an equivalent for `SqliteRow`, but after digging through the code I found out
- `PgRow` has a custom `Debug` which prints out the contents of the row using `debug_map()`
- `MySqlRow` uses a derived `Debug`
- `SqliteRow` does not implement `Debug`

Rather than implement similar logic to `PgRow` for `SqliteRow` I figured it might be better to unify the implementations as the various traits (e.g. `Row`, `Database`, `TypeChecking`) provide everything needed to implement `PgRow`'s version generically.

Also related: https://github.com/launchbadge/sqlx/issues/150 

### Proposed changes

1. Introduce a new `sqlx_core::row::debug_row` function
2. Use (1) to implement `Debug` on `SqliteRow`
3. Use (1) to replace `PgRow`'s `Debug` implementation
4. Use (1) to replace `MySqlRow`'s derived `Debug`

### Is this a breaking change?

Yes.

1. `PgRow`'s `Debug` implementation changes a little bit because of the use of `std::any::type_name`<br>(This could be avoided by passing a name to `debug_row` instead but is definitely less elegant)
2. `MySqlRow`'s `Debug` implementation would be completely different

If this is too ambitious of a change I'm happy to pare it down to just the `SqliteRow` change as that's fundamentally what I'm after.