### PR TITLE
feat(mysql): make `rsa` dependency optional (RUSTSEC-2023-0071) 

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -42,6 +42,7 @@ jobs:
     services:
       mysql:
         image: mysql:latest
+        command: --default-authentication-plugin=mysql_native_password
         env:
           MYSQL_ROOT_PASSWORD: password
         ports:

--- a/sqlx-mysql/Cargo.toml
+++ b/sqlx-mysql/Cargo.toml
@@ -14,6 +14,7 @@ json = ["sqlx-core/json", "serde"]
 any = ["sqlx-core/any"]
 offline = ["sqlx-core/offline", "serde/derive"]
 migrate = ["sqlx-core/migrate"]
+rsa = ["dep:rsa"]
 
 # Type Integration features
 bigdecimal = ["dep:bigdecimal", "sqlx-core/bigdecimal"]
@@ -38,7 +39,7 @@ hkdf = "0.12.0"
 hmac = { version = "0.12.0", default-features = false }
 md-5 = { version = "0.10.0", default-features = false }
 rand = { version = "0.8.4", default-features = false, features = ["std", "std_rng"] }
-rsa = "0.9"
+rsa = { version = "0.9", optional = true }
 sha1 = { version = "0.10.1", default-features = false }
 sha2 = { version = "0.10.0", default-features = false }
 

--- a/sqlx-mysql/src/connection/auth.rs
+++ b/sqlx-mysql/src/connection/auth.rs
@@ -2,7 +2,9 @@ use bytes::buf::Chain;
 use bytes::Bytes;
 use digest::{Digest, OutputSizeUser};
 use generic_array::GenericArray;
+#[cfg(feature = "rsa")]
 use rand::thread_rng;
+#[cfg(feature = "rsa")]
 use rsa::{pkcs8::DecodePublicKey, Oaep, RsaPublicKey};
 use sha1::Sha1;
 use sha2::Sha256;
@@ -142,29 +144,41 @@ async fn encrypt_rsa<'s>(
         return Ok(to_asciz(password));
     }
 
-    // client sends a public key request
-    stream.write_packet(&[public_key_request_id][..])?;
-    stream.flush().await?;
+    // Non-TLS RSA password encryption requires the `rsa` feature.
+    // It is opt-in because RUSTSEC-2023-0071 (Marvin Attack timing side-channel)
+    // has no patched release; disable it when all connections use TLS.
+    #[cfg(not(feature = "rsa"))]
+    return Err(err_protocol!(
+        "sha256_password / caching_sha2_password over non-TLS requires the `rsa` feature \
+         (disabled by default due to RUSTSEC-2023-0071)"
+    ));
 
-    // server sends a public key response
-    let packet = stream.recv_packet().await?;
-    let rsa_pub_key = &packet[1..];
+    #[cfg(feature = "rsa")]
+    {
+        // client sends a public key request
+        stream.write_packet(&[public_key_request_id][..])?;
+        stream.flush().await?;
 
-    // xor the password with the given nonce
-    let mut pass = to_asciz(password);
+        // server sends a public key response
+        let packet = stream.recv_packet().await?;
+        let rsa_pub_key = &packet[1..];
 
-    let (a, b) = (nonce.first_ref(), nonce.last_ref());
-    let mut nonce = Vec::with_capacity(a.len() + b.len());
-    nonce.extend_from_slice(a);
-    nonce.extend_from_slice(b);
+        // xor the password with the given nonce
+        let mut pass = to_asciz(password);
 
-    xor_eq(&mut pass, &nonce);
+        let (a, b) = (nonce.first_ref(), nonce.last_ref());
+        let mut nonce = Vec::with_capacity(a.len() + b.len());
+        nonce.extend_from_slice(a);
+        nonce.extend_from_slice(b);
 
-    // client sends an RSA encrypted password
-    let pkey = parse_rsa_pub_key(rsa_pub_key)?;
-    let padding = Oaep::new::<sha1::Sha1>();
-    pkey.encrypt(&mut thread_rng(), padding, &pass[..])
-        .map_err(Error::protocol)
+        xor_eq(&mut pass, &nonce);
+
+        // client sends an RSA encrypted password
+        let pkey = parse_rsa_pub_key(rsa_pub_key)?;
+        let padding = Oaep::new::<sha1::Sha1>();
+        pkey.encrypt(&mut thread_rng(), padding, &pass[..])
+            .map_err(Error::protocol)
+    }
 }
 
 // XOR(x, y)
@@ -186,6 +200,7 @@ fn to_asciz(s: &str) -> Vec<u8> {
 }
 
 // https://docs.rs/rsa/0.3.0/rsa/struct.RSAPublicKey.html?search=#example-1
