### PR TITLE
fix: Use correct path in error when failing to create tmp dir in prepare

### DIFF
--- a/sqlx-cli/src/prepare.rs
+++ b/sqlx-cli/src/prepare.rs
@@ -161,7 +161,7 @@ fn run_prepare_step(ctx: &PrepareCtx, cache_dir: &Path) -> anyhow::Result<()> {
     let tmp_dir = ctx.metadata.target_directory().join("sqlx-tmp");
     fs::create_dir_all(&tmp_dir).context(format!(
         "Failed to create temporary query cache directory: {:?}",
-        cache_dir
+        tmp_dir
     ))?;
 
     // Only delete sqlx-*.json files to avoid accidentally deleting any user data.


### PR DESCRIPTION
I came across this because my tmp dir was owned by `root:root` (due to a Docker build) and the error message contained a path that was not. That made it confusing to fix. 

### Does your PR solve an issue?

Not an issue I created a Github issue for. Just a minor inconvenience. 

### Is this a breaking change?

No.
