### PR TITLE
[postgres] Display line number in error message

### DIFF
--- a/sqlx-postgres/src/error.rs
+++ b/sqlx-postgres/src/error.rs
@@ -156,7 +156,11 @@ impl Debug for PgDatabaseError {
 
 impl Display for PgDatabaseError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.write_str(self.message())
+        f.write_str(self.message())?;
+        if let Some(line) = self.line() {
+            write!(f, " at line {line}")?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
<!-- 
PR AUTHOR INSTRUCTIONS; PLEASE READ.

Give your pull request an accurate and descriptive title. It should mention what component(s) or database driver(s) it touches.
Pull requests with undescriptive or inaccurate titles *may* be closed or have their titles changed before merging.

Fill out the fields below.

All pull requests *must* pass CI to be merged. Check your pull request frequently for build failures until all checks pass.
Address build failures by pushing new commits or amending existing ones. Feel free to ask for help if you get stuck.
If a failure seems spurious (timeout or cache failure), you may push a new commit to re-run it.

After addressing review comments, re-request review to show that you are ready for your PR to be looked at again.

Pull requests which sit for a long time with broken CI or unaddressed review comments will be closed to clear the backlog.
If this happens, you are welcome to open a new pull request, but please be sure to address the feedback you have received previously.

Bug fixes should include a regression test which fails before the fix and passes afterwards. If this is infeasible, please explain why.

New features *should* include unit or integration tests in the appropriate folders. Database specific tests should go in `tests/<database>`.

Note that unsolicited pull requests implementing large or complex changes may not be reviwed right away.
Maintainer time and energy is limited and massive unsolicited pull requests require an outsized effort to review.

To make the best use of your time and ours, search for and participate in existing discussion on the issue tracker before opening a pull request.
The solution you came up with may have already been rejected or postponed due to other work needing to be done first,
or there may be a pending solution going down a different direction that you hadn't considered.

Pull requests that take existing discussion into account are the most likely to be merged.

Delete this block comment before submission to show that you have read and understand these instructions.
-->

### Does your PR solve an issue?

This makes Postgres errors include the line number for easier debugging. This makes the error output similar to what MySQL and SQLite do by default.

### Is this a breaking change?

While changing the display of an error could in theory break weird workflows, it seems quite unlikely. Worst case people who have already implemented workarounds will get two line numbers.

### Alternatives Considered

An alternative would be to print the position rather than the line number. This could maybe be combined with the macros to put an error only under the relevant line, but as an isolated change a line number is more human readable, and more in line with what the other databases implement.