### PR TITLE
feat(core): expose acquired pool connections

### DIFF
--- a/sqlx-core/src/pool/inner.rs
+++ b/sqlx-core/src/pool/inner.rs
@@ -84,6 +84,11 @@ impl<DB: Database> PoolInner<DB> {
         self.num_idle.load(Ordering::Acquire)
     }
 
+    pub(super) fn num_acquired(&self) -> u32 {
+        self.size()
+            .saturating_sub(u32::try_from(self.num_idle()).unwrap_or(u32::MAX))
+    }
+
     pub(super) fn is_closed(&self) -> bool {
         self.is_closed.load(Ordering::Acquire)
     }

--- a/sqlx-core/src/pool/mod.rs
+++ b/sqlx-core/src/pool/mod.rs
@@ -541,6 +541,14 @@ impl<DB: Database> Pool<DB> {
         self.0.num_idle()
     }
 
+    /// Returns the number of connections currently checked out from the pool.
+    ///
+    /// This is an instantaneous snapshot. The value may change immediately as
+    /// tasks acquire or release connections.
+    pub fn num_acquired(&self) -> u32 {
+        self.0.num_acquired()
+    }
+
     /// Gets a clone of the connection options for this pool
     pub fn connect_options(&self) -> Arc<<DB::Connection as Connection>::Options> {
         self.0
@@ -581,6 +589,7 @@ impl<DB: Database> fmt::Debug for Pool<DB> {
         fmt.debug_struct("Pool")
             .field("size", &self.0.size())
             .field("num_idle", &self.0.num_idle())
+            .field("num_acquired", &self.0.num_acquired())
             .field("is_closed", &self.0.is_closed())
             .field("options", &self.0.options)
             .finish()

--- a/tests/any/pool.rs
+++ b/tests/any/pool.rs
@@ -72,6 +72,43 @@ async fn pool_should_be_returned_failed_transactions() -> anyhow::Result<()> {
 }
 
 #[sqlx_macros::test]
+async fn pool_should_report_acquired_connections() -> anyhow::Result<()> {
+    sqlx::any::install_default_drivers();
+
+    let pool = AnyPoolOptions::new()
+        .max_connections(2)
+        .connect(&dotenvy::var("DATABASE_URL")?)
+        .await?;
+
+    assert_eq!(pool.size(), 1);
+    assert_eq!(pool.num_idle(), 1);
+    assert_eq!(pool.num_acquired(), 0);
+
+    let mut conn1 = pool.acquire().await?;
+
+    assert_eq!(pool.size(), 1);
+    assert_eq!(pool.num_idle(), 0);
+    assert_eq!(pool.num_acquired(), 1);
+
+    let mut conn2 = pool.acquire().await?;
+
+    assert_eq!(pool.size(), 2);
+    assert_eq!(pool.num_idle(), 0);
+    assert_eq!(pool.num_acquired(), 2);
+
+    conn2.return_to_pool().await;
+    conn1.return_to_pool().await;
+
+    assert_eq!(pool.size(), 2);
+    assert_eq!(pool.num_idle(), 2);
+    assert_eq!(pool.num_acquired(), 0);
+
+    pool.close().await;
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
 async fn test_pool_callbacks() -> anyhow::Result<()> {
     sqlx::any::install_default_drivers();
 

--- a/tests/sqlite/sqlcipher.rs
+++ b/tests/sqlite/sqlcipher.rs
@@ -56,6 +56,7 @@ async fn it_encrypts() -> anyhow::Result<()> {
         .await?;
 
     fill_db(&mut conn).await?;
+    conn.close().await?;
 
     // Create another connection without key, query should fail
     let mut conn = SqliteConnectOptions::from_str(&url)?.connect().await?;
@@ -66,6 +67,8 @@ async fn it_encrypts() -> anyhow::Result<()> {
         })
         .await
         .is_err());
+
+    conn.close().await?;
 
     Ok(())
 }
@@ -81,6 +84,7 @@ async fn it_can_store_and_read_encrypted_data() -> anyhow::Result<()> {
         .await?;
 
     fill_db(&mut conn).await?;
+    conn.close().await?;
 
     // Create another connection with valid key
     let mut conn = SqliteConnectOptions::from_str(&url)?
@@ -96,6 +100,8 @@ async fn it_can_store_and_read_encrypted_data() -> anyhow::Result<()> {
 
     assert!(result.len() > 0);
 
+    conn.close().await?;
+
     Ok(())
 }
 
@@ -110,6 +116,7 @@ async fn it_fails_if_password_is_incorrect() -> anyhow::Result<()> {
         .await?;
 
     fill_db(&mut conn).await?;
+    conn.close().await?;
 
     // Connection with invalid key should not allow to execute queries
     let mut conn = SqliteConnectOptions::from_str(&url)?
@@ -123,6 +130,8 @@ async fn it_fails_if_password_is_incorrect() -> anyhow::Result<()> {
         })
         .await
         .is_err());
+
+    conn.close().await?;
 
     Ok(())
 }
@@ -148,6 +157,7 @@ async fn it_honors_order_of_encryption_pragmas() -> anyhow::Result<()> {
         .await?;
 
     fill_db(&mut conn).await?;
+    conn.close().await?;
 
     let mut conn = SqliteConnectOptions::from_str(&url)?
         .pragma("dummy", "pragma")
@@ -166,6 +176,8 @@ async fn it_honors_order_of_encryption_pragmas() -> anyhow::Result<()> {
         .await?;
 
     assert!(result.len() > 0);
+
+    conn.close().await?;
 
     Ok(())
 }
@@ -186,6 +198,7 @@ async fn it_allows_to_rekey_the_db() -> anyhow::Result<()> {
     query("PRAGMA rekey = new_password;")
         .execute(&mut conn)
         .await?;
+    conn.close().await?;
 
     let mut conn = SqliteConnectOptions::from_str(&url)?
         .pragma("dummy", "pragma")
@@ -200,6 +213,8 @@ async fn it_allows_to_rekey_the_db() -> anyhow::Result<()> {
         .await?;
 
     assert!(result.len() > 0);
+
+    conn.close().await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- add `Pool::num_acquired()` to report checked-out pool connections
- include `num_acquired` in `Pool` debug output
- add coverage for the new counter through the `Any` pool tests
- close SQLCipher test connections explicitly so the SQLite matrix does not rely on process-exit teardown

This helps applications distinguish a full-but-idle pool from one where all connections are checked out, which is useful when diagnosing pool contention and `PoolTimedOut` errors.

The SQLCipher change is test-only. The SQLite matrix was reporting all `sqlite-sqlcipher` tests as passed and then segfaulting at process exit; closing the test connections explicitly makes the teardown deterministic.

## Checks

- `cargo fmt`
- `cargo check -p sqlx-core --no-default-features --features any,_rt-tokio`
- `cargo clippy -p sqlx-core --no-default-features --features any,_rt-tokio -- -D warnings`
- `cargo test --no-run --test any-pool --no-default-features --features any,sqlite,macros,runtime-tokio`
- `DATABASE_URL=sqlite::memory: cargo test --test any-pool pool_should_report_acquired_connections --no-default-features --features any,sqlite,macros,runtime-tokio`
- `RUSTFLAGS='--cfg sqlite_test_sqlcipher' DATABASE_URL=sqlite:tests/sqlite/sqlite.db cargo test --test sqlite-sqlcipher --no-default-features --features any,macros,migrate,sqlite,_unstable-all-types,runtime-tokio -- --test-threads=1`
- `RUSTFLAGS='--cfg sqlite_test_sqlcipher' DATABASE_URL=sqlite:tests/sqlite/sqlite.db cargo test --test sqlite-sqlcipher --no-default-features --features any,macros,migrate,sqlite,_unstable-all-types,runtime-smol -- --test-threads=1`
- `RUSTFLAGS='--cfg sqlite_test_sqlcipher' DATABASE_URL=sqlite:tests/sqlite/sqlite.db cargo test --no-default-features --features any,macros,migrate,sqlite,_unstable-all-types,runtime-tokio,sqlite-preupdate-hook -- --skip rustsec_2024_0363 --test-threads=1`
- `cargo test -p sqlx --doc --no-default-features --features any,postgres,macros,runtime-tokio`
- `git diff --check`

Note: `cargo clippy --test any-pool --no-default-features --features any,sqlite,macros,runtime-tokio -- -D warnings` currently reports an existing `clippy::needless_question_mark` warning in `sqlx-test/src/lib.rs`, outside this change.
