### PR TITLE
Add on unimplemented diagnostic to `SqlStr`

### DIFF
--- a/sqlx-core/src/sql_str.rs
+++ b/sqlx-core/src/sql_str.rs
@@ -42,7 +42,7 @@ use std::sync::Arc;
 
 To bypass this error, manually audit for potential injection vulnerabilities and wrap with `AssertSqlSafe()`.
 For details, see the docs for `SqlSafeStr`.\n",
-    note = "by default, this trait is only implemented for `&'static str`, not all `&str` like the compiler error may suggest"
+    note = "this trait is only implemented for `&'static str`, not all `&str` like the compiler error may suggest"
 )]
 pub trait SqlSafeStr {
     /// Convert `self` to a [`SqlStr`].


### PR DESCRIPTION
This pr adds `diagnostic::on_unimplemented` to `SqlStr` so it generates better compiler errors.

This is how the error looks:
```rust
error[E0277]: dynamic SQL strings should be audited for possible injections
   --> src/sqlx_main.rs:9:17
    |
  9 |     sqlx::query(format!("SELECT * FROM {}", user_input))
    |     ----------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dynamic SQL string
    |     |
    |     required by a bound introduced by this call
    |
    = help: the trait `SqlSafeStr` is not implemented for `std::string::String`
    = note: prefer literal SQL strings with bind parameters or `QueryBuilder` to add dynamic data to a query.

            To bypass this error, manually audit for potential injection vulnerabilities and wrap with `AssertSqlSafe()`.
            For details, see the docs for `SqlSafeStr`.

    = note: by default, this trait is only implemented for `&'static str`, not all `&str` like the compiler error may suggest
    = help: the trait `SqlSafeStr` is implemented for `&str`
note: required by a bound in `sqlx::query`
   --> /home/joey/dev/sqlx/sqlx-core/src/query.rs:653:32
    |
653 | pub fn query<'a, DB>(sql: impl SqlSafeStr) -> Query<'a, DB, <DB as Database>::Arguments>
    |                                ^^^^^^^^^^ required by this bound in `query`

```