### PR TITLE
Defer PostgreSQL passfile lookup

### DIFF
--- a/sqlx-postgres/src/connection/establish.rs
+++ b/sqlx-postgres/src/connection/establish.rs
@@ -77,7 +77,7 @@ impl PgConnection {
 
                         stream
                             .send(Password::Cleartext(
-                                options.password.as_deref().unwrap_or_default(),
+                                &options.get_password().unwrap_or_default(),
                             ))
                             .await?;
                     }
@@ -91,7 +91,7 @@ impl PgConnection {
                         stream
                             .send(Password::Md5 {
                                 username: &options.username,
-                                password: options.password.as_deref().unwrap_or_default(),
+                                password: &options.get_password().unwrap_or_default(),
                                 salt: body.salt,
                             })
                             .await?;

--- a/sqlx-postgres/src/connection/sasl.rs
+++ b/sqlx-postgres/src/connection/sasl.rs
@@ -87,7 +87,7 @@ pub(crate) async fn authenticate(
 
     // SaltedPassword := Hi(Normalize(password), salt, i)
     let salted_password = hi(
-        options.password.as_deref().unwrap_or_default(),
+        &options.get_password().unwrap_or_default(),
         &cont.salt,
         cont.iterations,
     )?;

--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 pub use ssl_mode::PgSslMode;
 
+use crate::options::pgpass::PGPassFile;
 use crate::{connection::LogSettings, net::tls::CertificateInput};
 
 mod connect;
@@ -20,6 +21,7 @@ pub struct PgConnectOptions {
     pub(crate) socket: Option<PathBuf>,
     pub(crate) username: String,
     pub(crate) password: Option<String>,
+    pub(crate) passfile: PGPassFile,
     pub(crate) database: Option<String>,
     pub(crate) ssl_mode: PgSslMode,
     pub(crate) ssl_root_cert: Option<CertificateInput>,
@@ -74,6 +76,7 @@ impl PgConnectOptions {
             socket: None,
             username,
             password: var("PGPASSWORD").ok(),
+            passfile: PGPassFile::default(),
             database,
             ssl_root_cert: var("PGSSLROOTCERT").ok().map(CertificateInput::from),
             ssl_client_cert: var("PGSSLCERT").ok().map(CertificateInput::from),
@@ -94,14 +97,7 @@ impl PgConnectOptions {
     }
 
     pub(crate) fn apply_pgpass(mut self) -> Self {
-        if self.password.is_none() {
-            self.password = pgpass::load_password(
-                &self.host,
-                self.port,
-                &self.username,
-                self.database.as_deref(),
-            );
-        }
+        self.passfile = PGPassFile::load().unwrap_or_default();
 
         self
     }
@@ -531,7 +527,14 @@ impl PgConnectOptions {
         if self.password.is_some() {
             return self.password.as_deref().map(Cow::Borrowed);
         }
-        None
+        self.passfile
+            .password_if_matching(
+                &self.host,
+                self.port,
+                self.database.as_deref(),
+                &self.username,
+            )
+            .map(Cow::Owned)
     }
 
     /// Get the current database name.

--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -519,6 +519,21 @@ impl PgConnectOptions {
         &self.username
     }
 
+    /// Get the password.
+    ///
+    /// ```rust
+    /// # use sqlx_postgres::PgConnectOptions;
+    /// let options = PgConnectOptions::new()
+    ///     .password("53C237");
+    /// assert_eq!(options.get_password().as_deref(), Some("53C237"));
+    /// ```
+    pub fn get_password(&self) -> Option<Cow<'_, str>> {
+        if self.password.is_some() {
+            return self.password.as_deref().map(Cow::Borrowed);
+        }
+        None
+    }
+
     /// Get the current database name.
     ///
     /// # Example


### PR DESCRIPTION
Loads the the PostgreSQL passfile on `apply_pgpass` and defers querying the password to `get_password` calls. This ensures the correct password is retrieved, even when builder methods are called on `PgConnectOptions` after initialization.

### Does your PR solve an issue?

Fixes #2658

### Is this a breaking change?

Yes. Parameters set by `PgConnectOptions` builder methods are now honored by the passfile lookup.