### PR TITLE
Add container-level #[sqlx(try_from = T)]

### DIFF
--- a/sqlx-macros-core/src/derives/attributes.rs
+++ b/sqlx-macros-core/src/derives/attributes.rs
@@ -59,6 +59,7 @@ pub struct SqlxContainerAttributes {
     pub repr: Option<Ident>,
     pub no_pg_array: bool,
     pub default: bool,
+    pub try_from: Option<Type>,
 }
 
 pub enum JsonAttribute {
@@ -82,6 +83,7 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
     let mut rename_all = None;
     let mut no_pg_array = None;
     let mut default = None;
+    let mut try_from = None;
 
     for attr in input {
         if attr.path().is_ident("sqlx") {
@@ -92,6 +94,10 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
                     try_set!(no_pg_array, true, attr);
                 } else if meta.path.is_ident("default") {
                     try_set!(default, true, attr);
+                } else if meta.path.is_ident("try_from") {
+                    meta.input.parse::<Token![=]>()?;
+                    let val: LitStr = meta.input.parse()?;
+                    try_set!(try_from, val.parse()?, val);
                 } else if meta.path.is_ident("rename_all") {
                     meta.input.parse::<Token![=]>()?;
                     let lit: LitStr = meta.input.parse()?;
@@ -140,6 +146,7 @@ pub fn parse_container_attributes(input: &[Attribute]) -> syn::Result<SqlxContai
         rename_all,
         no_pg_array: no_pg_array.unwrap_or(false),
         default: default.unwrap_or(false),
+        try_from,
     })
 }
 

--- a/tests/sqlite/derives.rs
+++ b/tests/sqlite/derives.rs
@@ -32,3 +32,20 @@ test_type!(transparent_named<TransparentNamed>(Sqlite,
     "0" == TransparentNamed { field: 0 },
     "23523" == TransparentNamed { field: 23523 },
 ));
+
+#[derive(PartialEq, Eq, Debug, sqlx::Type)]
+#[sqlx(try_from = "i64")]
+struct TryFromI64(i64);
+
+impl TryFrom<i64> for TryFromI64 {
+    type Error = std::num::TryFromIntError;
+
+    fn try_from(value: i64) -> Result<Self, Self::Error> {
+        Ok(Self(i32::try_from(value)? as i64))
+    }
+}
+
+test_type!(try_from_i64<TryFromI64>(Sqlite,
+    "0" == TryFromI64(0),
+    "23523" == TryFromI64(23523),
+));


### PR DESCRIPTION
### Does your PR solve an issue?
https://github.com/launchbadge/sqlx/discussions/2833

### Is this a breaking change?
This is a new feature without breaking changes.

---

This PR adds ability to experience the pleasure of writing code like as follows.

```rust
use anyhow::*;

use derive_more::Display;

use serde::{Deserialize, Serialize};

use sqlx::Type;

#[derive(Clone, PartialEq, Display, Deserialize, Serialize, Type)]
#[serde(try_from = "String")]
#[sqlx(try_from = "String")]
pub struct Id(String);

impl TryFrom<String> for Id {
    type Error = Error;

    fn try_from(value: String) -> Result<Self> {
        if value.len() != 36 {
            bail!("user id length must be 36");
        }

        let id = Self(value);

        Ok(id)
    }
}
```

```rust
#[get("/api/users", database: Extension<Database>)]
async fn get_users() -> Result<Vec<(user::Id, user::Name)>, anyhow::Error> {
    sqlx::query(include_str!("./queries/get_users.sql"))
        .fetch_all(database.pool())
        .await
        .context("failed to execute query `get_users`")?
        .into_iter()
        .map(|row| {
            Ok::<_, anyhow::Error>((
                row.try_get::<user::Id, _>(0)
                    .context("failed to decode user id")?,
                row.try_get::<user::Name, _>(1)
                    .context("failed to decode user name")?,
            ))
        })
        .try_collect()
}
```