### PR TITLE
add release workflow and support for binstall for sqlx cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,91 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            args: --features openssl-vendored
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+          - target: x86_64-apple-darwin
+            os: macOS-15-intel
+          - target: aarch64-apple-darwin
+            os: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup override set stable
+          rustup target add ${{ matrix.target }}
+
+      - name: Install musl tools
+        if: contains(matrix.target, 'musl')
+        run: sudo apt-get install -y musl-tools
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: >
+          cargo build --release
+          --manifest-path sqlx-cli/Cargo.toml
+          --target ${{ matrix.target }}
+          ${{ matrix.args }}
+
+      - name: Package (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          ARCHIVE="sqlx-cli-${VERSION}-${{ matrix.target }}.tgz"
+          tar czf "${ARCHIVE}" \
+            -C "target/${{ matrix.target }}/release" \
+            sqlx cargo-sqlx
+          echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
+
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $version = "$env:GITHUB_REF_NAME"
+          $archive = "sqlx-cli-$version-${{ matrix.target }}.zip"
+          $binDir = "target/${{ matrix.target }}/release"
+          Compress-Archive -Path "$binDir/sqlx.exe", "$binDir/cargo-sqlx.exe" -DestinationPath $archive
+          "ARCHIVE=$archive" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: ${{ env.ARCHIVE }}
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: artifacts/
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*
+          generate_release_notes: true

--- a/sqlx-cli/Cargo.toml
+++ b/sqlx-cli/Cargo.toml
@@ -79,5 +79,13 @@ _sqlite = []
 assert_cmd = "2.1.1"
 tempfile = "3.10.1"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }{ archive-suffix }"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.'cfg(target_os = "windows")']
+pkg-fmt = "zip"
+
 [lints]
 workspace = true


### PR DESCRIPTION
  #### Add cargo-binstall support for sqlx-cli

The motivation behind this PR is to avoid in every CI builds to re-compile the sqlx cli and wait for 6' for every builds.

 This PR will allow users to install sqlx-cli pre-built binaries via cargo binstall sqlx-cli instead of compiling from source.

  ### Changes

  `sqlx-cli/Cargo.toml` — adds `[package.metadata.binstall]` metadata:
  - Defines the release asset URL template pointing to GitHub releases
  - Sets .tgz as the default archive format, with a .zip override for Windows
  - Maps both sqlx and cargo-sqlx binaries to the archive root

  `.github/workflows/release.yml` — new workflow triggered on version tags (v*.*.*):
  - Builds sqlx and cargo-sqlx for all four supported targets (x86_64-unknown-linux-musl, x86_64-pc-windows-msvc, x86_64-apple-darwin, aarch64-apple-darwin)
  - Packages each target into a sqlx-cli-v{version}-{target}.tgz / .zip archive containing both binaries
  - Creates a GitHub release with auto-generated notes and all archives attached

  ### Usage

  Once a release tag is pushed:
```
  cargo binstall sqlx-cli
```

### Does your PR solve an issue?
fixes #1201

### Is this a breaking change?
No

