### PR TITLE
PostgreSQL: Cache salted password and client key

### DIFF
--- a/sqlx-postgres/src/connection/mod.rs
+++ b/sqlx-postgres/src/connection/mod.rs
@@ -23,6 +23,8 @@ use sqlx_core::sql_str::SqlSafeStr;
 
 pub use self::stream::PgStream;
 
+pub use sasl::ClientKeyCache;
+
 pub(crate) mod describe;
 mod establish;
 mod executor;

--- a/sqlx-postgres/src/message/mod.rs
+++ b/sqlx-postgres/src/message/mod.rs
@@ -30,7 +30,7 @@ mod startup;
 mod sync;
 mod terminate;
 
-pub use authentication::{Authentication, AuthenticationSasl};
+pub use authentication::{Authentication, AuthenticationSasl, AuthenticationSaslContinue};
 pub use backend_key_data::BackendKeyData;
 pub use bind::Bind;
 pub use close::Close;

--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -5,7 +5,10 @@ use std::path::{Path, PathBuf};
 
 pub use ssl_mode::PgSslMode;
 
-use crate::{connection::LogSettings, net::tls::CertificateInput};
+use crate::{
+    connection::{ClientKeyCache, LogSettings},
+    net::tls::CertificateInput,
+};
 
 mod connect;
 mod parse;
@@ -30,6 +33,7 @@ pub struct PgConnectOptions {
     pub(crate) log_settings: LogSettings,
     pub(crate) extra_float_digits: Option<Cow<'static, str>>,
     pub(crate) options: Option<String>,
+    pub(crate) sasl_client_key_cache: ClientKeyCache,
 }
 
 impl Default for PgConnectOptions {
@@ -90,6 +94,7 @@ impl PgConnectOptions {
             extra_float_digits: Some("2".into()),
             log_settings: Default::default(),
             options: var("PGOPTIONS").ok(),
+            sasl_client_key_cache: ClientKeyCache::new(),
         }
     }
 
@@ -267,7 +272,7 @@ impl PgConnectOptions {
     /// -----BEGIN CERTIFICATE-----
     /// <Certificate data here.>
     /// -----END CERTIFICATE-----";
-    ///    
+    ///
     /// let options = PgConnectOptions::new()
     ///     // Providing a CA certificate with less than VerifyCa is pointless
     ///     .ssl_mode(PgSslMode::VerifyCa)


### PR DESCRIPTION
A simple single-entry cache for the salted password and client key.

### Does your PR solve an issue?

Fixes #4032

### Is this a breaking change?

No. The cache is internal.
