### PR TITLE
sqlx-postgres: add support to abstract sockets

### DIFF
--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -457,7 +457,10 @@ impl PgConnectOptions {
     pub(crate) fn fetch_socket(&self) -> Option<String> {
         match self.socket {
             Some(ref socket) => {
-                let full_path = format!("{}/.s.PGSQL.{}", socket.display(), self.port);
+                let mut full_path = format!("{}/.s.PGSQL.{}", socket.display(), self.port);
+                if full_path.starts_with("@") {
+                    full_path.replace_range(0..1, "\0")
+                }
                 Some(full_path)
             }
             None if self.host.starts_with('/') => {

--- a/sqlx-postgres/src/options/parse.rs
+++ b/sqlx-postgres/src/options/parse.rs
@@ -12,7 +12,9 @@ impl PgConnectOptions {
         if let Some(host) = url.host_str() {
             let host_decoded = percent_decode_str(host);
             options = match host_decoded.clone().next() {
-                Some(b'/') => options.socket(&*host_decoded.decode_utf8().map_err(Error::config)?),
+                Some(b'/') | Some(b'@') => {
+                    options.socket(&*host_decoded.decode_utf8().map_err(Error::config)?)
+                }
                 _ => options.host(host),
             }
         }
@@ -67,7 +69,7 @@ impl PgConnectOptions {
                 }
 
                 "host" => {
-                    if value.starts_with('/') {
+                    if value.starts_with('/') || value.starts_with('@') {
                         options = options.socket(&*value);
                     } else {
                         options = options.host(&value);
@@ -186,6 +188,14 @@ fn it_parses_socket_correctly_from_parameter() {
     let opts = PgConnectOptions::from_str(url).unwrap();
 
     assert_eq!(Some("/var/run/postgres/".into()), opts.socket);
+}
+
+#[test]
+fn it_parses_abstract_socket_correctly_from_parameter() {
+    let url = "postgres:///?host=@pgdata";
+    let opts = PgConnectOptions::from_str(url).unwrap();
+
+    assert_eq!(Some("@pgdata".into()), opts.socket);
 }
 
 #[test]

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -28,6 +28,23 @@ async fn it_connects() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[ignore = "requires a PostgreSQL instance listening on the abstract Unix socket @pg_data"]
+#[sqlx_macros::test]
+async fn it_connects_via_abstract_socket() -> anyhow::Result<()> {
+    setup_if_needed();
+
+    let opts: PgConnectOptions = env::var("DATABASE_URL")?.parse().unwrap();
+    let opts = opts.socket("@pg_data");
+
+    let mut conn = PgConnection::connect_with(&opts).await?;
+
+    let value: i32 = sqlx::query_scalar("SELECT 1").fetch_one(&mut conn).await?;
+    assert_eq!(1, value);
+
+    Ok(())
+}
+
 #[sqlx_macros::test]
 async fn it_can_select_void() -> anyhow::Result<()> {
     let mut conn = new::<Postgres>().await?;


### PR DESCRIPTION
PostgreSQL treats hosts starting with @ as abstract sockets (linux only). This patch modifies `parse` to correctly read `host` parameter as socket in these cases. It also modifies `fetch_socket` to provide the proper argument to `net::connect_uds`.
Note that in this case, we cannot pass the host in its standard form in DATABASE_URL because the @ would break the url standard syntax. Instead, we should pass the host as a query parameter (see example in test case).

### Does your PR solve an issue?
There is no issue yet

### Is this a breaking change?
No. It should not break anything. If someone was using a hostname starting by "@", their setup was already broken.