### PR TITLE
Jp/sqlite arg lifetime

### DIFF
--- a/tests/sqlite/error.rs
+++ b/tests/sqlite/error.rs
@@ -1,4 +1,4 @@
-use sqlx::{error::ErrorKind, sqlite::Sqlite, Connection, Error, Executor};
+use sqlx::{error::ErrorKind, sqlite::Sqlite, Connection, Error};
 use sqlx_test::new;
 
 #[sqlx_macros::test]

--- a/tests/sqlite/types.rs
+++ b/tests/sqlite/types.rs
@@ -1,7 +1,7 @@
 extern crate time_ as time;
 
 use sqlx::sqlite::{Sqlite, SqliteRow};
-use sqlx::{FromRow, Type};
+use sqlx::Type;
 use sqlx_core::executor::Executor;
 use sqlx_core::row::Row;
 use sqlx_core::types::Text;
@@ -172,19 +172,6 @@ mod bstr {
     test_type!(bstring<BString>(Sqlite,
         "cast('abc123' as blob)" == BString::from(&b"abc123"[..]),
         "x'0001020304'" == BString::from(&b"\x00\x01\x02\x03\x04"[..])
-    ));
-}
-
-#[cfg(feature = "git2")]
-mod git2 {
-    use super::*;
-    use sqlx::types::git2::Oid;
-
-    test_type!(oid<Oid>(
-        Sqlite,
-        "x'0000000000000000000000000000000000000000'" == Oid::zero(),
-        "x'000102030405060708090a0b0c0d0e0f10111213'"
-            == Oid::from_str("000102030405060708090a0b0c0d0e0f10111213").unwrap()
     ));
 }
 


### PR DESCRIPTION
Demonstrates but does not fix an inconsistency with allowed usage of references as arguments to query macros in the context of the sqlite feature compared to features for other db platforms, such as Postgres.

Compare the test added with this pr vs the existing test by the same name for Postgres:


The [existing test for Postgres](https://github.com/launchbadge/sqlx/blob/24317d5eab40fbc33caf1142946e2f39caad73ea/tests/postgres/macros.rs#L261-L285) compiles and passes because `PgArguments` does not have a lifetime parameter. The new test for sqlite fails to compile because `SqliteArguments` has a lifetime parameter which causes the return value of the `query!` macro to be borrowing a reference to a value that is an argument to `query!` but goes out of scope when `query!` returns.

### Does your PR solve an issue?
No (not yet)

### Is this a breaking change?
Likely yes. A fix would likely involve adding or removing lifetime parameters on structs related to arguments, and those stucts are a part of the crate's public api.

