### PR TITLE
feat: add `Json::into_inner()`

### DIFF
--- a/sqlx-core/src/types/json.rs
+++ b/sqlx-core/src/types/json.rs
@@ -86,6 +86,13 @@ use crate::types::Type;
 #[serde(transparent)]
 pub struct Json<T: ?Sized>(pub T);
 
+impl<T> Json<T> {
+    /// Extract the inner value.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
 impl<T> From<T> for Json<T> {
     fn from(value: T) -> Self {
         Self(value)


### PR DESCRIPTION
### Does your PR solve an issue?
No, but i can create one if bureaucracy is expected. 

### Is this a breaking change?
No. Adding a new method for already existing type is not considered a breaking change for downstream-users.

ThIs PR introduces `.into_inner` method for `Json<T>` type, so that users can extract `T` from `Json<T>`, if they prefer to do so. Regarding sqlx-core types, there's already `.into_inner` method in [Text](https://github.com/launchbadge/sqlx/blob/e8384f2a00173c2b120eea72e99d120557fced8b/sqlx-core/src/types/text.rs#L78) type, but there is none in [Json](https://github.com/launchbadge/sqlx/blob/e8384f2a00173c2b120eea72e99d120557fced8b/sqlx-core/src/types/json.rs#L87) type. Using `.into_inner` might come really handy, especially when iterating and doing `.map(Json::into_inner)` instead of `.map(|Json(x)| x)`.

### Tests

Regarding tests and [Text](https://github.com/launchbadge/sqlx/blob/e8384f2a00173c2b120eea72e99d120557fced8b/sqlx-core/src/types/text.rs#L78) type, its `.into_inner` method is not found in examples / whatnot. Which is why there are no tests written -- I expected that if another type `.into_inner`'s method does not appear in tests / examples, similar the situation should be for my change. If I'm wrong -- never hesitate to announce that :)
