### PR TITLE
sqlx-mysql: Fix bug in cleanup test db's.

### DIFF
--- a/sqlx-mysql/src/testing/mod.rs
+++ b/sqlx-mysql/src/testing/mod.rs
@@ -56,8 +56,6 @@ impl TestSupport for MySql {
         for db_name in &delete_db_names {
             command.clear();
 
-            let db_name = format!("_sqlx_test_database_{db_name}");
-
             writeln!(command, "drop database if exists {db_name};").ok();
             match conn.execute(&*command).await {
                 Ok(_deleted) => {


### PR DESCRIPTION
While working on #3723 I noticed a bug in the `MySql` implementation of `TestSupport::cleanup_test_dbs` and didn't want to bury it into the massive pr. A part of the old implementation is still used to get the test db name. The code isn't used anywhere in SQLx but is part of the public API.

I can't find a way to add a regression test for this since this should be ran when all the tests are done running.