### PR TITLE
fix(sqlite): migrate datetime format builders off time 0.3.48-depreca…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ ipnet = "2.3.0"
 ipnetwork = "0.21.1"
 mac_address = "1.1.5"
 rust_decimal = { version = "1.36.0", default-features = false, features = ["std"] }
-time = { version = "0.3.47", features = ["formatting", "parsing", "macros"] }
+time = { version = "0.3.48", features = ["formatting", "parsing", "macros"] }
 uuid = "1.12.1"
 
 # Common utility crates

--- a/examples/postgres/axum-social-with-tests/Cargo.toml
+++ b/examples/postgres/axum-social-with-tests/Cargo.toml
@@ -17,7 +17,7 @@ rand = "0.10.1"
 regex = "1.6.0"
 serde = "1.0.219"
 serde_with = { version = "3.18.0", features = ["time_0_3"] }
-time = "0.3.47"
+time = "0.3.48"
 uuid = { version = "1.12.1", features = ["serde"] }
 validator = { version = "0.20.0", features = ["derive"] }
 

--- a/examples/postgres/multi-database/accounts/Cargo.toml
+++ b/examples/postgres/multi-database/accounts/Cargo.toml
@@ -15,7 +15,7 @@ uuid = { version = "1.12.1", features = ["serde"] }
 thiserror = "2.0.18"
 rand = "0.10.1"
 
-time = { version = "0.3.47", features = ["serde"] }
+time = { version = "0.3.48", features = ["serde"] }
 
 serde = { version = "1.0.219", features = ["derive"] }
 

