### PR TITLE
`Pool.close`: close all connections before returning

### DIFF
--- a/examples/postgres/listen/src/main.rs
+++ b/examples/postgres/listen/src/main.rs
@@ -68,6 +68,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
+    // The stream is holding one connection. It needs to be dropped to allow the connection to
+    // return to the pool, otherwise `pool.close()` would never return.
+    drop(stream);
+
     pool.close().await;
 
     Ok(())


### PR DESCRIPTION
Fixes https://github.com/launchbadge/sqlx/issues/3217.
Supersedes https://github.com/launchbadge/sqlx/pull/3299.

I'm taking into consideration the discussion that already happened in https://github.com/launchbadge/sqlx/pull/3299, and then I just rebase it on the latest `main` and add one commit on top of that to address the problem with child pools. The solution turned out to be pretty simple.