### PR TITLE
Add support for rustls-platform-verifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+[#4045]: https://github.com/launchbadge/sqlx/pull/4045
+
 ## 0.9.0 - 2026-05-06
 
 ### Important Announcements

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,9 +103,11 @@ runtime-tokio = ["_rt-tokio", "sqlx-core/_rt-tokio", "sqlx-macros?/_rt-tokio"]
 tls-native-tls = ["sqlx-core/_tls-native-tls", "sqlx-macros?/_tls-native-tls"]
 tls-rustls = ["tls-rustls-ring"] # For backwards compatibility
 tls-rustls-aws-lc-rs = ["sqlx-core/_tls-rustls-aws-lc-rs", "sqlx-macros?/_tls-rustls-aws-lc-rs"]
+tls-rustls-aws-lc-rs-platform-verifier = ["sqlx-core/_tls-rustls-aws-lc-rs-platform-verifier", "sqlx-macros?/_tls-rustls-aws-lc-rs-platform-verifier"]
 tls-rustls-ring = ["tls-rustls-ring-webpki"] # For backwards compatibility
 tls-rustls-ring-webpki = ["sqlx-core/_tls-rustls-ring-webpki", "sqlx-macros?/_tls-rustls-ring-webpki"]
-tls-rustls-ring-native-roots = ["sqlx-core/_tls-rustls-ring-native-roots", "sqlx-macros?/_tls-rustls-ring-native-roots"]
+tls-rustls-ring-native-roots = ["tls-rustls-ring-platform-verifier"] # For backwards compatibility
+tls-rustls-ring-platform-verifier = ["sqlx-core/_tls-rustls-aws-lc-rs-platform-verifier", "sqlx-macros?/_tls-rustls-aws-lc-rs-platform-verifier"]
 
 # No-op feature used by the workflows to compile without TLS enabled. Not meant for general use.
 tls-none = []

--- a/README.md
+++ b/README.md
@@ -139,9 +139,11 @@ sqlx = { version = "0.8", features = [ "runtime-tokio", "tls-native-tls" ] }
 # tokio + rustls with ring and WebPKI CA certificates
 sqlx = { version = "0.8", features = [ "runtime-tokio", "tls-rustls-ring-webpki" ] }
 # tokio + rustls with ring and platform's native CA certificates
-sqlx = { version = "0.8", features = [ "runtime-tokio", "tls-rustls-ring-native-roots" ] }
+sqlx = { version = "0.8", features = [ "runtime-tokio", "tls-rustls-ring-platform-verifier" ] }
 # tokio + rustls with aws-lc-rs
 sqlx = { version = "0.8", features = [ "runtime-tokio", "tls-rustls-aws-lc-rs" ] }
+# tokio + rustls with aws-lc-rs and platform's native CA certificates
+sqlx = { version = "0.8", features = [ "runtime-tokio", "tls-rustls-aws-lc-rs-platform-verifier" ] }
 
 # async-std (no TLS)
 sqlx = { version = "0.8", features = [ "runtime-async-std" ] }
@@ -150,9 +152,11 @@ sqlx = { version = "0.8", features = [ "runtime-async-std", "tls-native-tls" ] }
 # async-std + rustls with ring and WebPKI CA certificates
 sqlx = { version = "0.8", features = [ "runtime-async-std", "tls-rustls-ring-webpki" ] }
 # async-std + rustls with ring and platform's native CA certificates
-sqlx = { version = "0.8", features = [ "runtime-async-std", "tls-rustls-ring-native-roots" ] }
+sqlx = { version = "0.8", features = [ "runtime-async-std", "tls-rustls-ring-platform-verifier" ] }
 # async-std + rustls with aws-lc-rs
 sqlx = { version = "0.8", features = [ "runtime-async-std", "tls-rustls-aws-lc-rs" ] }
+# async-std + rustls with aws-lc-rs and platform's native CA certificates
+sqlx = { version = "0.8", features = [ "runtime-async-std", "tls-rustls-aws-lc-rs-platform-verifier" ] }
 ```
 
 #### Cargo Feature Flags

--- a/sqlx-cli/Cargo.toml
+++ b/sqlx-cli/Cargo.toml
@@ -58,6 +58,9 @@ default = ["postgres", "sqlite", "mysql", "native-tls", "completions", "sqlx-tom
 # TLS options
 rustls = ["sqlx/tls-rustls"]
 native-tls = ["sqlx/tls-native-tls"]
+tls-rustls-aws-lc-rs-platform-verifier = ["sqlx/tls-rustls-aws-lc-rs-platform-verifier"]
+tls-rustls-ring-platform-verifier = ["sqlx/tls-rustls-aws-lc-rs-platform-verifier"]
+
 
 # databases
 mysql = ["sqlx/mysql"]

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -29,8 +29,9 @@ _rt-tokio = ["tokio", "tokio-stream"]
 
 _tls-native-tls = ["native-tls"]
 _tls-rustls-aws-lc-rs = ["_tls-rustls", "rustls/aws-lc-rs", "webpki-roots"]
+_tls-rustls-aws-lc-rs-platform-verifier = ["_tls-rustls", "rustls/aws-lc-rs", "rustls-platform-verifier"]
 _tls-rustls-ring-webpki = ["_tls-rustls", "rustls/ring", "webpki-roots"]
-_tls-rustls-ring-native-roots = ["_tls-rustls", "rustls/ring", "rustls-native-certs"]
+_tls-rustls-ring-platform-verifier = ["_tls-rustls", "rustls/ring", "rustls-platform-verifier"]
 _tls-rustls = ["rustls"]
 _tls-none = []
 
@@ -57,7 +58,7 @@ native-tls = { version = "0.2.10", optional = true }
 
 rustls = { version = "0.23.24", default-features = false, features = ["std", "tls12"], optional = true }
 webpki-roots = { version = "1", optional = true }
-rustls-native-certs = { version = "0.8.0", optional = true }
+rustls-platform-verifier = { version = "0.7", optional = true }
 
 # Type Integrations
 bit-vec = { workspace = true, optional = true }

--- a/sqlx-macros-core/Cargo.toml
+++ b/sqlx-macros-core/Cargo.toml
@@ -19,8 +19,9 @@ _rt-tokio = ["tokio", "sqlx-core/_rt-tokio"]
 
 _tls-native-tls = ["sqlx-core/_tls-native-tls"]
 _tls-rustls-aws-lc-rs = ["sqlx-core/_tls-rustls-aws-lc-rs"]
+_tls-rustls-aws-lc-rs-platform-verifier = ["sqlx-core/_tls-rustls-aws-lc-rs-platform-verifier"]
 _tls-rustls-ring-webpki = ["sqlx-core/_tls-rustls-ring-webpki"]
-_tls-rustls-ring-native-roots = ["sqlx-core/_tls-rustls-ring-native-roots"]
+_tls-rustls-ring-platform-verifier = ["sqlx-core/_tls-rustls-aws-lc-rs-platform-verifier"]
 
 _sqlite = []
 

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -22,8 +22,9 @@ _rt-tokio = ["sqlx-macros-core/_rt-tokio"]
 
 _tls-native-tls = ["sqlx-macros-core/_tls-native-tls"]
 _tls-rustls-aws-lc-rs = ["sqlx-macros-core/_tls-rustls-aws-lc-rs"]
+_tls-rustls-aws-lc-rs-platform-verifier = ["sqlx-macros-core/_tls-rustls-aws-lc-rs-platform-verifier"]
 _tls-rustls-ring-webpki = ["sqlx-macros-core/_tls-rustls-ring-webpki"]
-_tls-rustls-ring-native-roots = ["sqlx-macros-core/_tls-rustls-ring-native-roots"]
+_tls-rustls-ring-platform-verifier = ["sqlx-macros-core/_tls-rustls-aws-lc-rs-platform-verifier"]
 
 # SQLx features
 derive = ["sqlx-macros-core/derive"]

--- a/sqlx-postgres/src/options/doc.md
+++ b/sqlx-postgres/src/options/doc.md
@@ -86,7 +86,8 @@ See `default_host()` in the same source file as this method for the current beha
 If `sslrootcert` is not set, the default root certificates used depends on Cargo features:
 
 * If `tls-native-tls` is enabled, the system root certificates are used.
-* If `tls-rustls-ring-native-roots` is enabled, the system root certificates are used.
+* If `tls-rustls-ring-platform-verifier` or `tls-rustls-aws-lc-rs-platform-verifier`
+  is enabled, the system root certificates are used.
 * Otherwise, TLS roots are populated using the [`webpki-roots`] crate.
 
 ## Environment Variables


### PR DESCRIPTION
### Does your PR solve an issue?

fixes #4044 

### Is this a breaking change?

No.

This PR
- Adds optional dependency on **rustls-platform-verifier**.
- Adds new feature flags `tls-rustls-aws-lc-rs-platform-verifier` and `tls-rustls-ring-platform-verifier` to enable platform's native CA certificates provided by rustls-platform-verifier.
- Removes dependency on **rustls-native-certs** (since rustls-platform-verifier is now recommended over it instead).
- Makes `tls-rustls-ring-native-roots` feature flag an alias to `tls-rustls-ring-platform-verifier` for backwards compatibility reasons.
