### PR TITLE
allow option for enabling the SSLKEYLOGFILE environment variable

### DIFF
--- a/sqlx-core/src/net/tls/mod.rs
+++ b/sqlx-core/src/net/tls/mod.rs
@@ -60,6 +60,7 @@ impl std::fmt::Display for CertificateInput {
 pub struct TlsConfig<'a> {
     pub accept_invalid_certs: bool,
     pub accept_invalid_hostnames: bool,
+    pub enable_keylog: bool,
     pub hostname: &'a str,
     pub root_cert_path: Option<&'a CertificateInput>,
     pub client_cert_path: Option<&'a CertificateInput>,

--- a/sqlx-core/src/net/tls/tls_rustls.rs
+++ b/sqlx-core/src/net/tls/tls_rustls.rs
@@ -13,7 +13,7 @@ use rustls::{
         pem::{self, PemObject},
         CertificateDer, PrivateKeyDer, ServerName, UnixTime,
     },
-    CertificateError, ClientConfig, ClientConnection, Error as TlsError, RootCertStore,
+    CertificateError, ClientConfig, ClientConnection, Error as TlsError, KeyLogFile, RootCertStore,
 };
 
 use crate::error::Error;
@@ -123,7 +123,7 @@ where
         }
     };
 
-    let config = if tls_config.accept_invalid_certs {
+    let mut config = if tls_config.accept_invalid_certs {
         if let Some(user_auth) = user_auth {
             config
                 .dangerous()
@@ -179,6 +179,9 @@ where
                 .with_no_client_auth()
         }
     };
+    if tls_config.enable_keylog {
+        config.key_log = Arc::new(KeyLogFile::new());
+    }
 
     let host = ServerName::try_from(tls_config.hostname.to_owned()).map_err(Error::tls)?;
 

--- a/sqlx-mysql/src/connection/tls.rs
+++ b/sqlx-mysql/src/connection/tls.rs
@@ -63,6 +63,7 @@ pub(super) async fn maybe_upgrade<S: Socket>(
         root_cert_path: options.ssl_ca.as_ref(),
         client_cert_path: options.ssl_client_cert.as_ref(),
         client_key_path: options.ssl_client_key.as_ref(),
+        enable_keylog: options.ssl_enable_keylog,
     };
 
     // Request TLS upgrade

--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -179,7 +179,7 @@ impl MySqlConnectOptions {
     }
 
     /// Enables the use of the `SSLKEYLOGFILE`` environment variable to export SSL session keys.
-    /// 
+    ///
     /// Only works with the `rustls` SSL backend
     pub fn ssl_enable_keylog(mut self, enable: bool) -> Self {
         self.ssl_enable_keylog = enable;

--- a/sqlx-mysql/src/options/mod.rs
+++ b/sqlx-mysql/src/options/mod.rs
@@ -71,6 +71,7 @@ pub struct MySqlConnectOptions {
     pub(crate) ssl_ca: Option<CertificateInput>,
     pub(crate) ssl_client_cert: Option<CertificateInput>,
     pub(crate) ssl_client_key: Option<CertificateInput>,
+    pub(crate) ssl_enable_keylog: bool,
     pub(crate) statement_cache_capacity: usize,
     pub(crate) charset: String,
     pub(crate) collation: Option<String>,
@@ -104,6 +105,7 @@ impl MySqlConnectOptions {
             ssl_ca: None,
             ssl_client_cert: None,
             ssl_client_key: None,
+            ssl_enable_keylog: false,
             statement_cache_capacity: 100,
             log_settings: Default::default(),
             pipes_as_concat: true,
@@ -173,6 +175,14 @@ impl MySqlConnectOptions {
     /// ```
     pub fn ssl_mode(mut self, mode: MySqlSslMode) -> Self {
         self.ssl_mode = mode;
+        self
+    }
+
+    /// Enables the use of the `SSLKEYLOGFILE`` environment variable to export SSL session keys.
+    /// 
+    /// Only works with the `rustls` SSL backend
+    pub fn ssl_enable_keylog(mut self, enable: bool) -> Self {
+        self.ssl_enable_keylog = enable;
         self
     }
 

--- a/sqlx-postgres/src/connection/tls.rs
+++ b/sqlx-postgres/src/connection/tls.rs
@@ -58,6 +58,7 @@ async fn maybe_upgrade<S: Socket>(
         root_cert_path: options.ssl_root_cert.as_ref(),
         client_cert_path: options.ssl_client_cert.as_ref(),
         client_key_path: options.ssl_client_key.as_ref(),
+        enable_keylog: options.ssl_enable_keylog,
     };
 
     tls::handshake(socket, config, SocketIntoBox).await

--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -25,6 +25,7 @@ pub struct PgConnectOptions {
     pub(crate) ssl_root_cert: Option<CertificateInput>,
     pub(crate) ssl_client_cert: Option<CertificateInput>,
     pub(crate) ssl_client_key: Option<CertificateInput>,
+    pub(crate) ssl_enable_keylog: bool,
     pub(crate) statement_cache_capacity: usize,
     pub(crate) application_name: Option<String>,
     pub(crate) log_settings: LogSettings,
@@ -92,6 +93,7 @@ impl PgConnectOptions {
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or_default(),
+            ssl_enable_keylog: false,
             statement_cache_capacity: 100,
             application_name: var("PGAPPNAME").ok(),
             extra_float_digits: Some("2".into()),
@@ -222,6 +224,14 @@ impl PgConnectOptions {
     /// ```
     pub fn ssl_mode(mut self, mode: PgSslMode) -> Self {
         self.ssl_mode = mode;
+        self
+    }
+
+    /// Enables the use of the `SSLKEYLOGFILE`` environment variable to export SSL session keys.
+    /// 
+    /// Only works with the `rustls` SSL backend
+    pub fn ssl_enable_keylog(mut self, enable: bool) -> Self {
+        self.ssl_enable_keylog = enable;
         self
     }
 

--- a/sqlx-postgres/src/options/mod.rs
+++ b/sqlx-postgres/src/options/mod.rs
@@ -228,7 +228,7 @@ impl PgConnectOptions {
     }
 
     /// Enables the use of the `SSLKEYLOGFILE`` environment variable to export SSL session keys.
-    /// 
+    ///
     /// Only works with the `rustls` SSL backend
     pub fn ssl_enable_keylog(mut self, enable: bool) -> Self {
         self.ssl_enable_keylog = enable;


### PR DESCRIPTION
### Is this a breaking change?
I think only for the core crate

I wanted to observe some database traffic which contained encrypted sqlx traffic and since there was no dedicated way to include a rustls ClientConfig in the connection, this would greatly help my use case.