### PR TITLE
fix(postgres): propagate `persistent` to intermediary queries

### DIFF
--- a/sqlx-postgres/src/arguments.rs
+++ b/sqlx-postgres/src/arguments.rs
@@ -111,6 +111,7 @@ impl PgArguments {
         &mut self,
         conn: &mut PgConnection,
         parameters: &[PgTypeInfo],
+        persistent: bool,
     ) -> Result<(), Error> {
         let PgArgumentBuffer {
             ref patches,
@@ -128,8 +129,8 @@ impl PgArguments {
 
         for (offset, kind) in type_holes {
             let oid = match kind {
-                HoleKind::Type { name } => conn.fetch_type_id_by_name(name).await?,
-                HoleKind::Array(array) => conn.fetch_array_type_id(array).await?,
+                HoleKind::Type { name } => conn.fetch_type_id_by_name(persistent, name).await?,
+                HoleKind::Array(array) => conn.fetch_array_type_id(persistent, array).await?,
             };
             buffer[*offset..(*offset + 4)].copy_from_slice(&oid.0.to_be_bytes());
         }


### PR DESCRIPTION
In some situations (e.g.: when using enums), sqlx will fire additional queries to fetch data from the database. Currently, these queries use `persistent=true`, regardless of whether the parent query did. Unfortunately, this means that sqlx can't be used with connection poolers that don't support named prepared statements.

In this patch, I try to propagate the `persistent` attribute from the parent query to the other queries.

Additionally, this requires a potential re-send of `Parse/Describe`, as the additional queries will replace the existing one Postgres-side. For example, this is a sequence that could happen (after propagating `persistent`):
```
Parse("", "SELECT * FROM mytable")
Describe("")
Sync()
Parse("", "SELECT enumlabel FROM pg_catalog.pg_enum WHERE enumtypid = $1 ORDER BY enumsortorder") Describe("")
Sync()
Bind(...)
Execute(..)
Sync()
Bind(...)
Execute(..)
Sync()
```
This obviously won't work, as the second Parse message overwrote the unnamed prepared statement. Hence I added a re-preparation of the original query:

```
Parse("", "SELECT * FROM mytable")
Describe("")
Sync()
Parse("", "SELECT enumlabel FROM pg_catalog.pg_enum WHERE enumtypid = $1 ORDER BY enumsortorder") Describe("")
Sync()
Bind(...)
Execute(..)
Sync()
Parse("", "SELECT * FROM mytable")
Describe("")
Bind(...)
Execute(..)
Sync()
```
Let me know if I missed any place where this should be done, or if you disagree in the concept.

### Is this a breaking change?
I don't believe so.