### PR TITLE
Add SQLite integration test for #[sqlx(json)] on TEXT columns

### DIFF
--- a/tests/sqlite/derives.rs
+++ b/tests/sqlite/derives.rs
@@ -1,5 +1,5 @@
 use sqlx::Sqlite;
-use sqlx_test::test_type;
+use sqlx_test::{new, test_type};
 
 #[derive(Debug, PartialEq, sqlx::Type)]
 #[repr(u32)]
@@ -32,3 +32,53 @@ test_type!(transparent_named<TransparentNamed>(Sqlite,
     "0" == TransparentNamed { field: 0 },
     "23523" == TransparentNamed { field: 23523 },
 ));
+
+// SQLite stores JSON as TEXT. The `#[sqlx(json)]` field attribute lets a struct
+// read such a column into a `serde_json::Value` (or any `Deserialize` type),
+// deserializing it with `serde_json` during decode.
+#[derive(Debug, PartialEq, sqlx::FromRow)]
+struct JsonRow {
+    id: i64,
+    #[sqlx(json)]
+    data: serde_json::Value,
+}
+
+#[sqlx_macros::test]
+async fn it_reads_json_from_text_column() -> anyhow::Result<()> {
+    let mut conn = new::<Sqlite>().await?;
+
+    let row: JsonRow = sqlx::query_as(
+        r#"SELECT 1 AS id, '{"key": "value"}' AS data"#,
+    )
+    .fetch_one(&mut conn)
+    .await?;
+
+    assert_eq!(
+        row,
+        JsonRow {
+            id: 1,
+            data: serde_json::json!({ "key": "value" }),
+        }
+    );
+
+    Ok(())
+}
+
+#[sqlx_macros::test]
+async fn it_surfaces_invalid_json_as_column_decode_error() -> anyhow::Result<()> {
+    let mut conn = new::<Sqlite>().await?;
+
+    let result: Result<JsonRow, sqlx::Error> =
+        sqlx::query_as(r#"SELECT 1 AS id, 'not valid json' AS data"#)
+            .fetch_one(&mut conn)
+            .await;
+
+    match result {
+        Err(sqlx::Error::ColumnDecode { index, .. }) => {
+            assert_eq!(index, "\"data\"");
+        }
+        other => panic!("expected ColumnDecode error, got {other:?}"),
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

SQLite stores JSON as `TEXT`. This adds integration test coverage for reading such a column into a `FromRow` struct field annotated with `#[sqlx(json)]`, decoding it via `serde_json`.

The `#[sqlx(json)]` attribute and its SQLite `Json<T>` decode path already exist; this PR adds the missing test coverage:

- `it_reads_json_from_text_column` — selects `'{"key": "value"}'` from a `TEXT` column into a struct with `#[sqlx(json)] data: serde_json::Value`.
- `it_surfaces_invalid_json_as_column_decode_error` — invalid JSON surfaces as `sqlx::Error::ColumnDecode`.

## Test plan

- `cargo test -p sqlx --test sqlite-derives` (with `sqlite,macros,migrate,json` features) — all 8 tests pass, including the 2 new ones.
- Existing derive tests unaffected. No changes to MySQL/PostgreSQL paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)