### PR TITLE
add sqlite serialize/deserialize example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3843,6 +3843,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlx-example-sqlite-serialize"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "sqlx",
+ "tokio",
+]
+
+[[package]]
 name = "sqlx-example-sqlite-todos"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "examples/postgres/transaction",
     "examples/sqlite/todos",
     "examples/sqlite/extension",
+    "examples/sqlite/serialize",
 ]
 
 [workspace.package]

--- a/examples/sqlite/serialize/Cargo.toml
+++ b/examples/sqlite/serialize/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sqlx-example-sqlite-serialize"
+version = "0.1.0"
+edition = "2024"
+workspace = "../../../"
+
+[dependencies]
+anyhow = "1.0"
+sqlx = { path = "../../../", features = ["sqlite", "sqlite-deserialize", "runtime-tokio"] }
+tokio = { version = "1", features = ["rt", "macros"] }

--- a/examples/sqlite/serialize/src/main.rs
+++ b/examples/sqlite/serialize/src/main.rs
@@ -1,0 +1,31 @@
+use sqlx::sqlite::SqliteOwnedBuf;
+use sqlx::{Connection, SqliteConnection};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    let mut conn = SqliteConnection::connect("sqlite::memory:").await?;
+
+    sqlx::raw_sql(
+        "create table notes(id integer primary key, body text not null);
+         insert into notes(body) values ('hello'), ('world');",
+    )
+    .execute(&mut conn)
+    .await?;
+
+    let snapshot: SqliteOwnedBuf = conn.serialize(None).await?;
+    let bytes: &[u8] = snapshot.as_ref();
+    conn.close().await?;
+
+    let owned = SqliteOwnedBuf::try_from(bytes)?;
+    let mut restored = SqliteConnection::connect("sqlite::memory:").await?;
+    restored.deserialize(None, owned, false).await?;
+
+    let rows = sqlx::query_as::<_, (i64, String)>("select id, body from notes order by id")
+        .fetch_all(&mut restored)
+        .await?;
+
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].1, "hello");
+    assert_eq!(rows[1].1, "world");
+    Ok(())
+}


### PR DESCRIPTION
### Does your PR solve an issue?

No, it's just an example to show how the `serialize` and `deserialize` APIs can be used.

### Is this a breaking change?

No.