### PR TITLE
refactor(core): Remove lifetime parameter from Arguments trait

### DIFF
--- a/sqlx-core/src/any/arguments.rs
+++ b/sqlx-core/src/any/arguments.rs
@@ -12,16 +12,16 @@ pub struct AnyArguments {
     pub values: AnyArgumentBuffer,
 }
 
-impl<'q> Arguments<'q> for AnyArguments {
+impl Arguments for AnyArguments {
     type Database = Any;
 
     fn reserve(&mut self, additional: usize, _size: usize) {
         self.values.0.reserve(additional);
     }
 
-    fn add<T>(&mut self, value: T) -> Result<(), BoxDynError>
+    fn add<'t, T>(&mut self, value: T) -> Result<(), BoxDynError>
     where
-        T: 'q + Encode<'q, Self::Database> + Type<Self::Database>,
+        T: Encode<'t, Self::Database> + Type<Self::Database>,
     {
         let _: IsNull = value.encode(&mut self.values)?;
         Ok(())
@@ -37,7 +37,7 @@ pub struct AnyArgumentBuffer(#[doc(hidden)] pub Vec<AnyValueKind>);
 
 impl AnyArguments {
     #[doc(hidden)]
-    pub fn convert_into<'a, A: Arguments<'a>>(self) -> Result<A, BoxDynError>
+    pub fn convert_into<'a, A: Arguments>(self) -> Result<A, BoxDynError>
     where
         Option<i32>: Type<A::Database> + Encode<'a, A::Database>,
         Option<bool>: Type<A::Database> + Encode<'a, A::Database>,

--- a/sqlx-core/src/any/database.rs
+++ b/sqlx-core/src/any/database.rs
@@ -25,8 +25,8 @@ impl Database for Any {
     type Value = AnyValue;
     type ValueRef<'r> = AnyValueRef<'r>;
 
-    type Arguments<'q> = AnyArguments;
-    type ArgumentBuffer<'q> = AnyArgumentBuffer;
+    type Arguments = AnyArguments;
+    type ArgumentBuffer = AnyArgumentBuffer;
 
     type Statement = AnyStatement;
 

--- a/sqlx-core/src/any/types/blob.rs
+++ b/sqlx-core/src/any/types/blob.rs
@@ -17,7 +17,7 @@ impl Type<Any> for [u8] {
 impl<'q> Encode<'q, Any> for &'q [u8] {
     fn encode_by_ref(
         &self,
-        buf: &mut <Any as Database>::ArgumentBuffer<'q>,
+        buf: &mut <Any as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         buf.0.push(AnyValueKind::Blob(Arc::new(self.to_vec())));
         Ok(IsNull::No)
@@ -39,10 +39,10 @@ impl Type<Any> for Vec<u8> {
     }
 }
 
-impl<'q> Encode<'q, Any> for Vec<u8> {
+impl Encode<'_, Any> for Vec<u8> {
     fn encode_by_ref(
         &self,
-        buf: &mut <Any as Database>::ArgumentBuffer<'q>,
+        buf: &mut <Any as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         buf.0.push(AnyValueKind::Blob(Arc::new(self.clone())));
         Ok(IsNull::No)

--- a/sqlx-core/src/any/types/bool.rs
+++ b/sqlx-core/src/any/types/bool.rs
@@ -13,10 +13,10 @@ impl Type<Any> for bool {
     }
 }
 
-impl<'q> Encode<'q, Any> for bool {
+impl Encode<'_, Any> for bool {
     fn encode_by_ref(
         &self,
-        buf: &mut <Any as Database>::ArgumentBuffer<'q>,
+        buf: &mut <Any as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         buf.0.push(AnyValueKind::Bool(*self));
         Ok(IsNull::No)

--- a/sqlx-core/src/any/types/float.rs
+++ b/sqlx-core/src/any/types/float.rs
@@ -37,10 +37,10 @@ impl Type<Any> for f64 {
     }
 }
 
-impl<'q> Encode<'q, Any> for f64 {
+impl Encode<'_, Any> for f64 {
     fn encode_by_ref(
         &self,
-        buf: &mut <Any as Database>::ArgumentBuffer<'q>,
+        buf: &mut <Any as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         buf.0.push(AnyValueKind::Double(*self));
         Ok(IsNull::No)

--- a/sqlx-core/src/any/types/int.rs
+++ b/sqlx-core/src/any/types/int.rs
@@ -17,10 +17,10 @@ impl Type<Any> for i16 {
     }
 }
 
-impl<'q> Encode<'q, Any> for i16 {
+impl Encode<'_, Any> for i16 {
     fn encode_by_ref(
         &self,
-        buf: &mut <Any as Database>::ArgumentBuffer<'q>,
+        buf: &mut <Any as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         buf.0.push(AnyValueKind::SmallInt(*self));
         Ok(IsNull::No)
@@ -45,10 +45,10 @@ impl Type<Any> for i32 {
     }
 }
 
-impl<'q> Encode<'q, Any> for i32 {
+impl Encode<'_, Any> for i32 {
     fn encode_by_ref(
         &self,
-        buf: &mut <Any as Database>::ArgumentBuffer<'q>,
+        buf: &mut <Any as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         buf.0.push(AnyValueKind::Integer(*self));
         Ok(IsNull::No)
@@ -73,10 +73,10 @@ impl Type<Any> for i64 {
     }
 }
 
-impl<'q> Encode<'q, Any> for i64 {
+impl Encode<'_, Any> for i64 {
     fn encode_by_ref(
         &self,
-        buf: &mut <Any as Database>::ArgumentBuffer<'q>,
+        buf: &mut <Any as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         buf.0.push(AnyValueKind::BigInt(*self));
         Ok(IsNull::No)

--- a/sqlx-core/src/any/types/str.rs
+++ b/sqlx-core/src/any/types/str.rs
@@ -16,7 +16,7 @@ impl Type<Any> for str {
 }
 
 impl<'a> Encode<'a, Any> for &'a str {
-    fn encode(self, buf: &mut <Any as Database>::ArgumentBuffer<'a>) -> Result<IsNull, BoxDynError>
+    fn encode(self, buf: &mut <Any as Database>::ArgumentBuffer) -> Result<IsNull, BoxDynError>
     where
         Self: Sized,
     {
@@ -26,7 +26,7 @@ impl<'a> Encode<'a, Any> for &'a str {
 
     fn encode_by_ref(
         &self,
-        buf: &mut <Any as Database>::ArgumentBuffer<'a>,
+        buf: &mut <Any as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         (*self).encode(buf)
     }
@@ -47,18 +47,15 @@ impl Type<Any> for String {
     }
 }
 
-impl<'q> Encode<'q, Any> for String {
-    fn encode(
-        self,
-        buf: &mut <Any as Database>::ArgumentBuffer<'q>,
-    ) -> Result<IsNull, BoxDynError> {
+impl Encode<'_, Any> for String {
+    fn encode(self, buf: &mut <Any as Database>::ArgumentBuffer) -> Result<IsNull, BoxDynError> {
         buf.0.push(AnyValueKind::Text(Arc::new(self)));
         Ok(IsNull::No)
     }
 
     fn encode_by_ref(
         &self,
-        buf: &mut <Any as Database>::ArgumentBuffer<'q>,
+        buf: &mut <Any as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         buf.0.push(AnyValueKind::Text(Arc::new(self.clone())));
         Ok(IsNull::No)

--- a/sqlx-core/src/arguments.rs
+++ b/sqlx-core/src/arguments.rs
@@ -9,7 +9,7 @@ use std::fmt::{self, Write};
 /// A tuple of arguments to be sent to the database.
 // This lint is designed for general collections, but `Arguments` is not meant to be as such.
 #[allow(clippy::len_without_is_empty)]
-pub trait Arguments<'q>: Send + Sized + Default {
+pub trait Arguments: Send + Sized + Default {
     type Database: Database;
 
     /// Reserves the capacity for at least `additional` more values (of `size` total bytes) to
@@ -17,9 +17,9 @@ pub trait Arguments<'q>: Send + Sized + Default {
     fn reserve(&mut self, additional: usize, size: usize);
 
     /// Add the value to the end of the arguments.
-    fn add<T>(&mut self, value: T) -> Result<(), BoxDynError>
+    fn add<'t, T>(&mut self, value: T) -> Result<(), BoxDynError>
     where
-        T: 'q + Encode<'q, Self::Database> + Type<Self::Database>;
+        T: Encode<'t, Self::Database> + Type<Self::Database>;
 
     /// The number of arguments that were already added.
     fn len(&self) -> usize;
@@ -29,19 +29,17 @@ pub trait Arguments<'q>: Send + Sized + Default {
     }
 }
 
-pub trait IntoArguments<'q, DB: Database>: Sized + Send {
-    fn into_arguments(self) -> <DB as Database>::Arguments<'q>;
+pub trait IntoArguments<DB: Database>: Sized + Send {
+    fn into_arguments(self) -> <DB as Database>::Arguments;
 }
 
 // NOTE: required due to lack of lazy normalization
 #[macro_export]
 macro_rules! impl_into_arguments_for_arguments {
     ($Arguments:path) => {
-        impl<'q>
-            $crate::arguments::IntoArguments<
-                'q,
-                <$Arguments as $crate::arguments::Arguments<'q>>::Database,
-            > for $Arguments
+        impl
+            $crate::arguments::IntoArguments<<$Arguments as $crate::arguments::Arguments>::Database>
+            for $Arguments
         {
             fn into_arguments(self) -> $Arguments {
                 self
@@ -51,13 +49,10 @@ macro_rules! impl_into_arguments_for_arguments {
 }
 
 /// used by the query macros to prevent supernumerary `.bind()` calls
-pub struct ImmutableArguments<'q, DB: Database>(pub <DB as Database>::Arguments<'q>);
+pub struct ImmutableArguments<DB: Database>(pub <DB as Database>::Arguments);
 
-impl<'q, DB: Database> IntoArguments<'q, DB> for ImmutableArguments<'q, DB> {
-    fn into_arguments(self) -> <DB as Database>::Arguments<'q> {
+impl<DB: Database> IntoArguments<DB> for ImmutableArguments<DB> {
+    fn into_arguments(self) -> <DB as Database>::Arguments {
         self.0
     }
 }
-
-// TODO: Impl `IntoArguments` for &[&dyn Encode]
-// TODO: Impl `IntoArguments` for (impl Encode, ...) x16

--- a/sqlx-core/src/database.rs
+++ b/sqlx-core/src/database.rs
@@ -96,9 +96,9 @@ pub trait Database: 'static + Sized + Send + Debug {
     type ValueRef<'r>: ValueRef<'r, Database = Self>;
 
     /// The concrete `Arguments` implementation for this database.
-    type Arguments<'q>: Arguments<'q, Database = Self>;
+    type Arguments: Arguments<Database = Self>;
     /// The concrete type used as a buffer for arguments while encoding.
-    type ArgumentBuffer<'q>;
+    type ArgumentBuffer;
 
     /// The concrete `Statement` implementation for this database.
     type Statement: Statement<Database = Self>;

--- a/sqlx-core/src/encode.rs
+++ b/sqlx-core/src/encode.rs
@@ -29,7 +29,7 @@ impl IsNull {
 /// Encode a single value to be sent to the database.
 pub trait Encode<'q, DB: Database> {
     /// Writes the value of `self` into `buf` in the expected format for the database.
-    fn encode(self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> Result<IsNull, BoxDynError>
+    fn encode(self, buf: &mut <DB as Database>::ArgumentBuffer) -> Result<IsNull, BoxDynError>
     where
         Self: Sized,
     {
@@ -42,7 +42,7 @@ pub trait Encode<'q, DB: Database> {
     /// memory.
     fn encode_by_ref(
         &self,
-        buf: &mut <DB as Database>::ArgumentBuffer<'q>,
+        buf: &mut <DB as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError>;
 
     fn produces(&self) -> Option<DB::TypeInfo> {
@@ -62,14 +62,14 @@ where
     T: Encode<'q, DB>,
 {
     #[inline]
-    fn encode(self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> Result<IsNull, BoxDynError> {
+    fn encode(self, buf: &mut <DB as Database>::ArgumentBuffer) -> Result<IsNull, BoxDynError> {
         <T as Encode<DB>>::encode_by_ref(self, buf)
     }
 
     #[inline]
     fn encode_by_ref(
         &self,
-        buf: &mut <DB as Database>::ArgumentBuffer<'q>,
+        buf: &mut <DB as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         <&T as Encode<DB>>::encode(self, buf)
     }
@@ -104,7 +104,7 @@ macro_rules! impl_encode_for_option {
             #[inline]
             fn encode(
                 self,
-                buf: &mut <$DB as $crate::database::Database>::ArgumentBuffer<'q>,
+                buf: &mut <$DB as $crate::database::Database>::ArgumentBuffer,
             ) -> Result<$crate::encode::IsNull, $crate::error::BoxDynError> {
                 if let Some(v) = self {
                     v.encode(buf)
@@ -116,7 +116,7 @@ macro_rules! impl_encode_for_option {
             #[inline]
             fn encode_by_ref(
                 &self,
-                buf: &mut <$DB as $crate::database::Database>::ArgumentBuffer<'q>,
+                buf: &mut <$DB as $crate::database::Database>::ArgumentBuffer,
             ) -> Result<$crate::encode::IsNull, $crate::error::BoxDynError> {
                 if let Some(v) = self {
                     v.encode_by_ref(buf)
@@ -142,7 +142,7 @@ macro_rules! impl_encode_for_smartpointer {
             #[inline]
             fn encode(
                 self,
-                buf: &mut <DB as Database>::ArgumentBuffer<'q>,
+                buf: &mut <DB as Database>::ArgumentBuffer,
             ) -> Result<IsNull, BoxDynError> {
                 <T as Encode<DB>>::encode_by_ref(self.as_ref(), buf)
             }
@@ -150,7 +150,7 @@ macro_rules! impl_encode_for_smartpointer {
             #[inline]
             fn encode_by_ref(
                 &self,
-                buf: &mut <DB as Database>::ArgumentBuffer<'q>,
+                buf: &mut <DB as Database>::ArgumentBuffer,
             ) -> Result<IsNull, BoxDynError> {
                 <&T as Encode<DB>>::encode(self, buf)
             }
@@ -178,14 +178,14 @@ where
     T: ToOwned,
 {
     #[inline]
-    fn encode(self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> Result<IsNull, BoxDynError> {
+    fn encode(self, buf: &mut <DB as Database>::ArgumentBuffer) -> Result<IsNull, BoxDynError> {
         <&T as Encode<DB>>::encode_by_ref(&self.as_ref(), buf)
     }
 
     #[inline]
     fn encode_by_ref(
         &self,
-        buf: &mut <DB as Database>::ArgumentBuffer<'q>,
+        buf: &mut <DB as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         <&T as Encode<DB>>::encode_by_ref(&self.as_ref(), buf)
     }
@@ -207,7 +207,7 @@ macro_rules! forward_encode_impl {
         impl<'q> Encode<'q, $db> for $for_type {
             fn encode_by_ref(
                 &self,
-                buf: &mut <$db as sqlx_core::database::Database>::ArgumentBuffer<'q>,
+                buf: &mut <$db as sqlx_core::database::Database>::ArgumentBuffer,
             ) -> Result<IsNull, BoxDynError> {
                 <$forward_to as Encode<$db>>::encode(self.as_ref(), buf)
             }

--- a/sqlx-core/src/executor.rs
+++ b/sqlx-core/src/executor.rs
@@ -204,13 +204,13 @@ pub trait Execute<'q, DB: Database>: Send + Sized {
     /// will be prepared (and cached) before execution.
     ///
     /// Returns `Err` if encoding any of the arguments failed.
-    fn take_arguments(&mut self) -> Result<Option<<DB as Database>::Arguments<'q>>, BoxDynError>;
+    fn take_arguments(&mut self) -> Result<Option<<DB as Database>::Arguments>, BoxDynError>;
 
     /// Returns `true` if the statement should be cached.
     fn persistent(&self) -> bool;
 }
 
-impl<'q, DB: Database, T> Execute<'q, DB> for T
+impl<DB: Database, T> Execute<'_, DB> for T
 where
     T: SqlSafeStr + Send,
 {
@@ -225,7 +225,7 @@ where
     }
 
     #[inline]
-    fn take_arguments(&mut self) -> Result<Option<<DB as Database>::Arguments<'q>>, BoxDynError> {
+    fn take_arguments(&mut self) -> Result<Option<<DB as Database>::Arguments>, BoxDynError> {
         Ok(None)
     }
 
@@ -235,7 +235,7 @@ where
     }
 }
 
-impl<'q, DB: Database, T> Execute<'q, DB> for (T, Option<<DB as Database>::Arguments<'q>>)
+impl<DB: Database, T> Execute<'_, DB> for (T, Option<<DB as Database>::Arguments>)
 where
     T: SqlSafeStr + Send,
 {
@@ -250,7 +250,7 @@ where
     }
 
     #[inline]
-    fn take_arguments(&mut self) -> Result<Option<<DB as Database>::Arguments<'q>>, BoxDynError> {
+    fn take_arguments(&mut self) -> Result<Option<<DB as Database>::Arguments>, BoxDynError> {
         Ok(self.1.take())
     }
 

--- a/sqlx-core/src/query.rs
+++ b/sqlx-core/src/query.rs
@@ -73,7 +73,7 @@ where
     }
 }
 
-impl<'q, DB: Database> Query<'q, DB, <DB as Database>::Arguments> {
+impl<DB: Database> Query<'_, DB, <DB as Database>::Arguments> {
     /// Bind a value for use with this SQL query.
     ///
     /// If the number of times this is called does not match the number of bind parameters that
@@ -84,7 +84,7 @@ impl<'q, DB: Database> Query<'q, DB, <DB as Database>::Arguments> {
     /// flavors will perform type coercion (Postgres will return a database error).
     ///
     /// If encoding the value fails, the error is stored and later surfaced when executing the query.
-    pub fn bind<T: 'q + Encode<'q, DB> + Type<DB>>(mut self, value: T) -> Self {
+    pub fn bind<'t, T: Encode<'t, DB> + Type<DB>>(mut self, value: T) -> Self {
         let Ok(arguments) = self.get_arguments() else {
             return self;
         };
@@ -101,7 +101,7 @@ impl<'q, DB: Database> Query<'q, DB, <DB as Database>::Arguments> {
     }
 
     /// Like [`Query::bind`] but immediately returns an error if encoding a value failed.
-    pub fn try_bind<T: 'q + Encode<'q, DB> + Type<DB>>(
+    pub fn try_bind<'t, T: Encode<'t, DB> + Type<DB>>(
         &mut self,
         value: T,
     ) -> Result<(), BoxDynError> {

--- a/sqlx-core/src/query.rs
+++ b/sqlx-core/src/query.rs
@@ -42,7 +42,7 @@ pub struct Map<'q, DB: Database, F, A> {
 impl<'q, DB, A> Execute<'q, DB> for Query<'q, DB, A>
 where
     DB: Database,
-    A: Send + IntoArguments<'q, DB>,
+    A: Send + IntoArguments<DB>,
 {
     #[inline]
     fn sql(self) -> SqlStr {
@@ -60,7 +60,7 @@ where
     }
 
     #[inline]
-    fn take_arguments(&mut self) -> Result<Option<<DB as Database>::Arguments<'q>>, BoxDynError> {
+    fn take_arguments(&mut self) -> Result<Option<<DB as Database>::Arguments>, BoxDynError> {
         self.arguments
             .take()
             .transpose()
@@ -73,7 +73,7 @@ where
     }
 }
 
-impl<'q, DB: Database> Query<'q, DB, <DB as Database>::Arguments<'q>> {
+impl<'q, DB: Database> Query<'q, DB, <DB as Database>::Arguments> {
     /// Bind a value for use with this SQL query.
     ///
     /// If the number of times this is called does not match the number of bind parameters that
@@ -110,7 +110,7 @@ impl<'q, DB: Database> Query<'q, DB, <DB as Database>::Arguments<'q>> {
         arguments.add(value)
     }
 
-    fn get_arguments(&mut self) -> Result<&mut DB::Arguments<'q>, BoxDynError> {
+    fn get_arguments(&mut self) -> Result<&mut DB::Arguments, BoxDynError> {
         let Some(Ok(arguments)) = self.arguments.as_mut().map(Result::as_mut) else {
             return Err("A previous call to Query::bind produced an error"
                 .to_owned()
@@ -144,7 +144,7 @@ where
 impl<'q, DB, A: Send> Query<'q, DB, A>
 where
     DB: Database,
-    A: 'q + IntoArguments<'q, DB>,
+    A: 'q + IntoArguments<DB>,
 {
     /// Map each row in the result to another type.
     ///
@@ -301,7 +301,7 @@ where
 impl<'q, DB, F: Send, A: Send> Execute<'q, DB> for Map<'q, DB, F, A>
 where
     DB: Database,
-    A: IntoArguments<'q, DB>,
+    A: IntoArguments<DB>,
 {
     #[inline]
     fn sql(self) -> SqlStr {
@@ -314,7 +314,7 @@ where
     }
 
     #[inline]
-    fn take_arguments(&mut self) -> Result<Option<<DB as Database>::Arguments<'q>>, BoxDynError> {
+    fn take_arguments(&mut self) -> Result<Option<<DB as Database>::Arguments>, BoxDynError> {
         self.inner.take_arguments()
     }
 
@@ -329,7 +329,7 @@ where
     DB: Database,
     F: FnMut(DB::Row) -> Result<O, Error> + Send,
     O: Send + Unpin,
-    A: 'q + Send + IntoArguments<'q, DB>,
+    A: 'q + Send + IntoArguments<DB>,
 {
     /// Map each row in the result to another type.
     ///
@@ -500,9 +500,7 @@ where
 }
 
 /// Execute a single SQL query as a prepared statement (explicitly created).
-pub fn query_statement<DB>(
-    statement: &DB::Statement,
-) -> Query<'_, DB, <DB as Database>::Arguments<'_>>
+pub fn query_statement<DB>(statement: &DB::Statement) -> Query<'_, DB, <DB as Database>::Arguments>
 where
     DB: Database,
 {
@@ -515,13 +513,10 @@ where
 }
 
 /// Execute a single SQL query as a prepared statement (explicitly created), with the given arguments.
-pub fn query_statement_with<'q, DB, A>(
-    statement: &'q DB::Statement,
-    arguments: A,
-) -> Query<'q, DB, A>
+pub fn query_statement_with<DB, A>(statement: &DB::Statement, arguments: A) -> Query<'_, DB, A>
 where
     DB: Database,
-    A: IntoArguments<'q, DB>,
+    A: IntoArguments<DB>,
 {
     Query {
         database: PhantomData,
@@ -655,7 +650,7 @@ where
 ///
 /// As an additional benefit, query parameters are usually sent in a compact binary encoding instead of a human-readable
 /// text encoding, which saves bandwidth.
-pub fn query<'a, DB>(sql: impl SqlSafeStr) -> Query<'a, DB, <DB as Database>::Arguments<'a>>
+pub fn query<'a, DB>(sql: impl SqlSafeStr) -> Query<'a, DB, <DB as Database>::Arguments>
 where
     DB: Database,
 {
@@ -673,7 +668,7 @@ where
 pub fn query_with<'q, DB, A>(sql: impl SqlSafeStr, arguments: A) -> Query<'q, DB, A>
 where
     DB: Database,
-    A: IntoArguments<'q, DB>,
+    A: IntoArguments<DB>,
 {
     query_with_result(sql, Ok(arguments))
 }
@@ -685,7 +680,7 @@ pub fn query_with_result<'q, DB, A>(
 ) -> Query<'q, DB, A>
 where
     DB: Database,
-    A: IntoArguments<'q, DB>,
+    A: IntoArguments<DB>,
 {
     Query {
         database: PhantomData,

--- a/sqlx-core/src/query_as.rs
+++ b/sqlx-core/src/query_as.rs
@@ -25,7 +25,7 @@ pub struct QueryAs<'q, DB: Database, O, A> {
 impl<'q, DB, O: Send, A: Send> Execute<'q, DB> for QueryAs<'q, DB, O, A>
 where
     DB: Database,
-    A: 'q + IntoArguments<'q, DB>,
+    A: 'q + IntoArguments<DB>,
 {
     #[inline]
     fn sql(self) -> SqlStr {
@@ -38,7 +38,7 @@ where
     }
 
     #[inline]
-    fn take_arguments(&mut self) -> Result<Option<<DB as Database>::Arguments<'q>>, BoxDynError> {
+    fn take_arguments(&mut self) -> Result<Option<<DB as Database>::Arguments>, BoxDynError> {
         self.inner.take_arguments()
     }
 
@@ -48,7 +48,7 @@ where
     }
 }
 
-impl<'q, DB: Database, O> QueryAs<'q, DB, O, <DB as Database>::Arguments<'q>> {
+impl<'q, DB: Database, O> QueryAs<'q, DB, O, <DB as Database>::Arguments> {
     /// Bind a value for use with this SQL query.
     ///
     /// See [`Query::bind`](Query::bind).
@@ -83,7 +83,7 @@ where
 impl<'q, DB, O, A> QueryAs<'q, DB, O, A>
 where
     DB: Database,
-    A: 'q + IntoArguments<'q, DB>,
+    A: 'q + IntoArguments<DB>,
     O: Send + Unpin + for<'r> FromRow<'r, DB::Row>,
 {
     /// Execute the query and return the generated results as a stream.
@@ -338,9 +338,7 @@ where
 ///
 /// ```
 #[inline]
-pub fn query_as<'q, DB, O>(
-    sql: impl SqlSafeStr,
-) -> QueryAs<'q, DB, O, <DB as Database>::Arguments<'q>>
+pub fn query_as<'q, DB, O>(sql: impl SqlSafeStr) -> QueryAs<'q, DB, O, <DB as Database>::Arguments>
 where
     DB: Database,
     O: for<'r> FromRow<'r, DB::Row>,
@@ -361,7 +359,7 @@ where
 pub fn query_as_with<'q, DB, O, A>(sql: impl SqlSafeStr, arguments: A) -> QueryAs<'q, DB, O, A>
 where
     DB: Database,
-    A: IntoArguments<'q, DB>,
+    A: IntoArguments<DB>,
     O: for<'r> FromRow<'r, DB::Row>,
 {
     query_as_with_result(sql, Ok(arguments))
@@ -375,7 +373,7 @@ pub fn query_as_with_result<'q, DB, O, A>(
 ) -> QueryAs<'q, DB, O, A>
 where
     DB: Database,
-    A: IntoArguments<'q, DB>,
+    A: IntoArguments<DB>,
     O: for<'r> FromRow<'r, DB::Row>,
 {
     QueryAs {
@@ -387,7 +385,7 @@ where
 // Make a SQL query from a statement, that is mapped to a concrete type.
 pub fn query_statement_as<DB, O>(
     statement: &DB::Statement,
-) -> QueryAs<'_, DB, O, <DB as Database>::Arguments<'_>>
+) -> QueryAs<'_, DB, O, <DB as Database>::Arguments>
 where
     DB: Database,
     O: for<'r> FromRow<'r, DB::Row>,
@@ -405,7 +403,7 @@ pub fn query_statement_as_with<'q, DB, O, A>(
 ) -> QueryAs<'q, DB, O, A>
 where
     DB: Database,
-    A: IntoArguments<'q, DB>,
+    A: IntoArguments<DB>,
     O: for<'r> FromRow<'r, DB::Row>,
 {
     QueryAs {

--- a/sqlx-core/src/query_scalar.rs
+++ b/sqlx-core/src/query_scalar.rs
@@ -23,7 +23,7 @@ pub struct QueryScalar<'q, DB: Database, O, A> {
 
 impl<'q, DB: Database, O: Send, A: Send> Execute<'q, DB> for QueryScalar<'q, DB, O, A>
 where
-    A: 'q + IntoArguments<'q, DB>,
+    A: 'q + IntoArguments<DB>,
 {
     #[inline]
     fn sql(self) -> SqlStr {
@@ -35,7 +35,7 @@ where
     }
 
     #[inline]
-    fn take_arguments(&mut self) -> Result<Option<<DB as Database>::Arguments<'q>>, BoxDynError> {
+    fn take_arguments(&mut self) -> Result<Option<<DB as Database>::Arguments>, BoxDynError> {
         self.inner.take_arguments()
     }
 
@@ -45,7 +45,7 @@ where
     }
 }
 
-impl<'q, DB: Database, O> QueryScalar<'q, DB, O, <DB as Database>::Arguments<'q>> {
+impl<'q, DB: Database, O> QueryScalar<'q, DB, O, <DB as Database>::Arguments> {
     /// Bind a value for use with this SQL query.
     ///
     /// See [`Query::bind`](crate::query::Query::bind).
@@ -81,7 +81,7 @@ impl<'q, DB, O, A> QueryScalar<'q, DB, O, A>
 where
     DB: Database,
     O: Send + Unpin,
-    A: 'q + IntoArguments<'q, DB>,
+    A: 'q + IntoArguments<DB>,
     (O,): Send + Unpin + for<'r> FromRow<'r, DB::Row>,
 {
     /// Execute the query and return the generated results as a stream.
@@ -321,7 +321,7 @@ where
 #[inline]
 pub fn query_scalar<'q, DB, O>(
     sql: impl SqlSafeStr,
-) -> QueryScalar<'q, DB, O, <DB as Database>::Arguments<'q>>
+) -> QueryScalar<'q, DB, O, <DB as Database>::Arguments>
 where
     DB: Database,
     (O,): for<'r> FromRow<'r, DB::Row>,
@@ -344,7 +344,7 @@ pub fn query_scalar_with<'q, DB, O, A>(
 ) -> QueryScalar<'q, DB, O, A>
 where
     DB: Database,
-    A: IntoArguments<'q, DB>,
+    A: IntoArguments<DB>,
     (O,): for<'r> FromRow<'r, DB::Row>,
 {
     query_scalar_with_result(sql, Ok(arguments))
@@ -358,7 +358,7 @@ pub fn query_scalar_with_result<'q, DB, O, A>(
 ) -> QueryScalar<'q, DB, O, A>
 where
     DB: Database,
-    A: IntoArguments<'q, DB>,
+    A: IntoArguments<DB>,
     (O,): for<'r> FromRow<'r, DB::Row>,
 {
     QueryScalar {
@@ -369,7 +369,7 @@ where
 // Make a SQL query from a statement, that is mapped to a concrete value.
 pub fn query_statement_scalar<DB, O>(
     statement: &DB::Statement,
-) -> QueryScalar<'_, DB, O, <DB as Database>::Arguments<'_>>
+) -> QueryScalar<'_, DB, O, <DB as Database>::Arguments>
 where
     DB: Database,
     (O,): for<'r> FromRow<'r, DB::Row>,
@@ -386,7 +386,7 @@ pub fn query_statement_scalar_with<'q, DB, O, A>(
 ) -> QueryScalar<'q, DB, O, A>
 where
     DB: Database,
-    A: IntoArguments<'q, DB>,
+    A: IntoArguments<DB>,
     (O,): for<'r> FromRow<'r, DB::Row>,
 {
     QueryScalar {

--- a/sqlx-core/src/raw_sql.rs
+++ b/sqlx-core/src/raw_sql.rs
@@ -120,7 +120,7 @@ pub fn raw_sql(sql: impl SqlSafeStr) -> RawSql {
     RawSql(sql.into_sql_str())
 }
 
-impl<'q, DB: Database> Execute<'q, DB> for RawSql {
+impl<DB: Database> Execute<'_, DB> for RawSql {
     fn sql(self) -> SqlStr {
         self.0
     }
@@ -129,7 +129,7 @@ impl<'q, DB: Database> Execute<'q, DB> for RawSql {
         None
     }
 
-    fn take_arguments(&mut self) -> Result<Option<<DB as Database>::Arguments<'q>>, BoxDynError> {
+    fn take_arguments(&mut self) -> Result<Option<<DB as Database>::Arguments>, BoxDynError> {
         Ok(None)
     }
 

--- a/sqlx-core/src/statement.rs
+++ b/sqlx-core/src/statement.rs
@@ -59,33 +59,33 @@ pub trait Statement: Send + Sync + Clone {
         Ok(&self.columns()[index.index(self)?])
     }
 
-    fn query(&self) -> Query<'_, Self::Database, <Self::Database as Database>::Arguments<'_>>;
+    fn query(&self) -> Query<'_, Self::Database, <Self::Database as Database>::Arguments>;
 
-    fn query_with<'s, A>(&'s self, arguments: A) -> Query<'s, Self::Database, A>
+    fn query_with<A>(&self, arguments: A) -> Query<'_, Self::Database, A>
     where
-        A: IntoArguments<'s, Self::Database>;
+        A: IntoArguments<Self::Database>;
 
     fn query_as<O>(
         &self,
-    ) -> QueryAs<'_, Self::Database, O, <Self::Database as Database>::Arguments<'_>>
+    ) -> QueryAs<'_, Self::Database, O, <Self::Database as Database>::Arguments>
     where
         O: for<'r> FromRow<'r, <Self::Database as Database>::Row>;
 
     fn query_as_with<'s, O, A>(&'s self, arguments: A) -> QueryAs<'s, Self::Database, O, A>
     where
         O: for<'r> FromRow<'r, <Self::Database as Database>::Row>,
-        A: IntoArguments<'s, Self::Database>;
+        A: IntoArguments<Self::Database>;
 
     fn query_scalar<O>(
         &self,
-    ) -> QueryScalar<'_, Self::Database, O, <Self::Database as Database>::Arguments<'_>>
+    ) -> QueryScalar<'_, Self::Database, O, <Self::Database as Database>::Arguments>
     where
         (O,): for<'r> FromRow<'r, <Self::Database as Database>::Row>;
 
     fn query_scalar_with<'s, O, A>(&'s self, arguments: A) -> QueryScalar<'s, Self::Database, O, A>
     where
         (O,): for<'r> FromRow<'r, <Self::Database as Database>::Row>,
-        A: IntoArguments<'s, Self::Database>;
+        A: IntoArguments<Self::Database>;
 }
 
 #[macro_export]
@@ -97,9 +97,9 @@ macro_rules! impl_statement_query {
         }
 
         #[inline]
-        fn query_with<'s, A>(&'s self, arguments: A) -> $crate::query::Query<'s, Self::Database, A>
+        fn query_with<A>(&self, arguments: A) -> $crate::query::Query<'_, Self::Database, A>
         where
-            A: $crate::arguments::IntoArguments<'s, Self::Database>,
+            A: $crate::arguments::IntoArguments<Self::Database>,
         {
             $crate::query::query_statement_with(self, arguments)
         }
@@ -111,7 +111,7 @@ macro_rules! impl_statement_query {
             '_,
             Self::Database,
             O,
-            <Self::Database as $crate::database::Database>::Arguments<'_>,
+            <Self::Database as $crate::database::Database>::Arguments,
         >
         where
             O: for<'r> $crate::from_row::FromRow<
@@ -132,7 +132,7 @@ macro_rules! impl_statement_query {
                 'r,
                 <Self::Database as $crate::database::Database>::Row,
             >,
-            A: $crate::arguments::IntoArguments<'s, Self::Database>,
+            A: $crate::arguments::IntoArguments<Self::Database>,
         {
             $crate::query_as::query_statement_as_with(self, arguments)
         }
@@ -144,7 +144,7 @@ macro_rules! impl_statement_query {
             '_,
             Self::Database,
             O,
-            <Self::Database as $crate::database::Database>::Arguments<'_>,
+            <Self::Database as $crate::database::Database>::Arguments,
         >
         where
             (O,): for<'r> $crate::from_row::FromRow<
@@ -165,7 +165,7 @@ macro_rules! impl_statement_query {
                 'r,
                 <Self::Database as $crate::database::Database>::Row,
             >,
-            A: $crate::arguments::IntoArguments<'s, Self::Database>,
+            A: $crate::arguments::IntoArguments<Self::Database>,
         {
             $crate::query_scalar::query_statement_scalar_with(self, arguments)
         }

--- a/sqlx-core/src/testing/fixtures.rs
+++ b/sqlx-core/src/testing/fixtures.rs
@@ -112,7 +112,7 @@ impl<DB: Database> FixtureSnapshot<DB> {
 #[allow(clippy::to_string_trait_impl)]
 impl<DB: Database> ToString for Fixture<DB>
 where
-    for<'a> <DB as Database>::Arguments<'a>: Default,
+    for<'a> <DB as Database>::Arguments: Default,
 {
     fn to_string(&self) -> String {
         let mut query = QueryBuilder::<DB>::new("");

--- a/sqlx-core/src/types/bstr.rs
+++ b/sqlx-core/src/types/bstr.rs
@@ -39,7 +39,7 @@ where
 {
     fn encode_by_ref(
         &self,
-        buf: &mut <DB as Database>::ArgumentBuffer<'q>,
+        buf: &mut <DB as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         <&[u8] as Encode<DB>>::encode(self.as_bytes(), buf)
     }
@@ -52,7 +52,7 @@ where
 {
     fn encode_by_ref(
         &self,
-        buf: &mut <DB as Database>::ArgumentBuffer<'q>,
+        buf: &mut <DB as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         <Vec<u8> as Encode<DB>>::encode(self.as_bytes().to_vec(), buf)
     }

--- a/sqlx-core/src/types/json.rs
+++ b/sqlx-core/src/types/json.rs
@@ -166,7 +166,7 @@ where
 {
     fn encode_by_ref(
         &self,
-        buf: &mut <DB as Database>::ArgumentBuffer<'q>,
+        buf: &mut <DB as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         <Json<&Self> as Encode<'q, DB>>::encode(Json(self), buf)
     }
@@ -203,7 +203,7 @@ where
 {
     fn encode_by_ref(
         &self,
-        buf: &mut <DB as Database>::ArgumentBuffer<'q>,
+        buf: &mut <DB as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         <Json<&Self> as Encode<'q, DB>>::encode(Json(self), buf)
     }
@@ -216,7 +216,7 @@ where
 {
     fn encode_by_ref(
         &self,
-        buf: &mut <DB as Database>::ArgumentBuffer<'q>,
+        buf: &mut <DB as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         <Json<&Self> as Encode<'q, DB>>::encode(Json(self), buf)
     }
@@ -229,7 +229,7 @@ where
 {
     fn encode_by_ref(
         &self,
-        buf: &mut <DB as Database>::ArgumentBuffer<'q>,
+        buf: &mut <DB as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         <Json<&Self> as Encode<'q, DB>>::encode(Json(self), buf)
     }

--- a/sqlx-core/src/types/non_zero.rs
+++ b/sqlx-core/src/types/non_zero.rs
@@ -33,11 +33,11 @@ macro_rules! impl_non_zero {
             DB: Database,
             $int: Encode<'q, DB>,
         {
-            fn encode_by_ref(&self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> Result<IsNull, crate::error::BoxDynError> {
+            fn encode_by_ref(&self, buf: &mut <DB as Database>::ArgumentBuffer) -> Result<IsNull, crate::error::BoxDynError> {
                 <$int as Encode<'q, DB>>::encode_by_ref(&self.get(), buf)
             }
 
-            fn encode(self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> Result<IsNull, crate::error::BoxDynError>
+            fn encode(self, buf: &mut <DB as Database>::ArgumentBuffer) -> Result<IsNull, crate::error::BoxDynError>
             where
                 Self: Sized,
             {

--- a/sqlx-core/src/types/text.rs
+++ b/sqlx-core/src/types/text.rs
@@ -115,7 +115,7 @@ where
     String: Encode<'q, DB>,
     DB: Database,
 {
-    fn encode_by_ref(&self, buf: &mut <DB as Database>::ArgumentBuffer<'q>) -> Result<IsNull, BoxDynError> {
+    fn encode_by_ref(&self, buf: &mut <DB as Database>::ArgumentBuffer) -> Result<IsNull, BoxDynError> {
         self.0.to_string().encode(buf)
     }
 }

--- a/sqlx-macros-core/src/derives/encode.rs
+++ b/sqlx-macros-core/src/derives/encode.rs
@@ -89,7 +89,7 @@ fn expand_derive_encode_transparent(
         {
             fn encode_by_ref(
                 &self,
-                buf: &mut <DB as ::sqlx::database::Database>::ArgumentBuffer<#lifetime>,
+                buf: &mut <DB as ::sqlx::database::Database>::ArgumentBuffer,
             ) -> ::std::result::Result<::sqlx::encode::IsNull, ::sqlx::error::BoxDynError> {
                 <#ty as ::sqlx::encode::Encode<#lifetime, DB>>::encode_by_ref(&self.#field_ident, buf)
             }
@@ -128,7 +128,7 @@ fn expand_derive_encode_weak_enum(
         {
             fn encode_by_ref(
                 &self,
-                buf: &mut <DB as ::sqlx::database::Database>::ArgumentBuffer<'q>,
+                buf: &mut <DB as ::sqlx::database::Database>::ArgumentBuffer,
             ) -> ::std::result::Result<::sqlx::encode::IsNull, ::sqlx::error::BoxDynError> {
                 let value = match self {
                     #(#values)*
@@ -178,7 +178,7 @@ fn expand_derive_encode_strong_enum(
         {
             fn encode_by_ref(
                 &self,
-                buf: &mut <DB as ::sqlx::database::Database>::ArgumentBuffer<'q>,
+                buf: &mut <DB as ::sqlx::database::Database>::ArgumentBuffer,
             ) -> ::std::result::Result<::sqlx::encode::IsNull, ::sqlx::error::BoxDynError> {
                 let val = match self {
                     #(#value_arms)*

--- a/sqlx-macros-core/src/query/args.rs
+++ b/sqlx-macros-core/src/query/args.rs
@@ -22,7 +22,7 @@ pub fn quote_args<DB: DatabaseExt>(
 
     if input.arg_exprs.is_empty() {
         return Ok(quote! {
-            let query_args = ::core::result::Result::<_, ::sqlx::error::BoxDynError>::Ok(<#db_path as ::sqlx::database::Database>::Arguments::<'_>::default());
+            let query_args = ::core::result::Result::<_, ::sqlx::error::BoxDynError>::Ok(<#db_path as ::sqlx::database::Database>::Arguments::default());
         });
     }
 
@@ -95,7 +95,7 @@ pub fn quote_args<DB: DatabaseExt>(
 
         #args_check
 
-        let mut query_args = <#db_path as ::sqlx::database::Database>::Arguments::<'_>::default();
+        let mut query_args = <#db_path as ::sqlx::database::Database>::Arguments::default();
         query_args.reserve(
             #args_count,
             0 #(+ ::sqlx::encode::Encode::<#db_path>::size_hint(#arg_name))*

--- a/sqlx-mysql/src/arguments.rs
+++ b/sqlx-mysql/src/arguments.rs
@@ -37,7 +37,7 @@ impl MySqlArguments {
     }
 }
 
-impl<'q> Arguments<'q> for MySqlArguments {
+impl Arguments for MySqlArguments {
     type Database = MySql;
 
     fn reserve(&mut self, len: usize, size: usize) {
@@ -45,9 +45,9 @@ impl<'q> Arguments<'q> for MySqlArguments {
         self.values.reserve(size);
     }
 
-    fn add<T>(&mut self, value: T) -> Result<(), BoxDynError>
+    fn add<'t, T>(&mut self, value: T) -> Result<(), BoxDynError>
     where
-        T: Encode<'q, Self::Database> + Type<Self::Database>,
+        T: Encode<'t, Self::Database> + Type<Self::Database>,
     {
         self.add(value)
     }

--- a/sqlx-mysql/src/database.rs
+++ b/sqlx-mysql/src/database.rs
@@ -25,8 +25,8 @@ impl Database for MySql {
     type Value = MySqlValue;
     type ValueRef<'r> = MySqlValueRef<'r>;
 
-    type Arguments<'q> = MySqlArguments;
-    type ArgumentBuffer<'q> = Vec<u8>;
+    type Arguments = MySqlArguments;
+    type ArgumentBuffer = Vec<u8>;
 
     type Statement = MySqlStatement;
 

--- a/sqlx-mysql/src/types/mysql_time.rs
+++ b/sqlx-mysql/src/types/mysql_time.rs
@@ -409,10 +409,10 @@ impl<'r> Decode<'r, MySql> for MySqlTime {
     }
 }
 
-impl<'q> Encode<'q, MySql> for MySqlTime {
+impl Encode<'_, MySql> for MySqlTime {
     fn encode_by_ref(
         &self,
-        buf: &mut <MySql as Database>::ArgumentBuffer<'q>,
+        buf: &mut <MySql as Database>::ArgumentBuffer,
     ) -> Result<IsNull, BoxDynError> {
         if self.is_zero() {
             buf.put_u8(0);

--- a/sqlx-postgres/src/arguments.rs
+++ b/sqlx-postgres/src/arguments.rs
@@ -138,7 +138,7 @@ impl PgArguments {
     }
 }
 
-impl<'q> Arguments<'q> for PgArguments {
+impl Arguments for PgArguments {
     type Database = Postgres;
 
     fn reserve(&mut self, additional: usize, size: usize) {
@@ -146,9 +146,9 @@ impl<'q> Arguments<'q> for PgArguments {
         self.buffer.reserve(size);
     }
 
-    fn add<T>(&mut self, value: T) -> Result<(), BoxDynError>
+    fn add<'t, T>(&mut self, value: T) -> Result<(), BoxDynError>
     where
-        T: Encode<'q, Self::Database> + Type<Self::Database>,
+        T: Encode<'t, Self::Database> + Type<Self::Database>,
     {
         self.add(value)
     }

--- a/sqlx-postgres/src/database.rs
+++ b/sqlx-postgres/src/database.rs
@@ -27,8 +27,8 @@ impl Database for Postgres {
     type Value = PgValue;
     type ValueRef<'r> = PgValueRef<'r>;
 
-    type Arguments<'q> = PgArguments;
-    type ArgumentBuffer<'q> = PgArgumentBuffer;
+    type Arguments = PgArguments;
+    type ArgumentBuffer = PgArgumentBuffer;
 
     type Statement = PgStatement;
 

--- a/sqlx-sqlite/src/arguments.rs
+++ b/sqlx-sqlite/src/arguments.rs
@@ -28,10 +28,10 @@ pub struct SqliteArguments {
 #[derive(Default, Debug, Clone)]
 pub struct SqliteArgumentsBuffer(Vec<SqliteArgumentValue>);
 
-impl<'q> SqliteArguments {
-    pub(crate) fn add<T>(&mut self, value: T) -> Result<(), BoxDynError>
+impl SqliteArguments {
+    pub(crate) fn add<'t, T>(&mut self, value: T) -> Result<(), BoxDynError>
     where
-        T: Encode<'q, Sqlite>,
+        T: Encode<'t, Sqlite>,
     {
         let value_length_before_encoding = self.values.0.len();
 
@@ -49,16 +49,16 @@ impl<'q> SqliteArguments {
     }
 }
 
-impl<'q> Arguments<'q> for SqliteArguments {
+impl Arguments for SqliteArguments {
     type Database = Sqlite;
 
     fn reserve(&mut self, len: usize, _size_hint: usize) {
         self.values.0.reserve(len);
     }
 
-    fn add<T>(&mut self, value: T) -> Result<(), BoxDynError>
+    fn add<'t, T>(&mut self, value: T) -> Result<(), BoxDynError>
     where
-        T: Encode<'q, Self::Database>,
+        T: Encode<'t, Self::Database>,
     {
         self.add(value)
     }

--- a/sqlx-sqlite/src/database.rs
+++ b/sqlx-sqlite/src/database.rs
@@ -26,8 +26,8 @@ impl Database for Sqlite {
     type Value = SqliteValue;
     type ValueRef<'r> = SqliteValueRef<'r>;
 
-    type Arguments<'q> = SqliteArguments;
-    type ArgumentBuffer<'q> = SqliteArgumentsBuffer;
+    type Arguments = SqliteArguments;
+    type ArgumentBuffer = SqliteArgumentsBuffer;
 
     type Statement = SqliteStatement;
 

--- a/sqlx-sqlite/src/types/str.rs
+++ b/sqlx-sqlite/src/types/str.rs
@@ -85,10 +85,7 @@ impl Encode<'_, Sqlite> for Cow<'_, str> {
 }
 
 impl Encode<'_, Sqlite> for Arc<str> {
-    fn encode(
-        self,
-        args: &mut <Sqlite as Database>::ArgumentBuffer<'_>,
-    ) -> Result<IsNull, BoxDynError>
+    fn encode(self, args: &mut <Sqlite as Database>::ArgumentBuffer) -> Result<IsNull, BoxDynError>
     where
         Self: Sized,
     {

--- a/sqlx-test/src/lib.rs
+++ b/sqlx-test/src/lib.rs
@@ -1,5 +1,5 @@
 use sqlx::pool::PoolOptions;
-use sqlx::{Connection, Database, Pool};
+use sqlx::{Connection, Database, Error, Pool};
 use std::env;
 
 pub fn setup_if_needed() {
@@ -9,13 +9,15 @@ pub fn setup_if_needed() {
 
 // Make a new connection
 // Ensure [dotenvy] and [env_logger] have been setup
-pub async fn new<DB>() -> anyhow::Result<DB::Connection>
+pub async fn new<DB>() -> sqlx::Result<DB::Connection>
 where
     DB: Database,
 {
     setup_if_needed();
 
-    Ok(DB::Connection::connect(&env::var("DATABASE_URL")?).await?)
+    let db_url = env::var("DATABASE_URL").map_err(|e| Error::Configuration(Box::new(e)))?;
+
+    Ok(DB::Connection::connect(&db_url).await?)
 }
 
 // Make a new pool

--- a/tests/mysql/types.rs
+++ b/tests/mysql/types.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use sqlx::mysql::MySql;
-use sqlx::{Executor, FromRow, Row};
+use sqlx::{Executor, Row};
 
 use sqlx::types::Text;
 

--- a/tests/postgres/query_builder.rs
+++ b/tests/postgres/query_builder.rs
@@ -7,13 +7,13 @@ use sqlx_test::new;
 
 #[test]
 fn test_new() {
-    let qb: QueryBuilder<'_, Postgres> = QueryBuilder::new("SELECT * FROM users");
+    let qb: QueryBuilder<Postgres> = QueryBuilder::new("SELECT * FROM users");
     assert_eq!(qb.sql(), "SELECT * FROM users");
 }
 
 #[test]
 fn test_push() {
-    let mut qb: QueryBuilder<'_, Postgres> = QueryBuilder::new("SELECT * FROM users");
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new("SELECT * FROM users");
     let second_line = " WHERE last_name LIKE '[A-N]%';";
     qb.push(second_line);
 
@@ -26,7 +26,7 @@ fn test_push() {
 #[test]
 #[should_panic]
 fn test_push_panics_after_build_without_reset() {
-    let mut qb: QueryBuilder<'_, Postgres> = QueryBuilder::new("SELECT * FROM users;");
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new("SELECT * FROM users;");
 
     let _query = qb.build();
 
@@ -35,7 +35,7 @@ fn test_push_panics_after_build_without_reset() {
 
 #[test]
 fn test_push_bind() {
-    let mut qb: QueryBuilder<'_, Postgres> = QueryBuilder::new("SELECT * FROM users WHERE id = ");
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new("SELECT * FROM users WHERE id = ");
 
     qb.push_bind(42i32)
         .push(" OR membership_level = ")
@@ -49,7 +49,7 @@ fn test_push_bind() {
 
 #[test]
 fn test_build() {
-    let mut qb: QueryBuilder<'_, Postgres> = QueryBuilder::new("SELECT * FROM users");
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new("SELECT * FROM users");
 
     qb.push(" WHERE id = ").push_bind(42i32);
     let query = qb.build();
@@ -60,7 +60,7 @@ fn test_build() {
 
 #[test]
 fn test_reset() {
-    let mut qb: QueryBuilder<'_, Postgres> = QueryBuilder::new("");
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new("");
 
     {
         let _query = qb
@@ -76,7 +76,7 @@ fn test_reset() {
 
 #[test]
 fn test_query_builder_reuse() {
-    let mut qb: QueryBuilder<'_, Postgres> = QueryBuilder::new("");
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new("");
 
     let _query = qb
         .push("SELECT * FROM users WHERE id = ")
@@ -92,7 +92,7 @@ fn test_query_builder_reuse() {
 
 #[test]
 fn test_query_builder_with_args() {
-    let mut qb: QueryBuilder<'_, Postgres> = QueryBuilder::new("");
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new("");
 
     let mut query = qb
         .push("SELECT * FROM users WHERE id = ")
@@ -101,8 +101,7 @@ fn test_query_builder_with_args() {
 
     let args = query.take_arguments().unwrap().unwrap();
 
-    let mut qb: QueryBuilder<'_, Postgres> =
-        QueryBuilder::with_arguments(query.sql().as_str(), args);
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::with_arguments(query.sql().as_str(), args);
     let query = qb.push(" OR membership_level = ").push_bind(3i32).build();
 
     assert_eq!(
@@ -118,7 +117,7 @@ async fn test_max_number_of_binds() -> anyhow::Result<()> {
     //
     // https://github.com/launchbadge/sqlx/issues/3464
 
-    let mut qb: QueryBuilder<'_, Postgres> = QueryBuilder::new("SELECT ARRAY[");
+    let mut qb: QueryBuilder<Postgres> = QueryBuilder::new("SELECT ARRAY[");
 
     let mut elements = qb.separated(',');
 


### PR DESCRIPTION
* Simplifies the `Arguments` trait by removing the lifetime parameter
* Removal of lifetime parameter causes the `query!` macro's `println!` similar usage to be enforced at compile time across all `Database` implementations.

Builds on https://github.com/launchbadge/sqlx/pull/3958.

New commits with this pr are the last two:
* `refactor(core): Remove lifetime parameter from Arguments trait`
* `refactor(core): Also relax lifetime of argument passed to Query::bind and Query::try_bind`

### Does your PR solve an issue?
No, but it standardizes that all argument buffers own their data, which means that we also standardize how references can be used when passing bind parameters to `query!` macros so it is similar to the `println!` macro. Previous to https://github.com/launchbadge/sqlx/pull/3957, only the Postgres and MySQL drivers allowed the `query!` macro to be similar to the `println!` macro.

This ensures the flexibility of the Postgres driver is also supported with other drivers by preventing the introduction of a lifetime constraint to their implementation-specific argument buffer containers.

### Is this a breaking change?
Yes - removes lifetime argument on two traits that are a part of the public api (`Arguments` and `ArgumentBuffer`) and makes cascading changes to query related traits and the `Encode` trait.
