### PR TITLE
perf(sqlx-cli): avoid rewriting the entire .sqlx cache on prepare

### DIFF
--- a/sqlx-cli/src/prepare.rs
+++ b/sqlx-cli/src/prepare.rs
@@ -74,7 +74,9 @@ async fn prepare(ctx: &PrepareCtx<'_>) -> anyhow::Result<()> {
     }
 
     let prepare_dir = ctx.prepare_dir()?;
-    run_prepare_step(ctx, &prepare_dir)?;
+    let cache_dir = ctx.metadata.target_directory().join("sqlx-prepare");
+    run_prepare_step(ctx, &cache_dir)?;
+    sync_query_data(&cache_dir, &prepare_dir)?;
 
     // Warn if no queries were generated. Glob since the directory may contain unrelated files.
     if glob_query_files(prepare_dir)?.is_empty() {
@@ -199,6 +201,58 @@ fn run_prepare_step(ctx: &PrepareCtx, cache_dir: &Path) -> anyhow::Result<()> {
     };
     if !check_status.success() {
         bail!("`cargo check` failed with status: {}", check_status);
+    }
+
+    Ok(())
+}
+
+fn sync_query_data(cache_dir: &Path, prepare_dir: &Path) -> anyhow::Result<()> {
+    fs::create_dir_all(prepare_dir).context(format!(
+        "Failed to create query cache directory: {:?}",
+        prepare_dir
+    ))?;
+
+    let prepare_filenames: HashSet<String> = glob_query_files(prepare_dir)?
+        .into_iter()
+        .filter_map(|path| path.file_name().map(|f| f.to_string_lossy().into_owned()))
+        .collect();
+    let cache_filenames: HashSet<String> = glob_query_files(cache_dir)?
+        .into_iter()
+        .filter_map(|path| path.file_name().map(|f| f.to_string_lossy().into_owned()))
+        .collect();
+
+    for stale_filename in prepare_filenames.difference(&cache_filenames) {
+        let stale_file = prepare_dir.join(stale_filename);
+        fs::remove_file(&stale_file)
+            .with_context(|| format!("Failed to delete query file: {}", stale_file.display()))?;
+    }
+
+    for filename in cache_filenames {
+        let cache_file = cache_dir.join(&filename);
+        let prepare_file = prepare_dir.join(&filename);
+
+        let should_copy = match fs::read(&prepare_file) {
+            Ok(prepare_bytes) => {
+                let cache_json = load_json_file(&cache_file)?;
+                let prepare_json: serde_json::Value = serde_json::from_slice(&prepare_bytes)?;
+                prepare_json != cache_json
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => true,
+            Err(err) => {
+                return Err(err)
+                    .with_context(|| format!("failed to load file: {}", prepare_file.display()))
+            }
+        };
+
+        if should_copy {
+            fs::copy(&cache_file, &prepare_file).with_context(|| {
+                format!(
+                    "Failed to copy query file from {} to {}",
+                    cache_file.display(),
+                    prepare_file.display()
+                )
+            })?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
### Does your PR solve an issue?
N/A (no issue filed).

### Is this a breaking change?
No.

## Summary
- stop deleting all `query-*.json` files in `.sqlx` on every `cargo sqlx prepare`
- generate query data into a temporary cache directory and then sync only changed files into `.sqlx`
- prune stale query cache files while preserving unchanged entries to reduce filesystem churn

Motivation: I'm working on a large monorepo, with ~1500 sqlx cached query files, and every time I run `cargo sqlx prepare --workspace`, it deletes all the cached files, the IDE/lsp shows lots of compilation errors, and I need to wait several seconds (sometimes minutes) to have all the files back. This PR fixes that