### PR TITLE
make `#[derive(sqlx::Type)]` automatically generate `impl PgHasArrayType` by default for newtype structs

### DIFF
--- a/sqlx-macros-core/src/derives/type.rs
+++ b/sqlx-macros-core/src/derives/type.rs
@@ -124,6 +124,17 @@ fn expand_derive_has_sql_type_transparent(
                 }
             }
         ));
+
+        if !attr.no_pg_array {
+            tts.extend(quote!(
+                #[automatically_derived]
+                impl ::sqlx::postgres::PgHasArrayType for #ident #ty_generics {
+                    fn array_type_info() -> ::sqlx::postgres::PgTypeInfo {
+                        ::sqlx::postgres::PgTypeInfo::array_of(#ty_name)
+                    }
+                }
+            ));
+        }
     }
 
     Ok(tts)

--- a/tests/postgres/types.rs
+++ b/tests/postgres/types.rs
@@ -713,6 +713,22 @@ test_type!(nested_domain_types_1<Person>(Postgres,
     "ROW(1, 21::positive_int, 50::percentage)::person" == Person { id: 1, age: PositiveInt(21), percent: Percentage(PositiveInt(50)) })
 );
 
+test_type!(domain_type_array_1<Vec<PositiveInt>>(Postgres,
+    "ARRAY[1, 50, 1000]::positive_int[]" == vec![
+        PositiveInt(1),
+        PositiveInt(50),
+        PositiveInt(1000),
+    ],
+));
+
+test_type!(domain_type_array_2<Vec<Percentage>>(Postgres,
+    "ARRAY[4, 66, 100]::percentage[]" == vec![
+        Percentage(PositiveInt(4)),
+        Percentage(PositiveInt(66)),
+        Percentage(PositiveInt(100))
+    ],
+));
+
 #[derive(sqlx::Type, Debug, PartialEq)]
 #[sqlx(type_name = "leaf_composite")]
 struct LeafComposite {
@@ -730,8 +746,16 @@ struct RootComposite {
 }
 
 test_type!(nested_domain_types_2<RootComposite>(Postgres,
-    "ROW(ROW(1))::root_composite" == RootComposite { domain: Domain(LeafComposite { prim: 1})})
+    "ROW(ROW(1))::root_composite" == RootComposite { domain: Domain(LeafComposite { prim: 1 }) })
 );
+
+test_type!(domain_type_array_3<Vec<Domain>>(Postgres,
+    "ARRAY[ROW(50), ROW(1), ROW(1000)]::domain[]" == vec![
+        Domain(LeafComposite { prim: 50 }),
+        Domain(LeafComposite { prim: 1 }),
+        Domain(LeafComposite { prim: 1000 }),
+    ]
+));
 
 test_type!(test_arc<Arc<i32>>(Postgres, "1::INT4" == Arc::new(1i32)));
 test_type!(test_cow<Cow<'_, i32>>(Postgres, "1::INT4" == Cow::<i32>::Owned(1i32)));


### PR DESCRIPTION
### Does your PR solve an issue?
fixes #3996

See the issue for the reasoning behind the changes.

### Is this a breaking change?
Yes. People who use domain types in PostgreSQL have likely already implemented the `PgHasArrayType` trait manually to work around the problem from #3996. In that case, my changes would introduce a duplicate implementation of the trait. The solution would be to either remove the manual implementation or add the `#[sqlx(no_pg_array)]` attribute to the struct.