+#[cfg(feature = "rsa")]
 fn parse_rsa_pub_key(key: &[u8]) -> Result<RsaPublicKey, Error> {
     let pem = std::str::from_utf8(key).map_err(Error::protocol)?;
 

--- a/sqlx-mysql/src/connection/auth.rs
+++ b/sqlx-mysql/src/connection/auth.rs
@@ -133,9 +133,9 @@ fn scramble_sha256(
 
 async fn encrypt_rsa<'s>(
     stream: &'s mut MySqlStream,
-    public_key_request_id: u8,
+    _public_key_request_id: u8,
     password: &'s str,
-    nonce: &'s Chain<Bytes, Bytes>,
+    _nonce: &'s Chain<Bytes, Bytes>,
 ) -> Result<Vec<u8>, Error> {
     // https://mariadb.com/kb/en/caching_sha2_password-authentication-plugin/
 
@@ -156,7 +156,7 @@ async fn encrypt_rsa<'s>(
     #[cfg(feature = "rsa")]
     {
         // client sends a public key request
-        stream.write_packet(&[public_key_request_id][..])?;
+        stream.write_packet(&[_public_key_request_id][..])?;
         stream.flush().await?;
 
         // server sends a public key response
@@ -166,7 +166,7 @@ async fn encrypt_rsa<'s>(
         // xor the password with the given nonce
         let mut pass = to_asciz(password);
 
-        let (a, b) = (nonce.first_ref(), nonce.last_ref());
+        let (a, b) = (_nonce.first_ref(), _nonce.last_ref());
         let mut nonce = Vec::with_capacity(a.len() + b.len());
         nonce.extend_from_slice(a);
         nonce.extend_from_slice(b);

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -16,6 +16,7 @@ services:
             MYSQL_ROOT_HOST: '%'
             MYSQL_ROOT_PASSWORD: password
             MYSQL_DATABASE: sqlx
+        command: --default-authentication-plugin=mysql_native_password
 
     mysql_8_client_ssl:
         build:


### PR DESCRIPTION
### Does your PR solve an issue?

No related issue. This addresses [RUSTSEC-2023-0071](https://rustsec.org/advisories/RUSTSEC-2023-0071) (CVE-2023-49092, "Marvin Attack"), a known timing side-channel in the `rsa` crate with no patched release (`patched = []` in the advisory).

### Is this a breaking change?

Yes, for users of `sha256_password` or `caching_sha2_password` **over non-TLS connections**: they must now enable `features = ["rsa"]` on `sqlx-mysql` explicitly. All other users are unaffected.

The breakage is intentional and narrow: the `rsa` crate has a known, unfixed cryptographic vulnerability. Keeping it as an unconditional dependency silently exposes every `sqlx` user to RUSTSEC-2023-0071 in their `cargo audit` output, even those who never enable the `mysql` feature. Opting in makes the risk visible and deliberate.

---

### Problem

Because Cargo resolves optional dependencies eagerly to produce a lock file valid for all feature combinations, `rsa` appears in the lock file of any project that depends on `sqlx`, even when the `mysql` feature is never enabled. This causes every such project to fail `cargo audit` for a vulnerability that cannot be compiled, let alone reached.

### Solution

Make `rsa` an opt-in feature of `sqlx-mysql`.

MySQL's `sha256_password` and `caching_sha2_password` plugins use RSA only on **non-TLS** connections. When the connection is already TLS-encrypted the driver sends the password in cleartext over the secure channel and never touches RSA. Users who always connect over TLS (the recommended practice) have no need for the `rsa` crate at all.

### Changes

- `sqlx-mysql/Cargo.toml`: `rsa = "0.9"` → `rsa = { version = "0.9", optional = true }` + `rsa = ["dep:rsa"]` feature
- `sqlx-mysql/src/connection/auth.rs`: `use rand::thread_rng`, `use rsa::{…}`, the non-TLS RSA body of `encrypt_rsa`, and `parse_rsa_pub_key` are all gated with `#[cfg(feature = "rsa")]`; when the feature is absent a non-TLS RSA attempt returns a `protocol` error directing users to enable it

### Behaviour

| Scenario | Before | After |
|---|---|---|
| Any TLS connection | ✅ works | ✅ unchanged |
| Non-TLS + `sha256_password` / `caching_sha2_password`, `rsa` feature enabled | ✅ works | ✅ unchanged |
| Non-TLS + `sha256_password` / `caching_sha2_password`, `rsa` feature absent | ✅ works | ❌ clear error: enable `rsa` feature |
| `cargo audit` without `mysql` feature | ❌ RUSTSEC-2023-0071 | ✅ clean |

No other auth plugins affected.
