### PR TITLE
fix(mysql): return error instead of panic on truncated OK packet

### DIFF
--- a/sqlx-mysql/src/connection/executor.rs
+++ b/sqlx-mysql/src/connection/executor.rs
@@ -212,7 +212,7 @@ impl MySqlConnection {
                 // otherwise, this first packet is the start of the result-set metadata,
                 *self.inner.stream.waiting.front_mut().unwrap() = Waiting::Row;
 
-                let num_columns = packet.get_uint_lenenc(); // column count
+                let num_columns = packet.get_uint_lenenc()?; // column count
                 let num_columns = usize::try_from(num_columns)
                     .map_err(|_| err_protocol!("column count overflows usize: {num_columns}"))?;
 

--- a/sqlx-mysql/src/connection/stream.rs
+++ b/sqlx-mysql/src/connection/stream.rs
@@ -194,7 +194,7 @@ impl<S: Socket> MySqlStream<S> {
     }
 
     async fn skip_result_metadata(&mut self, mut packet: Packet<Bytes>) -> Result<(), Error> {
-        let num_columns: u64 = packet.get_uint_lenenc(); // column count
+        let num_columns: u64 = packet.get_uint_lenenc()?; // column count
 
         for _ in 0..num_columns {
             let _ = self.recv_packet().await?;

--- a/sqlx-mysql/src/protocol/response/ok.rs
+++ b/sqlx-mysql/src/protocol/response/ok.rs
@@ -24,8 +24,8 @@ impl ProtocolDecode<'_> for OkPacket {
             ));
         }
 
-        let affected_rows = buf.get_uint_lenenc();
-        let last_insert_id = buf.get_uint_lenenc();
+        let affected_rows = buf.get_uint_lenenc()?;
+        let last_insert_id = buf.get_uint_lenenc()?;
 
         if buf.remaining() < 4 {
             return Err(err_protocol!(

--- a/sqlx-mysql/src/protocol/statement/row.rs
+++ b/sqlx-mysql/src/protocol/statement/row.rs
@@ -76,7 +76,7 @@ impl<'de> ProtocolDecode<'de, &'de [MySqlColumn]> for BinaryRow {
                 | ColumnType::Decimal
                 | ColumnType::Json
                 | ColumnType::NewDecimal => {
-                    let size = buf.get_uint_lenenc();
+                    let size = buf.get_uint_lenenc()?;
                     usize::try_from(size)
                         .map_err(|_| err_protocol!("BLOB length out of range: {size}"))?
                 }

--- a/sqlx-mysql/src/protocol/text/column.rs
+++ b/sqlx-mysql/src/protocol/text/column.rs
@@ -147,7 +147,7 @@ impl ProtocolDecode<'_, Capabilities> for ColumnDefinition {
         let table = buf.get_bytes_lenenc()?;
         let alias = buf.get_bytes_lenenc()?;
         let name = buf.get_bytes_lenenc()?;
-        let _next_len = buf.get_uint_lenenc(); // always 0x0c
+        let _next_len = buf.get_uint_lenenc()?; // always 0x0c
         let collation = buf.get_u16_le();
         let max_size = buf.get_u32_le();
         let type_id = buf.get_u8();

--- a/sqlx-mysql/src/protocol/text/row.rs
+++ b/sqlx-mysql/src/protocol/text/row.rs
@@ -22,7 +22,7 @@ impl<'de> ProtocolDecode<'de, &'de [MySqlColumn]> for TextRow {
                 values.push(None);
                 buf.advance(1);
             } else {
-                let size = buf.get_uint_lenenc();
+                let size = buf.get_uint_lenenc()?;
                 if (buf.remaining() as u64) < size {
                     return Err(err_protocol!(
                         "buffer exhausted when reading data for column {:?}; decoded length is {}, but only {} bytes remain in buffer. Malformed packet or protocol error?",


### PR DESCRIPTION
### Does your PR solve an issue?
fixes #4139 

### Is this a breaking change?
No. This changes a panic into a returned `Err(Protocol(...))`, which callers already handle. The connection pool will gracefully discard the bad connection instead of crashing the tokio worker thread.
