### PR TITLE
fix(sqlite): silence time 0.3.48 modifier deprecations under -D warnings

### DIFF
--- a/sqlx-sqlite/src/types/time.rs
+++ b/sqlx-sqlite/src/types/time.rs
@@ -193,6 +193,15 @@ fn decode_datetime_from_text(value: &str) -> Option<PrimitiveDateTime> {
 }
 
 mod formats {
+    // `time` 0.3.48 deprecated the field-based `modifier::{Year, Month, Hour}`
+    // components and the raw-byte `BorrowedFormatItem::Literal` in favor of new
+    // `#[non_exhaustive]` components (`Year*`, `Month*`, `Hour24`, `StringLiteral`).
+    // Those replacements aren't `const`-constructible the way the format items
+    // below require, and the deprecated API still works, so suppress the lint
+    // here until the format builders are migrated.
+    // Tracking: https://github.com/transact-rs/sqlx/issues/4310
+    #![allow(deprecated)]
+
     use time::format_description::BorrowedFormatItem::{Component, Literal, Optional};
     use time::format_description::{modifier, BorrowedFormatItem, Component::*};
 


### PR DESCRIPTION
This change adds `#![allow(deprecated)]` for sqlite time formats to silence clippy warnings.

time 0.3.48 deprecated the field-based `modifier::{Year, Month, Hour}` format components and raw-byte `Literal`, which broke `clippy -D warnings` in CI (no Cargo.lock, so the latest `time` is resolved). The new `#[non_exhaustive]` replacements aren't const-constructible the way these `const` format items need, and the deprecated API still works, so scope an  to `mod formats` as a stopgap.

### Does your PR solve an issue?

This is a stopgap for #4310. #4310 tracks performing a migration, while this change gets main CI back to passing.

### Is this a breaking change?

No. To fully complete #4310, possibly but this PR does not cover that.
