### PR TITLE
fix: spec_error is used by try_from derive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ mod macros;
 #[doc(hidden)]
 pub mod ty_match;
 
-#[cfg(feature = "macros")]
+#[cfg(any(feature = "derive", feature = "macros"))]
 #[doc(hidden)]
 pub mod spec_error;
 


### PR DESCRIPTION
Hi, it's been a while :).

The `try_from` field attribute in `FromRow` uses `__spec_error` to generate a column decode error. The `spec_error` is currently gated behind the macros feature flag only, but should also be available when using only `derive`.
