### PR TITLE
Ensure Deterministic Migration Order 

### DIFF
--- a/sqlx-core/src/migrate/migration.rs
+++ b/sqlx-core/src/migrate/migration.rs
@@ -1,5 +1,6 @@
 use sha2::{Digest, Sha384};
 use std::borrow::Cow;
+use std::cmp::Ordering;
 
 use crate::sql_str::SqlStr;
 
@@ -13,6 +14,28 @@ pub struct Migration {
     pub sql: SqlStr,
     pub checksum: Cow<'static, [u8]>,
     pub no_tx: bool,
+}
+
+impl PartialEq for Migration {
+    fn eq(&self, other: &Self) -> bool {
+        self.version == other.version && self.migration_type == other.migration_type
+    }
+}
+
+impl Eq for Migration {}
+
+impl PartialOrd for Migration {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Migration {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.version
+            .cmp(&other.version)
+            .then_with(|| self.migration_type.cmp(&other.migration_type))
+    }
 }
 
 impl Migration {

--- a/sqlx-core/src/migrate/migration_type.rs
+++ b/sqlx-core/src/migrate/migration_type.rs
@@ -74,6 +74,14 @@ impl MigrationType {
         }
     }
 
+    /// Ordering helper to sort ups before downs when versions tie.
+    pub fn direction_order(&self) -> u8 {
+        match self {
+            MigrationType::ReversibleDown => 1,
+            MigrationType::Simple | MigrationType::ReversibleUp => 0,
+        }
+    }
+
     #[deprecated = "unused"]
     pub fn infer(migrator: &Migrator, reversible: bool) -> MigrationType {
         match migrator.iter().last() {

--- a/sqlx-core/src/migrate/migration_type.rs
+++ b/sqlx-core/src/migrate/migration_type.rs
@@ -74,15 +74,6 @@ impl MigrationType {
         }
     }
 
-    /// Ordering helper to sort ups before downs when versions tie.
-    pub fn direction_order(&self) -> u8 {
-        match self {
-            MigrationType::Simple => 0,
-            MigrationType::ReversibleUp => 1,
-            MigrationType::ReversibleDown => 2,
-        }
-    }
-
     #[deprecated = "unused"]
     pub fn infer(migrator: &Migrator, reversible: bool) -> MigrationType {
         match migrator.iter().last() {

--- a/sqlx-core/src/migrate/migration_type.rs
+++ b/sqlx-core/src/migrate/migration_type.rs
@@ -1,7 +1,7 @@
 use super::Migrator;
 
 /// Migration Type represents the type of migration
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MigrationType {
     /// Simple migration are single file migrations with no up / down queries
     Simple,
@@ -77,8 +77,9 @@ impl MigrationType {
     /// Ordering helper to sort ups before downs when versions tie.
     pub fn direction_order(&self) -> u8 {
         match self {
-            MigrationType::ReversibleDown => 1,
-            MigrationType::Simple | MigrationType::ReversibleUp => 0,
+            MigrationType::Simple => 0,
+            MigrationType::ReversibleUp => 1,
+            MigrationType::ReversibleDown => 2,
         }
     }
 

--- a/sqlx-core/src/migrate/migrator.rs
+++ b/sqlx-core/src/migrate/migrator.rs
@@ -87,8 +87,12 @@ impl Migrator {
     ///  let m = Migrator::with_migrations(migrations);
     /// ```
     pub fn with_migrations(mut migrations: Vec<Migration>) -> Self {
-        // Ensure that we are sorted by version in ascending order.
-        migrations.sort_by_key(|m| m.version);
+        // Ensure deterministic order: version ascending, then up before down when versions match.
+        migrations.sort_by(|a, b| {
+            a.version
+                .cmp(&b.version)
+                .then_with(|| a.migration_type.direction_order().cmp(&b.migration_type.direction_order()))
+        });
         Self {
             migrations: Cow::Owned(migrations),
             ..Self::DEFAULT

--- a/sqlx-core/src/migrate/migrator.rs
+++ b/sqlx-core/src/migrate/migrator.rs
@@ -89,9 +89,11 @@ impl Migrator {
     pub fn with_migrations(mut migrations: Vec<Migration>) -> Self {
         // Ensure deterministic order: version ascending, then up before down when versions match.
         migrations.sort_by(|a, b| {
-            a.version
-                .cmp(&b.version)
-                .then_with(|| a.migration_type.direction_order().cmp(&b.migration_type.direction_order()))
+            a.version.cmp(&b.version).then_with(|| {
+                a.migration_type
+                    .direction_order()
+                    .cmp(&b.migration_type.direction_order())
+            })
         });
         Self {
             migrations: Cow::Owned(migrations),

--- a/sqlx-core/src/migrate/migrator.rs
+++ b/sqlx-core/src/migrate/migrator.rs
@@ -87,14 +87,7 @@ impl Migrator {
     ///  let m = Migrator::with_migrations(migrations);
     /// ```
     pub fn with_migrations(mut migrations: Vec<Migration>) -> Self {
-        // Ensure deterministic order: version ascending, then up before down when versions match.
-        migrations.sort_by(|a, b| {
-            a.version.cmp(&b.version).then_with(|| {
-                a.migration_type
-                    .direction_order()
-                    .cmp(&b.migration_type.direction_order())
-            })
-        });
+        migrations.sort();
         Self {
             migrations: Cow::Owned(migrations),
             ..Self::DEFAULT

--- a/sqlx-core/src/migrate/source.rs
+++ b/sqlx-core/src/migrate/source.rs
@@ -248,9 +248,13 @@ pub fn resolve_blocking_with_config(
         ));
     }
 
-    // Ensure that we are sorted by version in ascending order.
-    migrations.sort_by_key(|(m, _)| m.version);
-
+    // Ensure deterministic order: version ascending, then up before down when versions match.
+    migrations.sort_by(|(a, _), (b, _)| {
+        a.version
+            .cmp(&b.version)
+            .then_with(|| a.migration_type.direction_order().cmp(&b.migration_type.direction_order()))
+    });
+    
     Ok(migrations)
 }
 

--- a/sqlx-core/src/migrate/source.rs
+++ b/sqlx-core/src/migrate/source.rs
@@ -250,11 +250,13 @@ pub fn resolve_blocking_with_config(
 
     // Ensure deterministic order: version ascending, then up before down when versions match.
     migrations.sort_by(|(a, _), (b, _)| {
-        a.version
-            .cmp(&b.version)
-            .then_with(|| a.migration_type.direction_order().cmp(&b.migration_type.direction_order()))
+        a.version.cmp(&b.version).then_with(|| {
+            a.migration_type
+                .direction_order()
+                .cmp(&b.migration_type.direction_order())
+        })
     });
-    
+
     Ok(migrations)
 }
 

--- a/sqlx-core/src/migrate/source.rs
+++ b/sqlx-core/src/migrate/source.rs
@@ -248,14 +248,7 @@ pub fn resolve_blocking_with_config(
         ));
     }
 
-    // Ensure deterministic order: version ascending, then up before down when versions match.
-    migrations.sort_by(|(a, _), (b, _)| {
-        a.version.cmp(&b.version).then_with(|| {
-            a.migration_type
-                .direction_order()
-                .cmp(&b.migration_type.direction_order())
-        })
-    });
+    migrations.sort();
 
     Ok(migrations)
 }


### PR DESCRIPTION
### What / why

When embedding migrations into the binary via `migrate!`, the *iteration order* of migration files can vary across filesystems/OSes. That makes the resulting embedded migration list (and thus the final binary) non-deterministic, which breaks reproducible builds.

This PR makes migration ordering deterministic by explicitly ordering reversible migration pairs so that **`up` is always before `down`** for the same migration version.

### Changes

* Add `MigrationType::direction_order()` to define a stable tie-break rule (`up`/`simple` first, `down` second).
* Update `Migrator::with_migrations()` to sort migrations by:

  1. version ascending
  2. then `direction_order()` for version ties.
* Apply the same deterministic sort when resolving migrations from a source (blocking resolver).

### Impact

* **Not a breaking change**: applied migrations and version ordering remain the same; only the deterministic ordering of reversible *pairs* is enforced.
* Fixes non-determinism in builds that embed migrations.