### PR TITLE
fix(sqlite): preserve NOT NULL from schema when explain loses it through ORDER BY

### DIFF
--- a/sqlx-sqlite/src/connection/describe.rs
+++ b/sqlx-sqlite/src/connection/describe.rs
@@ -82,7 +82,23 @@ pub(crate) fn describe(
             let col_nullable = stmt.handle.column_nullable(col)?;
             let exp_nullable = fallback_nullable.get(col).copied().and_then(identity);
 
-            nullable.push(exp_nullable.or(col_nullable));
+            // If the column has a known schema origin that says NOT NULL,
+            // trust that over the explain analysis which may lose NOT NULL
+            // constraints through ephemeral tables / sorters (e.g. ORDER BY).
+            // See: https://github.com/launchbadge/sqlx/issues/4147
+            let result_nullable = match (col_nullable, exp_nullable) {
+                // Schema says NOT NULL — trust it regardless of explain result
+                (Some(false), _) => Some(false),
+                // Schema doesn't know (e.g. expression column), use explain
+                (None, exp) => exp,
+                // Both agree or only schema has info
+                (col, None) => col,
+                // Schema says nullable, explain says not — be conservative, say nullable
+                (Some(true), Some(false)) => Some(true),
+                // Both say nullable
+                (Some(true), Some(true)) => Some(true),
+            };
+            nullable.push(result_nullable);
 
             columns.push(SqliteColumn {
                 name: name.into(),


### PR DESCRIPTION
Fixes #4147

When a query includes ORDER BY, SQLite routes data through an ephemeral sorter table. This causes two problems for nullability inference:

1. The EXPLAIN-based analysis loses NOT NULL constraints as data passes through the ephemeral table
2. `sqlite3_column_table_name()` returns NULL for columns from ephemeral tables, so the schema-based `column_nullable()` fallback also returns `None`

**Before:**
```rust
// exp_nullable = Some(true) (explain lost NOT NULL through sorter)
// col_nullable = None (origin unknown for ephemeral column)
nullable.push(exp_nullable.or(col_nullable));
// Result: Some(true) — incorrectly says nullable
```

The macro then generates `Option<String>` instead of `String`, causing a compile error.

**After:**
If the schema definitively says NOT NULL (`col_nullable = Some(false)`), that takes priority over explain. The schema is the source of truth for column constraints.

```rust
// col_nullable says NOT NULL → trust it
(Some(false), _) => Some(false)
```

This fixes the case where `query_as!` considers `TEXT NOT NULL` as nullable when ORDER BY is present.