### PR TITLE
fix documentation for rustls native root certificates

### DIFF
--- a/sqlx-postgres/src/options/doc.md
+++ b/sqlx-postgres/src/options/doc.md
@@ -86,7 +86,7 @@ See `default_host()` in the same source file as this method for the current beha
 If `sslrootcert` is not set, the default root certificates used depends on Cargo features:
 
 * If `tls-native-tls` is enabled, the system root certificates are used.
-* If `tls-rustls-native-roots` is enabled, the system root certificates are used.
+* If `tls-rustls-ring-native-roots` is enabled, the system root certificates are used.
 * Otherwise, TLS roots are populated using the [`webpki-roots`] crate.
 
 ## Environment Variables


### PR DESCRIPTION
pretty self-explanatory, I think someone forgot something here
