### PR TITLE
PostgreSQL SASL – run SHA256 in a blocking executor

### DIFF
--- a/sqlx-postgres/src/message/mod.rs
+++ b/sqlx-postgres/src/message/mod.rs
@@ -30,7 +30,7 @@ mod startup;
 mod sync;
 mod terminate;
 
-pub use authentication::{Authentication, AuthenticationSasl};
+pub use authentication::{Authentication, AuthenticationSasl, AuthenticationSaslContinue};
 pub use backend_key_data::BackendKeyData;
 pub use bind::Bind;
 pub use close::Close;


### PR DESCRIPTION
### Does your PR solve an issue?

Fixes #4005

### Is this a breaking change?

No

### Discussion

I've put together a PoC of offloading the SHA256 HMAC generation into a blocking executor, taking it off the main event loop.

There's also a little unit test demonstrating how long this code takes. On my machine this takes ~50ms.

I can remove the test and/or put something more useful in there before merging.