### PR TITLE
fix: correct spelling of "implementer" in column.rs comment

### DIFF
--- a/sqlx-core/src/column.rs
+++ b/sqlx-core/src/column.rs
@@ -30,7 +30,7 @@ pub trait Column: 'static + Send + Sync + Debug {
     /// Returns [`ColumnOrigin::Unknown`] if the database driver does not have that information,
     /// or has not overridden this method.
     // This method returns an owned value instead of a reference,
-    // to give the implementor more flexibility.
+    // to give the implementer more flexibility.
     fn origin(&self) -> ColumnOrigin {
         ColumnOrigin::Unknown
     }


### PR DESCRIPTION
Fix a minor spelling error in a code comment in `sqlx-core/src/column.rs`.

`implementor` → `implementer` (the correct standard English spelling)

This is a one-line comment on the `Column::origin()` method explaining why it returns an owned value.