### PR TITLE
Fix typo in migration example from 'uesrs' to 'users'

### DIFF
--- a/sqlx-core/src/migrate/migrator.rs
+++ b/sqlx-core/src/migrate/migrator.rs
@@ -80,7 +80,7 @@ impl Migrator {
     /// // Define your migrations.
     /// // You can also use include_str!("./xxx.sql") instead of hard-coded SQL statements.
     /// let migrations = vec![
-    ///     Migration::new(1, "user".into(), ReversibleUp, "create table uesrs ( ... )".into_sql_str(), false),
+    ///     Migration::new(1, "user".into(), ReversibleUp, "create table users ( ... )".into_sql_str(), false),
     ///     Migration::new(2, "post".into(), ReversibleUp, "create table posts ( ... )".into_sql_str(), false),
     ///     // add more...
     ///  ];


### PR DESCRIPTION
### Does your PR solve an issue?
No

### Is this a breaking change?
No, just fixes a typo in an example.