### PR TITLE
chore(deps): Resolve deprecation warning for chrono Date and ymd methods

### DIFF
--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -243,7 +243,7 @@ jobs:
         env:
           DATABASE_URL: postgres://postgres:password@localhost:5432/sqlx
           SQLX_OFFLINE_DIR: .sqlx
-          RUSTFLAGS: --cfg postgres="${{ matrix.postgres }}"
+          RUSTFLAGS: -D warnings --cfg postgres="${{ matrix.postgres }}"
 
       # Run the `test-attr` test again to cover cleanup.
       - run: >
@@ -254,7 +254,7 @@ jobs:
         env:
           DATABASE_URL: postgres://postgres:password@localhost:5432/sqlx
           SQLX_OFFLINE_DIR: .sqlx
-          RUSTFLAGS: --cfg postgres="${{ matrix.postgres }}"
+          RUSTFLAGS: -D warnings --cfg postgres="${{ matrix.postgres }}"
 
       - if: matrix.tls != 'none'
         run: >
@@ -264,7 +264,7 @@ jobs:
         env:
           DATABASE_URL: postgres://postgres:password@localhost:5432/sqlx?sslmode=verify-ca&sslrootcert=.%2Ftests%2Fcerts%2Fca.crt
           SQLX_OFFLINE_DIR: .sqlx
-          RUSTFLAGS: --cfg postgres="${{ matrix.postgres }}"
+          RUSTFLAGS: -D warnings --cfg postgres="${{ matrix.postgres }}"
 
       # Remove test artifacts
       - run: cargo clean -p sqlx
@@ -290,7 +290,7 @@ jobs:
           DATABASE_URL: postgres://postgres:password@localhost:5432/sqlx
           SQLX_OFFLINE: true
           SQLX_OFFLINE_DIR: .sqlx
-          RUSTFLAGS: --cfg postgres="${{ matrix.postgres }}"
+          RUSTFLAGS: -D warnings --cfg postgres="${{ matrix.postgres }}"
 
   postgres-ssl-auth:
     name: Postgres SSL Auth
@@ -322,7 +322,7 @@ jobs:
           --features any,postgres,macros,_unstable-all-types,runtime-${{ matrix.runtime }},tls-${{ matrix.tls }}
         env:
           DATABASE_URL: postgres://postgres@localhost:5432/sqlx?sslmode=verify-ca&sslrootcert=.%2Ftests%2Fcerts%2Fca.crt&sslkey=.%2Ftests%2Fcerts%2Fkeys%2Fclient.key&sslcert=.%2Ftests%2Fcerts%2Fclient.crt
-          RUSTFLAGS: --cfg postgres="${{ matrix.postgres }}"
+          RUSTFLAGS: -D warnings --cfg postgres="${{ matrix.postgres }}"
 
   mysql:
     name: MySQL

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -330,7 +330,15 @@ mod chrono {
 
     test_type!(chrono_date_time_tz<DateTime::<FixedOffset>>(Postgres,
         "TIMESTAMPTZ '2019-01-02 05:10:20.115100+06:30'"
-            == FixedOffset::east_opt(60 * 60 * 6 + 1800).unwrap().ymd(2019, 1, 2).and_hms_micro_opt(5, 10, 20, 115100).unwrap()
+            == FixedOffset::east_opt(60 * 60 * 6 + 1800)
+                .unwrap()
+                .from_local_datetime(
+                    &NaiveDate::from_ymd_opt(2019, 1, 2)
+                        .unwrap()
+                        .and_hms_micro_opt(5, 10, 20, 115_100)
+                        .unwrap()
+                )
+                .unwrap()
     ));
 
     test_type!(chrono_date_time_tz_vec<Vec<DateTime::<Utc>>>(Postgres,


### PR DESCRIPTION
### Does your PR solve an issue?
Resolves a deprecation warning caused by the `chrono` crate deprecating its `Date` type and the `ymd` method that returned a `Date` value.

Example of deprecation warning:

```
warning: use of deprecated method `sqlx::types::chrono::TimeZone::ymd`: use `with_ymd_and_hms()` instead
   --> tests/postgres/types.rs:355:67
    |
355 |             == FixedOffset::east_opt(60 * 60 * 6 + 1800).unwrap().ymd(2019, 1, 2).and_hms_micro_opt(5, 10, 20, 115100).unwrap()
    |                                                                   ^^^
    |
    = note: `#[warn(deprecated)]` on by default
```

### Is this a breaking change?
No; only changes tests:

* Replace deprecated builder methods with newer ones
* Add `-D warnings` to `RUSTFLAGS` for postgres ci jobs, now that all of the compile warnings are resolved.

There is still a warning about cargo features, but that is not affected by `-D warnings`.
