### PR TITLE
chore(ci): Add timeouts to ci jobs

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -11,6 +11,8 @@ jobs:
   sqlx-cli:
     name: Build SQLx CLI
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+
     steps:
       - uses: actions/checkout@v4
 
@@ -38,6 +40,7 @@ jobs:
     name: MySQL Examples
     runs-on: ubuntu-latest
     needs: sqlx-cli
+    timeout-minutes: 30
 
     services:
       mysql:
@@ -83,6 +86,7 @@ jobs:
     name: PostgreSQL Examples
     runs-on: ubuntu-latest
     needs: sqlx-cli
+    timeout-minutes: 30
 
     services:
       postgres:
@@ -245,6 +249,7 @@ jobs:
     name: SQLite Examples
     runs-on: ubuntu-latest
     needs: sqlx-cli
+    timeout-minutes: 30
 
     steps:
       - name: Get SQLx-CLI

--- a/.github/workflows/sqlx-cli.yml
+++ b/.github/workflows/sqlx-cli.yml
@@ -11,6 +11,7 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -47,6 +48,8 @@ jobs:
           - macOS-13
           - macOS-latest
 
+    timeout-minutes: 30
+
     steps:
       - uses: actions/checkout@v4
 
@@ -70,6 +73,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: password
     env:
       BASE_URL: mysql://root:password@localhost
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -149,6 +153,7 @@ jobs:
           POSTGRES_PASSWORD: password
     env:
       BASE_URL: postgres://postgres:password@localhost
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -220,6 +225,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BASE_URL: sqlite://.
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4
@@ -312,6 +318,8 @@ jobs:
           - os: macOS-latest
             target: aarch64-apple-darwin
             bin: target/debug/cargo-sqlx
+
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -11,6 +11,7 @@ jobs:
   format:
     name: Format
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - run: rustup component add rustfmt
@@ -23,6 +24,7 @@ jobs:
       matrix:
         runtime: [ async-std, tokio ]
         tls: [ native-tls, rustls, none ]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -54,6 +56,7 @@ jobs:
   check-minimal-versions:
     name: Check build using minimal versions
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust
@@ -66,6 +69,7 @@ jobs:
   test:
     name: Unit Tests
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -121,6 +125,7 @@ jobs:
         runtime: [ async-std, tokio ]
         linking: [ sqlite, sqlite-unbundled ]
     needs: check
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -206,6 +211,7 @@ jobs:
         runtime: [ async-std, tokio ]
         tls: [ native-tls, rustls-aws-lc-rs, rustls-ring, none ]
     needs: check
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -323,6 +329,7 @@ jobs:
         runtime: [ async-std, tokio ]
         tls: [ native-tls, rustls-aws-lc-rs, rustls-ring, none ]
     needs: check
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -423,6 +430,7 @@ jobs:
         runtime: [ async-std, tokio ]
         tls: [ native-tls, rustls-aws-lc-rs, rustls-ring, none ]
     needs: check
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Occasionally a CI job will hang infinitely, recently observed with one of the Postgres 13 CI jobs running well over an hour. In that example, a test was hung: `test test_pg_listener_allows_pool_to_close has been running for over 60 seconds` causing the job to not make progress after 1h 45m.

https://github.com/launchbadge/sqlx/actions/runs/16864658928/job/47769903098?pr=3958

### Does your PR solve an issue?
Fails CI jobs that are hung.

### Is this a breaking change?
No - only changes CI configuration
