### PR TITLE
refactor(ci): Use separate job for postgres ssl auth tests

### DIFF
--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -231,6 +231,8 @@ jobs:
 
       - run: |
           docker compose -f tests/docker-compose.yml run -d -p 5432:5432 --name postgres_${{ matrix.postgres }} postgres_${{ matrix.postgres }}
+
+      - run: |
           docker exec postgres_${{ matrix.postgres }} bash -c "until pg_isready; do sleep 1; done"
 
       # Create data dir for offline mode
@@ -302,15 +304,31 @@ jobs:
           # but `PgLTree` should just fall back to text format
           RUSTFLAGS: --cfg postgres_${{ matrix.postgres }}
 
-      # client SSL authentication
+  postgres-ssl-auth:
+    name: Postgres SSL Auth
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        postgres: [ 13, 17 ]
+        runtime: [ async-std, tokio ]
+        tls: [ native-tls, rustls-aws-lc-rs, rustls-ring ]
+    needs: check
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        run: rustup show active-toolchain || rustup toolchain install
+
+      - uses: Swatinem/rust-cache@v2
 
       - run: |
-          docker stop postgres_${{ matrix.postgres }}
           docker compose -f tests/docker-compose.yml run -d -p 5432:5432 --name postgres_${{ matrix.postgres }}_client_ssl postgres_${{ matrix.postgres }}_client_ssl
+
+      - run: |
           docker exec postgres_${{ matrix.postgres }}_client_ssl bash -c "until pg_isready; do sleep 1; done"
 
-      - if: matrix.tls != 'none'
-        run: >
+      - run: >
           cargo test
           --no-default-features
           --features any,postgres,macros,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }}

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
     #
     # MySQL 8.x, 5.7.x


### PR DESCRIPTION
Make Postgres CI job more reliable by splitting the Postgres GitHub workflow job into two jobs which use their own separate docker container, instead of the current situation where one job attempts to tear down the container used by previous steps, and start a new one bound to the same host port.

Prevents bind failures.

Also fixes a deprecation warning by removing the deprecated `version` field from the docker compose file.

This pr is a cherry pick out of https://github.com/launchbadge/sqlx/pull/3950.

### Does your PR solve an issue?
Prevents CI failures caused by bind failures during the creation of the Postgres container used for testing SSL based authentication.

### Is this a breaking change?
No - only changes the GitHub workflow and another file used by tests.