### PR TITLE
Postgres: move `PgLTree::from` to `From<Vec<PgLTreeLabel>>` implementation

### DIFF
--- a/sqlx-postgres/src/types/ltree.rs
+++ b/sqlx-postgres/src/types/ltree.rs
@@ -96,7 +96,7 @@ impl PgLTree {
     }
 
     /// creates ltree from a [`Vec<PgLTreeLabel>`]
-    pub fn from(labels: Vec<PgLTreeLabel>) -> Self {
+    pub fn from_labels(labels: Vec<PgLTreeLabel>) -> Self {
         Self { labels }
     }
 
@@ -135,6 +135,12 @@ impl PgLTree {
     /// pop a label from ltree
     pub fn pop(&mut self) -> Option<PgLTreeLabel> {
         self.labels.pop()
+    }
+}
+
+impl From<Vec<PgLTreeLabel>> for PgLTree {
+    fn from(labels: Vec<PgLTreeLabel>) -> Self {
+        Self { labels }
     }
 }
 


### PR DESCRIPTION
The title should be self-describing.

### Does your PR solve an issue?

fixes #3948 .

### Is this a breaking change?

Yes, it affects trait resolution and type inference. See [playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=1a555189191bbd7aa087b4b45aa9d4e5).
