### PR TITLE
fix(sqlite): return 0 for changes if statement is read-only

### DIFF
--- a/sqlx-sqlite/src/connection/execute.rs
+++ b/sqlx-sqlite/src/connection/execute.rs
@@ -108,7 +108,15 @@ impl Iterator for ExecuteIter<'_> {
             Ok(false) => {
                 let last_insert_rowid = self.handle.last_insert_rowid();
 
-                let changes = statement.handle.changes();
+                // `sqlite3_changes()` returns the row count for the most recently completed
+                // INSERT/UPDATE/DELETE on the connection, not necessarily this statement.
+                // For read-only statements (SELECT, BEGIN, COMMIT, etc.) we must report 0.
+                // See https://sqlite.org/c3ref/changes.html
+                let changes = if statement.handle.read_only() {
+                    0
+                } else {
+                    statement.handle.changes()
+                };
                 self.logger.increase_rows_affected(changes);
 
                 let done = SqliteQueryResult {

--- a/tests/sqlite/sqlite.rs
+++ b/tests/sqlite/sqlite.rs
@@ -1437,3 +1437,35 @@ async fn issue_3982() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[sqlx_macros::test]
+async fn issue_4300() -> anyhow::Result<()> {
+    use sqlx::migrate::Migrator;
+    use sqlx::sqlite::SqlitePoolOptions;
+    use std::path::Path;
+
+    let pool = SqlitePoolOptions::new().connect("sqlite::memory:").await?;
+
+    let migrator = Migrator::new(Path::new("tests/sqlite/migrations_issue_4300")).await?;
+    migrator.run(&pool).await?;
+
+    sqlx::query("CREATE TABLE my_table ( qqq TEXT )")
+        .execute(&pool)
+        .await?;
+
+    sqlx::query("CREATE TABLE other_table ( www TEXT )")
+        .execute(&pool)
+        .await?;
+
+    sqlx::query("INSERT INTO my_table (qqq) VALUES ('temporary')")
+        .execute(&pool)
+        .await?;
+
+    let result = sqlx::query("BEGIN TRANSACTION; COMMIT;")
+        .execute(&pool)
+        .await?;
+
+    assert_eq!(result.rows_affected(), 0);
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #4300

The issue repro is added as a test called `issue_4300`.