### PR TITLE
feat: Support for specifying multiple databases in test macros.

### DIFF
--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -752,20 +752,20 @@ jobs:
       - run: cargo build --features any,postgres,mysql,macros,migrate,_unstable-all-types,runtime-${{ matrix.runtime }}
 
       - run: |
-          docker compose -f tests/docker-compose.yml run -d -p 5432:5432 --name postgres_${{ matrix.postgres }} postgres_${{ matrix.postgres }}
-          docker exec postgres_${{ matrix.postgres }} bash -c "until pg_isready; do sleep 1; done"
+          docker compose -f tests/docker-compose.yml run -d -p 5432:5432 --name postgres_1_${{ matrix.postgres }} postgres_${{ matrix.postgres }}
+          docker exec postgres_1_${{ matrix.postgres }} bash -c "until pg_isready; do sleep 1; done"
 
       - run: |
-          docker compose -f tests/docker-compose.yml run -d -p 5433:5432 --name postgres_users_${{ matrix.postgres }} postgres_${{ matrix.postgres }}
-          docker exec postgres_users_${{ matrix.postgres }} bash -c "until pg_isready; do sleep 1; done"
+          docker compose -f tests/docker-compose.yml run -d -p 5433:5432 --name postgres_2_${{ matrix.postgres }} postgres_${{ matrix.postgres }}
+          docker exec postgres_2_${{ matrix.postgres }} bash -c "until pg_isready; do sleep 1; done"
 
       - run: |
-          docker compose -f tests/docker-compose.yml run -d -p 3306:3306 --name mysql_posts_${{ matrix.mysql }} mysql_${{ matrix.mysql }}
-          docker exec mysql_posts_${{ matrix.mysql }} bash -c "until mysqladmin ping; do sleep 1; done"
+          docker compose -f tests/docker-compose.yml run -d -p 3306:3306 --name mysql_1_${{ matrix.mysql }} mysql_${{ matrix.mysql }}
+          docker exec mysql_1_${{ matrix.mysql }} bash -c "until mysqladmin ping; do sleep 1; done"
 
       - run: |
-          docker compose -f tests/docker-compose.yml run -d -p 3307:3306 --name mysql_comments_${{ matrix.mysql }} mysql_${{ matrix.mysql }}
-          docker exec mysql_comments_${{ matrix.mysql }} bash -c "until mysqladmin ping; do sleep 1; done"
+          docker compose -f tests/docker-compose.yml run -d -p 3307:3306 --name mysql_2_${{ matrix.mysql }} mysql_${{ matrix.mysql }}
+          docker exec mysql_2_${{ matrix.mysql }} bash -c "until mysqladmin ping; do sleep 1; done"
 
       # Create data dir for offline mode
       - run: mkdir .sqlx
@@ -778,9 +778,10 @@ jobs:
           --features any,postgres,mysql,macros,migrate,_unstable-all-types,runtime-${{ matrix.runtime }}
         env:
           DATABASE_URL: postgres://postgres:password@localhost:5432/sqlx
-          PG_USERS_DATABASE_URL: postgres://postgres:password@localhost:5433/sqlx
-          MYSQL_POSTS_DATABASE_URL: mysql://root:password@localhost:3306/sqlx
-          MYSQL_COMMENTS_DATABASE_URL: mysql://root:password@localhost:3307/sqlx
+          PG_1_DATABASE_URL: postgres://postgres:password@localhost:5432/sqlx
+          PG_2_DATABASE_URL: postgres://postgres:password@localhost:5433/sqlx
+          MYSQL_1_DATABASE_URL: mysql://root:password@localhost:3306/sqlx
+          MYSQL_2_DATABASE_URL: mysql://root:password@localhost:3307/sqlx
           SQLX_OFFLINE_DIR: .sqlx
           RUSTFLAGS: -D warnings --cfg postgres="${{ matrix.postgres }}" --cfg mysql_${{ matrix.mysql }}
 

--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -732,3 +732,57 @@ jobs:
         env:
           DATABASE_URL: mysql://root@localhost:3306/sqlx?sslmode=verify_ca&ssl-ca=.%2Ftests%2Fcerts%2Fca.crt&ssl-key=.%2Ftests%2Fcerts%2Fkeys%2Fclient.key&ssl-cert=.%2Ftests%2Fcerts%2Fclient.crt
           RUSTFLAGS: --cfg mariadb="${{ matrix.mariadb }}"
