### PR TITLE
fix(macros): added SQLX_SQLITE_REGISTER_REGEXP environment variable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,7 +160,7 @@ mac_address = ["sqlx-core/mac_address", "sqlx-macros?/mac_address", "sqlx-postgr
 rust_decimal = ["sqlx-core/rust_decimal", "sqlx-macros?/rust_decimal", "sqlx-mysql?/rust_decimal", "sqlx-postgres?/rust_decimal"]
 time = ["sqlx-core/time", "sqlx-macros?/time", "sqlx-mysql?/time", "sqlx-postgres?/time", "sqlx-sqlite?/time"]
 uuid = ["sqlx-core/uuid", "sqlx-macros?/uuid", "sqlx-mysql?/uuid", "sqlx-postgres?/uuid", "sqlx-sqlite?/uuid"]
-regexp = ["sqlx-sqlite?/regexp"]
+regexp = ["sqlx-sqlite?/regexp", "sqlx-macros?/regexp"]
 bstr = ["sqlx-core/bstr"]
 
 [workspace.dependencies]

--- a/sqlx-macros-core/Cargo.toml
+++ b/sqlx-macros-core/Cargo.toml
@@ -54,6 +54,8 @@ rust_decimal = ["sqlx-core/rust_decimal", "sqlx-mysql?/rust_decimal", "sqlx-post
 time = ["sqlx-core/time", "sqlx-mysql?/time", "sqlx-postgres?/time", "sqlx-sqlite?/time"]
 uuid = ["sqlx-core/uuid", "sqlx-mysql?/uuid", "sqlx-postgres?/uuid", "sqlx-sqlite?/uuid"]
 
+regexp = ["sqlx-sqlite?/regexp"]
+
 [dependencies]
 sqlx-core = { workspace = true, features = ["offline"] }
 sqlx-mysql = { workspace = true, features = ["offline", "migrate"], optional = true, default-features = false }

--- a/sqlx-macros/Cargo.toml
+++ b/sqlx-macros/Cargo.toml
@@ -53,6 +53,8 @@ time = ["sqlx-macros-core/time"]
 uuid = ["sqlx-macros-core/uuid"]
 json = ["sqlx-macros-core/json"]
 
+regexp = ["sqlx-macros-core/regexp"]
+
 [dependencies]
 sqlx-core = { workspace = true, features = ["any"] }
 sqlx-macros-core = { workspace = true }

--- a/sqlx-sqlite/src/options/mod.rs
+++ b/sqlx-sqlite/src/options/mod.rs
@@ -193,6 +193,11 @@ impl SqliteConnectOptions {
         // Soft limit on the number of rows that `ANALYZE` touches per index.
         pragmas.insert("analysis_limit".into(), None);
 
+        #[cfg(feature = "regexp")]
+        let register_regexp_function = std::env::var("SQLX_SQLITE_REGISTER_REGEXP")
+            .ok()
+            .is_some_and(|val| val.eq_ignore_ascii_case("true") || val == "1");
+
         Self {
             filename: Cow::Borrowed(Path::new(":memory:")),
             in_memory: false,
@@ -214,7 +219,7 @@ impl SqliteConnectOptions {
             row_channel_size: 50,
             optimize_on_close: OptimizeOnClose::Disabled,
             #[cfg(feature = "regexp")]
-            register_regexp_function: false,
+            register_regexp_function,
         }
     }
 

--- a/tests/sqlite/macros.rs
+++ b/tests/sqlite/macros.rs
@@ -358,4 +358,20 @@ async fn test_column_override_exact_nullable() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Requires SQLX_SQLITE_REGISTER_REGEXP environment variable to compile and succeed.
+#[cfg(feature = "regexp")]
+#[sqlx_macros::test]
+async fn test_regexp_function_is_registered_via_env() -> anyhow::Result<()> {
+    let mut conn = new::<Sqlite>().await?;
+
+    let record =
+        sqlx::query!(r#"select id as "id?: MyInt" from tweet where text regexp 'is pretty cool'"#)
+            .fetch_one(&mut conn)
+            .await?;
+
+    assert_eq!(record.id, Some(MyInt(1)));
+
+    Ok(())
+}
+
 // we don't emit bind parameter typechecks for SQLite so testing the overrides is redundant


### PR DESCRIPTION
### Does your PR solve an issue?

Fixes #3070

As it's my first ever contribution to an open-source project, please tell me everything I've got wrong or if I can improve the PR to be clearer.

This intend to allow sqlite `regexp` function to be used with macros, it extends an already-supported feature. 

The change also allows by-design the use of the new `SQLX_SQLITE_REGISTER_REGEXP` with `sqlx-cli prepare` command. 

I'm waiting a run of CI to make sure that the new test does not fail (ie if the new `SQLX_SQLITE_REGISTER_REGEXP` needs to be added to the existing environment workflow).

### Is this a breaking change?

No. 