### PR TITLE
fix(macros-core): update unstable proc_macro APIs for recent nightly

### DIFF
--- a/sqlx-macros-core/clippy.toml
+++ b/sqlx-macros-core/clippy.toml
@@ -1,3 +1,3 @@
 [[disallowed-methods]]
 path = "std::env::var"
-reason = "use `crate::env()` instead, which optionally calls `proc_macro::tracked_env::var()`"
+reason = "use `crate::env()` instead, which optionally calls `proc_macro::tracked::env_var()`"

--- a/sqlx-macros-core/src/lib.rs
+++ b/sqlx-macros-core/src/lib.rs
@@ -16,8 +16,11 @@
 
 #![cfg_attr(
     any(sqlx_macros_unstable, procmacro2_semver_exempt),
-    feature(track_path)
+    feature(proc_macro_tracked_path, proc_macro_tracked_env)
 )]
+
+#[cfg(any(sqlx_macros_unstable, procmacro2_semver_exempt))]
+extern crate proc_macro;
 
 use cfg_if::cfg_if;
 use std::path::PathBuf;
@@ -96,7 +99,7 @@ pub fn env_opt(var: &str) -> Result<Option<String>> {
     use std::env::VarError;
 
     #[cfg(any(sqlx_macros_unstable, procmacro2_semver_exempt))]
-    let res: Result<String, VarError> = proc_macro::tracked_env::var(var);
+    let res: Result<String, VarError> = proc_macro::tracked::env_var(var);
 
     #[cfg(not(any(sqlx_macros_unstable, procmacro2_semver_exempt)))]
     let res: Result<String, VarError> = std::env::var(var);

--- a/sqlx-macros-core/src/migrate.rs
+++ b/sqlx-macros-core/src/migrate.rs
@@ -1,6 +1,3 @@
-#[cfg(any(sqlx_macros_unstable, procmacro2_semver_exempt))]
-extern crate proc_macro;
-
 use std::path::{Path, PathBuf};
 
 use proc_macro2::{Span, TokenStream};
@@ -132,7 +129,7 @@ pub fn expand_with_path(config: &Config, path: &Path) -> crate::Result<TokenStre
             )
         })?;
 
-        proc_macro::tracked_path::path(path);
+        proc_macro::tracked::path(path);
     }
 
     Ok(quote! {

--- a/sqlx-macros-core/src/query/cache.rs
+++ b/sqlx-macros-core/src/query/cache.rs
@@ -71,7 +71,7 @@ impl MtimeCacheBuilder {
 
         #[cfg(any(sqlx_macros_unstable, procmacro2_semver_exempt))]
         {
-            proc_macro::tracked_path::path(&path);
+            proc_macro::tracked::path(&path);
         }
 
         self.file_mtimes.push((path, mtime));


### PR DESCRIPTION
### Does your PR solve an issue?
fixes #4150

### Is this a breaking change?
No. The change only touches code gated behind `#[cfg(any(sqlx_macros_unstable, procmacro2_semver_exempt))]`, which is opt-in and only compiles on nightly.

---

The unstable proc_macro tracking APIs were restructured in [rust-lang/rust#149400](https://github.com/rust-lang/rust/pull/149400):

- modules `tracked_env` and `tracked_path` were merged into a single module `tracked`
- `proc_macro::tracked_env::var` → `proc_macro::tracked::env_var` (note: also renamed from `var` to `env_var`)
- `proc_macro::tracked_path::path` → `proc_macro::tracked::path`
- features `track_path` → `proc_macro_tracked_path` (+ `proc_macro_tracked_env`)

Building `sqlx-macros-core` with `--cfg=sqlx_macros_unstable` on recent nightly fails for two reasons:

1. The renames above.
2. `extern crate proc_macro;` was declared only in `migrate.rs`, so `proc_macro` was not in scope from `lib.rs` (line 99) or `query/cache.rs` (line 74). The reporter only saw the rename error because the missing-crate error happens later in the compilation order.

This PR moves the gated `extern crate proc_macro;` to the crate root in `lib.rs` (so it's visible to all modules), drops the duplicate from `migrate.rs`, and updates the four API call sites plus the `clippy.toml` reason field.

Verified locally on `nightly-2026-04-02`:

```
RUSTFLAGS='--cfg=sqlx_macros_unstable' cargo +nightly check -p sqlx-macros-core
    Finished `dev` profile [unoptimized + debuginfo] target(s)
```

Stable also unaffected.

Drafted with AI assistance. I reviewed every change, reproduced the bug locally on nightly, and verified the fix.