### PR TITLE
fix(sqlx-cli): bump openssl minimum to 0.10.46

### DIFF
--- a/sqlx-cli/Cargo.toml
+++ b/sqlx-cli/Cargo.toml
@@ -37,7 +37,7 @@ console = "0.15.0"
 dialoguer = { version = "0.11", default-features = false }
 serde_json = "1.0.73"
 glob = "0.3.0"
-openssl = { version = "0.10.38", optional = true }
+openssl = { version = "0.10.46", optional = true }
 cargo_metadata = "0.18.1"
 filetime = "0.2"
 


### PR DESCRIPTION
native-tls 0.2.12 calls `Pkcs12::parse2()` which was added in openssl 0.10.46, but declares its minimum as 0.10.29. The minimal-versions resolver picked openssl 0.10.38 (our previous lower bound), which lacks `parse2`.

### Does your PR solve an issue?

No this is to fix failing CI on main.

See unrelated PR's with the same build failures:

- https://github.com/launchbadge/sqlx/actions/runs/22158543499/job/64068995824?pr=4171
- https://github.com/launchbadge/sqlx/actions/runs/22121726927/job/63943086670?pr=4167

### Is this a breaking change?

No