### PR TITLE
postgres: infer RETURNING OLD/NEW columns as nullable

### DIFF
--- a/sqlx-postgres/src/connection/describe.rs
+++ b/sqlx-postgres/src/connection/describe.rs
@@ -186,6 +186,19 @@ impl PgConnection {
 
 fn visit_plan(plan: &Plan, outputs: &[String], nullables: &mut Vec<Option<bool>>) {
     if let Some(plan_outputs) = &plan.output {
+        // Columns from the OLD/NEW transition relations of a `RETURNING` clause
+        // (Postgres 18+) are nullable: OLD is null for a row added by `INSERT`
+        // (including `ON CONFLICT DO NOTHING`), NEW is null for one removed by `DELETE`.
+        if plan.node_type.as_deref() == Some("ModifyTable") {
+            for output in plan_outputs {
+                if output.starts_with("old.") || output.starts_with("new.") {
+                    if let Some(i) = outputs.iter().position(|o| o == output) {
+                        nullables[i] = Some(true);
+                    }
+                }
+            }
+        }
+
         // all outputs of a Full Join must be marked nullable
         // otherwise, all outputs of the inner half of an outer join must be marked nullable
         if plan.join_type.as_deref() == Some("Full")
@@ -234,6 +247,8 @@ enum Explain {
 
 #[derive(serde::Deserialize, Debug)]
 struct Plan {
+    #[serde(rename = "Node Type")]
+    node_type: Option<String>,
     #[serde(rename = "Join Type")]
     join_type: Option<String>,
     #[serde(rename = "Parent Relationship")]
@@ -299,4 +314,39 @@ fn explain_parsing() {
         matches!(utility_statement_parsed, [Explain::Other(_)]),
         "unexpected parse from {utility_statement:?}: {utility_statement_parsed:?}"
     )
+}
+
+// https://github.com/launchbadge/sqlx/issues/4332
+#[test]
+fn nullable_from_explain_returning_old() {
+    // `INSERT ... ON CONFLICT DO NOTHING RETURNING old.hash` on a NOT NULL column:
+    // `old.hash` is null for the freshly inserted row, so it must be nullable.
+    let explain = r#"[
+      {
+        "Plan": {
+          "Node Type": "ModifyTable",
+          "Operation": "Insert",
+          "Relation Name": "files",
+          "Output": ["old.hash"],
+          "Conflict Resolution": "NOTHING",
+          "Conflict Arbiter Indexes": ["files_pkey"],
+          "Plans": [
+            {
+              "Node Type": "Result",
+              "Parent Relationship": "Outer",
+              "Output": ["'\\xdeadbeef'::bytea", "NULL::bytea[]"]
+            }
+          ]
+        }
+      }
+    ]"#;
+
+    let [Explain::Plan { plan }] = &serde_json::from_str::<[Explain; 1]>(explain).unwrap() else {
+        panic!("unexpected parse from {explain:?}");
+    };
+    let outputs = plan.output.clone().unwrap();
+    let mut nullables = vec![None; outputs.len()];
+    visit_plan(plan, &outputs, &mut nullables);
+
+    assert_eq!(nullables, [Some(true)]);
 }


### PR DESCRIPTION
## Why

`sqlx::query!` infers a non-nullable column for a `RETURNING old.<col>` clause even when the value is null at runtime, producing an unexpected-null error.

A `RETURNING` clause can reference the OLD/NEW transition relations (Postgres 18+). Those columns are nullable regardless of the underlying column's `NOT NULL` constraint:

- `OLD` is null for a row added by `INSERT` (including `ON CONFLICT DO NOTHING`),
- `NEW` is null for a row removed by `DELETE`.

The EXPLAIN-based nullability inference only marked outer-join columns as nullable, so `RETURNING old.hash` on a `NOT NULL PRIMARY KEY` was reported as non-nullable (see #4332).

## What changed

`visit_plan` now marks any `ModifyTable` output referencing an `old.`/`new.` transition relation as nullable, mirroring the existing over-approximation used for outer joins (a false positive here is safe; a false negative causes the runtime error). This required parsing the `Node Type` field from the EXPLAIN plan.

## Testing

Added a unit test built from the exact `EXPLAIN (VERBOSE, FORMAT JSON)` output in #4332; it fails on the current code (`[None]`) and passes with the fix (`[Some(true)]`). `cargo test -p sqlx-postgres`, `cargo fmt --check` and `cargo clippy -p sqlx-postgres` are clean.

Fixes #4332.

---
<sub>Disclosure: prepared with AI assistance.</sub>
