### PR TITLE
chore(core): Fix docstring for Query::try_bind

### DIFF
--- a/sqlx-core/src/query.rs
+++ b/sqlx-core/src/query.rs
@@ -100,7 +100,7 @@ impl<'q, DB: Database> Query<'q, DB, <DB as Database>::Arguments<'q>> {
         self
     }
 
-    /// Like [`Query::bind`] but immediately returns an error if encoding an earlier value had failed.
+    /// Like [`Query::bind`] but immediately returns an error if encoding a value failed.
     pub fn try_bind<T: 'q + Encode<'q, DB> + Type<DB>>(
         &mut self,
         value: T,

--- a/sqlx-core/src/query.rs
+++ b/sqlx-core/src/query.rs
@@ -100,7 +100,7 @@ impl<'q, DB: Database> Query<'q, DB, <DB as Database>::Arguments<'q>> {
         self
     }
 
-    /// Like [`Query::try_bind`] but immediately returns an error if encoding the value failed.
+    /// Like [`Query::bind`] but immediately returns an error if encoding an earlier value had failed.
     pub fn try_bind<T: 'q + Encode<'q, DB> + Type<DB>>(
         &mut self,
         value: T,


### PR DESCRIPTION
### Does your PR solve an issue?

The docstring for `Query::try_bind` is incorrect and misleading:

* Incorrect - should reference the `bind` function just above it; references itself instead
* Unclear - says error is returned for encoding the given bind argument value; actual behavior is to return an error if a prior  bind argument value had failed encoding or the current bind argument failed encoding

### Is this a breaking change?

No; documentation only
