### PR TITLE
chore: Fix warnings for custom postgres_## cfg flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,6 +245,10 @@ level = 'warn'
 check-cfg = [
     'cfg(mariadb, values(any()))',
     'cfg(sqlite_ipaddr)',
+    'cfg(postgres_12)',
+    'cfg(postgres_13)',
+    'cfg(postgres_14)',
+    'cfg(postgres_15)',
     'cfg(sqlite_test_sqlcipher)',
 ]
 


### PR DESCRIPTION
Resolves build warnings related to custom `cfg` conditions that are present in the code because they are set for various CI runs defined in a matrix in the GitHub workflow.

Example warning that disappears with this change:

```text
warning: unexpected `cfg` condition name: `postgres_15`
   --> tests/postgres/types.rs:691:24
    |
691 | #[cfg(any(postgres_14, postgres_15))]
    |                        ^^^^^^^^^^^
    |
    = help: consider using a Cargo feature instead
    = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
             [lints.rust]
             unexpected_cfgs = { level = "warn", check-cfg = ['cfg(postgres_15)'] }
    = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(postgres_15)");` to the top of the `build.rs`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
```

Note that even though `sqlx` supports Postgres 16 and 17, we do not need to add entries for those because they are never referenced as `cfg` conditions.

### Does your PR solve an issue?
No


### Is this a breaking change?
No - informs linter of an expected set of possible custom `cfg` parameter values

