### PR TITLE
sqlx-postgres: Make `PgNotification` struct clone

### DIFF
--- a/sqlx-postgres/src/listener.rs
+++ b/sqlx-postgres/src/listener.rs
@@ -36,6 +36,7 @@ pub struct PgListener {
 }
 
 /// An asynchronous notification from Postgres.
+#[derive(Clone)]
 pub struct PgNotification(Notification);
 
 impl PgListener {

--- a/sqlx-postgres/src/message/notification.rs
+++ b/sqlx-postgres/src/message/notification.rs
@@ -4,7 +4,7 @@ use crate::error::Error;
 use crate::io::BufExt;
 use crate::message::{BackendMessage, BackendMessageFormat};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Notification {
     pub(crate) process_id: u32,
     pub(crate) channel: Bytes,


### PR DESCRIPTION
I have a rest endpoint that does SSE (Server Sent Events) where I listen on a Postgres channel on a notification to look for new rows in a table. I multiplex the [`PgListener`](https://docs.rs/sqlx/0.8.6/sqlx/postgres/struct.PgListener.html) through a tokio broadcast channel to reuse the same connection for multiple requests. For this the `PgNotification` struct needs to be `Clone`. 

There is no reason I see why it shouldn't be, `Bytes` is designed to be cloned.

### Does your PR solve an issue?

No, the authors of #303 though thought it was related.

### Is this a breaking change?

No, I think this should be fine (no negative trait impls yet).
