### PR TITLE
Fix query macros against CockroachDB by gating plan_cache_mode on EXPLAIN support

### DIFF
--- a/sqlx-macros-core/src/database/impls.rs
+++ b/sqlx-macros-core/src/database/impls.rs
@@ -3,11 +3,13 @@ macro_rules! impl_database_ext {
         $database:path,
         row: $row:path,
         $(describe-blocking: $describe:path,)?
+        $(prepare-connection: $prepare:path,)?
     ) => {
         impl $crate::database::DatabaseExt for $database {
             const DATABASE_PATH: &'static str = stringify!($database);
             const ROW_PATH: &'static str = stringify!($row);
             impl_describe_blocking!($database, $($describe)?);
+            impl_prepare_describe_connection!($database, $($prepare)?);
         }
     }
 }
@@ -38,6 +40,19 @@ macro_rules! impl_describe_blocking {
     };
 }
 
+macro_rules! impl_prepare_describe_connection {
+    ($database:path $(,)?) => {
+        // No override: use the `DatabaseExt::prepare_describe_connection` default (no-op).
+    };
+    ($database:path, $prepare:path) => {
+        async fn prepare_describe_connection(
+            conn: &mut <Self as sqlx_core::database::Database>::Connection,
+        ) -> sqlx_core::Result<()> {
+            $prepare(conn).await
+        }
+    };
+}
+
 // The paths below will also be emitted from the macros, so they need to match the final facade.
 mod sqlx {
     #[cfg(feature = "mysql")]
@@ -61,6 +76,7 @@ impl_database_ext! {
 impl_database_ext! {
     sqlx::postgres::Postgres,
     row: sqlx::postgres::PgRow,
+    prepare-connection: sqlx::postgres::PgConnection::force_generic_plan_for_describe,
 }
 
 #[cfg(feature = "_sqlite")]

--- a/sqlx-macros-core/src/database/mod.rs
+++ b/sqlx-macros-core/src/database/mod.rs
@@ -30,6 +30,18 @@ pub trait DatabaseExt: Database + TypeChecking {
         database_url: &str,
         driver_config: &config::drivers::Config,
     ) -> sqlx_core::Result<Describe<Self>>;
+
+    /// Prepare a freshly-opened connection used by the query macros for `describe`.
+    ///
+    /// Defaults to a no-op. Postgres overrides this to force a generic query plan,
+    /// which gives more accurate nullability inference for parameterized queries
+    /// (see launchbadge/sqlx#3541). The override is gated so it is skipped where it
+    /// doesn't apply -- e.g. CockroachDB, which rejected the previous implementation
+    /// (see launchbadge/sqlx#4274).
+    #[allow(async_fn_in_trait)]
+    async fn prepare_describe_connection(_conn: &mut Self::Connection) -> sqlx_core::Result<()> {
+        Ok(())
+    }
 }
 
 #[allow(dead_code)]
@@ -65,25 +77,7 @@ impl<DB: DatabaseExt> CachingDescribeBlocking<DB> {
                 hash_map::Entry::Occupied(hit) => hit.into_mut(),
                 hash_map::Entry::Vacant(miss) => {
                     let conn = miss.insert(DB::Connection::connect(database_url).await?);
-
-                    #[cfg(feature = "postgres")]
-                    if DB::NAME == sqlx_postgres::Postgres::NAME {
-                        conn.execute(
-                            "
-                            DO $$
-                            BEGIN
-                                IF EXISTS (
-                                    SELECT 1
-                                    FROM pg_settings
-                                    WHERE name = 'plan_cache_mode'
-                                ) THEN
-                                    SET SESSION plan_cache_mode = 'force_generic_plan';
-                                END IF;
-                            END $$;
-                        ",
-                        )
-                        .await?;
-                    }
+                    DB::prepare_describe_connection(conn).await?;
                     conn
                 }
             };

--- a/sqlx-postgres/src/connection/describe.rs
+++ b/sqlx-postgres/src/connection/describe.rs
@@ -1,4 +1,5 @@
 use crate::error::Error;
+use crate::executor::Executor;
 use crate::io::StatementId;
 use crate::query_as::query_as;
 use crate::statement::PgStatementMetadata;
@@ -16,6 +17,29 @@ impl PgConnection {
         let is_materialize = parameter_statuses.contains_key("mz_version");
         let is_questdb = parameter_statuses.contains_key("questdb_version");
         !is_cockroachdb && !is_materialize && !is_questdb
+    }
+
+    /// Prepare a freshly-opened connection that the query macros use for `describe`.
+    ///
+    /// Forces a generic query plan so that nullability inference via `EXPLAIN` reflects
+    /// the real query shape, rather than a plan specialized for the `NULL` placeholder
+    /// arguments bound while describing a statement.
+    /// See <https://github.com/launchbadge/sqlx/pull/3541>.
+    ///
+    /// Gated on `is_explain_available()`: the setting only matters for the `EXPLAIN`-based
+    /// inference, which is skipped on databases that don't support it -- CockroachDB,
+    /// Materialize and QuestDB -- and on the server version, as `plan_cache_mode` was only
+    /// introduced in PostgreSQL 12. Issuing it unconditionally previously broke the macros
+    /// against CockroachDB, which rejects `SET` inside the `DO` block this used to run
+    /// (`SQLSTATE 0A000`). See <https://github.com/launchbadge/sqlx/issues/4274>.
+    #[doc(hidden)]
+    pub async fn force_generic_plan_for_describe(&mut self) -> Result<(), Error> {
+        if self.is_explain_available() && self.server_version_num().is_some_and(|v| v >= 120_000) {
+            self.execute("SET plan_cache_mode = 'force_generic_plan'")
+                .await?;
+        }
+
+        Ok(())
     }
 
     pub(crate) async fn get_nullable_for_columns(

--- a/tests/postgres/describe.rs
+++ b/tests/postgres/describe.rs
@@ -42,6 +42,28 @@ async fn it_describes_expression() -> anyhow::Result<()> {
     Ok(())
 }
 
+// Regression test for launchbadge/sqlx#3541 and #4274: the query macros force a
+// generic query plan on their describe connection so that nullability inference via
+// `EXPLAIN` isn't skewed by the `NULL` placeholder arguments bound during `describe`.
+// This checks the mechanism still applies on PostgreSQL.
+//
+// The complementary half of #4274 -- skipping this on databases without `EXPLAIN`
+// support (CockroachDB, Materialize, QuestDB), where the previous `DO` block failed
+// to even parse -- cannot be exercised here, as CI runs no such database.
+#[sqlx_macros::test]
+async fn it_forces_generic_plan_for_describe() -> anyhow::Result<()> {
+    let mut conn = new::<Postgres>().await?;
+
+    conn.force_generic_plan_for_describe().await?;
+
+    let mode: String = sqlx::query_scalar("SHOW plan_cache_mode")
+        .fetch_one(&mut conn)
+        .await?;
+    assert_eq!(mode, "force_generic_plan");
+
+    Ok(())
+}
+
 #[sqlx_macros::test]
 async fn it_describes_enum() -> anyhow::Result<()> {
     let mut conn = new::<Postgres>().await?;


### PR DESCRIPTION
## Problem

Since 0.9.0 the compile-time query macros (`query!`, `query_as!`,
`query_scalar!`) fail against CockroachDB:

```
error: error returned from database: unimplemented: SET usage inside a
function definition (SQLSTATE 0A000)
```

#3541 prepares the macros' describe connection by running
`SET plan_cache_mode = 'force_generic_plan'` inside a `DO $$ … $$` block.
CockroachDB rejects `SET` inside a function/`DO` body at parse time, so the
block fails before its `IF EXISTS` guard runs. Closes #4274.

## Fix

`plan_cache_mode = force_generic_plan` exists solely to keep EXPLAIN-based
nullability inference from being skewed by the `NULL` placeholder arguments
bound during `describe`. That inference already runs only when
`is_explain_available()` is true — false for CockroachDB, Materialize and
QuestDB (detected via their `crdb_version` / `mz_version` / `questdb_version`
parameter statuses).

The setting is moved out of the generic macro layer into `PgConnection`,
behind that same `is_explain_available()` check (plus a
`server_version_num() >= 12` guard in place of the old `pg_settings` probe).
The macro layer now calls a per-database `DatabaseExt::prepare_describe_connection`
hook (a no-op for MySQL/SQLite). The setting is therefore skipped, by
construction, on every database that cannot use it — fixing CockroachDB and
pre-empting the same breakage on Materialize/QuestDB — while behaving exactly
as before on PostgreSQL.

## Behaviour on standard PostgreSQL

Unchanged: the dedicated describe connection still gets `force_generic_plan`
(verified by the existing `describe` tests). `describe()` itself is untouched,
so no reused connection is affected.

## Testing

- Existing `tests/postgres/describe.rs` suite passes, plus a new
  `it_forces_generic_plan_for_describe` regression test.
- Verified manually against CockroachDB v26.2.1: before this change a `query!`
  macro fails with SQLSTATE 0A000; afterwards it compiles and `plan_cache_mode`
  is left untouched. CockroachDB is not in the CI matrix, so that half cannot
  be covered by an automated test; the fix is structural (gated on the
  pre-existing, already-tested CockroachDB detection).
- `cargo clippy -- -D warnings` and `rustfmt --check` are clean.
