### PR TITLE
PostgreSQL connection: Username as fallback for database

### DIFF
--- a/sqlx-postgres/src/connection/establish.rs
+++ b/sqlx-postgres/src/connection/establish.rs
@@ -33,21 +33,21 @@ impl PgConnection {
             ("TimeZone", "UTC"),
         ];
 
-        if let Some(ref extra_float_digits) = options.extra_float_digits {
+        if let Some(extra_float_digits) = options.get_extra_float_digits() {
             params.push(("extra_float_digits", extra_float_digits));
         }
 
-        if let Some(ref application_name) = options.application_name {
+        if let Some(application_name) = options.get_application_name() {
             params.push(("application_name", application_name));
         }
 
-        if let Some(ref options) = options.options {
+        if let Some(options) = options.get_options() {
             params.push(("options", options));
         }
 
         stream.write(Startup {
-            username: Some(&options.username),
-            database: options.database.as_deref(),
+            username: Some(options.get_username()),
+            database: Some(options.get_database()),
             params: &params,
         })?;
 
@@ -77,7 +77,7 @@ impl PgConnection {
 
                         stream
                             .send(Password::Cleartext(
-                                options.password.as_deref().unwrap_or_default(),
+                                options.get_password().unwrap_or_default(),
                             ))
                             .await?;
                     }
@@ -90,8 +90,8 @@ impl PgConnection {
 
                         stream
                             .send(Password::Md5 {
-                                username: &options.username,
-                                password: options.password.as_deref().unwrap_or_default(),
+                                username: options.get_username(),
+                                password: options.get_password().unwrap_or_default(),
                                 salt: body.salt,
                             })
                             .await?;

--- a/sqlx-postgres/src/connection/sasl.rs
+++ b/sqlx-postgres/src/connection/sasl.rs
@@ -52,7 +52,7 @@ pub(crate) async fn authenticate(
     BASE64_STANDARD.encode_string(GS2_HEADER, &mut channel_binding);
 
     // "n=" saslname ;; Usernames are prepared using SASLprep.
-    let username = format!("{}={}", USERNAME_ATTR, options.username);
+    let username = format!("{}={}", USERNAME_ATTR, options.get_username());
     let username = match saslprep(&username) {
         Ok(v) => v,
         // TODO(danielakhterov): Remove panic when we have proper support for configuration errors
@@ -87,7 +87,7 @@ pub(crate) async fn authenticate(
 
     // SaltedPassword := Hi(Normalize(password), salt, i)
     let salted_password = hi(
-        options.password.as_deref().unwrap_or_default(),
+        options.get_password().unwrap_or_default(),
         &cont.salt,
         cont.iterations,
     )?;

--- a/sqlx-postgres/src/connection/stream.rs
+++ b/sqlx-postgres/src/connection/stream.rs
@@ -44,7 +44,14 @@ impl PgStream {
     pub(super) async fn connect(options: &PgConnectOptions) -> Result<Self, Error> {
         let socket_result = match options.fetch_socket() {
             Some(ref path) => net::connect_uds(path, MaybeUpgradeTls(options)).await?,
-            None => net::connect_tcp(&options.host, options.port, MaybeUpgradeTls(options)).await?,
+            None => {
+                net::connect_tcp(
+                    options.get_host(),
+                    options.get_port(),
+                    MaybeUpgradeTls(options),
+                )
+                .await?
+            }
         };
 
         let socket = socket_result?;

--- a/sqlx-postgres/src/connection/tls.rs
+++ b/sqlx-postgres/src/connection/tls.rs
@@ -20,7 +20,7 @@ async fn maybe_upgrade<S: Socket>(
     options: &PgConnectOptions,
 ) -> Result<Box<dyn Socket>, Error> {
     // https://www.postgresql.org/docs/12/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS
-    match options.ssl_mode {
+    match options.get_ssl_mode() {
         // FIXME: Implement ALLOW
         PgSslMode::Allow | PgSslMode::Disable => return Ok(Box::new(socket)),
 
@@ -46,15 +46,15 @@ async fn maybe_upgrade<S: Socket>(
     }
 
     let accept_invalid_certs = !matches!(
-        options.ssl_mode,
+        options.get_ssl_mode(),
         PgSslMode::VerifyCa | PgSslMode::VerifyFull
     );
-    let accept_invalid_hostnames = !matches!(options.ssl_mode, PgSslMode::VerifyFull);
+    let accept_invalid_hostnames = !matches!(options.get_ssl_mode(), PgSslMode::VerifyFull);
 
     let config = TlsConfig {
         accept_invalid_certs,
         accept_invalid_hostnames,
-        hostname: &options.host,
+        hostname: options.get_host(),
         root_cert_path: options.ssl_root_cert.as_ref(),
         client_cert_path: options.ssl_client_cert.as_ref(),
         client_key_path: options.ssl_client_key.as_ref(),

--- a/sqlx-postgres/src/migrate.rs
+++ b/sqlx-postgres/src/migrate.rs
@@ -18,25 +18,22 @@ use crate::query_scalar::query_scalar;
 use crate::{PgConnectOptions, PgConnection, Postgres};
 
 fn parse_for_maintenance(url: &str) -> Result<(PgConnectOptions, String), Error> {
-    let mut options = PgConnectOptions::from_str(url)?;
+    let options = PgConnectOptions::from_str(url)?;
 
     // pull out the name of the database to create
     let database = options
-        .database
-        .as_deref()
-        .unwrap_or(&options.username)
+        .get_database()
+        .unwrap_or(options.get_username())
         .to_owned();
 
     // switch us to the maintenance database
     // use `postgres` _unless_ the database is postgres, in which case, use `template1`
     // this matches the behavior of the `createdb` util
-    options.database = if database == "postgres" {
-        Some("template1".into())
+    if database == "postgres" {
+        Ok((options.database("template1"), database))
     } else {
-        Some("postgres".into())
-    };
-
-    Ok((options, database))
+        Ok((options.database("postgres"), database))
+    }
 }
 
 impl MigrateDatabase for Postgres {

--- a/sqlx-postgres/src/migrate.rs
+++ b/sqlx-postgres/src/migrate.rs
@@ -21,10 +21,7 @@ fn parse_for_maintenance(url: &str) -> Result<(PgConnectOptions, String), Error>
     let options = PgConnectOptions::from_str(url)?;
 
     // pull out the name of the database to create
-    let database = options
-        .get_database()
-        .unwrap_or(options.get_username())
-        .to_owned();
+    let database = options.get_database().to_owned();
 
     // switch us to the maintenance database
     // use `postgres` _unless_ the database is postgres, in which case, use `template1`

--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -99,7 +99,7 @@ impl PgConnectOptions {
                 self.get_host(),
                 self.get_port(),
                 self.get_username(),
-                Some(self.get_database()),
+                self.get_database(),
             );
         }
 

--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -96,10 +96,10 @@ impl PgConnectOptions {
     pub(crate) fn apply_pgpass(mut self) -> Self {
         if self.password.is_none() {
             self.password = pgpass::load_password(
-                &self.host,
-                self.port,
-                &self.username,
-                self.database.as_deref(),
+                self.get_host(),
+                self.get_port(),
+                self.get_username(),
+                self.get_database(),
             );
         }
 
@@ -519,6 +519,18 @@ impl PgConnectOptions {
         &self.username
     }
 
+    /// Get the password.
+    ///
+    /// ```rust
+    /// # use sqlx_postgres::PgConnectOptions;
+    /// let options = PgConnectOptions::new()
+    ///     .password("53C237");
+    /// assert_eq!(options.get_password(), Some("53C237"));
+    /// ```
+    pub fn get_password(&self) -> Option<&str> {
+        self.password.as_deref()
+    }
+
     /// Get the current database name.
     ///
     /// # Example
@@ -558,6 +570,19 @@ impl PgConnectOptions {
     /// ```
     pub fn get_application_name(&self) -> Option<&str> {
         self.application_name.as_deref()
+    }
+
+    /// Get the extra float digits.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use sqlx_postgres::PgConnectOptions;
+    /// let options = PgConnectOptions::new();
+    /// assert_eq!(options.get_extra_float_digits(), Some("2"));
+    /// ```
+    pub fn get_extra_float_digits(&self) -> std::option::Option<&str> {
+        self.extra_float_digits.as_deref()
     }
 
     /// Get the options.

--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -99,7 +99,7 @@ impl PgConnectOptions {
                 self.get_host(),
                 self.get_port(),
                 self.get_username(),
-                self.get_database(),
+                Some(self.get_database()),
             );
         }
 
@@ -533,16 +533,20 @@ impl PgConnectOptions {
 
     /// Get the current database name.
     ///
+    /// Defaults to username if not given.
+    ///
     /// # Example
     ///
     /// ```rust
     /// # use sqlx_postgres::PgConnectOptions;
-    /// let options = PgConnectOptions::new()
-    ///     .database("postgres");
-    /// assert!(options.get_database().is_some());
+    /// let options = PgConnectOptions::new().database("postgres");
+    /// assert_eq!(options.get_database(), "postgres");
+    ///
+    /// let options = PgConnectOptions::new().username("alice");
+    /// assert_eq!(options.get_database(), "alice");
     /// ```
-    pub fn get_database(&self) -> Option<&str> {
-        self.database.as_deref()
+    pub fn get_database(&self) -> &str {
+        self.database.as_deref().unwrap_or(&self.username)
     }
 
     /// Get the SSL mode.

--- a/sqlx-postgres/src/testing/mod.rs
+++ b/sqlx-postgres/src/testing/mod.rs
@@ -108,14 +108,14 @@ async fn test_context(args: &TestArgs) -> Result<TestContext<Postgres>, Error> {
         Err((existing, pool)) => {
             // Sanity checks.
             assert_eq!(
-                existing.connect_options().host,
-                pool.connect_options().host,
+                existing.connect_options().get_host(),
+                pool.connect_options().get_host(),
                 "DATABASE_URL changed at runtime, host differs"
             );
 
             assert_eq!(
-                existing.connect_options().database,
-                pool.connect_options().database,
+                existing.connect_options().get_database(),
+                pool.connect_options().get_database(),
                 "DATABASE_URL changed at runtime, database differs"
             );
 


### PR DESCRIPTION
This PR works on the `PgConnectOptions` to implement the fallback to the username if no database name is given. It notably touches the passfile lookup and connection establishment.

The first commit is a bit broader refactor to use getter methods for fields where appropriate. This better distinguishes raw user-supplied values vs. their derived form.

### Is this a breaking change?

Yes. The following changes in observable behavior are intended:

- Passfile lookup defaulting to the username when not given a database name (breaking, did default to the empty string)
- Always passing a database name when establishing a connection (breaking, did pass None on missing database)
- Changed signature of `get_database` (breaking)
- New public getter methods `get_password` and `get_extra_float_digits` (not breaking)
