### PR TITLE
native tls handshake: build TlsConnector in blocking threadpool

### DIFF
--- a/sqlx-core/src/net/tls/tls_native_tls.rs
+++ b/sqlx-core/src/net/tls/tls_native_tls.rs
@@ -62,6 +62,8 @@ pub async fn handshake<S: Socket>(
         builder.identity(identity);
     }
 
+    // The openssl TlsConnector synchronously loads certificates from files.
+    // Loading these files can block for tens of milliseconds.
     let connector = rt::spawn_blocking(move || builder.build())
         .await
         .map_err(Error::tls)?;


### PR DESCRIPTION
The openssl TlsConnector synchronously loads certificates from files. Loading these files can block for tens of milliseconds.

### Does your PR solve an issue?
fixes #4026 

### Is this a breaking change?
No. It should only offload work to a different thread.