### PR TITLE
mysql: make pub: MySqlValueRef::format/as_bytes/as_str()

### DIFF
--- a/sqlx-mysql/src/value.rs
+++ b/sqlx-mysql/src/value.rs
@@ -33,18 +33,18 @@ pub struct MySqlValueRef<'r> {
 }
 
 impl<'r> MySqlValueRef<'r> {
-    pub(crate) fn format(&self) -> MySqlValueFormat {
+    pub fn format(&self) -> MySqlValueFormat {
         self.format
     }
 
-    pub(crate) fn as_bytes(&self) -> Result<&'r [u8], BoxDynError> {
+    pub fn as_bytes(&self) -> Result<&'r [u8], BoxDynError> {
         match &self.value {
             Some(v) => Ok(v),
             None => Err(UnexpectedNullError.into()),
         }
     }
 
-    pub(crate) fn as_str(&self) -> Result<&'r str, BoxDynError> {
+    pub fn as_str(&self) -> Result<&'r str, BoxDynError> {
         Ok(from_utf8(self.as_bytes()?)?)
     }
 }


### PR DESCRIPTION
I need these methods to be public (well, actually I only need `as_bytes`) in order to implement custom JSON deserialization. The Postgres driver already allows to get raw values.

### Does your PR solve an issue?
No.

### Is this a breaking change?
No.

