### PR TITLE
Give SQLX_OFFLINE_DIR from environment precedence in macros

### DIFF
--- a/sqlx-macros-core/src/query/mod.rs
+++ b/sqlx-macros-core/src/query/mod.rs
@@ -124,6 +124,11 @@ fn init_metadata(manifest_dir: &String) -> crate::Result<Metadata> {
         .map(|s| s.eq_ignore_ascii_case("true") || s == "1")
         .unwrap_or(false);
 
+    let offline_dir = env("SQLX_OFFLINE_DIR")
+        .ok()
+        .or(offline_dir.as_ref().cloned())
+        .or(offline_dir);
+
     let config = Config::try_from_crate_or_default()?;
 
     let database_url = env(config.common.database_url_var()).ok().or(database_url);


### PR DESCRIPTION
We need to be able to supply this variable via the environment when built via Nix Crane, which uses cargo vendor for dependencies, which will filter the .sqlx path.  Renaming is necessary in that case.

Fixes #3961 

Tested container build on a branch of 0.8.6 :heavy_check_mark: 