### PR TITLE
sqlx-sqlite: relax libsqlite3-sys constraint to allow 0.36.x

### DIFF
--- a/sqlx-sqlite/Cargo.toml
+++ b/sqlx-sqlite/Cargo.toml
@@ -56,7 +56,7 @@ _unstable-docs = [
 
 [dependencies.libsqlite3-sys]
 # See `sqlx-sqlite/src/lib.rs` for details.
-version = ">=0.30.0, <0.36.0"
+version = ">=0.30.0, <0.37.0"
 default-features = false
 features = [
     "pkg-config",


### PR DESCRIPTION
### Does your PR solve an issue?
Fixes #4160

### Is this a breaking change?
No
