### PR TITLE
feat(ok): add correct handling of ok packets in MYSQL implementation

### DIFF
--- a/sqlx-mysql/src/protocol/response/ok.rs
+++ b/sqlx-mysql/src/protocol/response/ok.rs
@@ -50,3 +50,29 @@ fn test_decode_ok_packet() {
     assert!(p.status.contains(Status::SERVER_STATUS_AUTOCOMMIT));
     assert!(p.status.contains(Status::SERVER_SESSION_STATE_CHANGED));
 }
+
+#[test]
+fn test_decode_ok_packet_with_info() {
+    // OK packet with 0xfe header and length >= 9 (with appended info)
+    const DATA: &[u8] = b"\xfe\x01\x00\x02\x00\x00\x00\x05\x09info data";
+
+    let p = OkPacket::decode(DATA.into()).unwrap();
+
+    assert_eq!(p.affected_rows, 1);
+    assert_eq!(p.last_insert_id, 0);
+    assert_eq!(p.warnings, 0);
+    assert!(p.status.contains(Status::SERVER_STATUS_AUTOCOMMIT));
+}
+
+#[test]
+fn test_decode_ok_packet_with_extended_info() {
+    // OK packet with 0xfe header, affected rows, last insert id, and extended info
+    const DATA: &[u8] = b"\xfe\x05\x64\x02\x00\x01\x00\x0e\x14extended information";
+
+    let p = OkPacket::decode(DATA.into()).unwrap();
+
+    assert_eq!(p.affected_rows, 5);
+    assert_eq!(p.last_insert_id, 100);
+    assert_eq!(p.warnings, 1);
+    assert!(p.status.contains(Status::SERVER_STATUS_AUTOCOMMIT));
+}


### PR DESCRIPTION
As per the Mysql documentation, OK and EOF packets have the following structure

OK: header = 0 and length of packet >= 7
EOF: header = 0xfe and length of packet < 8

Right now we are checking to see if the packet is smaller than 9 which is fine for most cases however there are some projects that implement the MySQL protocol which include information in the packet (e.g query speed, rows returned in human readable text)

https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_basic_ok_packet.html

For example in the project manticore https://github.com/manticoresoftware/manticoresearch (Which is why I found this bug) their ok packet to designate the end of the data will include more information. This would result in sqlx treating the the OK packet as a text field due to the fact that the length is larger than 8.

```
Search error: encountered unexpected or invalid data: buffer exhausted when reading data for column MySqlColumn { ordinal: 0, name: id, type_info: MySqlTypeInfo { type: LongLong, flags: ColumnFlags(0x0), max_size: Some(20) }, flags: Some(ColumnFlags(0x0)) }; decoded length is 3251880405938339840, but only 32 bytes remain in buffer. Malformed packet or protocol error? (sqlx_mysql::protocol::text::row:27)
```

```
b"\0\0\0\x02\0\0\0"
b"\0\0\0\x02\0\0\0"
b"\x03"
b"\x03def\tManticore\0\0\x02id\x02id\x0c!\0\x14\0\0\0\x08\0\0\0\0\0"
b"\x03def\tManticore\0\0\x04name\x04name\x0c!\0\xff\0\0\0\xfe\0\0\0\0\0"
b"\x03def\tManticore\0\0\x0bdescription\x0bdescription\x0c!\0\xff\0\0\0\xfe\0\0\0\0\0"
b"\x0291\x05Tacos\x17All the best taco spots"
b"\x0292\x05Tacos\x17All the best taco spots"
b"\x0293\x05Tacos\x17All the best taco spots"
b"\x0294\x05Tacos\x17All the best taco spots"
b"\x0295\x05Tacos\x17All the best taco spots"
b"\x0290\x05Tacos\x17All the best taco spots"
b"\xfe\0\0\x02\0\0\0!--- 6 out of 6 results in 3ms ---" <---- this part
```

There is a larger deep dive in the manticore project [here](https://github.com/manticoresoftware/manticoresearch/issues/3492) but the gist is that the current decoder skips the optional info field in valid mysql ok packets