--- a/examples/postgres/multi-database/payments/Cargo.toml
+++ b/examples/postgres/multi-database/payments/Cargo.toml
@@ -9,7 +9,7 @@ sqlx = { workspace = true, features = ["postgres", "time", "uuid", "rust_decimal
 
 rust_decimal = "1.36.0"
 
-time = "0.3.47"
+time = "0.3.48"
 uuid = "1.12.1"
 
 [dependencies.accounts]

--- a/examples/postgres/multi-tenant/accounts/Cargo.toml
+++ b/examples/postgres/multi-tenant/accounts/Cargo.toml
@@ -14,7 +14,7 @@ uuid = { version = "1.12.1", features = ["serde"] }
 thiserror = "2.0.18"
 rand = "0.10.1"
 
-time = { version = "0.3.47", features = ["serde"] }
+time = { version = "0.3.48", features = ["serde"] }
 
 serde = { version = "1.0.219", features = ["derive"] }
 

--- a/examples/postgres/multi-tenant/payments/Cargo.toml
+++ b/examples/postgres/multi-tenant/payments/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 rust_decimal = "1.36.0"
 
-time = "0.3.47"
+time = "0.3.48"
 uuid = "1.12.1"
 
 [dependencies.sqlx]

--- a/examples/postgres/preferred-crates/uses-time/Cargo.toml
+++ b/examples/postgres/preferred-crates/uses-time/Cargo.toml
@@ -10,7 +10,7 @@ authors.workspace = true
 
 [dependencies]
 serde = "1.0.219"
-time = "0.3.47"
+time = "0.3.48"
 uuid = "1.12.1"
 
 [dependencies.sqlx]

--- a/sqlx-sqlite/src/types/time.rs
+++ b/sqlx-sqlite/src/types/time.rs
@@ -145,7 +145,12 @@ fn decode_offset_datetime_from_text(value: &str) -> Option<OffsetDateTime> {
         return Some(dt);
     }
 
-    if let Ok(dt) = OffsetDateTime::parse(value, formats::OFFSET_DATE_TIME) {
+    if let Ok(dt) = OffsetDateTime::parse(
+        value,
+        &fd!(
+            "[year]-[month]-[day][optional [ ]][optional [T]][hour]:[minute][optional [:[second]]][optional [.[subsecond]]][optional [[offset_hour]]][optional [:[offset_minute]]]"
+        ),
+    ) {
         return Some(dt);
     }
 
@@ -181,8 +186,12 @@ fn decode_datetime_from_text(value: &str) -> Option<PrimitiveDateTime> {
     }
 
     let formats = [
-        BorrowedFormatItem::Compound(formats::PRIMITIVE_DATE_TIME_SPACE_SEPARATED),
-        BorrowedFormatItem::Compound(formats::PRIMITIVE_DATE_TIME_T_SEPARATED),
+        BorrowedFormatItem::Compound(fd!(
+            "[year]-[month]-[day] [hour]:[minute][optional [:[second]]][optional [.[subsecond]]][optional [Z]]"
+        )),
+        BorrowedFormatItem::Compound(fd!(
+            "[year]-[month]-[day]T[hour]:[minute][optional [:[second]]][optional [.[subsecond]]][optional [Z]]"
+        )),
     ];
 
     if let Ok(dt) = PrimitiveDateTime::parse(value, &BorrowedFormatItem::First(&formats)) {
@@ -190,130 +199,4 @@ fn decode_datetime_from_text(value: &str) -> Option<PrimitiveDateTime> {
     }
 
     None
-}
-
-mod formats {
-    use time::format_description::BorrowedFormatItem::{Component, Literal, Optional};
-    use time::format_description::{modifier, BorrowedFormatItem, Component::*};
-
-    const YEAR: BorrowedFormatItem<'_> = Component(Year({
-        let mut value = modifier::Year::default();
-        value.padding = modifier::Padding::Zero;
-        value.repr = modifier::YearRepr::Full;
-        value.iso_week_based = false;
-        value.sign_is_mandatory = false;
-        value
-    }));
-
-    const MONTH: BorrowedFormatItem<'_> = Component(Month({
-        let mut value = modifier::Month::default();
-        value.padding = modifier::Padding::Zero;
-        value.repr = modifier::MonthRepr::Numerical;
-        value.case_sensitive = true;
-        value
-    }));
-
-    const DAY: BorrowedFormatItem<'_> = Component(Day({
-        let mut value = modifier::Day::default();
-        value.padding = modifier::Padding::Zero;
-        value
-    }));
-
-    const HOUR: BorrowedFormatItem<'_> = Component(Hour({
-        let mut value = modifier::Hour::default();
-        value.padding = modifier::Padding::Zero;
-        value.is_12_hour_clock = false;
-        value
-    }));
-
-    const MINUTE: BorrowedFormatItem<'_> = Component(Minute({
-        let mut value = modifier::Minute::default();
-        value.padding = modifier::Padding::Zero;
-        value
-    }));
-
-    const SECOND: BorrowedFormatItem<'_> = Component(Second({
-        let mut value = modifier::Second::default();
-        value.padding = modifier::Padding::Zero;
-        value
-    }));
-
-    const SUBSECOND: BorrowedFormatItem<'_> = Component(Subsecond({
-        let mut value = modifier::Subsecond::default();
-        value.digits = modifier::SubsecondDigits::OneOrMore;
-        value
-    }));
-
-    const OFFSET_HOUR: BorrowedFormatItem<'_> = Component(OffsetHour({
-        let mut value = modifier::OffsetHour::default();
-        value.sign_is_mandatory = true;
-        value.padding = modifier::Padding::Zero;
-        value
-    }));
-
-    const OFFSET_MINUTE: BorrowedFormatItem<'_> = Component(OffsetMinute({
-        let mut value = modifier::OffsetMinute::default();
-        value.padding = modifier::Padding::Zero;
-        value
-    }));
-
-    pub(super) const OFFSET_DATE_TIME: &[BorrowedFormatItem<'_>] = {
-        &[
-            YEAR,
-            Literal(b"-"),
-            MONTH,
-            Literal(b"-"),
-            DAY,
-            Optional(&Literal(b" ")),
-            Optional(&Literal(b"T")),
-            HOUR,
-            Literal(b":"),
-            MINUTE,
-            Optional(&Literal(b":")),
-            Optional(&SECOND),
-            Optional(&Literal(b".")),
-            Optional(&SUBSECOND),
-            Optional(&OFFSET_HOUR),
-            Optional(&Literal(b":")),
-            Optional(&OFFSET_MINUTE),
-        ]
-    };
-
-    pub(super) const PRIMITIVE_DATE_TIME_SPACE_SEPARATED: &[BorrowedFormatItem<'_>] = {
-        &[
-            YEAR,
-            Literal(b"-"),
-            MONTH,
-            Literal(b"-"),
-            DAY,
-            Literal(b" "),
-            HOUR,
-            Literal(b":"),
-            MINUTE,
-            Optional(&Literal(b":")),
-            Optional(&SECOND),
-            Optional(&Literal(b".")),
-            Optional(&SUBSECOND),
-            Optional(&Literal(b"Z")),
-        ]
-    };
-
-    pub(super) const PRIMITIVE_DATE_TIME_T_SEPARATED: &[BorrowedFormatItem<'_>] = {
-        &[
-            YEAR,
-            Literal(b"-"),
-            MONTH,
-            Literal(b"-"),
-            DAY,
-            Literal(b"T"),
-            HOUR,
-            Literal(b":"),
-            MINUTE,
-            Optional(&Literal(b":")),
-            Optional(&SECOND),
-            Optional(&Literal(b".")),
-            Optional(&SUBSECOND),
-            Optional(&Literal(b"Z")),
-        ]
-    };
 }


### PR DESCRIPTION
Does your PR solve an issue?

Closes #4310.

Replaces the #![allow(deprecated)] stopgap from #4310  with the actual migration to format_description! macros, matching the approach used by the mysql and postgres drivers.

Is this a breaking change?

No. The parsing behavior is unchanged — the same format descriptors are produced, just constructed via the format_description! macro instead of manually-built BorrowedFormatItem trees.