### PR TITLE
fix(macros-core): more consistent env loading and reading logic

### DIFF
--- a/sqlx-macros-core/src/query/mod.rs
+++ b/sqlx-macros-core/src/query/mod.rs
@@ -157,7 +157,7 @@ pub fn expand_input<'a>(
     let mut metadata_lock = METADATA.lock().unwrap();
 
     let metadata = match metadata_lock.entry(manifest_dir) {
-        hash_map::Entry::Occupied(occupied) => Arc::clone(&occupied.get()),
+        hash_map::Entry::Occupied(occupied) => Arc::clone(occupied.get()),
         hash_map::Entry::Vacant(vacant) => {
             let metadata = init_metadata(vacant.key())?;
             vacant.insert(Arc::clone(&metadata));


### PR DESCRIPTION
### Context, problem statement and description

While giving the new `sqlx.toml` feature a try, I discovered that its `database_url_var` setting behaved inconsistently compared to other environment variables: it wasn't loaded from `.env` files, causing it to be effectively ignored in favor of the default `DATABASE_URL` variable. This is an inconvenient outcome for the multi-database workspaces that this feature is designed to support.

To address this issue, I reworked the `.env` loading logic to account for this configuration and make it simpler to use to achieve consistent behavior. The new algorithm works as follows:

- First, it generates lists of environment variables that can be loaded from `.env` files and candidate `.env` file paths. When applicable, the compiler is informed to track changes to their elements.
- Next, it loads the set of potentially tracked environment variables to a static hash map (in a previous revision of this PR, `set_env` was used, but I changed it as a response to the review comments below). When a variable is defined in both the process environment and a `.env` file, the process environment takes precedence, as before.
- Macro code can now use the `env` function freely to read environment variable values, abstracting itself away from their source, which results in simpler, less error-prone code.

Trivially, this rework resolves the issue I encountered because the `database_url_var` value is now part of the list of loadable environment variables. Future code can easily make such additions as necessary.

### Does your PR solve an issue?

To my knowledge, this PR doesn't directly address any previously reported issue in this repository.

### Is this a breaking change?

Technically yes when compared to the released `0.9.0` alpha version, as environment variables like `database_url_var` may now be loaded from another source. However, I don't think this technically breaking change will cause significant inconvenience for most users, especially since the new behavior is more consistent and useful, and the affected variables are bound to not be widely used due to them being published as an alpha release so far.