### PR TITLE
Add public pg connect options fields

### DIFF
--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -15,21 +15,21 @@ mod ssl_mode;
 #[doc = include_str!("doc.md")]
 #[derive(Debug, Clone)]
 pub struct PgConnectOptions {
-    pub(crate) host: String,
-    pub(crate) port: u16,
-    pub(crate) socket: Option<PathBuf>,
-    pub(crate) username: String,
-    pub(crate) password: Option<String>,
-    pub(crate) database: Option<String>,
-    pub(crate) ssl_mode: PgSslMode,
-    pub(crate) ssl_root_cert: Option<CertificateInput>,
-    pub(crate) ssl_client_cert: Option<CertificateInput>,
-    pub(crate) ssl_client_key: Option<CertificateInput>,
-    pub(crate) statement_cache_capacity: usize,
-    pub(crate) application_name: Option<String>,
-    pub(crate) log_settings: LogSettings,
-    pub(crate) extra_float_digits: Option<Cow<'static, str>>,
-    pub(crate) options: Option<String>,
+    pub host: String,
+    pub port: u16,
+    pub socket: Option<PathBuf>,
+    pub username: String,
+    pub password: Option<String>,
+    pub database: Option<String>,
+    pub ssl_mode: PgSslMode,
+    pub ssl_root_cert: Option<CertificateInput>,
+    pub ssl_client_cert: Option<CertificateInput>,
+    pub ssl_client_key: Option<CertificateInput>,
+    pub statement_cache_capacity: usize,
+    pub application_name: Option<String>,
+    pub log_settings: LogSettings,
+    pub extra_float_digits: Option<Cow<'static, str>>,
+    pub options: Option<String>,
 }
 
 impl Default for PgConnectOptions {


### PR DESCRIPTION
* 3rd party tools can provide a wrapper around this object and can construct the PG options as strict as they want to, while not having to deal with this libraries default behavior at all.


### Is this a breaking change?

no.


This is an alternative to the issues I raised in #3832, it would enable me to go abitrarily strict in my wrappers and have full control in how I construct `PgConnectOptions`.

I admit its a bit of an extreme measure, and not as nice for users who go that option but these users would opt into "higher maintenance" burden explicitly, but I see no reason to not give users more sophisticated options than this library is willing to do.