### PR TITLE
Add `Migrator::with_migrations()` constructor

### DIFF
--- a/sqlx-core/src/migrate/migrator.rs
+++ b/sqlx-core/src/migrate/migrator.rs
@@ -78,7 +78,7 @@ impl Migrator {
     /// use sqlx::{ SqlSafeStr, migrate::{Migration, MigrationType::*, Migrator}};
     ///
     /// // Define your migrations.
-    /// // You can also use include_str!() instead of hard-coded SQL statements.
+    /// // You can also use include_str!("./xxx.sql") instead of hard-coded SQL statements.
     /// let migrations = vec![
     ///     Migration::new(1, "user".into(), ReversibleUp, "create table uesrs ( ... )".into_sql_str(), false),
     ///     Migration::new(2, "post".into(), ReversibleUp, "create table posts ( ... )".into_sql_str(), false),


### PR DESCRIPTION
This function allows users to build `migrations` programmatically.

### Is this a breaking change?
No.

