### PR TITLE
refactor(sqlite): Resolve duplicate test target warning for macros.rs

### DIFF
--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -181,7 +181,7 @@ jobs:
       - run: >
           cargo build
           --no-default-features
-          --test ${{ matrix.linking }}-macros
+          --test sqlite-macros
           --features any,macros,${{ matrix.linking }},_unstable-all-types,runtime-${{ matrix.runtime }}
         env:
           SQLX_OFFLINE: true
@@ -193,7 +193,7 @@ jobs:
       - run: >
           cargo test
           --no-default-features
-          --test ${{ matrix.linking }}-macros
+          --test sqlite-macros
           --features any,macros,${{ matrix.linking }},_unstable-all-types,runtime-${{ matrix.runtime }}
         env:
           DATABASE_URL: sqlite://tests/sqlite/sqlite.db

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -299,7 +299,7 @@ required-features = ["sqlite"]
 [[test]]
 name = "sqlite-macros"
 path = "tests/sqlite/macros.rs"
-required-features = ["macros"]  # Also requires either sqlite or sqlite-unbundled
+required-features = ["_sqlite", "macros"]
 
 [[test]]
 name = "sqlite-derives"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -299,12 +299,7 @@ required-features = ["sqlite"]
 [[test]]
 name = "sqlite-macros"
 path = "tests/sqlite/macros.rs"
-required-features = ["sqlite", "macros"]
-
-[[test]]
-name = "sqlite-unbundled-macros"
-path = "tests/sqlite/macros.rs"
-required-features = ["sqlite-unbundled", "macros"]
+required-features = ["macros"]  # Also requires either sqlite or sqlite-unbundled
 
 [[test]]
 name = "sqlite-derives"

--- a/tests/sqlite/macros.rs
+++ b/tests/sqlite/macros.rs
@@ -1,3 +1,5 @@
+#![cfg(any(feature = "sqlite", feature = "sqlite-unbundled"))]
+
 use sqlx::Sqlite;
 use sqlx_test::new;
 

--- a/tests/sqlite/macros.rs
+++ b/tests/sqlite/macros.rs
@@ -1,5 +1,3 @@
-#![cfg(any(feature = "sqlite", feature = "sqlite-unbundled"))]
-
 use sqlx::Sqlite;
 use sqlx_test::new;
 


### PR DESCRIPTION
### Does your PR solve an issue?
Resolves this `cargo` warning:

```
warning: ./Cargo.toml: file `./tests/sqlite/macros.rs` found to be present in multiple build targets:
  * `integration-test` target `sqlite-macros`
  * `integration-test` target `sqlite-unbundled-macros`
```

Merges the two target definitions in `Cargo.toml` and moves the `sqlite` vs `sqlite-unbundled` feature check to the top of the `macros.rs` module.

### Is this a breaking change?
No; only affects test target configuration.
