### PR TITLE
test(sqlite): add regression test for ORDER BY + LIMIT nullability (#4147)

### DIFF
--- a/tests/sqlite/describe.rs
+++ b/tests/sqlite/describe.rs
@@ -591,6 +591,50 @@ async fn it_describes_table_order_by() -> anyhow::Result<()> {
     Ok(())
 }
 
+// Regression test for https://github.com/launchbadge/sqlx/issues/4147
+// ORDER BY + LIMIT routes data through an ephemeral sorter table;
+// the NOT NULL constraint must survive the round-trip.
+#[sqlx_macros::test]
+async fn it_describes_order_by_with_limit() -> anyhow::Result<()> {
+    let mut conn = new::<Sqlite>().await?;
+
+    let info = conn
+        .describe("SELECT text FROM tweet ORDER BY id DESC LIMIT 10".into_sql_str())
+        .await?;
+    assert_eq!(info.column(0).type_info().name(), "TEXT");
+    assert_eq!(
+        info.nullable(0),
+        Some(false),
+        "NOT NULL column should stay NOT NULL with ORDER BY + LIMIT"
+    );
+
+    let info = conn
+        .describe("SELECT text, is_sent FROM tweet ORDER BY id DESC LIMIT 10000".into_sql_str())
+        .await?;
+    assert_eq!(
+        info.nullable(0),
+        Some(false),
+        "text should be NOT NULL with ORDER BY DESC + large LIMIT"
+    );
+    assert_eq!(
+        info.nullable(1),
+        Some(false),
+        "is_sent should be NOT NULL with ORDER BY DESC + large LIMIT"
+    );
+
+    // nullable column must remain nullable
+    let info = conn
+        .describe("SELECT owner_id FROM tweet ORDER BY id DESC LIMIT 10".into_sql_str())
+        .await?;
+    assert_eq!(
+        info.nullable(0),
+        Some(true),
+        "nullable column should stay nullable with ORDER BY + LIMIT"
+    );
+
+    Ok(())
+}
+
 #[sqlx_macros::test]
 async fn it_describes_union() -> anyhow::Result<()> {
     async fn assert_union_described(


### PR DESCRIPTION
Adds a regression test for #4147 — `query_as!` incorrectly inferred `TEXT NOT NULL` as nullable when the query included `ORDER BY ... LIMIT`.

The root cause was that ORDER BY + LIMIT routes data through an ephemeral sorter table, and the old explain analysis lost NOT NULL constraints through the round-trip. This is already fixed on main (the 0.9 explain rewrite handles it correctly), but there was no test covering this specific combination.

The new test verifies:
- NOT NULL columns stay NOT NULL with ORDER BY + LIMIT
- Multiple NOT NULL columns preserve constraints with ORDER BY DESC + large LIMIT
- Nullable columns remain nullable (no false negatives)

All 30 describe tests pass.