### PR TITLE
sqlx-postgres(tests): cleanup 2 unit tests.

### DIFF
--- a/sqlx-core/src/types/json.rs
+++ b/sqlx-core/src/types/json.rs
@@ -196,20 +196,6 @@ where
     }
 }
 
-impl<DB> Type<DB> for Box<JsonRawValue>
-where
-    for<'a> Json<&'a Self>: Type<DB>,
-    DB: Database,
-{
-    fn type_info() -> DB::TypeInfo {
-        <Json<&Self> as Type<DB>>::type_info()
-    }
-
-    fn compatible(ty: &DB::TypeInfo) -> bool {
-        <Json<&Self> as Type<DB>>::compatible(ty)
-    }
-}
-
 impl<'q, DB> Encode<'q, DB> for JsonRawValue
 where
     for<'a> Json<&'a Self>: Encode<'q, DB>,

--- a/tests/postgres/derives.rs
+++ b/tests/postgres/derives.rs
@@ -818,7 +818,7 @@ async fn test_custom_pg_array() -> anyhow::Result<()> {
 
     impl PgHasArrayType for User {
         fn array_type_info() -> sqlx::postgres::PgTypeInfo {
-            sqlx::postgres::PgTypeInfo::array_of("Gebruiker")
+            sqlx::postgres::PgTypeInfo::array_of("User")
         }
     }
     Ok(())

--- a/tests/postgres/setup.sql
+++ b/tests/postgres/setup.sql
@@ -69,7 +69,7 @@ CREATE TABLE circles (
     EXCLUDE USING gist (c WITH &&)
 );
 
-CREATE DOMAIN positive_int AS integer CHECK (VALUE >= 0);
+CREATE DOMAIN positive_int AS integer CHECK (VALUE > 0);
 CREATE DOMAIN percentage AS positive_int CHECK (VALUE <= 100);
 
 CREATE TYPE person as (


### PR DESCRIPTION
This cleans up 2 of my tests that were added in previous PRs.

The first commit is a unit tests from #3641.It was also mentioned in https://github.com/launchbadge/sqlx/issues/3996#issuecomment-3221971241 but 0 is not positive.

The second is from #3453, for some reason I put it in dutch not english.

Edit: This pr also removes a duplicate `sqlx::Type` impl for `Box<serde_json::value::RawValue>` that slipped in after #3859 was merged.