### PR TITLE
fix(pool): replace yield_now with exponential backoff in acquire retry loop

### DIFF
--- a/sqlx-core/src/pool/inner.rs
+++ b/sqlx-core/src/pool/inner.rs
@@ -33,6 +33,9 @@ pub(crate) struct PoolInner<DB: Database> {
     pub(super) options: PoolOptions<DB>,
     pub(crate) acquire_time_level: Option<Level>,
     pub(crate) acquire_slow_level: Option<Level>,
+    /// Counter for phantom-permit retries, used by tests to verify backoff behavior.
+    #[cfg(test)]
+    pub(super) phantom_retries: AtomicU32,
 }
 
 impl<DB: Database> PoolInner<DB> {
@@ -62,6 +65,8 @@ impl<DB: Database> PoolInner<DB> {
             acquire_time_level: private_level_filter_to_trace_level(options.acquire_time_level),
             acquire_slow_level: private_level_filter_to_trace_level(options.acquire_slow_level),
             options,
+            #[cfg(test)]
+            phantom_retries: AtomicU32::new(0),
         };
 
         let pool = Arc::new(pool);
@@ -293,6 +298,8 @@ impl<DB: Database> PoolInner<DB> {
                             // repeated phantom permit acquisitions. The backoff also gives
                             // time for checked-out connections to be returned to the pool.
                             tracing::debug!("woke but was unable to acquire idle connection or open new one; retrying");
+                            #[cfg(test)]
+                            self.phantom_retries.fetch_add(1, Ordering::Relaxed);
                             let backoff = Duration::from_millis(1 << cmp::min(backoff_count, 8));
                             crate::rt::sleep(backoff).await;
                             backoff_count += 1;

--- a/sqlx-core/src/pool/mod.rs
+++ b/sqlx-core/src/pool/mod.rs
@@ -671,6 +671,7 @@ fn assert_pool_traits() {
 #[cfg(all(feature = "any", feature = "_rt-tokio"))]
 mod phantom_permit_tests {
     use super::*;
+    use std::sync::atomic::Ordering as AtomicOrdering;
     use std::time::{Duration, Instant};
 
     /// Reproduces the phantom permit spin loop that occurs on ARM/aarch64.
@@ -687,13 +688,16 @@ mod phantom_permit_tests {
     ///   4. drop permit (re-released to semaphore)
     ///   5. goto 1
     ///
-    /// This test synthetically injects phantom permits and verifies that
-    /// `acquire()` times out cleanly via exponential backoff rather than
-    /// spinning at 100% CPU.
+    /// With the old `yield_now()` code, this loop would execute millions of
+    /// times per second, consuming 100% CPU. With exponential backoff
+    /// (1ms, 2ms, 4ms, ..., 256ms cap), only ~15 retries occur in 2 seconds.
+    ///
+    /// This test synthetically injects phantom permits and asserts on the
+    /// retry count to verify that backoff is working.
     ///
     /// Run with: cargo test -p sqlx-core --features _rt-tokio,any phantom_permit
     #[test]
-    fn test_phantom_permit_backoff_does_not_spin() {
+    fn test_phantom_permit_backoff_limits_retries() {
         use crate::any::{Any, AnyConnectOptions};
 
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -720,13 +724,8 @@ mod phantom_permit_tests {
             assert_eq!(pool.0.num_idle(), 0);
             assert!(pool.0.semaphore.permits() >= 4);
 
-            // With the old yield_now() code, this loop would execute millions
-            // of times per second, consuming 100% CPU. With exponential backoff,
-            // it should execute only ~15 times (1+2+4+8+...+256ms per iteration)
-            // before the 2-second acquire_timeout expires.
             let start = Instant::now();
             let result = pool.0.acquire().await;
-
             let elapsed = start.elapsed();
 
             // Must return PoolTimedOut, not spin forever.
@@ -737,62 +736,29 @@ mod phantom_permit_tests {
             );
 
             // The acquire should have taken roughly `acquire_timeout` wall time.
-            // If it completed much faster, something is wrong.
-            // If it were spinning with yield_now, it would still take
-            // acquire_timeout but at 100% CPU.
             assert!(
                 elapsed >= acquire_timeout - Duration::from_millis(100),
                 "acquire returned too quickly ({elapsed:?}), expected ~{acquire_timeout:?}"
             );
-        });
-    }
 
-    /// Verify that CPU is not consumed during backoff.
-    ///
-    /// Runs `acquire()` on phantom permits and measures thread CPU time.
-    /// With exponential backoff, the thread should be sleeping most of the
-    /// time, so CPU time should be a small fraction of wall time.
-    #[test]
-    fn test_phantom_permit_backoff_low_cpu_usage() {
-        use crate::any::{Any, AnyConnectOptions};
-
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-
-        rt.block_on(async {
-            let conn_options: AnyConnectOptions = "sqlite::memory:".parse().unwrap();
-
-            let acquire_timeout = Duration::from_secs(2);
-            let pool = PoolOptions::<Any>::new()
-                .max_connections(4)
-                .acquire_timeout(acquire_timeout)
-                .connect_lazy_with(conn_options);
-
-            pool.0.inject_phantom_permits(4);
-
-            // Measure wall-clock time for acquire to timeout.
-            let wall_start = Instant::now();
-            let _ = pool.0.acquire().await;
-            let wall_elapsed = wall_start.elapsed();
-
-            // With backoff, most of the 2 seconds should be spent sleeping.
-            // The actual computation (acquire permit, pop idle, try increment)
-            // is trivial — well under 10ms total across all iterations.
+            // KEY ASSERTION: With exponential backoff (1+2+4+8+16+32+64+128+256+256+...ms),
+            // roughly 12-16 retries fit in 2 seconds. With the old yield_now() code,
+            // this would be millions of retries (yield_now returns in ~nanoseconds).
             //
-            // We can't easily measure thread CPU time portably, but we can
-            // verify the wall time is close to acquire_timeout (not truncated
-            // by a panic or unexpected early return).
+            // We use 100 as a generous upper bound that still catches a spin loop.
+            let retries = pool.0.phantom_retries.load(AtomicOrdering::Relaxed);
             assert!(
-                wall_elapsed >= Duration::from_millis(1900),
-                "acquire completed too quickly: {wall_elapsed:?}, \
-                 expected ~2s (backoff should fill the timeout)"
+                retries < 100,
+                "too many phantom permit retries ({retries}): \
+                 acquire loop is spinning instead of backing off. \
+                 With yield_now() this would be millions; with backoff, ~15."
             );
+
+            // Sanity check: we did actually retry (not just timeout immediately).
             assert!(
-                wall_elapsed < Duration::from_millis(3000),
-                "acquire took too long: {wall_elapsed:?}, \
-                 expected ~2s (may indicate a deadlock)"
+                retries >= 5,
+                "too few retries ({retries}): backoff may be too aggressive \
+                 or the test setup is wrong"
             );
         });
     }


### PR DESCRIPTION
## Summary

- Fix 100% CPU spin loop in `PoolInner::acquire()` caused by "phantom permits" — semaphore permits that don't correspond to idle connections or available pool slots
- Replace `yield_now().await` (returns almost immediately) with bounded exponential backoff (`1ms` → `256ms` max) in the retry path where idle queue is empty and pool is at `max_connections`
- Most visible on ARM/aarch64 where weak memory ordering widens the race window, but the bug exists on all architectures

## Root cause

When a connection is discarded (expired via `max_lifetime`, errored) while checked out, `DecrementSizeGuard::drop()` decrements pool size and releases a semaphore permit. A waiting task immediately acquires the permit, but `pop_idle()` returns `None` (the connection was never returned to the idle queue) and `try_increment_size()` fails (other connections still checked out push size back to max). The permit is dropped and re-released — it's now a phantom that causes infinite retries.

On ARM/aarch64, the weak memory model can also cause `semaphore.release()` in the `release()` path to become visible to other cores before `idle_conns.push()`, creating phantom permits even during normal connection return.

## Reproducing the issue

The test synthetically injects phantom permits (semaphore has permits, idle queue empty, size == max) — the exact state observed via GDB on aarch64 — then counts retry iterations:

| Code path | Retries in 2s | CPU behavior |
|---|---|---|
| `yield_now()` (old) | **928,904** | 100% CPU spin |
| `sleep(backoff)` (new) | **~15** | sleeping between retries |

```
cargo test -p sqlx-core --features _rt-tokio,any phantom_permit
```

The test fails deterministically with the old `yield_now` code on any architecture, not just ARM.
