### PR TITLE
fix(mysql): use lenient flag comparison for ENUM types

### DIFF
--- a/sqlx-mysql/src/type_info.rs
+++ b/sqlx-mysql/src/type_info.rs
@@ -106,6 +106,13 @@ impl PartialEq<MySqlTypeInfo> for MySqlTypeInfo {
             | ColumnType::String
             | ColumnType::VarString
             | ColumnType::Enum => {
+                // For ENUM types, only require both have ENUM flag set.
+                // MySQL-compatible databases like TiDB may return additional flags
+                // like NOT_NULL that don't affect type compatibility.
+                if self.flags.contains(ColumnFlags::ENUM) && other.flags.contains(ColumnFlags::ENUM)
+                {
+                    return true;
+                }
                 return self.flags == other.flags;
             }
             _ => {}


### PR DESCRIPTION
## Summary

MySQL-compatible databases like TiDB may return ENUM columns with additional flags like `NOT_NULL` or `NO_DEFAULT_VALUE`. The previous exact flag comparison in `MySqlTypeInfo::eq()` caused type mismatches even though both sides were valid ENUM types.

This change makes ENUM comparison check only that both types have the ENUM flag set, ignoring other flags that don't affect type compatibility.

## The Problem

When using `#[derive(sqlx::Type)]` on a Rust enum to decode from a MySQL ENUM column, decoding fails with:

```
mismatched types; Rust type `MyEnum` (as SQL type `ENUM`) is not compatible with SQL type `ENUM`
```

The issue is that `MySqlTypeInfo::__enum()` creates type info with only the `ENUM` flag (0x100), but the database may return columns with additional flags like `NOT_NULL | ENUM` (0x101). The strict equality check `self.flags == other.flags` fails.

## The Fix

For ENUM types, only check that both sides have the ENUM flag set:

```rust
if self.flags.contains(ColumnFlags::ENUM) && other.flags.contains(ColumnFlags::ENUM) {
    return true;
}
```

## Testing

- All existing `sqlx-mysql` tests pass
- Tested against TiDB Cloud with ENUM columns successfully

Fixes #3750
Refs #1241