### PR TITLE
feat(postgres): keepalives for tcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3596,6 +3596,7 @@ dependencies = [
  "sha2",
  "smallvec",
  "smol",
+ "socket2",
  "sqlx",
  "thiserror 2.0.17",
  "time",

--- a/sqlx-core/Cargo.toml
+++ b/sqlx-core/Cargo.toml
@@ -21,12 +21,11 @@ json = ["serde", "serde_json"]
 
 # for conditional compilation
 _rt-async-global-executor = ["async-global-executor", "_rt-async-io", "_rt-async-task"]
-_rt-async-io = ["async-io", "async-fs"] # see note at async-fs declaration
+_rt-async-io = ["async-io", "async-fs", "socket2"] # see note at async-fs declaration
 _rt-async-std = ["async-std", "_rt-async-io"]
 _rt-async-task = ["async-task"]
 _rt-smol = ["smol", "_rt-async-io", "_rt-async-task"]
-_rt-tokio = ["tokio", "tokio-stream"]
-
+_rt-tokio = ["tokio", "tokio-stream", "socket2"]
 _tls-native-tls = ["native-tls"]
 _tls-rustls-aws-lc-rs = ["_tls-rustls", "rustls/aws-lc-rs", "webpki-roots"]
 _tls-rustls-ring-webpki = ["_tls-rustls", "rustls/ring", "webpki-roots"]
@@ -102,6 +101,7 @@ hashlink = "0.11.0"
 indexmap = "2.0"
 event-listener = "5.2.0"
 hashbrown = "0.16.0"
+socket2 = { version = "0.5", features = ["all"], optional = true }
 
 thiserror.workspace = true
 

--- a/sqlx-core/src/net/mod.rs
+++ b/sqlx-core/src/net/mod.rs
@@ -2,5 +2,6 @@ mod socket;
 pub mod tls;
 
 pub use socket::{
-    connect_tcp, connect_uds, BufferedSocket, Socket, SocketIntoBox, WithSocket, WriteBuffer,
+    connect_tcp, connect_uds, BufferedSocket, KeepaliveConfig, Socket, SocketIntoBox, WithSocket,
+    WriteBuffer,
 };

--- a/sqlx-mysql/src/connection/establish.rs
+++ b/sqlx-mysql/src/connection/establish.rs
@@ -17,7 +17,9 @@ impl MySqlConnection {
 
         let handshake = match &options.socket {
             Some(path) => crate::net::connect_uds(path, do_handshake).await?,
-            None => crate::net::connect_tcp(&options.host, options.port, do_handshake).await?,
+            None => {
+                crate::net::connect_tcp(&options.host, options.port, None, do_handshake).await?
+            }
         };
 
         let stream = handshake?;


### PR DESCRIPTION
### Does your PR solve an issue?
Situations where a server disconnects abruptly without sending a FIN packet

### Is this a breaking change?
Yes

```
  Added                                                                                                                                                                                    
  - feat(postgres): TCP keepalive support — PostgreSQL connections now support TCP keepalive probes, matching libpq behavior. Keepalive is enabled by default (keepalives=1), consistent with libpq.

  - New PgConnectOptions methods:
    - keepalives(bool) / get_keepalives() — enable or disable TCP keepalives
    - keepalives_idle(Duration) / get_keepalives_idle() — idle time before probes begin
    - keepalives_interval(Duration) / get_keepalives_interval() — interval between probes
    - keepalives_retries(u32) / get_keepalives_retries() — max failed probes before dropping (Unix only)

  Changed
  - sqlx-core::net::connect_tcp now accepts an optional &KeepaliveConfig parameter to configure keepalive on the underlying TCP socket.
  - New dependency: socket2 0.5 (optional, enabled with _rt-tokio or _rt-async-std features) for cross-platform TCP keepalive configuration.

  Notes
  - MySQL connections pass None for keepalive (no keepalive configuration support yet).
  - Unix domain socket connections are unaffected — keepalive settings are ignored for UDS.
  - Zero values for timer parameters (keepalives_idle=0, keepalives_interval=0) are treated as "use OS default" and are not stored.
```
