### PR TITLE
feat(postgres): allow for passing a maintenance database in the url

### DIFF
--- a/sqlx-postgres/src/migrate.rs
+++ b/sqlx-postgres/src/migrate.rs
@@ -376,3 +376,32 @@ fn generate_lock_id(database_name: &str) -> i64 {
     // 0x3d32ad9e chosen by fair dice roll
     0x3d32ad9e * (CRC_IEEE.checksum(database_name.as_bytes()) as i64)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::parse_for_maintenance;
+
+    #[test]
+    fn test_parse_for_maintenance() {
+        let (opts, db) = parse_for_maintenance("postgres://user:pass@host/mydb").unwrap();
+        assert_eq!(opts.database.as_deref(), Some("postgres"));
+        assert_eq!(db, "mydb");
+
+        let (opts, db) = parse_for_maintenance("postgres://user:pass@host/postgres").unwrap();
+        assert_eq!(opts.database.as_deref(), Some("template1"));
+        assert_eq!(db, "postgres");
+
+        let (opts, db) =
+            parse_for_maintenance("postgres://user:pass@host/mydb?maintenance_database=defaultdb")
+                .unwrap();
+        assert_eq!(opts.database.as_deref(), Some("defaultdb"));
+        assert_eq!(db, "mydb");
+
+        let (opts, db) = parse_for_maintenance(
+            "postgres://user:pass@host/mydb?sslmode=require&maintenance_database=defaultdb",
+        )
+        .unwrap();
+        assert_eq!(opts.database.as_deref(), Some("defaultdb"));
+        assert_eq!(db, "mydb");
+    }
+}


### PR DESCRIPTION
Ideally, this would be a flag on the `database` part of the CLI (in my head, anyway). But doing that properly would require changing the `sqlx_core::migrate::MigrateDatabase` trait I think, which seemed like a gargantuan change in comparison to this.

### Does your PR solve an issue?

closes #2774

### Is this a breaking change?

No, it is not a breaking change, as it adds an optional parameter to Postgres database URLs, which uses the existing functionality when omitted.

