### PR TITLE
feat: add custom socket transport support for Postgres and MySQL

### DIFF
--- a/sqlx-core/src/net/mod.rs
+++ b/sqlx-core/src/net/mod.rs
@@ -2,5 +2,6 @@ mod socket;
 pub mod tls;
 
 pub use socket::{
-    connect_tcp, connect_uds, BufferedSocket, Socket, SocketIntoBox, WithSocket, WriteBuffer,
+    connect_socket, connect_tcp, connect_uds, BufferedSocket, Socket, SocketIntoBox, WithSocket,
+    WriteBuffer,
 };

--- a/sqlx-core/src/net/socket/mod.rs
+++ b/sqlx-core/src/net/socket/mod.rs
@@ -202,6 +202,20 @@ pub async fn connect_tcp<Ws: WithSocket>(
     }
 }
 
+/// Connect using a pre-connected socket that implements [`Socket`].
+///
+/// This allows using custom transport layers (e.g., vsock, QUIC, or any
+/// `AsyncRead + AsyncWrite` type) with SQLx database connections.
+///
+/// The socket will be passed through the `with_socket` handler, which
+/// typically performs TLS upgrade negotiation.
+pub async fn connect_socket<S: Socket, Ws: WithSocket>(
+    socket: S,
+    with_socket: Ws,
+) -> crate::Result<Ws::Output> {
+    Ok(with_socket.with_socket(socket).await)
+}
+
 /// Open a TCP socket to `host` and `port`.
 ///
 /// If `host` is a hostname, attempt to connect to each address it resolves to.

--- a/sqlx-mysql/src/connection/establish.rs
+++ b/sqlx-mysql/src/connection/establish.rs
@@ -22,7 +22,21 @@ impl MySqlConnection {
 
         let stream = handshake?;
 
-        Ok(Self {
+        Ok(Self::establish_with_stream(stream, options))
+    }
+
+    pub(crate) async fn establish_with_socket<S: Socket>(
+        socket: S,
+        options: &MySqlConnectOptions,
+    ) -> Result<Self, Error> {
+        let do_handshake = DoHandshake::new(options)?;
+        let stream = do_handshake.with_socket(socket).await?;
+
+        Ok(Self::establish_with_stream(stream, options))
+    }
+
+    fn establish_with_stream(stream: MySqlStream, options: &MySqlConnectOptions) -> Self {
+        Self {
             inner: Box::new(MySqlConnectionInner {
                 stream,
                 transaction_depth: 0,
@@ -30,7 +44,7 @@ impl MySqlConnection {
                 cache_statement: StatementCache::new(options.statement_cache_capacity),
                 log_settings: options.log_settings.clone(),
             }),
-        })
+        }
     }
 }
 

