### PR TITLE
Move `QueryLogger` back

### DIFF
--- a/sqlx-core/src/logger.rs
+++ b/sqlx-core/src/logger.rs
@@ -87,6 +87,10 @@ impl QueryLogger {
         self.rows_affected += n;
     }
 
+    pub fn sql(&self) -> &SqlStr {
+        &self.sql
+    }
+
     pub fn finish(&self) {
         let elapsed = self.start.elapsed();
 


### PR DESCRIPTION
In #3723 I moved the `QueryLogger` around in the mysql and postgres drivers but that also delays the start of the logger. This pr moves them back to where they were before.