### PR TITLE
[mysql] Add Fallback to column scanning when column_names is empty for stored procedures

### DIFF
--- a/sqlx-mysql/src/row.rs
+++ b/sqlx-mysql/src/row.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
 pub(crate) use sqlx_core::row::*;
+use std::sync::Arc;
 
 use crate::column::ColumnIndex;
 use crate::error::Error;
@@ -39,29 +39,25 @@ impl Row for MySqlRow {
     }
 }
 
-
-
 impl ColumnIndex<MySqlRow> for &'_ str {
-   
     fn index(&self, row: &MySqlRow) -> Result<usize, Error> {
-
         // Original fast path (works for normal SELECTs)
-        if let Some(&idx) = row.column_names.get(*self) {   
+        if let Some(&idx) = row.column_names.get(*self) {
             return Ok(idx);
-        } 
+        }
 
         // NEW: Fallback for stored procedures / CALL (your requested change)
         // We scan the real columns and add the name→index mapping on the fly
         for (i, col) in row.columns.iter().enumerate() {
-            if  &*col.name == *self {
+            if &*col.name == *self {
                 // Optional: you could even mutate the map here if you want to "cache" it,
                 // but for simplicity we just return the index.
 
                 return Ok(i);
-            }        }
-        
+            }
+        }
+
         Err(Error::ColumnNotFound((*self).into()))
-        
     }
 }
 
@@ -70,5 +66,3 @@ impl std::fmt::Debug for MySqlRow {
         debug_row(self, f)
     }
 }
-
-


### PR DESCRIPTION
**Problem**  
When executing a MySQL/MariaDB stored procedure with `CALL`, the `MySqlRow.column_names` map is often empty due to MySQL protocol limitations on procedure result sets. This causes `row.try_get("column_name")` to fail with `ColumnNotFound`, forcing users to use positional indexing (`try_get(0)`, etc.) as a workaround.  
See: https://github.com/launchbadge/sqlx/issues/1742 (open since 2022)

**Solution**  
Add a fallback in the `ColumnIndex<MySqlRow>` impl for `&str`:  
- First try the existing `column_names` map (unchanged fast path for normal queries)  
- On miss: scan `row.columns` by comparing `col.name.as_ref()` to the requested name  
- Return matching index if found, otherwise original `ColumnNotFound` error  

This enables reliable named access after `CALL` procedures without changing any user code.

**Trade-offs**  
- Linear scan over columns (typically < 20 → negligible performance impact)  
- No caching (could be future improvement with `OnceCell` + `Mutex`)  
- Tested manually on simple stored procedures returning named columns

**Related**  
Fixes #1530
Closes #1742  
Similar reports in #2206, Stack Overflow, etc.

Happy to add integration tests, make it opt-in (feature flag), or adjust based on feedback.