+
+  mixed:
+    name: Mixed in Postgres and MySQL
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        postgres: [ 17, 13 ]
+        mysql: [ 8 ]
+        runtime: [ async-global-executor, smol, tokio ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        run: rustup show active-toolchain || rustup toolchain install
+
+      - uses: Swatinem/rust-cache@v2
+
+      - run: cargo build --features any,postgres,mysql,macros,migrate,_unstable-all-types,runtime-${{ matrix.runtime }}
+
+      - run: |
+          docker compose -f tests/docker-compose.yml run -d -p 5432:5432 --name postgres_${{ matrix.postgres }} postgres_${{ matrix.postgres }}
+          docker exec postgres_${{ matrix.postgres }} bash -c "until pg_isready; do sleep 1; done"
+
+      - run: |
+          docker compose -f tests/docker-compose.yml run -d -p 5433:5432 --name postgres_users_${{ matrix.postgres }} postgres_${{ matrix.postgres }}
+          docker exec postgres_users_${{ matrix.postgres }} bash -c "until pg_isready; do sleep 1; done"
+
+      - run: |
+          docker compose -f tests/docker-compose.yml run -d -p 3306:3306 --name mysql_posts_${{ matrix.mysql }} mysql_${{ matrix.mysql }}
+          docker exec mysql_posts_${{ matrix.mysql }} bash -c "until mysqladmin ping; do sleep 1; done"
+
+      - run: |
+          docker compose -f tests/docker-compose.yml run -d -p 3307:3306 --name mysql_comments_${{ matrix.mysql }} mysql_${{ matrix.mysql }}
+          docker exec mysql_comments_${{ matrix.mysql }} bash -c "until mysqladmin ping; do sleep 1; done"
+
+      # Create data dir for offline mode
+      - run: mkdir .sqlx
+
+      # Run the `test-attr` test again to cover cleanup.
+      - run: >
+          cargo test
+          --test mixed-test-attr
+          --no-default-features
+          --features any,postgres,mysql,macros,migrate,_unstable-all-types,runtime-${{ matrix.runtime }}
+        env:
+          DATABASE_URL: postgres://postgres:password@localhost:5432/sqlx
+          PG_USERS_DATABASE_URL: postgres://postgres:password@localhost:5433/sqlx
+          MYSQL_POSTS_DATABASE_URL: mysql://root:password@localhost:3306/sqlx
+          MYSQL_COMMENTS_DATABASE_URL: mysql://root:password@localhost:3307/sqlx
+          SQLX_OFFLINE_DIR: .sqlx
+          RUSTFLAGS: -D warnings --cfg postgres="${{ matrix.postgres }}" --cfg mysql_${{ matrix.mysql }}
+
+      # Remove test artifacts
+      - run: cargo clean -p sqlx

--- a/.github/workflows/sqlx.yml
+++ b/.github/workflows/sqlx.yml
@@ -749,7 +749,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - run: cargo build --features any,postgres,mysql,macros,migrate,_unstable-all-types,runtime-${{ matrix.runtime }}
+      - run: cargo build --features any,postgres,mysql,mysql-rsa,macros,migrate,_unstable-all-types,runtime-${{ matrix.runtime }}
 
       - run: |
           docker compose -f tests/docker-compose.yml run -d -p 5432:5432 --name postgres_1_${{ matrix.postgres }} postgres_${{ matrix.postgres }}
@@ -775,7 +775,7 @@ jobs:
           cargo test
           --test mixed-test-attr
           --no-default-features
-          --features any,postgres,mysql,macros,migrate,_unstable-all-types,runtime-${{ matrix.runtime }}
+          --features any,postgres,mysql,mysql-rsa,macros,migrate,_unstable-all-types,runtime-${{ matrix.runtime }}
         env:
           DATABASE_URL: postgres://postgres:password@localhost:5432/sqlx
           PG_1_DATABASE_URL: postgres://postgres:password@localhost:5432/sqlx

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -468,3 +468,11 @@ required-features = ["postgres"]
 name = "postgres-rustsec"
 path = "tests/postgres/rustsec.rs"
 required-features = ["postgres", "macros", "migrate"]
+
+#
+# Mixed in Postgres and MySQL
+#
+[[test]]
+name = "mixed-test-attr"
+path = "tests/mixed/test-attr.rs"
+required-features = ["postgres", "mysql", "macros", "migrate"]

--- a/sqlx-core/src/testing/mod.rs
+++ b/sqlx-core/src/testing/mod.rs
@@ -500,7 +500,7 @@ impl_test_fn!(
     run_test_with_pool3;
     ('c DB1, args1, tc1, tp1, po1, co1, p1, c1),
     ('d DB2, args2, tc2, tp2, po2, co2, p2, c2),
-    ('d DB3, args3, tc3, tp3, po3, co3, p3, c3),
+    ('e DB3, args3, tc3, tp3, po3, co3, p3, c3),
     ;
 );
 
@@ -510,7 +510,7 @@ impl_test_fn!(
     run_test_with_pool4;
     ('c DB1, args1, tc1, tp1, po1, co1, p1, c1),
     ('d DB2, args2, tc2, tp2, po2, co2, p2, c2),
-    ('d DB3, args3, tc3, tp3, po3, co3, p3, c3),
-    ('e DB4, args4, tc4, tp4, po4, co4, p4, c4),
+    ('e DB3, args3, tc3, tp3, po3, co3, p3, c3),
+    ('f DB4, args4, tc4, tp4, po4, co4, p4, c4),
     ;
 );

--- a/sqlx-macros-core/src/test_attr.rs
+++ b/sqlx-macros-core/src/test_attr.rs
@@ -6,6 +6,7 @@ use syn::parse::Parser;
 struct Args {
     fixtures: Vec<(FixturesType, Vec<syn::LitStr>)>,
     migrations: MigrationsOpt,
+    database_url_var: DatabaseUrlOpt,
 }
 
 #[cfg(feature = "migrate")]
@@ -22,6 +23,19 @@ enum MigrationsOpt {
     ExplicitPath(syn::LitStr),
     ExplicitMigrator(syn::Path),
     Disabled,
+}
+
+#[cfg(feature = "migrate")]
+enum DatabaseUrlOpt {
+    EnvironmentVariable(syn::LitStr),
+    ExplicitVariable(syn::Path),
+}
+
+#[cfg(feature = "migrate")]
+struct ParsedArgs {
+    fixtures: Vec<TokenStream>,
+    migrations: TokenStream,
+    database_url_var: TokenStream,
 }
 
 type AttributeArgs = syn::punctuated::Punctuated<syn::Meta, syn::Token![,]>;
@@ -85,9 +99,121 @@ fn expand_advanced(args: AttributeArgs, input: syn::ItemFn) -> crate::Result<Tok
     let body = &input.block;
     let attrs = &input.attrs;
 
-    let args = parse_args(args)?;
+    let parsed_args_list = parse_attr_args(&args, &input, &config)?;
 
     let fn_arg_types = inputs.iter().map(|_| quote! { _ });
+
+    match parsed_args_list.len() {
+        0 => {
+            return Ok(quote! {
+                #(#attrs)*
+                #[::core::prelude::v1::test]
+                fn #name() #ret {
+                    async fn #name(#inputs) #ret {
+                        #body
+                    }
+
+                    let mut args = ::sqlx::testing::TestArgs::new(concat!(module_path!(), "::", stringify!(#name)));
+
+                    // We need to give a coercion site or else we get "unimplemented trait" errors.
+                    let f: fn(#(#fn_arg_types),*) -> _ = #name;
+
+                    ::sqlx::testing::TestFn::run_test(f, args)
+                }
+            });
+        }
+        args_num @ 1..=4 => {
+            use proc_macro2::Span;
+            use syn::Ident;
+
+            let mut run_fn_args = Vec::with_capacity(args_num);
+            for i in 1..=args_num {
+                run_fn_args.push(Ident::new(&format!("args{i}"), Span::call_site()));
+            }
+            let run_fn = if args_num == 1 {
+                quote! { ::sqlx::testing::TestFn::run_test(f, #(#run_fn_args,)*) }
+            } else {
+                let test_fn = Ident::new(&format!("TestFn{args_num}"), Span::call_site());
+                quote! { ::sqlx::testing::#test_fn::run_test(f, #(#run_fn_args,)*) }
+            };
+
+            let mut args = Vec::new();
+            for (i, parsed_args) in parsed_args_list.iter().enumerate() {
+                let args_name = Ident::new(&format!("args{}", 1 + i), Span::call_site());
+                let database_url_var = &parsed_args.database_url_var;
+                let migrations = &parsed_args.migrations;
+                let fixtures = parsed_args.fixtures.as_slice();
+
+                args.push(quote! {
+                    let mut #args_name = ::sqlx::testing::TestArgs::new(concat!(module_path!(), "::", stringify!(#name), "#{", #i, "}"));
+                    #args_name.#migrations
+                    #args_name.fixtures(&[#(#fixtures),*]);
+                    #args_name.database_url_var(#database_url_var);
+                });
+            }
+
+            return Ok(quote! {
+                #(#attrs)*
+                #[::core::prelude::v1::test]
+                fn #name() #ret {
+                    async fn #name(#inputs) #ret {
+                        #body
+                    }
+
+                    #(#args)*
+
+                    // We need to give a coercion site or else we get "unimplemented trait" errors.
+                    let f: fn(#(#fn_arg_types),*) -> _ = #name;
+
+                    #run_fn
+                }
+            });
+        }
+        _ => {
+            return Err(Box::new(syn::Error::new_spanned(
+                args.first().unwrap(),
+                "expect to no more than 4 env attributes.",
+            )));
+        }
+    }
+}
+
+#[cfg(feature = "migrate")]
+fn parse_attr_args(
+    args: &AttributeArgs,
+    input: &syn::ItemFn,
+    config: &sqlx_core::config::Config,
+) -> crate::Result<Vec<ParsedArgs>> {
+    let parser = AttributeArgs::parse_terminated;
+
+    let mut parsed_args: Vec<ParsedArgs> = Vec::new();
+
+    for arg in args {
+        match arg {
+            syn::Meta::List(list) if list.path.is_ident("env") => {
+                let args = parser.parse2(list.tokens.clone())?;
+                let parsed = parse_one_attr_args(args, input, config)?;
+                parsed_args.push(parsed);
+            }
+            _ => {
+                let parsed = parse_one_attr_args(args.clone(), input, config)?;
+                return Ok(vec![parsed]);
+            }
+        }
+    }
+
+    Ok(parsed_args)
+}
+
+#[cfg(feature = "migrate")]
+fn parse_one_attr_args(
+    args: AttributeArgs,
+    input: &syn::ItemFn,
+    config: &sqlx_core::config::Config,
+) -> crate::Result<ParsedArgs> {
+    let inputs = &input.sig.inputs;
+
+    let args = parse_args(args)?;
 
     let mut fixtures = Vec::new();
 
@@ -146,7 +272,7 @@ fn expand_advanced(args: AttributeArgs, input: syn::ItemFn) -> crate::Result<Tok
     let migrations = match args.migrations {
         MigrationsOpt::ExplicitPath(path) => {
             let migrator = crate::migrate::expand(Some(path))?;
-            quote! { args.migrator(&#migrator); }
+            quote! { migrator(&#migrator); }
         }
         MigrationsOpt::InferredPath if !inputs.is_empty() => {
             let path = crate::migrate::default_path(&config);
@@ -155,41 +281,34 @@ fn expand_advanced(args: AttributeArgs, input: syn::ItemFn) -> crate::Result<Tok
 
             if resolved_path.is_dir() {
                 let migrator = crate::migrate::expand_with_path(&config, &resolved_path)?;
-                quote! { args.migrator(&#migrator); }
+                quote! { migrator(&#migrator); }
             } else {
-                quote! {}
+                quote! { no_migrator(); }
             }
         }
         MigrationsOpt::ExplicitMigrator(path) => {
-            quote! { args.migrator(&#path); }
+            quote! { migrator(&#path); }
         }
-        _ => quote! {},
+        _ => quote! { no_migrator(); },
     };
 
-    Ok(quote! {
-        #(#attrs)*
-        #[::core::prelude::v1::test]
-        fn #name() #ret {
-            async fn #name(#inputs) #ret {
-                #body
-            }
-
-            let mut args = ::sqlx::testing::TestArgs::new(concat!(module_path!(), "::", stringify!(#name)));
-
-            #migrations
-
-            args.fixtures(&[#(#fixtures),*]);
-
-            // We need to give a coercion site or else we get "unimplemented trait" errors.
-            let f: fn(#(#fn_arg_types),*) -> _ = #name;
-
-            ::sqlx::testing::TestFn::run_test(f, args)
+    let database_url_var = match args.database_url_var {
+        DatabaseUrlOpt::EnvironmentVariable(name) => {
+            quote! { #name }
         }
+        DatabaseUrlOpt::ExplicitVariable(path) => quote! { #path },
+    };
+
+    Ok(ParsedArgs {
+        fixtures,
+        migrations,
+        database_url_var,
     })
 }
 
 #[cfg(feature = "migrate")]
 fn parse_args(attr_args: AttributeArgs) -> syn::Result<Args> {
+    use proc_macro2::Span;
     use syn::{
         parenthesized, parse::Parse, punctuated::Punctuated, token::Comma, Expr, Lit, LitStr, Meta,
         MetaNameValue, Token,
@@ -197,6 +316,8 @@ fn parse_args(attr_args: AttributeArgs) -> syn::Result<Args> {
 
     let mut fixtures = Vec::new();
     let mut migrations = MigrationsOpt::InferredPath;
+    let mut database_url_var =
+        DatabaseUrlOpt::EnvironmentVariable(LitStr::new("DATABASE_URL", Span::call_site()));
 
     for arg in attr_args {
         let path = arg.path().clone();
@@ -292,11 +413,27 @@ fn parse_args(attr_args: AttributeArgs) -> syn::Result<Args> {
 
                 migrations = MigrationsOpt::ExplicitMigrator(lit.parse()?);
             }
+            // var = "<path>"
+            Meta::NameValue(MetaNameValue { value, .. }) if path.is_ident("var") => {
+                let Expr::Lit(syn::ExprLit {
+                    lit: Lit::Str(lit), ..
+                }) = value
+                else {
+                    return Err(syn::Error::new_spanned(path, "expected string"));
+                };
+
+                database_url_var = DatabaseUrlOpt::ExplicitVariable(lit.parse()?);
+            }
+            // var("<environment variable name>")
+            Meta::List(list) if path.is_ident("var") => {
+                let s: LitStr = list.parse_args()?;
+                database_url_var = DatabaseUrlOpt::EnvironmentVariable(s);
+            }
             arg => {
                 return Err(syn::Error::new_spanned(
                     arg,
-                    r#"expected `fixtures("<filename>", ...)` or `migrations = "<path>" | false` or `migrator = "<rust path>"`"#,
-                ))
+                    r#"expected `fixtures("<filename>", ...)` or `migrations = "<path>" | false` or `migrator = "<rust path>"` or `var("DATABASE_URL")` or `var = "<rust path>"`"#,
+                ));
             }
         }
     }
@@ -304,6 +441,7 @@ fn parse_args(attr_args: AttributeArgs) -> syn::Result<Args> {
     Ok(Args {
         fixtures,
         migrations,
+        database_url_var,
     })
 }
 

--- a/sqlx-postgres/src/testing/mod.rs
+++ b/sqlx-postgres/src/testing/mod.rs
@@ -1,13 +1,14 @@
 use std::future::Future;
 use std::ops::Deref;
 use std::str::FromStr;
-use std::sync::OnceLock;
+use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 
 use sqlx_core::connection::Connection;
 use sqlx_core::query_builder::QueryBuilder;
 use sqlx_core::query_scalar::query_scalar;
 use sqlx_core::sql_str::AssertSqlSafe;
+use sqlx_core::HashMap;
 
 use crate::error::Error;
 use crate::executor::Executor;
@@ -17,8 +18,8 @@ use crate::{PgConnectOptions, PgConnection, Postgres};
 
 pub(crate) use sqlx_core::testing::*;
 
-// Using a blocking `OnceLock` here because the critical sections are short.
-static MASTER_POOL: OnceLock<Pool<Postgres>> = OnceLock::new();
+static MASTER_POOLS: LazyLock<Mutex<HashMap<&'static str, Pool<Postgres>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 // Automatically delete any databases created before the start of the test binary.
 
 impl TestSupport for Postgres {
@@ -28,19 +29,24 @@ impl TestSupport for Postgres {
         test_context(args)
     }
 
-    async fn cleanup_test(db_name: &str) -> Result<(), Error> {
-        let mut conn = MASTER_POOL
-            .get()
-            .expect("cleanup_test() invoked outside `#[sqlx::test]`")
-            .acquire()
-            .await?;
+    async fn cleanup_test(args: &TestArgs) -> Result<(), Error> {
+        let db_name = Self::db_name(args);
 
-        do_cleanup(&mut conn, db_name).await
+        let master_pool = get_master_pool(args.database_url_var);
+        let mut conn = master_pool.acquire().await?;
+
+        do_cleanup(&mut conn, &db_name).await
     }
 
     async fn cleanup_test_dbs() -> Result<Option<usize>, Error> {
         let url = dotenvy::var("DATABASE_URL").expect("DATABASE_URL must be set");
 
+        let count = Self::cleanup_test_dbs_by_url(&url).await?;
+
+        Ok(count)
+    }
+
+    async fn cleanup_test_dbs_by_url(url: &str) -> Result<Option<usize>, Error> {
         let mut conn = PgConnection::connect(&url).await?;
 
         let delete_db_names: Vec<String> = query_scalar("select db_name from _sqlx_test.databases")
@@ -90,7 +96,9 @@ impl TestSupport for Postgres {
 }
 
 async fn test_context(args: &TestArgs) -> Result<TestContext<Postgres>, Error> {
-    let url = dotenvy::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let database_url_var = args.database_url_var;
+
+    let url = dotenvy::var(database_url_var).expect("DATABASE_URL must be set");
 
     let master_opts = PgConnectOptions::from_str(&url).expect("failed to parse DATABASE_URL");
 
@@ -103,7 +111,7 @@ async fn test_context(args: &TestArgs) -> Result<TestContext<Postgres>, Error> {
         .after_release(|_conn, _| Box::pin(async move { Ok(false) }))
         .connect_lazy_with(master_opts);
 
-    let master_pool = match once_lock_try_insert_polyfill(&MASTER_POOL, pool) {
+    let master_pool = match try_insert_polyfill(database_url_var, pool) {
         Ok(inserted) => inserted,
         Err((existing, pool)) => {
             // Sanity checks.
@@ -143,7 +151,7 @@ async fn test_context(args: &TestArgs) -> Result<TestContext<Postgres>, Error> {
             created_at timestamptz not null default now()
         );
 
-        create index if not exists databases_created_at 
+        create index if not exists databases_created_at
             on _sqlx_test.databases(created_at);
 
         create sequence if not exists _sqlx_test.database_ids;
@@ -167,6 +175,8 @@ async fn test_context(args: &TestArgs) -> Result<TestContext<Postgres>, Error> {
     let create_command = format!("create database {db_name:?}");
     debug_assert!(create_command.starts_with("create database \""));
     conn.execute(AssertSqlSafe(create_command)).await?;
+
+    eprintln!("created database {db_name}");
 
     Ok(TestContext {
         pool_opts: PoolOptions::new()
@@ -197,11 +207,30 @@ async fn do_cleanup(conn: &mut PgConnection, db_name: &str) -> Result<(), Error>
     Ok(())
 }
 
-fn once_lock_try_insert_polyfill<T>(this: &OnceLock<T>, value: T) -> Result<&T, (&T, T)> {
-    let mut value = Some(value);
-    let res = this.get_or_init(|| value.take().unwrap());
-    match value {
-        None => Ok(res),
-        Some(value) => Err((res, value)),
+fn get_master_pool(database_url_var: &'static str) -> Pool<Postgres> {
+    let guard = MASTER_POOLS
+        .lock()
+        .expect("failed to acquire lock of master pools");
+    guard
+        .get(database_url_var)
+        .expect("cleanup_test() invoked outside `#[sqlx::test]`")
+        .clone()
+}
+
+fn try_insert_polyfill(
+    database_url_var: &'static str,
+    pool: Pool<Postgres>,
+) -> Result<Pool<Postgres>, (Pool<Postgres>, Pool<Postgres>)> {
+    let mut guard = MASTER_POOLS
+        .lock()
+        .expect("failed to acquire lock of master pools");
+    let master_pool = guard.get(database_url_var);
+
+    match master_pool {
+        None => {
+            guard.insert(database_url_var, pool.clone());
+            Ok(pool)
+        }
+        Some(master_pool) => Err((master_pool.clone(), pool)),
     }
 }

--- a/sqlx-postgres/src/testing/mod.rs
+++ b/sqlx-postgres/src/testing/mod.rs
@@ -47,7 +47,7 @@ impl TestSupport for Postgres {
     }
 
     async fn cleanup_test_dbs_by_url(url: &str) -> Result<Option<usize>, Error> {
-        let mut conn = PgConnection::connect(&url).await?;
+        let mut conn = PgConnection::connect(url).await?;
 
         let delete_db_names: Vec<String> = query_scalar("select db_name from _sqlx_test.databases")
             .fetch_all(&mut conn)

--- a/sqlx-sqlite/src/testing/mod.rs
+++ b/sqlx-sqlite/src/testing/mod.rs
@@ -16,14 +16,19 @@ impl TestSupport for Sqlite {
         test_context(args)
     }
 
-    async fn cleanup_test(db_name: &str) -> Result<(), Error> {
-        crate::fs::remove_file(db_name).await?;
+    async fn cleanup_test(args: &TestArgs) -> Result<(), Error> {
+        let db_name = Self::db_name(args);
+        crate::fs::remove_file(&db_name).await?;
         Ok(())
     }
 
     async fn cleanup_test_dbs() -> Result<Option<usize>, Error> {
         crate::fs::remove_dir_all(BASE_PATH).await?;
         Ok(None)
+    }
+
+    async fn cleanup_test_dbs_by_url(_: &str) -> Result<Option<usize>, Error> {
+        unimplemented!()
     }
 
     async fn snapshot(_conn: &mut Self::Connection) -> Result<FixtureSnapshot<Self>, Error> {

--- a/tests/mixed/fixtures/mysql/comments.sql
+++ b/tests/mixed/fixtures/mysql/comments.sql
@@ -1,0 +1,16 @@
+insert into comment(comment_id, post_id, user_id, content, created_at)
+values (1,
+        1,
+        2,
+        'lol bet ur still bad, 1v1 me',
+        timestamp(now(), '-0:50:00')),
+       (2,
+        1,
+        1,
+        'you''re on!',
+        timestamp(now(), '-0:45:00')),
+       (3,
+        2,
+        1,
+        'lol you''re just mad you lost :P',
+        timestamp(now(), '-0:15:00'));

--- a/tests/mixed/fixtures/mysql/posts.sql
+++ b/tests/mixed/fixtures/mysql/posts.sql
@@ -1,0 +1,9 @@
+insert into post(post_id, user_id, content, created_at)
+values (1,
+        1,
+        'This new computer is lightning-fast!',
+        timestamp(now(), '-1:00:00')),
+       (2,
+        2,
+        '@alice is a haxxor :(',
+        timestamp(now(), '-0:30:00'));

--- a/tests/mixed/fixtures/postgres/users.sql
+++ b/tests/mixed/fixtures/postgres/users.sql
@@ -1,0 +1,2 @@
+insert into "user"(user_id, username)
+values ('6592b7c0-b531-4613-ace5-94246b7ce0c3', 'alice'), ('297923c5-a83c-4052-bab0-030887154e52', 'bob');

--- a/tests/mixed/test-attr.rs
+++ b/tests/mixed/test-attr.rs
@@ -5,25 +5,25 @@ use sqlx::{MySqlPool, PgPool};
 const PG_MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("tests/postgres/migrations");
 const MYSQL_MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("tests/mysql/migrations");
 
-const PG_USERS_DATABASE_URL: &'static str = "PG_USERS_DATABASE_URL";
-const MYSQL_COMMENTS_DATABASE_URL: &'static str = "MYSQL_COMMENTS_DATABASE_URL";
+const PG_2_DATABASE_URL: &'static str = "PG_2_DATABASE_URL";
+const MYSQL_2_DATABASE_URL: &'static str = "MYSQL_2_DATABASE_URL";
 
 #[sqlx::test(
     env(migrations = "tests/postgres/migrations"), // no database url var
     env(
         migrator = "PG_MIGRATOR",
         fixtures(path = "fixtures/postgres", scripts("users")),
-        var = "PG_USERS_DATABASE_URL", // rust path
+        var = "PG_2_DATABASE_URL", // rust path
     ),
     env(
         migrations = "tests/mysql/migrations",
         fixtures(path = "fixtures/mysql", scripts("posts")),
-        var("MYSQL_POSTS_DATABASE_URL"), // string literal
+        var("MYSQL_1_DATABASE_URL"), // string literal
     ),
     env(
         migrator = "MYSQL_MIGRATOR",
         fixtures(path = "fixtures/mysql", scripts("comments")),
-        var = "MYSQL_COMMENTS_DATABASE_URL", // rust path
+        var = "MYSQL_2_DATABASE_URL", // rust path
     ),
 )]
 async fn it_gets_from_invidual_environments(

--- a/tests/mixed/test-attr.rs
+++ b/tests/mixed/test-attr.rs
@@ -1,0 +1,73 @@
+// The no-arg variant is covered by other tests already.
+
+use sqlx::{MySqlPool, PgPool};
+
+const PG_MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("tests/postgres/migrations");
+const MYSQL_MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("tests/mysql/migrations");
+
+const PG_USERS_DATABASE_URL: &'static str = "PG_USERS_DATABASE_URL";
+const MYSQL_COMMENTS_DATABASE_URL: &'static str = "MYSQL_COMMENTS_DATABASE_URL";
+
+#[sqlx::test(
+    env(migrations = "tests/postgres/migrations"), // no database url var
+    env(
+        migrator = "PG_MIGRATOR",
+        fixtures(path = "fixtures/postgres", scripts("users")),
+        var = "PG_USERS_DATABASE_URL", // rust path
+    ),
+    env(
+        migrations = "tests/mysql/migrations",
+        fixtures(path = "fixtures/mysql", scripts("posts")),
+        var("MYSQL_POSTS_DATABASE_URL"), // string literal
+    ),
+    env(
+        migrator = "MYSQL_MIGRATOR",
+        fixtures(path = "fixtures/mysql", scripts("comments")),
+        var = "MYSQL_COMMENTS_DATABASE_URL", // rust path
+    ),
+)]
+async fn it_gets_from_invidual_environments(
+    pg_pool_1: PgPool,
+    pg_pool_2: PgPool,
+    mysql_pool_1: MySqlPool,
+    mysql_pool_2: MySqlPool,
+) -> sqlx::Result<()> {
+    let db_name: String = sqlx::query_scalar("SELECT current_database()")
+        .fetch_one(&pg_pool_1)
+        .await?;
+
+    assert!(db_name.starts_with("_sqlx_test"), "dbname: {db_name:?}");
+
+    let pg_pool_2_usernames: Vec<String> =
+        sqlx::query_scalar(r#"SELECT username FROM "user" ORDER BY username"#)
+            .fetch_all(&pg_pool_2)
+            .await?;
+
+    assert_eq!(pg_pool_2_usernames, ["alice", "bob"]);
+
+    let mysql_pool_1_posts: Vec<String> =
+        sqlx::query_scalar("SELECT content FROM post ORDER BY post_id")
+            .fetch_all(&mysql_pool_1)
+            .await?;
+
+    assert_eq!(
+        mysql_pool_1_posts,
+        [
+            "This new computer is lightning-fast!",
+            "@alice is a haxxor :("
+        ]
+    );
+
+    let mysql_pool_2_comments: Vec<String> =
+        sqlx::query_scalar("SELECT content FROM comment WHERE post_id = ? ORDER BY created_at")
+            .bind(1)
+            .fetch_all(&mysql_pool_2)
+            .await?;
+
+    assert_eq!(
+        mysql_pool_2_comments,
+        ["lol bet ur still bad, 1v1 me", "you're on!"]
+    );
+
+    Ok(())
+}

--- a/tests/sqlite/test-attr.rs
+++ b/tests/sqlite/test-attr.rs
@@ -99,6 +99,50 @@ async fn it_gets_comments(pool: SqlitePool) -> sqlx::Result<()> {
 }
 
 #[sqlx::test(
+    env(migrations = "tests/sqlite/migrations", fixtures("users")),
+    env(migrator = "MIGRATOR", fixtures("users", "posts", "comments"))
+)]
+async fn it_gets_from_invidual_environments(
+    pool_1: SqlitePool,
+    pool_2: SqlitePool,
+) -> sqlx::Result<()> {
+    let pool_1_usernames: Vec<String> =
+        sqlx::query_scalar(r#"SELECT username FROM "user" ORDER BY username"#)
+            .fetch_all(&pool_1)
+            .await?;
+
+    assert_eq!(pool_1_usernames, ["alice", "bob"]);
+
+    let pool_2_usernames: Vec<String> =
+        sqlx::query_scalar(r#"SELECT username FROM "user" ORDER BY username"#)
+            .fetch_all(&pool_2)
+            .await?;
+
+    assert_eq!(pool_2_usernames, ["alice", "bob"]);
+
+    let pool_1_post_comments: Vec<String> =
+        sqlx::query_scalar("SELECT content FROM comment WHERE post_id = ? ORDER BY created_at")
+            .bind(&1)
+            .fetch_all(&pool_1)
+            .await?;
+
+    assert_eq!(pool_1_post_comments.len(), 0);
+
+    let pool_2_post_comments: Vec<String> =
+        sqlx::query_scalar("SELECT content FROM comment WHERE post_id = ? ORDER BY created_at")
+            .bind(&1)
+            .fetch_all(&pool_2)
+            .await?;
+
+    assert_eq!(
+        pool_2_post_comments,
+        ["lol bet ur still bad, 1v1 me", "you're on!"]
+    );
+
+    Ok(())
+}
+
+#[sqlx::test(
     migrations = "tests/sqlite/migrations",
     fixtures(path = "./fixtures", scripts("users", "posts"))
 )]


### PR DESCRIPTION
This makes it possible to specify multiple databases with the `sqlx::test` macro.

Adds grouping by `env` and specification of environment variable names by `var` as macro arguments.

This makes it easier to write tests for the following cases:

- Sharded databases

- Multiple types of databases (for example, the case below).

  - Uses Sqlite as local master data and stores variable data in remote PostgreSQL.

  - A relational database and a RDB compatible NoSQL database.

#### Concerns

Are the argument names `env` and `var` ambiguous?

#### Other changes.
- Added `TestArgs::no_migrator` to simplify macro implementation.
- Added `TestArgs::database_url_var` to save the environment variable name when running tests.
- Added `cleanup_test_dbs_by_url` function to `TestSupport`, which deletes test databases from the database_url argument.
- Added a macro to implement test functions that support multiple databases.
  - It is possible to replace the existing `TestFn` with a macro, but this is not done as this is intended to be a reference implementation for macro implementation.
- Modified MASTER_POOL during testing so that it is retained for each environment variable name.
- Changed to display the database name created during PostgreSQL testing.
  - It was displayed in MySQL, so I changed it, but is that okay?
- Added a test for using multiple databases for CI.

### Does your PR solve an issue?
closes #2220 
closes #3947 

### Is this a breaking change?
Yes.

`TestSupport::cleanup_test` will be changed to take `TestArgs` as an argument.
