### PR TITLE
fix(sqlite) Migrate revert with no-transaction

### DIFF
--- a/sqlx-sqlite/src/migrate.rs
+++ b/sqlx-sqlite/src/migrate.rs
@@ -207,7 +207,7 @@ CREATE TABLE IF NOT EXISTS {table_name} (
             let start = Instant::now();
 
             if migration.no_tx {
-                execute_migration(self, table_name, migration).await?;
+                revert_migration(self, table_name, migration).await?;
             } else {
                 // Use a single transaction for the actual migration script and the essential bookkeeping so we never
                 // execute migrations twice. See https://github.com/launchbadge/sqlx/issues/1966.

--- a/tests/sqlite/migrations_no_tx_reversible/0_vacuum.down.sql
+++ b/tests/sqlite/migrations_no_tx_reversible/0_vacuum.down.sql
@@ -1,0 +1,3 @@
+-- no-transaction
+
+PRAGMA JOURNAL_MODE = DELETE;

--- a/tests/sqlite/migrations_no_tx_reversible/0_vacuum.up.sql
+++ b/tests/sqlite/migrations_no_tx_reversible/0_vacuum.up.sql
@@ -1,0 +1,3 @@
+-- no-transaction
+
+PRAGMA JOURNAL_MODE = WAL;


### PR DESCRIPTION
### Does your PR solve an issue?
None created yet.

### Is this a breaking change?
No, it's a bug fix.

### Summary of changes
Migration reverts using `no-tx` in SQLite  currently try to reapply (and fail) migrations, instead of reverting/downgrading.