### PR TITLE
fix(postgres): remove home crate in favor of std::env::home_dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3954,7 +3954,6 @@ dependencies = [
  "hex",
  "hkdf",
  "hmac",
- "home",
  "ipnet",
  "ipnetwork",
  "itoa",

--- a/sqlx-postgres/Cargo.toml
+++ b/sqlx-postgres/Cargo.toml
@@ -57,7 +57,6 @@ base64 = { version = "0.22.0", default-features = false, features = ["std"] }
 bitflags = { version = "2", default-features = false }
 byteorder = { version = "1.4.3", default-features = false, features = ["std"] }
 hex = "0.4.3"
-home = "0.5.5"
 itoa = "1.0.1"
 log = "0.4.18"
 memchr = { version = "2.4.1", default-features = false }

--- a/sqlx-postgres/src/options/pgpass.rs
+++ b/sqlx-postgres/src/options/pgpass.rs
@@ -21,7 +21,9 @@ pub fn load_password(
     }
 
     #[cfg(not(target_os = "windows"))]
-    let default_file = home::home_dir().map(|path| path.join(".pgpass"));
+    // home_dir fixed in 1.85 (rust-lang/rust#132515) and un-deprecated in 1.87 (rust-lang/rust#137327)
+    #[allow(deprecated)]
+    let default_file = std::env::home_dir().map(|path| path.join(".pgpass"));
     #[cfg(target_os = "windows")]
     let default_file = {
         use etcetera::BaseStrategy;


### PR DESCRIPTION
`home_dir()` was fixed in Rust 1.85 (rust-lang/rust#132515) and
un-deprecated in 1.87 (rust-lang/rust#137327). Since our MSRV is 1.86, the function is correct but still carries a deprecation warning until MSRV is bumped to 1.87.

This will allow other targets to compile including WebAssembly, see https://github.com/rust-lang/cargo/issues/12297

### Does your PR solve an issue?

This is related to #4056 to allow for targeting additional environments. I encountered this when compiling for `wasm32-wasip2`. The rust ecosystem is moving off of the `home` crate in favor of std so regardless of desire to support WebAssembly as a target, this will improve portability and maintainability of sqlx.

### Is this a breaking change?

No
