### PR TITLE
use random ports for all conatiners

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -230,7 +230,7 @@ services:
             args:
                 VERSION: 17
         ports:
-            - 5432:5432
+            - 5432
         environment:
             POSTGRES_DB: sqlx
             POSTGRES_HOST_AUTH_METHOD: trust
@@ -374,7 +374,7 @@ services:
             args:
                 VERSION: 13
         ports:
-            - 5432:5432
+            - 5432
         environment:
             POSTGRES_DB: sqlx
             POSTGRES_HOST_AUTH_METHOD: trust


### PR DESCRIPTION
I couldn't follow the steps in `tests/README.md` because two containers failed to bind to the same port, already used by a local running database.

### Does your PR solve an issue?
No. I didn't create one just for such a simple change.

### Is this a breaking change?
No, it doesn't even touch the Rust code.