### PR TITLE
breaking(any+mysql): correctly convert text and blob types to `AnyTypeInfo`

### DIFF
--- a/sqlx-mysql/src/any.rs
+++ b/sqlx-mysql/src/any.rs
@@ -16,6 +16,7 @@ use sqlx_core::database::Database;
 use sqlx_core::executor::Executor;
 use sqlx_core::sql_str::SqlStr;
 use sqlx_core::transaction::TransactionManager;
+use sqlx_core::types::Type;
 use std::{future, pin::pin};
 
 sqlx_core::declare_driver_with_optional_migrate!(DRIVER = MySql);
@@ -164,13 +165,9 @@ impl<'a> TryFrom<&'a MySqlTypeInfo> for AnyTypeInfo {
                 ColumnType::LongLong => AnyTypeInfoKind::BigInt,
                 ColumnType::Float => AnyTypeInfoKind::Real,
                 ColumnType::Double => AnyTypeInfoKind::Double,
-                ColumnType::Blob
-                | ColumnType::TinyBlob
-                | ColumnType::MediumBlob
-                | ColumnType::LongBlob => AnyTypeInfoKind::Blob,
-                ColumnType::String | ColumnType::VarString | ColumnType::VarChar => {
-                    AnyTypeInfoKind::Text
-                }
+                // Checks for any applicable type and compatible collations
+                _ if <str as Type<MySql>>::compatible(type_info) => AnyTypeInfoKind::Text,
+                _ if <[u8] as Type<MySql>>::compatible(type_info) => AnyTypeInfoKind::Blob,
                 _ => {
                     return Err(sqlx_core::Error::AnyDriverError(
                         format!("Any driver does not support MySql type {type_info:?}").into(),

--- a/tests/mysql/mysql.rs
+++ b/tests/mysql/mysql.rs
@@ -3,6 +3,7 @@ use futures_util::TryStreamExt;
 use sqlx::mysql::{MySql, MySqlConnection, MySqlPool, MySqlPoolOptions, MySqlRow};
 use sqlx::{Column, Connection, Executor, Row, SqlSafeStr, Statement, TypeInfo};
 use sqlx_core::connection::ConnectOptions;
+use sqlx_core::types::Type;
 use sqlx_mysql::MySqlConnectOptions;
 use sqlx_test::{new, setup_if_needed};
 use std::env;
@@ -663,6 +664,66 @@ async fn it_can_name_columns_issue_2206() -> anyhow::Result<()> {
     let name: String = row.get("name");
 
     assert_eq!(&name, "Alice");
+
+    Ok(())
+}
+
+#[cfg(feature = "any")]
+#[sqlx_macros::test]
+async fn any_blob_conversions() -> anyhow::Result<()> {
+    use sqlx::Any;
+    use sqlx::Decode;
+    use sqlx::ValueRef;
+
+    sqlx::any::install_default_drivers();
+
+    let mut conn = new::<Any>().await?;
+
+    sqlx::raw_sql(
+        r#"
+        CREATE TEMPORARY TABLE any_blob_conversions(
+            id INTEGER PRIMARY KEY,
+            regular_text TEXT NOT NULL,
+            text_binary TEXT COLLATE "utf8mb4_bin" NOT NULL,
+            binary_blob BLOB NOT NULL
+        );
+
+        INSERT INTO any_blob_conversions(id, regular_text, text_binary, binary_blob)
+        VALUES (1, 'Hello, world!', 'Lorem ipsum dolor sit amet', X'01020304DEADBEEF');
+   "#,
+    )
+    .execute(&mut conn)
+    .await?;
+
+    let row = sqlx::query("SELECT * FROM any_blob_conversions")
+        .fetch_one(&mut conn)
+        .await?;
+
+    let id = row.try_get_raw("id")?;
+    let regular_text = row.try_get_raw("regular_text")?;
+    let text_binary = row.try_get_raw("text_binary")?;
+    let binary_blob = row.try_get_raw("binary_blob")?;
+
+    assert_eq!(*id.type_info(), <i32 as Type<Any>>::type_info());
+    assert_eq!(<i32 as Decode<Any>>::decode(id).unwrap(), 1);
+
+    assert_eq!(*regular_text.type_info(), <str as Type<Any>>::type_info());
+    assert_eq!(
+        <&str as Decode<Any>>::decode(regular_text).unwrap(),
+        "Hello, world!"
+    );
+
+    assert_eq!(*text_binary.type_info(), <str as Type<Any>>::type_info());
+    assert_eq!(
+        <&str as Decode<Any>>::decode(text_binary).unwrap(),
+        "Lorem ipsum dolor sit amet"
+    );
+
+    assert_eq!(*binary_blob.type_info(), <[u8] as Type<Any>>::type_info());
+    assert_eq!(
+        <&[u8] as Decode<Any>>::decode(binary_blob).unwrap(),
+        [0x01, 0x02, 0x03, 0x04, 0xDE, 0xAD, 0xBE, 0xEF],
+    );
 
     Ok(())
 }


### PR DESCRIPTION
### Does your PR solve an issue?
closes #4225 (superceded PR)
closes #4132
closes #3635

related to #3387

### Is this a breaking change?
Columns previously reported as `BLOB` from the MySQL `Any` driver may now be reported and decoded as `TEXT` and vice versa.