### PR TITLE
chore: update hashlink to v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1664,11 +1664,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -98,7 +98,7 @@ tracing = { version = "0.1.37", features = ["log"] }
 smallvec = "1.7.0"
 url = { version = "2.2.2" }
 bstr = { version = "1.0", default-features = false, features = ["std"], optional = true }
-hashlink = "0.10.0"
+hashlink = "0.11.0"
 indexmap = "2.0"
 event-listener = "5.2.0"
 hashbrown = "0.16.0"


### PR DESCRIPTION
### Does your PR solve an issue?
I did not create an issue, but I encountered an compatability issue when trying to compile an application
with both sqlx and swc (which specify different versions of hashlink).

### Is this a breaking change?
As far as I can see hashlink and the subdependency have added/exposed functionality and not broken existing functionality.
So probably no, potentially yes (Hyrum's Law).