--- a/sqlx-mysql/src/connection/mod.rs
+++ b/sqlx-mysql/src/connection/mod.rs
@@ -52,6 +52,38 @@ pub(crate) struct MySqlConnectionInner {
 }
 
 impl MySqlConnection {
+    /// Connect to a MySQL database using a pre-connected socket.
+    ///
+    /// This allows using custom transport layers such as vsock, QUIC,
+    /// or any type that implements [`sqlx_core::net::Socket`].
+    ///
+    /// The provided socket will go through TLS upgrade negotiation based on the
+    /// SSL mode configured in `options`.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use sqlx::mysql::{MySqlConnectOptions, MySqlConnection};
+    ///
+    /// # async fn example() -> sqlx::Result<()> {
+    /// let socket: tokio::net::TcpStream = todo!();
+    /// let options = MySqlConnectOptions::new()
+    ///     .username("root")
+    ///     .database("mydb");
+    ///
+    /// let _conn = MySqlConnection::connect_socket(socket, &options).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn connect_socket<S: sqlx_core::net::Socket>(
+        socket: S,
+        options: &MySqlConnectOptions,
+    ) -> Result<Self, Error> {
+        let mut conn = Self::establish_with_socket(socket, options).await?;
+        options.configure_session(&mut conn).await?;
+        Ok(conn)
+    }
+
     pub(crate) fn in_transaction(&self) -> bool {
         self.inner
             .status_flags

--- a/sqlx-mysql/src/options/connect.rs
+++ b/sqlx-mysql/src/options/connect.rs
@@ -24,9 +24,26 @@ impl ConnectOptions for MySqlConnectOptions {
     {
         let mut conn = MySqlConnection::establish(self).await?;
 
-        // After the connection is established, we initialize by configuring a few
-        // connection parameters
+        self.configure_session(&mut conn).await?;
 
+        Ok(conn)
+    }
+
+    fn log_statements(mut self, level: LevelFilter) -> Self {
+        self.log_settings.log_statements(level);
+        self
+    }
+
+    fn log_slow_statements(mut self, level: LevelFilter, duration: Duration) -> Self {
+        self.log_settings.log_slow_statements(level, duration);
+        self
+    }
+}
+
+impl MySqlConnectOptions {
+    /// After the connection is established, initialize by configuring
+    /// connection parameters (sql_mode, time_zone, charset).
+    pub(crate) async fn configure_session(&self, conn: &mut MySqlConnection) -> Result<(), Error> {
         // https://mariadb.com/kb/en/sql-mode/
 
         // PIPES_AS_CONCAT - Allows using the pipe character (ASCII 124) as string concatenation operator.
@@ -88,16 +105,6 @@ impl ConnectOptions for MySqlConnectOptions {
                 .await?;
         }
 
-        Ok(conn)
-    }
-
-    fn log_statements(mut self, level: LevelFilter) -> Self {
-        self.log_settings.log_statements(level);
-        self
-    }
-
-    fn log_slow_statements(mut self, level: LevelFilter, duration: Duration) -> Self {
-        self.log_settings.log_slow_statements(level, duration);
-        self
+        Ok(())
     }
 }

--- a/sqlx-postgres/src/connection/establish.rs
+++ b/sqlx-postgres/src/connection/establish.rs
@@ -7,6 +7,7 @@ use crate::io::StatementId;
 use crate::message::{
     Authentication, BackendKeyData, BackendMessageFormat, Password, ReadyForQuery, Startup,
 };
+use crate::net::Socket;
 use crate::{PgConnectOptions, PgConnection};
 
 use super::PgConnectionInner;
@@ -16,9 +17,22 @@ use super::PgConnectionInner;
 
 impl PgConnection {
     pub(crate) async fn establish(options: &PgConnectOptions) -> Result<Self, Error> {
-        // Upgrade to TLS if we were asked to and the server supports it
-        let mut stream = PgStream::connect(options).await?;
+        let stream = PgStream::connect(options).await?;
+        Self::establish_with_stream(stream, options).await
+    }
 
+    pub(crate) async fn establish_with_socket<S: Socket>(
+        socket: S,
+        options: &PgConnectOptions,
+    ) -> Result<Self, Error> {
+        let stream = PgStream::connect_socket(socket, options).await?;
+        Self::establish_with_stream(stream, options).await
+    }
+
+    async fn establish_with_stream(
+        mut stream: PgStream,
+        options: &PgConnectOptions,
+    ) -> Result<Self, Error> {
         // To begin a session, a frontend opens a connection to the server
         // and sends a startup message.
 

--- a/sqlx-postgres/src/connection/mod.rs
+++ b/sqlx-postgres/src/connection/mod.rs
@@ -85,6 +85,36 @@ pub(crate) struct TableColumns {
 }
 
 impl PgConnection {
+    /// Connect to a PostgreSQL database using a pre-connected socket.
+    ///
+    /// This allows using custom transport layers such as vsock, QUIC,
+    /// or any type that implements [`sqlx_core::net::Socket`].
+    ///
+    /// The provided socket will go through TLS upgrade negotiation based on the
+    /// SSL mode configured in `options`.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use sqlx::postgres::{PgConnectOptions, PgConnection};
+    ///
+    /// # async fn example() -> sqlx::Result<()> {
+    /// let socket: tokio::net::TcpStream = todo!();
+    /// let options = PgConnectOptions::new()
+    ///     .username("postgres")
+    ///     .database("mydb");
+    ///
+    /// let _conn = PgConnection::connect_socket(socket, &options).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn connect_socket<S: sqlx_core::net::Socket>(
+        socket: S,
+        options: &PgConnectOptions,
+    ) -> Result<Self, Error> {
+        Self::establish_with_socket(socket, options).await
+    }
+
     /// the version number of the server in `libpq` format
     pub fn server_version_num(&self) -> Option<u32> {
         self.inner.stream.server_version_num

--- a/sqlx-postgres/src/connection/stream.rs
+++ b/sqlx-postgres/src/connection/stream.rs
@@ -57,6 +57,22 @@ impl PgStream {
         })
     }
 
+    pub(super) async fn connect_socket<S: Socket>(
+        socket: S,
+        options: &PgConnectOptions,
+    ) -> Result<Self, Error> {
+        let socket = net::connect_socket(socket, MaybeUpgradeTls(options)).await?;
+
+        let socket = socket?;
+
+        Ok(Self {
+            inner: BufferedSocket::new(socket),
+            notifications: None,
+            parameter_statuses: BTreeMap::default(),
+            server_version_num: None,
+        })
+    }
+
     #[inline(always)]
     pub(crate) fn write_msg(&mut self, message: impl FrontendMessage) -> Result<(), Error> {
         self.write(EncodeMessage(message))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,12 @@ pub mod decode {
 
 pub use self::decode::Decode;
 
+/// Networking traits for custom transport implementations.
+pub mod net {
+    pub use sqlx_core::io::ReadBuf;
+    pub use sqlx_core::net::Socket;
+}
+
 /// Types and traits for the `query` family of functions and macros.
 pub mod query {
     pub use sqlx_core::query::{Map, Query};


### PR DESCRIPTION
## Summary

Add `connect_socket()` methods to `PgConnection` and `MySqlConnection` that accept any pre-connected socket implementing the `Socket` trait. This enables using custom transport layers without forking sqlx.

**Motivation**: In environments like AWS Nitro Enclaves, vsock is the only available networking transport. Currently, sqlx hardcodes its connection establishment to TCP and Unix domain sockets, making it impossible to use with non-standard transports without forking. This PR makes the `Socket` trait usable as a public extension point.

## Before / After

### Before

There is no way to provide a custom socket to sqlx. The only connection paths are TCP and Unix domain sockets, hardcoded in `PgStream::connect()` and `MySqlConnection::establish()`:

```rust
// The only options: TCP or Unix domain socket via connection URL
let conn = PgConnection::connect("postgres://user:pass@host/db").await?;
let conn = MySqlConnection::connect("mysql://user:pass@host/db").await?;

// For vsock or other transports, you had to:
// 1. Fork sqlx entirely, OR
// 2. Run a TCP-to-vsock proxy (adds latency + operational complexity)
```

### After

Users can connect over any transport by providing a pre-connected socket:

```rust
use sqlx::net::Socket;

// 1. Implement Socket for your transport type
impl Socket for tokio_vsock::VsockStream {
    fn try_read(&mut self, buf: &mut dyn ReadBuf) -> io::Result<usize> { /* ... */ }
    fn try_write(&mut self, buf: &[u8]) -> io::Result<usize> { /* ... */ }
    fn poll_read_ready(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> { /* ... */ }
    fn poll_write_ready(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> { /* ... */ }
    fn poll_shutdown(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> { /* ... */ }
}

// 2. Connect with your custom socket — TLS upgrade works automatically
let socket = VsockStream::connect(VsockAddr::new(3, 5432)).await?;
let options = PgConnectOptions::new()
    .username("postgres")
    .database("mydb");
let conn = PgConnection::connect_socket(socket, &options).await?;

// MySQL works the same way
let socket = VsockStream::connect(VsockAddr::new(3, 3306)).await?;
let options = MySqlConnectOptions::new()
    .username("root")
    .database("mydb");
let conn = MySqlConnection::connect_socket(socket, &options).await?;
```

## Changes

### New public API

- `PgConnection::connect_socket(socket, &options)` — connect to PostgreSQL over any `Socket` impl
- `MySqlConnection::connect_socket(socket, &options)` — connect to MySQL over any `Socket` impl
- `sqlx::net::Socket` — re-exported trait for implementing custom transports
- `sqlx::net::ReadBuf` — re-exported trait needed by `Socket` implementations

### Files changed

- **`sqlx-core/src/net/socket/mod.rs`**: Add `connect_socket()` helper function
- **`sqlx-core/src/net/mod.rs`**: Re-export `connect_socket`
- **`sqlx-postgres/src/connection/stream.rs`**: Add `PgStream::connect_socket()`
- **`sqlx-postgres/src/connection/establish.rs`**: Refactor `establish()` to extract `establish_with_stream()`, add `establish_with_socket()`
- **`sqlx-postgres/src/connection/mod.rs`**: Add public `PgConnection::connect_socket()`
- **`sqlx-mysql/src/connection/establish.rs`**: Refactor to extract `establish_with_stream()`, add `establish_with_socket()`
- **`sqlx-mysql/src/connection/mod.rs`**: Add public `MySqlConnection::connect_socket()`
- **`sqlx-mysql/src/options/connect.rs`**: Extract `configure_session()` from `ConnectOptions::connect()` for reuse by `connect_socket`
- **`src/lib.rs`**: Add `sqlx::net` module re-exporting `Socket` and `ReadBuf`

### Design decisions

- **Separate methods, not modified options**: `PgConnectOptions`/`MySqlConnectOptions` derive `Clone + Debug`, which prevents storing `Box<dyn Socket>`. A separate `connect_socket()` method is cleaner and more ergonomic.
- **TLS works automatically**: Custom sockets go through the same `MaybeUpgradeTls` / `DoHandshake` flow, so TLS upgrade negotiation works out of the box.
- **Minimal refactoring**: The establish logic was factored into `establish_with_stream()` to share code between the TCP/UDS path and the custom socket path. No behavioral changes to existing code.
- **No new dependencies or feature flags**: Custom socket support is always available since it only depends on the existing `Socket` trait.

### Use cases

- **AWS Nitro Enclaves**: Connect to databases over vsock (via `tokio-vsock`)
- **QUIC-based transports**: Use QUIC streams as database connections
- **Custom proxied connections**: Pre-connected sockets through SSH tunnels, SOCKS proxies, etc.
- **Testing**: Inject mock sockets for testing database connection logic

## Checklist

- [x] `cargo check --all-features` passes
- [x] No changes to existing tests
- [x] Doc comments on all new public APIs
- [x] No new dependencies added
- [x] No feature flags added