### PR TITLE
fix(mysql): treat BINARY columns as Blob in Any type mapping

### DIFF
--- a/sqlx-mysql/src/any.rs
+++ b/sqlx-mysql/src/any.rs
@@ -1,4 +1,4 @@
-use crate::protocol::text::ColumnType;
+use crate::protocol::text::{ColumnFlags, ColumnType};
 use crate::{
     MySql, MySqlColumn, MySqlConnectOptions, MySqlConnection, MySqlQueryResult, MySqlRow,
     MySqlTransactionManager, MySqlTypeInfo,
@@ -169,7 +169,11 @@ impl<'a> TryFrom<&'a MySqlTypeInfo> for AnyTypeInfo {
                 | ColumnType::MediumBlob
                 | ColumnType::LongBlob => AnyTypeInfoKind::Blob,
                 ColumnType::String | ColumnType::VarString | ColumnType::VarChar => {
-                    AnyTypeInfoKind::Text
+                    if type_info.flags.contains(ColumnFlags::BINARY) {
+                        AnyTypeInfoKind::Blob
+                    } else {
+                        AnyTypeInfoKind::Text
+                    }
                 }
                 _ => {
                     return Err(sqlx_core::Error::AnyDriverError(


### PR DESCRIPTION
### Does your PR solve an issue?
Fixes #4132

### Is this a breaking change?
Yes, this is a breaking behavior change.

Previously, MySQL `BINARY(size)` columns were mapped through the Any driver to `AnyTypeInfoKind::Text`, which caused a UTF-8 decoding panic (`Utf8Error { valid_up_to: 4, error_len: Some(1) }`) when reading raw binary data through `AnyRow`. After this change, those columns are mapped to `AnyTypeInfoKind::Blob` and can be decoded as `Vec<u8>` / `&[u8]` instead.

Code that previously relied on the (broken) `Text` mapping and was somehow decoding these columns as strings would need to switch to a binary type, so per Hyrum's Law this should land in the next major release (`0.{x + 1}.0`).

---

MySQL `BINARY(size)` columns report `ColumnType::String` with the `BINARY` flag set. The Any driver's type conversion checked the column type but not the flags, so BINARY columns got mapped to `AnyTypeInfoKind::Text`. Reading raw binary data through `AnyRow` then blew up with a UTF-8 decoding error.

**Before:**
```
SELECT * FROM test  -- where `id` is BINARY(16)
-- panics: Utf8Error { valid_up_to: 4, error_len: Some(1) }
```

**After:**
```
-- works: BINARY columns correctly mapped to Blob
```

The fix checks `ColumnFlags::BINARY` for `String`/`VarString`/`VarChar` column types and maps to `Blob` when set.