### PR TITLE
Feature: Add exclusion violation error kind

### DIFF
--- a/sqlx-core/src/error.rs
+++ b/sqlx-core/src/error.rs
@@ -197,6 +197,8 @@ pub enum ErrorKind {
     NotNullViolation,
     /// Check constraint violation.
     CheckViolation,
+    /// Exclusion constraint violation.
+    ExclusionViolation,
     /// An unmapped error.
     Other,
 }

--- a/sqlx-postgres/src/error.rs
+++ b/sqlx-postgres/src/error.rs
@@ -214,6 +214,7 @@ impl DatabaseError for PgDatabaseError {
             error_codes::FOREIGN_KEY_VIOLATION => ErrorKind::ForeignKeyViolation,
             error_codes::NOT_NULL_VIOLATION => ErrorKind::NotNullViolation,
             error_codes::CHECK_VIOLATION => ErrorKind::CheckViolation,
+            error_codes::EXCLUSION_VIOLATION => ErrorKind::ExclusionViolation,
             _ => ErrorKind::Other,
         }
     }
@@ -239,4 +240,6 @@ pub(crate) mod error_codes {
     pub const NOT_NULL_VIOLATION: &str = "23502";
     /// Caused when a check constraint is violated.
     pub const CHECK_VIOLATION: &str = "23514";
+    /// Caused when a exclude constraint is violated.
+    pub const EXCLUSION_VIOLATION: &str = "23P01";
 }

--- a/tests/postgres/setup.sql
+++ b/tests/postgres/setup.sql
@@ -63,3 +63,8 @@ CREATE SCHEMA IF NOT EXISTS foo;
 CREATE TYPE foo."Foo" as ENUM ('Bar', 'Baz');
 
 CREATE TABLE mytable(f HSTORE);
+
+CREATE TABLE circles (
+    c circle,
+    EXCLUDE USING gist (c WITH &&)
+);


### PR DESCRIPTION
A rather trival addition, though there are other error codes which could probably be considered aswell. It seems as though the selection of error kinds has been kept small for a reason, i.e. only add error kind for the most "normal" errors a user would want to programmatically handle, do something with. For my usecase, the exclusion violation fits this premise, and I would say it's destinct enough from the unique violation to deserve it's own kind. Anyhow, thank you for a great library, and feel free to do with this PR what you want! 😄  

### Does your PR solve an issue?
No.

### Is this a breaking change?
No, the enum is marked as `non_exhaustive`, so adding a variant is backwards compatible.
