### PR TITLE
Bump bit-vec to v0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,7 @@ sqlx = { version = "=0.9.0-alpha.1", path = ".", default-features = false }
 # Common type integrations shared by multiple driver crates.
 # These are optional unless enabled in a workspace crate.
 bigdecimal = "0.4.0"
-bit-vec = "0.6.3"
+bit-vec = "0.8"
 chrono = { version = "0.4.34", default-features = false, features = ["std", "clock"] }
 ipnet = "2.3.0"
 ipnetwork = "0.21.1"


### PR DESCRIPTION
[bit-vec](https://github.com/contain-rs/bit-vec)

bit-vec v0.8 has been out for over a year.

I have run test as per [[tests/README.md]]. Some tests failed to compile (`cargo test --no-default-features --manifest-path sqlx-core/Cargo.toml --features json,offline,migrate,_rt-async-std,_tls-rustls`)  because of some feature not set in [[tests/x.py:151]]. After adding those features manually it compiled and passed.