### PR TITLE
postgres: update pgpass path on windows

### DIFF
--- a/sqlx-postgres/src/options/pgpass.rs
+++ b/sqlx-postgres/src/options/pgpass.rs
@@ -28,7 +28,7 @@ pub fn load_password(
 
         etcetera::base_strategy::Windows::new()
             .ok()
-            .map(|basedirs| basedirs.data_dir().join("postgres").join("pgpass.conf"))
+            .map(|basedirs| basedirs.data_dir().join("postgresql").join("pgpass.conf"))
     };
     load_password_from_file(default_file?, host, port, username, database)
 }


### PR DESCRIPTION
### Does your PR solve an issue?
fixes #4097

The creator of the issue added a link to the libpq source code (thanks!), which was used to create this pr (https://github.com/postgres/postgres/blob/master/src/interfaces/libpq/fe-connect.c#L8262).


### Is this a breaking change?

Behavior changes _can_ be breaking if significant enough.
Consider [Hyrum's Law](https://www.hyrumslaw.com/):

> With a sufficient number of users of an API,  
> it does not matter what you promise in the contract:  
> all observable behaviors of your system  
> will be depended on by somebody.

No, no public api is changed. However, this does change the behavior of loading in a pgpass file on windows.