### PR TITLE
docs: fix "re-using"/"re-used" typo in sqlx-core doc comments

### DIFF
--- a/sqlx-core/src/encode.rs
+++ b/sqlx-core/src/encode.rs
@@ -38,7 +38,7 @@ pub trait Encode<'q, DB: Database> {
 
     /// Writes the value of `self` into `buf` without moving `self`.
     ///
-    /// Where possible, make use of `encode` instead as it can take advantage of re-using
+    /// Where possible, make use of `encode` instead as it can take advantage of reusing
     /// memory.
     fn encode_by_ref(
         &self,

--- a/sqlx-core/src/pool/mod.rs
+++ b/sqlx-core/src/pool/mod.rs
@@ -4,7 +4,7 @@
 //! become expensive. Furthermore, sharing a database connection between threads and functions
 //! can be difficult to express in Rust.
 //!
-//! A connection pool is a standard technique that can manage opening and re-using connections.
+//! A connection pool is a standard technique that can manage opening and reusing connections.
 //! Normally it also enforces a maximum number of connections as these are an expensive resource
 //! on the database server.
 //!

--- a/sqlx-core/src/statement.rs
+++ b/sqlx-core/src/statement.rs
@@ -15,7 +15,7 @@ use either::Either;
 /// look at that cache in-between the statement being prepared and it being executed. This contains
 /// the expected columns to be returned and the expected parameter types (if available).
 ///
-/// Statements can be re-used with any connection and on first-use it will be re-prepared and
+/// Statements can be reused with any connection and on first-use it will be re-prepared and
 /// cached within the connection.
 pub trait Statement: Send + Sync + Clone {
     type Database: Database;


### PR DESCRIPTION

**Repo:** launchbadge/sqlx (⭐ 13000)
**Type:** docs
**Files changed:** 3
**Lines:** +3/-3

## What
Replaces the hyphenated spellings "re-using" / "re-used" with the canonical
single-word forms "reusing" / "reused" in three sqlx-core doc comments
(`encode.rs`, `pool/mod.rs`, `statement.rs`). Detected via `codespell`.

## Why
`codespell` flags these as misspellings and the standard English form is
unhyphenated. Doc comments here are surfaced on docs.rs as part of the
public API docs, so polishing them improves the reader experience at no
risk to runtime behavior.

## Testing
Pure documentation comment edits — no behavior change. `cargo doc` would
still build; `codespell sqlx-core/src` no longer reports these three sites.

## Risk
Low — comment-only changes in public-facing docs.
