### PR TITLE
Mention in docs that many `#[sqlx::test]`s can slow down rebuild time

### DIFF
--- a/src/macros/test.md
+++ b/src/macros/test.md
@@ -173,6 +173,8 @@ async fn basic_test(pool: PgPool) -> sqlx::Result<()> {
 # }
 ```
 
+Note that if you have a large number of tests and migrations, embedding the migrations next to each `#[sqlx::test]` can significantly slow down compilation times. In that case consider storing the migrations into a shared variable in your crate and then reference that variable using `migrator = <path>` in each test.
+
 ### Automatic Fixture Application (requires `migrate` feature)
 
 Since tests are isolated from each other but may require data to already exist in the database to keep from growing


### PR DESCRIPTION
This PR adds a mention to the docs of `#[sqlx::test]` to warn users that having many such tests that embed migrations in the generated source code can lead to severe source code bloat and long compilation times. I described this in https://github.com/transact-rs/sqlx/issues/4318.

### Does your PR solve an issue?

It provides a hint to users that might run into this issue: https://github.com/transact-rs/sqlx/issues/4318

### Is this a breaking change?

No