### PR TITLE
fix(pool): bound each step of returning a connection to the pool

### DIFF
--- a/sqlx-core/src/pool/connection.rs
+++ b/sqlx-core/src/pool/connection.rs
@@ -15,6 +15,15 @@ use crate::pool::options::PoolConnectionMetadata;
 
 const CLOSE_ON_DROP_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Bounds each step of returning a connection to the pool.
+///
+/// Every step here does I/O on a connection that may be dead in a way the socket
+/// cannot report: if the server disappeared without closing it, and the client has
+/// nothing left to retransmit, reads never complete. The returning task holds the
+/// pool's `DecrementSizeGuard` for as long as it runs, so an unbounded step leaks a
+/// permit and the pool shrinks by one connection every time it happens.
+const RETURN_TO_POOL_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// A connection managed by a [`Pool`][crate::pool::Pool].
 ///
 /// Will be returned to the pool on-drop.
@@ -275,29 +284,37 @@ impl<DB: Database> Floating<DB, Live<DB>> {
     async fn return_to_pool(mut self) -> bool {
         // Immediately close the connection.
         if self.guard.pool.is_closed() {
-            self.close().await;
+            self.close_bounded().await;
             return false;
         }
 
         // If the connection is beyond max lifetime, close the connection and
         // immediately create a new connection
         if is_beyond_max_lifetime(&self.inner, &self.guard.pool.options) {
-            self.close().await;
+            self.close_bounded().await;
             return false;
         }
 
         if let Some(test) = &self.guard.pool.options.after_release {
             let meta = self.metadata();
-            match (test)(&mut self.inner.raw, meta).await {
-                Ok(true) => (),
-                Ok(false) => {
-                    self.close().await;
+            let result =
+                crate::rt::timeout(RETURN_TO_POOL_TIMEOUT, (test)(&mut self.inner.raw, meta)).await;
+
+            match result {
+                Ok(Ok(true)) => (),
+                Ok(Ok(false)) => {
+                    self.close_bounded().await;
                     return false;
                 }
-                Err(error) => {
+                Ok(Err(error)) => {
                     tracing::warn!(%error, "error from `after_release`");
                     // Connection is broken, don't try to gracefully close as
                     // something weird might happen.
+                    self.close_hard().await;
+                    return false;
+                }
+                Err(_) => {
+                    tracing::warn!("timed out in `after_release`; discarding the connection");
                     self.close_hard().await;
                     return false;
                 }
@@ -311,20 +328,40 @@ impl<DB: Database> Floating<DB, Live<DB>> {
         // returned to the pool; also of course, if it was dropped due to an error
         // this is simply a band-aid as SQLx-next connections should be able
         // to recover from cancellations
-        if let Err(error) = self.raw.ping().await {
-            tracing::warn!(
-                %error,
-                "error occurred while testing the connection on-release",
-            );
+        let result = crate::rt::timeout(RETURN_TO_POOL_TIMEOUT, self.raw.ping()).await;
 
-            // Connection is broken, don't try to gracefully close.
-            self.close_hard().await;
-            false
-        } else {
-            // if the connection is still viable, release it to the pool
-            self.release();
-            true
+        match result {
+            Ok(Ok(())) => {
+                // if the connection is still viable, release it to the pool
+                self.release();
+                true
+            }
+            Ok(Err(error)) => {
+                tracing::warn!(
+                    %error,
+                    "error occurred while testing the connection on-release",
+                );
+
+                // Connection is broken, don't try to gracefully close.
+                self.close_hard().await;
+                false
+            }
+            Err(_) => {
+                tracing::warn!("timed out while testing the connection on-release; discarding it",);
+
+                // The socket is not answering; dropping it is the only way to get the
+                // pool permit back.
+                self.close_hard().await;
+                false
+            }
         }
+    }
+
+    /// Close the connection, giving up on a graceful close if it does not complete
+    /// promptly. Cancelling `close()` still drops the connection and releases the
+    /// pool permit, which is the outcome that matters here.
+    async fn close_bounded(self) {
+        let _ = crate::rt::timeout(RETURN_TO_POOL_TIMEOUT, self.close()).await;
     }
 
     pub async fn close(self) {

--- a/tests/postgres/postgres.rs
+++ b/tests/postgres/postgres.rs
@@ -12,7 +12,7 @@ use sqlx_test::{new, pool, setup_if_needed};
 use std::env;
 use std::pin::{pin, Pin};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 #[sqlx_macros::test]
 async fn it_connects() -> anyhow::Result<()> {
@@ -317,6 +317,34 @@ async fn it_can_fail_and_recover() -> anyhow::Result<()> {
 
         assert_eq!(val, i);
     }
+
+    Ok(())
+}
+
+/// A hook that never completes must not hold the pool permit forever: returning a
+/// connection to the pool does I/O on a socket that may be dead in a way it cannot
+/// report, so each step is bounded and the connection is discarded on timeout.
+#[sqlx_macros::test]
+async fn pool_recovers_from_a_hanging_after_release() -> anyhow::Result<()> {
+    setup_if_needed();
+
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .acquire_timeout(Duration::from_secs(30))
+        .after_release(|_conn, _meta| Box::pin(std::future::pending()))
+        .connect(&env::var("DATABASE_URL")?)
+        .await?;
+
+    let conn = pool.acquire().await?;
+    drop(conn);
+
+    // The permit comes back once the bounded return-to-pool gives up on the hook.
+    let started_at = Instant::now();
+    let _conn = pool.acquire().await?;
+    assert!(
+        started_at.elapsed() < Duration::from_secs(30),
+        "acquire waited on a connection whose return never finished",
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #4349.

## The problem

`Floating::return_to_pool` holds the pool's `DecrementSizeGuard` while it does I/O on the connection being returned: the `after_release` hook, the `ping()` that checks the connection is still usable, and the graceful `close()` on the max-lifetime and pool-closed paths. None of those are bounded.

That is fine when a connection is either healthy or visibly broken. It is not fine when the socket is dead in a way it cannot report. If the server disappeared *without* closing the connection (a failover, a killed container, a dropped NAT mapping) and the client has nothing left to retransmit, no RST is ever provoked and the read never completes. The spawned task that is returning the connection then holds its permit forever, and the pool shrinks by one usable connection.

Repeat that `max_connections` times and every `acquire()` fails with `PoolTimedOut` from then on, even after the server comes back, because the permits are held by tasks parked on dead sockets.

We hit this in production behind a maintenance loop that had a query in flight when its Postgres instance went away.

## The fix

Each step gets `RETURN_TO_POOL_TIMEOUT` (5s, matching the existing `CLOSE_ON_DROP_TIMEOUT` a few lines up), and on expiry the connection is discarded with `close_hard()`, which does no I/O. Cancelling `close()` likewise drops the connection and releases the permit, so the bounded-close path is safe too.

## Test

`pool_recovers_from_a_hanging_after_release` uses an `after_release` hook that never completes, as a deterministic stand-in for a socket that never answers. On `main` it exhausts `acquire_timeout` and fails after 30s; with this change the pool is usable again after the 5s bound:

```
# on main
test result: FAILED. 0 passed; 1 failed; finished in 30.05s

# with this change
test pool_recovers_from_a_hanging_after_release ... ok
test result: ok. 1 passed; 0 failed; finished in 5.08s
```

## Note on #3582

I saw in #4146 that the new pool architecture in #3582 already covers this with a timeout of its own. This is meant as the fix for `main` until that lands, and should be straightforward to drop when it does. Happy to close it if you would rather not carry an interim change.
