### PR TITLE
Make `whoami` an optional feature for postgres

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ features = ["_unstable-docs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["any", "macros", "migrate", "json"]
+default = ["any", "macros", "migrate", "json", "whoami"]
 
 derive = ["sqlx-macros/derive"]
 macros = ["derive", "sqlx-macros/macros", "sqlx-core/offline", "sqlx-mysql?/offline", "sqlx-postgres?/offline", "sqlx-sqlite?/offline"]
@@ -161,6 +161,7 @@ rust_decimal = ["sqlx-core/rust_decimal", "sqlx-macros?/rust_decimal", "sqlx-mys
 time = ["sqlx-core/time", "sqlx-macros?/time", "sqlx-mysql?/time", "sqlx-postgres?/time", "sqlx-sqlite?/time"]
 uuid = ["sqlx-core/uuid", "sqlx-macros?/uuid", "sqlx-mysql?/uuid", "sqlx-postgres?/uuid", "sqlx-sqlite?/uuid"]
 regexp = ["sqlx-sqlite?/regexp"]
+whoami = ["sqlx-postgres?/whoami"]
 bstr = ["sqlx-core/bstr"]
 
 [workspace.dependencies]

--- a/sqlx-postgres/Cargo.toml
+++ b/sqlx-postgres/Cargo.toml
@@ -14,6 +14,7 @@ any = ["sqlx-core/any"]
 json = ["dep:serde", "dep:serde_json", "sqlx-core/json"]
 migrate = ["sqlx-core/migrate", "dep:crc"]
 offline = ["json", "sqlx-core/offline", "smallvec/serde"]
+whoami = ["dep:whoami"]
 
 # Type Integration features
 bigdecimal = ["dep:bigdecimal", "dep:num-bigint", "sqlx-core/bigdecimal"]
@@ -64,7 +65,7 @@ num-bigint = { version = "0.4.3", optional = true }
 smallvec = { version = "1.13.1" }
 stringprep = "0.1.2"
 tracing = { version = "0.1.37", features = ["log"] }
-whoami = { version = "2.0.2", default-features = false }
+whoami = { version = "2.0.2", default-features = false, optional = true }
 
 dotenvy.workspace = true
 thiserror.workspace = true

--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -64,14 +64,7 @@ impl PgConnectOptions {
             .or_else(|| var("PGHOST").ok())
             .unwrap_or_else(|| default_host(port));
 
-        let username = if let Ok(username) = var("PGUSER") {
-            username
-        } else if let Ok(username) = whoami::username() {
-            username
-        } else {
-            // keep the same fallback as previous version
-            "unknown".to_string()
-        };
+        let username = var("PGUSER").ok().unwrap_or_else(default_username);
 
         let database = var("PGDATABASE").ok();
 
@@ -580,6 +573,16 @@ impl PgConnectOptions {
     pub fn get_options(&self) -> Option<&str> {
         self.options.as_deref()
     }
+}
+
+fn default_username() -> String {
+    #[cfg(feature = "whoami")]
+    if let Ok(username) = whoami::username() {
+        return username;
+    }
+
+    // keep the same fallback as previous version
+    "unknown".to_string()
 }
 
 fn default_host(port: u16) -> String {


### PR DESCRIPTION
Make the `whoami` dependency a feature gate (`whoami`) on `sqlx-postgres` so it can be disabled by users who don't need OS username fallback.

The feature is included in the top-level `sqlx` crate's default features, so existing behavior is preserved.

### Does your PR solve an issue?

This is related to #4056 to allow for targeting additional environments. I encountered this when compiling for `wasm32-wasip2`.

Follows up on #1571 and #2319 as well as related to change #4143

### Is this a breaking change?

No. 